### PR TITLE
fix(http): treat zero stale_time/cache_time as immediately stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a `stale_time`/`cache_time` of `Duration::ZERO` not being treated as
+  immediately stale/expired at the exact boundary (requires `http` feature)
+  - Cache staleness and garbage collection used a strict `>` comparison against
+    the elapsed time, so an entry was only stale/expired once elapsed time
+    *exceeded* the configured duration; this contradicted the documented
+    "immediately stale" semantics of the default `stale_time` of 0
+  - Both comparisons now use `>=`, so a duration of `Duration::ZERO` marks the
+    entry stale/expired immediately. In practice this only affects the exact
+    boundary; wall-clock elapsed time is virtually never exactly equal to the
+    configured duration, and these cache internals are not part of the public API
+
 - Fixed `Query` subscriptions with the same key on different `QueryClient`
   instances being treated as identical, so switching the client did not restart
   the subscription (requires `http` feature)

--- a/src/subscription/http/cache.rs
+++ b/src/subscription/http/cache.rs
@@ -15,7 +15,7 @@ pub trait AnyCacheEntry: Send + Sync {
     /// Marks the entry as stale without knowing its concrete value type.
     fn mark_stale(&mut self);
 
-    /// Returns `true` if the entry has outlived `cache_time` and should be
+    /// Returns `true` if the entry has reached `cache_time` and should be
     /// garbage collected.
     fn is_expired(&self, cache_time: Duration) -> bool;
 }
@@ -59,10 +59,10 @@ impl<T> CacheEntry<T> {
     /// Checks if this entry is stale based on the given stale time.
     ///
     /// Returns `true` if the entry was explicitly marked stale via
-    /// [`mark_stale`](Self::mark_stale) or if `stale_time` has elapsed
+    /// [`mark_stale`](Self::mark_stale) or if at least `stale_time` has elapsed
     /// since the entry was created.  Does **not** mutate the entry.
     pub fn check_staleness(&self, stale_time: Duration) -> bool {
-        self.is_stale || self.timestamp.elapsed() > stale_time
+        self.is_stale || self.timestamp.elapsed() >= stale_time
     }
 
     /// Marks this entry as stale.
@@ -80,7 +80,7 @@ impl<T> CacheEntry<T> {
 
     /// Checks if this entry should be garbage collected based on cache time.
     pub fn should_gc(&self, cache_time: Duration) -> bool {
-        self.timestamp.elapsed() > cache_time
+        self.timestamp.elapsed() >= cache_time
     }
 }
 
@@ -120,6 +120,15 @@ mod tests {
     }
 
     #[test]
+    fn test_check_staleness_zero_is_immediately_stale() {
+        let entry = CacheEntry::new(42);
+        assert!(
+            entry.check_staleness(Duration::ZERO),
+            "zero stale_time should mark an entry stale immediately"
+        );
+    }
+
+    #[test]
     fn test_check_staleness_respects_mark_stale() {
         // An entry that was explicitly marked stale via mark_stale should
         // be reported as stale by check_staleness even within the stale_time.
@@ -148,5 +157,14 @@ mod tests {
         entry.update(100);
         assert_eq!(entry.data, 100);
         assert!(!entry.is_stale);
+    }
+
+    #[test]
+    fn test_should_gc_zero_is_immediately_expired() {
+        let entry = CacheEntry::new(42);
+        assert!(
+            entry.should_gc(Duration::ZERO),
+            "zero cache_time should expire an entry immediately"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Cache staleness and garbage collection compared elapsed time with a strict `>`, so an entry only became stale/expired once elapsed time *exceeded* the configured duration. This contradicted the documented "immediately stale" semantics of the default `stale_time` of 0.

## Changes

- `CacheEntry::check_staleness` and `CacheEntry::should_gc` now use `>=` instead of `>`, so `Duration::ZERO` marks an entry stale/expired immediately.
- Doc wording updated ("outlived"/"has elapsed" → "reached"/"at least ... has elapsed").
- Added boundary tests: `test_check_staleness_zero_is_immediately_stale`, `test_should_gc_zero_is_immediately_expired`.

## Bug fix, not a breaking change (0.8.3)

- The affected methods live in the **private** `cache` module (`mod cache;`) and are **not** re-exported, so they are not part of the public API — downstream code cannot call them or depend on their exact boundary behavior.
- The only observable difference between `>` and `>=` is at the exact instant `elapsed == duration`. `CacheEntry::new` always sets `timestamp = Instant::now()` and there is no public way to inject a controlled timestamp, so a monotonic-clock `elapsed()` is virtually never exactly equal to a fixed `Duration`. For `Duration::ZERO` this merely makes "immediately stale/expired" deterministic (it already behaved that way once a single nanosecond had passed).
- This aligns the implementation with the documented default semantics — a backwards-compatible fix suitable for a patch release.

## Tests

All 37 `subscription::http` tests pass; `just clippy` (`--all-targets --all-features -D warnings`) is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)