### PR TITLE
fix(http): change check_staleness to &self to stop silently discarding mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `CacheEntry::check_staleness` having a misleading `&mut self` signature
+  (requires `http` feature)
+  - The method set `self.is_stale = true` on the receiver, but `QueryClient::get_cache`
+    returns a clone of the entry, so the mutation was silently discarded and the
+    actual cached entry's `is_stale` field remained `false` forever
+  - The method now takes `&self`; staleness is evaluated as
+    `self.is_stale || stale_time_elapsed`, preserving the existing return-value
+    semantics while making the immutability explicit
+
 - Fixed `Query` subscriptions with the same string key but different value types
   overwriting each other's cache entries (requires `http` feature)
   - The cache was keyed by the plain string key, so `Query<i32>` and `Query<String>`

--- a/src/subscription/http/cache.rs
+++ b/src/subscription/http/cache.rs
@@ -46,11 +46,12 @@ impl<T> CacheEntry<T> {
     }
 
     /// Checks if this entry is stale based on the given stale time.
-    pub fn check_staleness(&mut self, stale_time: Duration) -> bool {
-        if self.timestamp.elapsed() > stale_time {
-            self.is_stale = true;
-        }
-        self.is_stale
+    ///
+    /// Returns `true` if the entry was explicitly marked stale via
+    /// [`mark_stale`](Self::mark_stale) or if `stale_time` has elapsed
+    /// since the entry was created.  Does **not** mutate the entry.
+    pub fn check_staleness(&self, stale_time: Duration) -> bool {
+        self.is_stale || self.timestamp.elapsed() > stale_time
     }
 
     /// Marks this entry as stale.
@@ -87,7 +88,7 @@ mod tests {
 
     #[test]
     fn test_check_staleness_fresh() {
-        let mut entry = CacheEntry::new(42);
+        let entry = CacheEntry::new(42);
         let is_stale = entry.check_staleness(Duration::from_secs(1));
         assert!(!is_stale);
         assert!(!entry.is_stale);
@@ -95,11 +96,29 @@ mod tests {
 
     #[test]
     fn test_check_staleness_stale() {
-        let mut entry = CacheEntry::new(42);
+        let entry = CacheEntry::new(42);
         sleep(Duration::from_millis(10));
         let is_stale = entry.check_staleness(Duration::from_millis(5));
         assert!(is_stale);
-        assert!(entry.is_stale);
+        // check_staleness must NOT mutate the entry — previously this
+        // was called on a clone from the cache so the mutation was silently
+        // discarded anyway; now the signature enforces immutability.
+        assert!(
+            !entry.is_stale,
+            "check_staleness must not mutate is_stale on the entry"
+        );
+    }
+
+    #[test]
+    fn test_check_staleness_respects_mark_stale() {
+        // An entry that was explicitly marked stale via mark_stale should
+        // be reported as stale by check_staleness even within the stale_time.
+        let mut entry = CacheEntry::new(42);
+        entry.mark_stale();
+        assert!(
+            entry.check_staleness(Duration::from_secs(3600)),
+            "entry marked stale should be reported stale regardless of elapsed time"
+        );
     }
 
     #[test]

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -395,12 +395,12 @@ where
                         let rx = client.subscribe_invalidation();
 
                         // Check cache first
-                        if let Some(mut cached) = client.get_cache::<V>(&key) {
+                        if let Some(cached) = client.get_cache::<V>(&key) {
                             let is_stale = cached.check_staleness(client.config().stale_time);
 
                             let result = QueryResult {
                                 state: QueryState::Success {
-                                    data: cached.data.clone(),
+                                    data: cached.data,
                                     is_stale,
                                 },
                             };


### PR DESCRIPTION
## Summary

- `CacheEntry::check_staleness` took `&mut self` and set `self.is_stale = true` when the timestamp exceeded `stale_time`.
- However, `QueryClient::get_cache` returns a **clone** of the cached entry, so every call to `check_staleness` in `State::Initial` operated on a throw-away copy. The mutation was silently discarded: the actual cached entry's `is_stale` field remained `false` forever.
- In practice no correctness bug resulted (the return value was always computed correctly from `timestamp.elapsed()`), but the `&mut self` signature implied persistent side effects that never materialised.

**Root cause:** Changed the signature to `&self` with the body:
```rust
self.is_stale || self.timestamp.elapsed() > stale_time
```
This preserves the documented semantics — an entry explicitly marked stale via `mark_stale()` remains stale even within `stale_time` — while making the immutability explicit.

**Side effects of the change:**
- The `if let Some(mut cached)` binding in `State::Initial` no longer needs `mut`.
- `cached.data` can now be moved rather than cloned, which clippy had correctly flagged as `redundant_clone` once the `mut` binding was removed.

## Test plan

- [x] `test_check_staleness_stale` — updated: now asserts `entry.is_stale == false` after `check_staleness` returns `true`, confirming the method does **not** mutate the entry. Would have asserted `entry.is_stale == true` on the old code.
- [x] `test_check_staleness_respects_mark_stale` — new test: verifies that an entry explicitly flagged via `mark_stale()` is still reported as stale by `check_staleness` even with a large `stale_time`.
- [x] Full test suite: `just fmt && just clippy && just test` — 149 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)