### PR TITLE
fix(http): mark cached entries stale on invalidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `QueryClient::invalidate` not marking cached entries stale, so
+  invalidations were lost when no query subscription was active (requires
+  `http` feature)
+  - Previously `invalidate` only broadcast a notification; a `broadcast` channel
+    only reaches current subscribers, so if no query was subscribed at that
+    moment the cache stayed fresh and a later subscription within `stale_time`
+    would serve the outdated data as fresh (mutation results appearing to "revert")
+  - This was masked by the default `stale_time` of 0 (entries are treated as
+    stale on next access anyway) and only surfaced with a configured
+    `stale_time > 0`
+  - `invalidate` now marks every typed cache entry sharing the invalidated key
+    as stale via a new type-erased `AnyCacheEntry::mark_stale`, so a query that
+    subscribes afterwards sees the entry as stale and refetches, in addition to
+    the existing broadcast that refetches already-active queries
+
 ## [0.8.2] - 2026-07-02
 
 ### Fixed

--- a/src/subscription/http/cache.rs
+++ b/src/subscription/http/cache.rs
@@ -12,6 +12,9 @@ pub trait AnyCacheEntry: Send + Sync {
     /// concrete `CacheEntry<T>`.
     fn as_any(&self) -> &dyn Any;
 
+    /// Marks the entry as stale without knowing its concrete value type.
+    fn mark_stale(&mut self);
+
     /// Returns `true` if the entry has outlived `cache_time` and should be
     /// garbage collected.
     fn is_expired(&self, cache_time: Duration) -> bool;
@@ -20,6 +23,14 @@ pub trait AnyCacheEntry: Send + Sync {
 impl<T: Send + Sync + 'static> AnyCacheEntry for CacheEntry<T> {
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn mark_stale(&mut self) {
+        // Call the inherent method explicitly. `self.mark_stale()` would also
+        // resolve to it today (inherent methods take priority over trait
+        // methods), but being explicit avoids silently turning into infinite
+        // recursion if the inherent method is ever renamed or removed.
+        Self::mark_stale(self);
     }
 
     fn is_expired(&self, cache_time: Duration) -> bool {
@@ -55,7 +66,6 @@ impl<T> CacheEntry<T> {
     }
 
     /// Marks this entry as stale.
-    #[allow(dead_code)]
     pub const fn mark_stale(&mut self) {
         self.is_stale = true;
     }

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -213,6 +213,7 @@ impl QueryClient {
     where
         Msg: Send + 'static,
     {
+        let cache = self.cache.clone();
         let tx = self.invalidation_tx.clone();
         let key_string = key.to_string();
 
@@ -220,10 +221,13 @@ impl QueryClient {
         Command {
             stream: Some(
                 futures::stream::once(async move {
-                    // Note: We cannot directly mark cache entries as stale because
-                    // the cache stores `Box<dyn Any>` and we don't know the concrete type.
-                    // Instead, we just broadcast the invalidation notification,
-                    // which will trigger Query subscriptions to refetch.
+                    // Mark all typed cache entries for this user key as stale so
+                    // invalidations are preserved even when no query is active.
+                    for mut entry in cache.iter_mut() {
+                        if entry.key().1.as_str() == key_string.as_str() {
+                            entry.value_mut().mark_stale();
+                        }
+                    }
 
                     // Broadcast invalidation notification
                     let _ = tx.send(key_string);
@@ -727,6 +731,105 @@ mod tests {
             .expect("Should receive notification within timeout")
             .expect("Channel should not be closed");
         assert_eq!(key, "nonexistent");
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_marks_matching_cache_entries_stale() {
+        use futures::StreamExt;
+
+        let config = QueryConfig::new(Duration::from_secs(3600), Duration::from_secs(3600));
+        let client = QueryClient::with_config(config);
+
+        client.set_cache("data".to_string(), CacheEntry::new(42i32));
+        client.set_cache("data".to_string(), CacheEntry::new("hello".to_string()));
+        client.set_cache("other".to_string(), CacheEntry::new(7i32));
+
+        let cmd: Command<()> = client.invalidate(&"data");
+        if let Some(stream) = cmd.stream {
+            let _: Vec<_> = stream.collect().await;
+        }
+
+        assert!(
+            client
+                .get_cache::<i32>("data")
+                .expect("i32 data cache should exist")
+                .is_stale,
+            "invalidate should mark matching i32 cache entries stale"
+        );
+        assert!(
+            client
+                .get_cache::<String>("data")
+                .expect("String data cache should exist")
+                .is_stale,
+            "invalidate should mark matching String cache entries stale"
+        );
+        assert!(
+            !client
+                .get_cache::<i32>("other")
+                .expect("other cache should exist")
+                .is_stale,
+            "invalidate should not mark unrelated keys stale"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_without_active_subscription_refetches_on_next_subscribe() {
+        use futures::StreamExt;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let config = QueryConfig::new(Duration::from_secs(3600), Duration::from_secs(3600));
+        let client = Arc::new(QueryClient::with_config(config));
+        client.set_cache("key".to_string(), CacheEntry::new(42));
+
+        let cmd: Command<()> = client.invalidate(&"key");
+        if let Some(stream) = cmd.stream {
+            let _: Vec<_> = stream.collect().await;
+        }
+
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+        let fetch_count_clone = fetch_count.clone();
+        let query = Query::new(
+            &"key",
+            move || {
+                let count = fetch_count_clone.clone();
+                Box::pin(async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Ok::<i32, QueryError>(99)
+                })
+            },
+            client,
+        );
+
+        let mut stream = query.stream();
+
+        let cached = stream.next().await;
+        assert!(
+            matches!(
+                cached,
+                Some(QueryResult {
+                    state: QueryState::Success {
+                        data: 42,
+                        is_stale: true
+                    }
+                })
+            ),
+            "invalidated cache should be emitted as stale even with long stale_time"
+        );
+
+        let fetched = stream.next().await;
+        assert!(
+            matches!(
+                fetched,
+                Some(QueryResult {
+                    state: QueryState::Success {
+                        data: 99,
+                        is_stale: false
+                    }
+                })
+            ),
+            "stale invalidated cache should trigger a refetch"
+        );
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`QueryClient::invalidate` previously only broadcast an invalidation notification. A `broadcast` channel only delivers to *current* subscribers, so an invalidation sent while no query was subscribed was silently lost — the cache entry stayed fresh and a later subscription within `stale_time` would serve the outdated data as fresh (e.g. a mutation result appearing to revert).

This PR makes `invalidate` also update the cache itself so invalidations survive periods with no active subscription.

## Changes

- Add a type-erased `AnyCacheEntry::mark_stale` so the type-erased cache (`Box<dyn AnyCacheEntry>`) can be marked stale without knowing the concrete value type. The trait impl delegates to the existing inherent `CacheEntry::mark_stale` (previously `#[allow(dead_code)]`, now used).
- `QueryClient::invalidate` iterates the cache and marks every typed entry sharing the invalidated string key (across all `TypeId`s) as stale, then broadcasts as before. The `invalidate` signature is unchanged — no breaking change.

## Notes

- This was masked by the default `stale_time` of 0 (entries are treated as stale on next access anyway) and only surfaced with a configured `stale_time > 0`.
- The broadcast path is retained so already-active queries still refetch immediately.

## Tests

- `test_invalidate_marks_matching_cache_entries_stale`: `invalidate` marks all typed entries for the key stale and leaves unrelated keys untouched.
- `test_invalidate_without_active_subscription_refetches_on_next_subscribe`: invalidating with no active subscription (and a long `stale_time`) causes the next subscribing query to emit the cached value as stale and then refetch.

All 33 `subscription::http` tests pass; `cargo clippy --features http` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)