### PR TITLE
docs(http): clarify query error handling and mutation helper types

### DIFF
--- a/src/subscription/http/mutation.rs
+++ b/src/subscription/http/mutation.rs
@@ -14,6 +14,11 @@
 //! return a Command. After a successful mutation, you typically want to invalidate
 //! related queries to trigger refetching.
 //!
+//! [`Mutation::mutate`] returns a `Command<Result<_, QueryError>>` and does not
+//! emit [`MutationState`] values by itself. [`MutationState`] and
+//! [`MutationResult`] are helper types for applications that want to store
+//! mutation status in their own model.
+//!
 //! # Example
 //!
 //! ```rust,ignore
@@ -61,6 +66,10 @@ use crate::Command;
 use super::query::QueryError;
 
 /// The state of a mutation result.
+///
+/// This is a helper type for application models. [`Mutation::mutate`] returns a
+/// `Command<Result<_, QueryError>>`; it does not automatically emit
+/// `MutationState` values.
 #[derive(Debug, Clone)]
 pub enum MutationState<T> {
     /// Mutation is idle (not yet started).
@@ -74,6 +83,9 @@ pub enum MutationState<T> {
 }
 
 /// A mutation result containing the current state.
+///
+/// This is a helper type for applications that choose to track mutation state
+/// explicitly in their model.
 #[derive(Debug, Clone)]
 pub struct MutationResult<T> {
     /// The current state of the mutation.

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -12,6 +12,11 @@
 //! 2. If data is stale or missing, a fetch is automatically triggered
 //! 3. When the cache is invalidated, refetching happens automatically
 //!
+//! Failed fetches are emitted as [`QueryState::Error`] and are not retried
+//! automatically. To retry after an error, invalidate the query key with
+//! [`QueryClient::invalidate`], or include your own retry/backoff behavior in
+//! the fetcher.
+//!
 //! This design keeps your UI in sync with the data state without manual management.
 //!
 //! # Example
@@ -319,6 +324,11 @@ impl Default for QueryClient {
 /// 1. If cached data exists, it's immediately emitted as `Success`
 /// 2. If data is missing or stale, a fetch is triggered and `Loading` is emitted
 /// 3. When invalidated, the query automatically refetches
+///
+/// If a fetch fails, the query emits [`QueryState::Error`] and waits for the
+/// next invalidation. It does not retry automatically; call
+/// [`QueryClient::invalidate`] to request another fetch, or implement retry
+/// behavior inside the fetcher.
 ///
 /// # Query keys
 ///


### PR DESCRIPTION
## Summary

Documentation-only clarifications for the `http` feature. No behavior change.

## Changes

- **Query error handling (⑤)**: document on the module and on `Query` that a failed fetch is emitted as `QueryState::Error` and is **not** retried automatically. Recovery is via `QueryClient::invalidate` (manual refetch) or a retry/backoff implemented inside the fetcher.
- **Mutation helper types (⑦)**: document on the module and on `MutationState` / `MutationResult` that these are helper types for application models — `Mutation::mutate` returns a `Command<Result<_, QueryError>>` and does not emit `MutationState` values by itself.

## Rationale

The module docs emphasize "automatic refetching", which led to an expectation of automatic retry after errors; and the public `MutationState` / `MutationResult` types looked like state managed by the library. These notes close the gap between the API's apparent and actual behavior.

## Notes

No CHANGELOG entry: these are documentation clarifications with no user-facing behavior change. `just clippy` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)