### PR TITLE
fix(http): garbage collect expired query cache entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `QueryClient::gc()` to manually garbage collect expired cache entries (requires `http` feature)
+  - Removes cached entries older than the configured `cache_time`
+  - Useful for reclaiming memory for keys that are no longer being fetched
+
+### Fixed
+
+- Fixed WebSocket connections leaking when a subscription is cancelled (requires `ws` feature)
+  - The connection task could stay parked on `read.next()` and `cmd_rx.recv()` after the
+    subscription's message stream was dropped, keeping the underlying connection open
+  - The connection task now observes the dropped message receiver via `msg_tx.closed()` and
+    shuts the connection down cleanly, during both connection setup and the main loop
+- Fixed the query cache growing without bound (requires `http` feature)
+  - Cached entries were never removed, so `cache_time` had no effect and memory grew as new
+    keys were fetched over time
+  - Entries older than `cache_time` are now garbage collected automatically on each cache
+    insertion, and can also be reclaimed manually via `QueryClient::gc()`
+
 ## [0.8.0] - 2026-01-22
 
 ### Added

--- a/src/subscription/http/cache.rs
+++ b/src/subscription/http/cache.rs
@@ -1,4 +1,31 @@
+use std::any::Any;
 use std::time::{Duration, Instant};
+
+/// A type-erased view over a [`CacheEntry`] used by the query cache.
+///
+/// The cache stores entries for arbitrary value types behind `Box<dyn ...>`.
+/// This trait exposes the operations the cache needs without knowing the
+/// concrete value type: downcasting for retrieval and expiry checks for
+/// garbage collection.
+pub trait AnyCacheEntry: Send + Sync {
+    /// Returns the entry as `&dyn Any` so callers can downcast to the
+    /// concrete `CacheEntry<T>`.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Returns `true` if the entry has outlived `cache_time` and should be
+    /// garbage collected.
+    fn is_expired(&self, cache_time: Duration) -> bool;
+}
+
+impl<T: Send + Sync + 'static> AnyCacheEntry for CacheEntry<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn is_expired(&self, cache_time: Duration) -> bool {
+        self.should_gc(cache_time)
+    }
+}
 
 /// A cached entry with timestamp and staleness information.
 #[derive(Debug, Clone)]
@@ -41,7 +68,6 @@ impl<T> CacheEntry<T> {
     }
 
     /// Checks if this entry should be garbage collected based on cache time.
-    #[allow(dead_code)]
     pub fn should_gc(&self, cache_time: Duration) -> bool {
         self.timestamp.elapsed() > cache_time
     }

--- a/src/subscription/http/config.rs
+++ b/src/subscription/http/config.rs
@@ -13,7 +13,10 @@ pub struct QueryConfig {
 
     /// How long cached data is retained before being garbage collected.
     ///
-    /// Cached data that hasn't been accessed for this duration will be removed.
+    /// Cached data is removed once this much time has elapsed since it was
+    /// last fetched or updated. Garbage collection happens automatically when
+    /// new entries are inserted, and can be triggered manually via
+    /// [`QueryClient::gc`](crate::subscription::http::QueryClient::gc).
     pub cache_time: Duration,
 }
 

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -52,7 +52,7 @@
 //! }
 //! ```
 
-use std::any::Any;
+use std::fmt;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
@@ -66,7 +66,7 @@ use tokio::sync::broadcast;
 use crate::Command;
 use crate::subscription::{SubscriptionId, SubscriptionSource};
 
-use super::cache::CacheEntry;
+use super::cache::{AnyCacheEntry, CacheEntry};
 use super::config::QueryConfig;
 
 /// Error type for query operations.
@@ -153,11 +153,22 @@ impl<T> QueryResult<T> {
 ///
 /// let client = Arc::new(QueryClient::with_config(config));
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct QueryClient {
-    cache: Arc<DashMap<String, Box<dyn Any + Send + Sync>>>,
+    cache: Arc<DashMap<String, Box<dyn AnyCacheEntry>>>,
     invalidation_tx: broadcast::Sender<String>,
     config: QueryConfig,
+}
+
+impl fmt::Debug for QueryClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The cached values are type-erased and may not be `Debug`, so only
+        // expose the number of cached keys rather than their contents.
+        f.debug_struct("QueryClient")
+            .field("cached_keys", &self.cache.len())
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
 }
 
 impl QueryClient {
@@ -227,12 +238,47 @@ impl QueryClient {
     fn get_cache<T: Clone + Send + Sync + 'static>(&self, key: &str) -> Option<CacheEntry<T>> {
         self.cache
             .get(key)
-            .and_then(|entry| entry.downcast_ref::<CacheEntry<T>>().cloned())
+            .and_then(|entry| entry.as_any().downcast_ref::<CacheEntry<T>>().cloned())
     }
 
     /// Sets a cached entry for the given key.
+    ///
+    /// Performs a garbage-collection sweep before inserting so that entries
+    /// older than `cache_time` are removed and the cache does not grow without
+    /// bound as new keys are fetched over time.
     fn set_cache<T: Clone + Send + Sync + 'static>(&self, key: String, entry: CacheEntry<T>) {
+        self.gc_expired();
         self.cache.insert(key, Box::new(entry));
+    }
+
+    /// Removes cached entries that have outlived `cache_time`.
+    ///
+    /// This is called automatically on every cache insertion. Applications can
+    /// also call [`QueryClient::gc`] to trigger a sweep explicitly (for example
+    /// when no further fetches are expected for a while).
+    fn gc_expired(&self) {
+        let cache_time = self.config.cache_time;
+        self.cache.retain(|_, entry| !entry.is_expired(cache_time));
+    }
+
+    /// Removes cached entries that have outlived the configured `cache_time`.
+    ///
+    /// Cache entries are also garbage collected automatically whenever a new
+    /// entry is inserted. Use this method to reclaim memory for keys that are
+    /// no longer being fetched (which would otherwise wait for the next
+    /// insertion to be swept).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tears::subscription::http::QueryClient;
+    ///
+    /// let client = QueryClient::new();
+    /// // ... time passes, queries become inactive ...
+    /// client.gc();
+    /// ```
+    pub fn gc(&self) {
+        self.gc_expired();
     }
 
     /// Gets the query configuration.
@@ -714,5 +760,84 @@ mod tests {
         // Same key but different types should produce different IDs
         // because SubscriptionId::of::<Self> includes the type information
         assert_ne!(query1.id(), query2.id());
+    }
+
+    #[test]
+    fn test_set_cache_evicts_expired_entries() {
+        use std::thread::sleep;
+
+        // Short cache_time so entries expire quickly.
+        let config = QueryConfig::new(Duration::from_secs(0), Duration::from_millis(10));
+        let client = QueryClient::with_config(config);
+
+        client.set_cache("old".to_string(), CacheEntry::new(1));
+        assert!(client.get_cache::<i32>("old").is_some());
+
+        // Let the entry exceed cache_time.
+        sleep(Duration::from_millis(20));
+
+        // Inserting another entry must trigger a GC sweep that removes the
+        // expired one, so the cache does not grow without bound.
+        client.set_cache("new".to_string(), CacheEntry::new(2));
+
+        assert!(
+            client.get_cache::<i32>("old").is_none(),
+            "expired entry should be evicted on insert"
+        );
+        assert!(
+            client.get_cache::<i32>("new").is_some(),
+            "fresh entry should remain"
+        );
+    }
+
+    #[test]
+    fn test_gc_removes_expired_entries() {
+        use std::thread::sleep;
+
+        let config = QueryConfig::new(Duration::from_secs(0), Duration::from_millis(10));
+        let client = QueryClient::with_config(config);
+
+        client.set_cache("a".to_string(), CacheEntry::new(1));
+        assert_eq!(client.cache.len(), 1);
+
+        sleep(Duration::from_millis(20));
+
+        client.gc();
+
+        assert!(client.get_cache::<i32>("a").is_none());
+        assert_eq!(client.cache.len(), 0);
+    }
+
+    #[test]
+    fn test_gc_keeps_fresh_entries() {
+        // Long cache_time so nothing expires during the test.
+        let config = QueryConfig::new(Duration::from_secs(0), Duration::from_secs(300));
+        let client = QueryClient::with_config(config);
+
+        client.set_cache("a".to_string(), CacheEntry::new(1));
+        client.set_cache("b".to_string(), CacheEntry::new(2));
+
+        client.gc();
+
+        assert!(client.get_cache::<i32>("a").is_some());
+        assert!(client.get_cache::<i32>("b").is_some());
+        assert_eq!(client.cache.len(), 2);
+    }
+
+    #[test]
+    fn test_gc_preserves_entries_of_different_types() {
+        let config = QueryConfig::new(Duration::from_secs(0), Duration::from_secs(300));
+        let client = QueryClient::with_config(config);
+
+        client.set_cache("int".to_string(), CacheEntry::new(42));
+        client.set_cache("str".to_string(), CacheEntry::new("hello".to_string()));
+
+        client.gc();
+
+        assert_eq!(client.get_cache::<i32>("int").map(|e| e.data), Some(42));
+        assert_eq!(
+            client.get_cache::<String>("str").map(|e| e.data),
+            Some("hello".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes unbounded growth of the query cache (`QueryClient`).

Entries were inserted via `set_cache` but **never removed**, so the `cache_time` configuration had no effect and memory grew as new keys were fetched over time. `CacheEntry::should_gc` and `cache_time` existed but were dead code.

## Fix

The cache stores values as `Box<dyn Any>`, so garbage collection needs to work without knowing the concrete value type. To enable this:

- Add an `AnyCacheEntry` trait exposing `as_any()` (for downcasting on retrieval) and `is_expired()` (backed by the existing `CacheEntry::should_gc`).
- Store cache values as `Box<dyn AnyCacheEntry>` and **sweep expired entries on every `set_cache`**. This bounds the dominant growth pattern where new unique keys are fetched continuously (e.g. paginated / per-user queries).
- Add a public **`QueryClient::gc()`** so applications can reclaim memory for keys that are no longer being fetched (the idle case not covered by insert-time sweeps).
- Replace the derived `Debug` with a manual impl (type-erased values are no longer `Debug`); it reports the number of cached keys.
- Clarify the `cache_time` docs: eviction is based on time since an entry was last fetched/updated (the timestamp is shared with stale-time logic and is intentionally not bumped on read).

## Test

Added unit tests (TDD — the eviction test fails against the previous code):

- `test_set_cache_evicts_expired_entries` — inserting a new entry evicts an expired one
- `test_gc_removes_expired_entries` — `gc()` removes expired entries
- `test_gc_keeps_fresh_entries` — fresh entries are preserved
- `test_gc_preserves_entries_of_different_types` — type-erased GC does not corrupt entries of differing value types

## CHANGELOG

Added `[Unreleased]` entries for this fix, the new `gc()` method, and the previously merged WebSocket connection leak fix (#81).

## Verification

- `cargo test --features ws,rustls,http` — all pass, no regressions
- `cargo clippy --features ws,rustls,http --all-targets` — no warnings (nursery/pedantic enabled)
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)