### PR TITLE
fix(runtime): compute frame interval with exact duration division

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     subscription, so it never refetched again
   - A lagged receiver now refetches (since a dropped notification may have been for its key)
     and only a genuinely closed channel ends the subscription
+- Improved frame rate timing accuracy in `Runtime`
+  - The frame interval was computed with integer millisecond division (`1000 / frame_rate`),
+    truncating the period; for example 60 FPS ran at 16ms (~62.5 FPS) and 144 FPS at 6ms
+  - The period is now derived from an exact `Duration` division, so the requested frame rate
+    is honored precisely
 
 ## [0.8.0] - 2026-01-22
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -191,7 +191,16 @@ impl<App: Application> Runtime<App> {
     pub fn new(flags: App::Flags, frame_rate: u32) -> Self {
         let state = ApplicationState::new(flags);
 
-        let frame_duration = Duration::from_millis(1000 / u64::from(frame_rate));
+        // Divide a one-second `Duration` directly so the period is exact (e.g.
+        // 60 FPS -> 16.667ms) instead of truncating to whole milliseconds (the
+        // old `1000 / frame_rate` gave 16ms, an effective ~62.5 FPS).
+        //
+        // FIXME(v0.9.0): `frame_rate` is not validated. `frame_rate == 0`
+        // panics (divide by zero) and extremely large values round the period
+        // down to zero, which panics `interval`. Resolve by validating the
+        // range, likely by making this constructor return a `Result` (a
+        // breaking API change).
+        let frame_duration = Duration::from_secs(1) / frame_rate;
         let mut frame_interval = interval(frame_duration);
         // Skip missed frames rather than trying to catch up
         frame_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -842,6 +851,27 @@ mod tests {
         let _runtime2 = Runtime::<TestApp>::new(0, 144);
 
         // Should handle different frame rates without panic
+    }
+
+    #[tokio::test]
+    async fn test_runtime_frame_interval_period_is_accurate() {
+        // 60 FPS should yield a ~16.667ms period. The previous integer
+        // millisecond division (1000 / 60 = 16ms) truncated this, producing
+        // an effective ~62.5 FPS.
+        let runtime = Runtime::<TestApp>::new(0, 60);
+        let period = runtime.frame_interval.period();
+        assert!(
+            period >= Duration::from_micros(16_600) && period <= Duration::from_micros(16_700),
+            "60 FPS period should be ~16.667ms, got {period:?}",
+        );
+
+        // 144 FPS should yield a ~6.944ms period (not the truncated 6ms).
+        let runtime = Runtime::<TestApp>::new(0, 144);
+        let period = runtime.frame_interval.period();
+        assert!(
+            period >= Duration::from_micros(6_900) && period <= Duration::from_micros(6_950),
+            "144 FPS period should be ~6.944ms, got {period:?}",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Improves frame-rate timing accuracy in `Runtime`.

The frame interval was computed as `Duration::from_millis(1000 / frame_rate)`, which truncates to whole milliseconds:

- 60 FPS → 16ms → effective **~62.5 FPS**
- 144 FPS → 6ms → effective **~166 FPS**

## Fix

Derive the period from an exact `Duration` division:

```rust
let frame_duration = Duration::from_secs(1) / frame_rate;
```

This honors the requested frame rate precisely (60 FPS → 16.667ms, 144 FPS → 6.944ms).

## Scope

This PR is intentionally limited to the precision fix to keep the release focused on bug fixes. Out-of-range `frame_rate` handling is **not** addressed here and is left as a documented `FIXME`:

- `frame_rate == 0` panics (divide by zero)
- extremely large values round the period down to zero, which panics `interval`

These will be addressed in **v0.9.0**, likely by validating the range and returning a `Result` from the constructor (a breaking API change).

## Test

Added `test_runtime_frame_interval_period_is_accurate` (TDD — fails against the previous code): it asserts the 60 FPS and 144 FPS interval periods (`Interval::period()`) match their true values rather than the truncated ones.

## Verification

- `cargo test --features ws,rustls,http` — all pass, no regressions
- `cargo clippy --features ws,rustls,http --all-targets` — no warnings (nursery/pedantic enabled)
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)