### PR TITLE
fix(ws): close WebSocket connection when subscription is cancelled

### DIFF
--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -219,15 +219,23 @@ impl WebSocket {
         mut cmd_rx: mpsc::UnboundedReceiver<WebSocketCommand>,
         cmd_tx: mpsc::UnboundedSender<WebSocketCommand>,
     ) {
-        // Attempt to connect to WebSocket server
-        let ws_stream = match connect_async(&url).await {
-            Ok((stream, _)) => stream,
-            Err(e) => {
-                let _ = msg_tx.send(WebSocketMessage::Error {
-                    error: format!("Connection failed: {e}"),
-                });
-                return;
-            }
+        // Attempt to connect to WebSocket server.
+        // Race the connection against `msg_tx.closed()` so that a subscription
+        // cancelled during connection setup terminates promptly instead of
+        // leaking the in-flight connection attempt.
+        let ws_stream = tokio::select! {
+            // The message receiver was dropped (subscription cancelled) before
+            // the connection completed: abort the connection attempt.
+            () = msg_tx.closed() => return,
+            result = connect_async(&url) => match result {
+                Ok((stream, _)) => stream,
+                Err(e) => {
+                    let _ = msg_tx.send(WebSocketMessage::Error {
+                        error: format!("Connection failed: {e}"),
+                    });
+                    return;
+                }
+            },
         };
 
         // Notify that connection was successful and provide command sender
@@ -243,6 +251,12 @@ impl WebSocket {
 
         loop {
             tokio::select! {
+                // The message receiver was dropped (subscription cancelled).
+                // Stop reading and close the connection cleanly so the task
+                // does not leak the connection while parked on `read.next()`.
+                () = msg_tx.closed() => {
+                    break;
+                }
                 // Handle incoming messages from WebSocket server
                 msg = read.next() => {
                     match msg {

--- a/tests/websocket_leak.rs
+++ b/tests/websocket_leak.rs
@@ -1,0 +1,85 @@
+//! Integration test for the WebSocket connection leak.
+//!
+//! Reproduces the scenario where a WebSocket subscription is cancelled
+//! (its message stream is dropped) while the application still holds the
+//! command sender obtained from `WebSocketMessage::Connected`.
+//!
+//! With the buggy implementation the inner connection task stays parked on
+//! `read.next().await` (the server is silent) and `cmd_rx.recv().await`
+//! (the sender is still alive), so the underlying connection is never closed.
+//! After the fix, dropping the stream must terminate the connection promptly.
+
+#![cfg(feature = "ws")]
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use tears::subscription::SubscriptionSource;
+use tears::subscription::websocket::{WebSocket, WebSocketMessage};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tokio_tungstenite::accept_async;
+
+#[tokio::test]
+async fn websocket_closes_connection_when_stream_dropped() {
+    // Start a local WebSocket server that accepts one connection and then
+    // stays silent, watching for the client to close the connection.
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local listener");
+    let addr = listener.local_addr().expect("local addr");
+
+    let server = tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.expect("accept tcp");
+        let mut ws = accept_async(tcp).await.expect("accept websocket");
+
+        // Stay silent and wait until the client side closes the connection.
+        // Returns `true` once a close / EOF / error is observed.
+        loop {
+            match ws.next().await {
+                Some(Ok(msg)) if msg.is_close() => return true,
+                Some(Ok(_)) => {} // ignore pings/pongs/etc.
+                // Connection reset (Err) or EOF (None) both count as closed.
+                Some(Err(_)) | None => return true,
+            }
+        }
+    });
+
+    let url = format!("ws://{addr}");
+
+    // Connect via the tears WebSocket subscription source.
+    let ws = WebSocket::new(url);
+    let mut stream = ws.stream();
+
+    // Wait for the Connected message and keep the command sender alive,
+    // mirroring how a real application stores it to send messages later.
+    let sender = timeout(Duration::from_secs(2), async {
+        loop {
+            match stream.next().await {
+                Some(WebSocketMessage::Connected { sender }) => break Some(sender),
+                Some(_) => {}
+                None => break None,
+            }
+        }
+    })
+    .await
+    .expect("should connect within timeout")
+    .expect("stream should yield Connected before ending");
+
+    // Cancel the subscription by dropping the consumer stream, while still
+    // holding the command sender (so cmd_rx stays open).
+    drop(stream);
+
+    // The server must observe the connection closing promptly.
+    let observed_close = timeout(Duration::from_secs(2), server).await;
+
+    // Keep the command sender alive until after the assertion so that the
+    // leak can only be resolved by detecting the dropped message receiver.
+    drop(sender);
+
+    assert!(
+        matches!(observed_close, Ok(Ok(true))),
+        "server should observe the websocket connection closing after the stream is dropped \
+         (connection leaked)"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes a WebSocket connection/task leak that occurs when a subscription is cancelled.

`WebSocket::stream()` spawns the connection loop as a detached task, but the `SubscriptionManager` only aborts the *outer* stream-reader task. When a subscription is cancelled while the application still holds the command sender obtained from `WebSocketMessage::Connected`, the inner task stays parked on:

- `read.next().await` — pending while the server is silent, and
- `cmd_rx.recv().await` — pending because the sender is still alive

so the underlying TCP/WebSocket connection is never closed until the server happens to send data or closes it. In an app that adds/removes WebSocket subscriptions dynamically, connections accumulate.

## Fix

Add `msg_tx.closed()` branches so the connection task notices when its message receiver (held by the consumer stream) is dropped:

- **Connection phase**: race `connect_async` against `msg_tx.closed()` so a cancellation during connection setup aborts the in-flight attempt instead of leaking it.
- **Main loop**: add a `() = msg_tx.closed() => break` arm to the `select!` so dropping the consumer stream breaks out and closes the connection cleanly via the existing `write.close().await` (graceful close frame).

The inner task stays detached but is now guaranteed to self-terminate when the stream is dropped, so no handle management is required.

## Test

Added `tests/websocket_leak.rs`, which reproduces the leak via a local WebSocket server:

1. Connect through the tears `WebSocket` subscription and keep the command sender alive (mirroring a real app).
2. Drop the consumer stream to cancel the subscription.
3. Assert the server observes the connection closing promptly.

Against the previous code this test times out (leak); with the fix the server observes the close immediately.

## Verification

- `cargo test --features ws,rustls,http` — all pass, no regressions
- `cargo clippy --features ws,rustls --all-targets` — no warnings (nursery/pedantic enabled)
- `cargo fmt --all -- --check` — clean
- `cargo build` (default features, `ws` disabled) — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)