### PR TITLE
feat!: validate runtime frame rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `Timer::try_new(u64) -> Option<Timer>` as a convenient constructor for
     millisecond values that may be zero
 
+- **BREAKING**: `Runtime::new` now takes a validated `FrameRate` instead of a
+  raw `u32`
+  - This prevents `frame_rate == 0` from panicking due to division by zero
+  - Extremely high frame rates that would round down to a zero-duration Tokio
+    interval are rejected
+  - Added `FrameRate::try_new(u32) -> Result<FrameRate, FrameRateError>` and
+    `Runtime::try_new(flags, u32) -> Result<Runtime<_>, FrameRateError>` as
+    convenient constructors for raw FPS values
+
 ## [0.8.3] - 2026-07-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ To run your application, create an `Runtime` and call `run()`:
 ```rust
 #[tokio::main]
 async fn main() -> Result<()> {
-    let runtime = Runtime::<App>::new((), 60);
+    let runtime = Runtime::<App>::try_new((), 60)?;
 
     // Setup terminal (see complete example below)
     // ...
@@ -164,7 +164,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<Counter>::new((), 60);
+    let runtime = Runtime::<Counter>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<Counter>::new((), 60);
+    let runtime = Runtime::<Counter>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -609,7 +609,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<App>::new((), 60);
+    let runtime = Runtime::<App>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/http_todo.rs
+++ b/examples/http_todo.rs
@@ -277,7 +277,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<App>::new((), 60);
+    let runtime = Runtime::<App>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -304,7 +304,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<App>::new((), 60);
+    let runtime = Runtime::<App>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/views.rs
+++ b/examples/views.rs
@@ -375,7 +375,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<App>::new((), 60);
+    let runtime = Runtime::<App>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -252,7 +252,7 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<EchoChat>::new((), 60);
+    let runtime = Runtime::<EchoChat>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/src/frame_rate.rs
+++ b/src/frame_rate.rs
@@ -1,0 +1,121 @@
+//! Frame rate value object for runtime scheduling.
+
+use std::fmt;
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+/// Target frames per second for [`Runtime`](crate::runtime::Runtime).
+///
+/// The value must be non-zero and small enough to produce a non-zero frame
+/// duration. This prevents divide-by-zero panics and invalid zero-duration
+/// Tokio intervals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FrameRate {
+    frames_per_second: NonZeroU32,
+}
+
+impl FrameRate {
+    /// Highest supported frame rate.
+    ///
+    /// `Duration::from_secs(1) / MAX` is exactly one nanosecond. Larger values
+    /// round down to a zero duration and cannot be used with Tokio intervals.
+    pub const MAX: u32 = 1_000_000_000;
+
+    /// Creates a frame rate from a non-zero FPS value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FrameRateError::TooHigh`] when the value is greater than
+    /// [`FrameRate::MAX`].
+    pub const fn new(frames_per_second: NonZeroU32) -> std::result::Result<Self, FrameRateError> {
+        let value = frames_per_second.get();
+        if value <= Self::MAX {
+            Ok(Self { frames_per_second })
+        } else {
+            Err(FrameRateError::TooHigh {
+                value,
+                max: Self::MAX,
+            })
+        }
+    }
+
+    /// Tries to create a frame rate from an FPS value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FrameRateError::Zero`] when `frames_per_second` is zero, or
+    /// [`FrameRateError::TooHigh`] when it is greater than [`FrameRate::MAX`].
+    pub const fn try_new(frames_per_second: u32) -> std::result::Result<Self, FrameRateError> {
+        match NonZeroU32::new(frames_per_second) {
+            Some(frames_per_second) => Self::new(frames_per_second),
+            None => Err(FrameRateError::Zero),
+        }
+    }
+
+    /// Returns the frame rate in frames per second.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.frames_per_second.get()
+    }
+
+    pub(crate) fn frame_duration(self) -> Duration {
+        Duration::from_secs(1) / self.get()
+    }
+}
+
+/// Error returned when constructing an invalid [`FrameRate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameRateError {
+    /// Frame rate must be non-zero.
+    Zero,
+    /// Frame rate is too high to produce a non-zero frame duration.
+    TooHigh {
+        /// Provided frame rate.
+        value: u32,
+        /// Maximum supported frame rate.
+        max: u32,
+    },
+}
+
+impl fmt::Display for FrameRateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Zero => f.write_str("frame rate must be non-zero"),
+            Self::TooHigh { value, max } => {
+                write!(f, "frame rate must be at most {max}, got {value}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FrameRateError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame_rate(value: u32) -> FrameRate {
+        FrameRate::try_new(value).expect("frame rate must be valid")
+    }
+
+    #[test]
+    fn test_frame_rate_try_new() {
+        assert_eq!(FrameRate::try_new(0), Err(FrameRateError::Zero));
+        assert_eq!(FrameRate::try_new(60).map(FrameRate::get), Ok(60));
+        assert_eq!(
+            FrameRate::try_new(FrameRate::MAX + 1),
+            Err(FrameRateError::TooHigh {
+                value: FrameRate::MAX + 1,
+                max: FrameRate::MAX,
+            }),
+        );
+    }
+
+    #[test]
+    fn test_frame_rate_frame_duration_bounds() {
+        assert_eq!(
+            frame_rate(FrameRate::MAX).frame_duration(),
+            Duration::from_nanos(1)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@
 
 pub mod application;
 pub mod command;
+mod frame_rate;
 pub mod prelude;
 pub mod runtime;
 pub mod subscription;
@@ -90,6 +91,7 @@ pub mod subscription;
 // Re-export commonly used types
 pub use application::Application;
 pub use command::{Action, Command};
+pub use frame_rate::{FrameRate, FrameRateError};
 pub use futures::stream::BoxStream;
 pub use runtime::Runtime;
 pub use subscription::{Subscription, SubscriptionId, SubscriptionSource};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,8 +11,10 @@
 //! - [`Action`] - Actions that commands can perform
 //! - [`Subscription`] - For handling event sources
 //! - [`Runtime`] - The runtime for running applications
+//! - [`FrameRate`] - Validated runtime frame rate
 
 pub use crate::application::Application;
 pub use crate::command::{Action, Command};
+pub use crate::frame_rate::{FrameRate, FrameRateError};
 pub use crate::runtime::Runtime;
 pub use crate::subscription::Subscription;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -8,7 +8,7 @@
 //!
 //! The runtime follows The Elm Architecture pattern:
 //!
-//! 1. **Initialization**: Create a [`Runtime`] with initial flags and frame rate
+//! 1. **Initialization**: Create a [`Runtime`] with initial flags and [`FrameRate`]
 //! 2. **Event Loop**: Process messages via [`Application::update`], render via [`Application::view`]
 //! 3. **Commands**: Execute asynchronous operations that produce messages
 //! 4. **Subscriptions**: Receive external events (timers, signals, etc.)
@@ -71,7 +71,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!     let runtime = Runtime::<CounterApp>::new((), 60);
+//!     let runtime = Runtime::<CounterApp>::try_new((), 60)?;
 //!     let mut terminal = ratatui::init();
 //!     runtime.run(&mut terminal).await?;
 //!     ratatui::restore();
@@ -92,6 +92,7 @@ use tokio::time::{Interval, MissedTickBehavior, interval};
 use crate::{
     application::Application,
     command::{Action, Command},
+    frame_rate::{FrameRate, FrameRateError},
     subscription::SubscriptionManager,
 };
 
@@ -170,7 +171,7 @@ impl<App: Application> Runtime<App> {
     /// # Arguments
     ///
     /// * `flags` - Configuration data passed to [`Application::new`]
-    /// * `frame_rate` - Target frames per second (typical values: 30, 60, 120, 144)
+    /// * `frame_rate` - Validated target frames per second
     ///
     /// # Notes
     ///
@@ -195,21 +196,17 @@ impl<App: Application> Runtime<App> {
     /// # }
     ///
     /// // Create runtime with 60 FPS target
-    /// let runtime = Runtime::<MyApp>::new((), 60);
+    /// let frame_rate = FrameRate::try_new(60).expect("frame rate must be valid");
+    /// let runtime = Runtime::<MyApp>::new((), frame_rate);
     /// ```
-    pub fn new(flags: App::Flags, frame_rate: u32) -> Self {
+    #[must_use]
+    pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self {
         let state = ApplicationState::new(flags);
 
         // Divide a one-second `Duration` directly so the period is exact (e.g.
         // 60 FPS -> 16.667ms) instead of truncating to whole milliseconds (the
         // old `1000 / frame_rate` gave 16ms, an effective ~62.5 FPS).
-        //
-        // FIXME(v0.9.0): `frame_rate` is not validated. `frame_rate == 0`
-        // panics (divide by zero) and extremely large values round the period
-        // down to zero, which panics `interval`. Resolve by validating the
-        // range, likely by making this constructor return a `Result` (a
-        // breaking API change).
-        let frame_duration = Duration::from_secs(1) / frame_rate;
+        let frame_duration = frame_rate.frame_duration();
         let mut frame_interval = interval(frame_duration);
         // Skip missed frames rather than trying to catch up
         frame_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -223,6 +220,41 @@ impl<App: Application> Runtime<App> {
             subscriptions_dirty: false,
             subscription_ids_hash: None, // No subscriptions cached yet
         }
+    }
+
+    /// Tries to create a new runtime with the given initialization flags and FPS value.
+    ///
+    /// This is a convenience wrapper around [`FrameRate::try_new`] and
+    /// [`Runtime::new`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FrameRateError`] when `frame_rate` is zero or too high to
+    /// produce a non-zero frame duration.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use tears::prelude::*;
+    /// # use ratatui::Frame;
+    /// #
+    /// # struct MyApp;
+    /// # enum Message {}
+    /// # impl Application for MyApp {
+    /// #     type Message = Message;
+    /// #     type Flags = ();
+    /// #     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+    /// #     fn update(&mut self, _: Message) -> Command<Message> { Command::none() }
+    /// #     fn view(&self, _: &mut Frame<'_>) {}
+    /// #     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+    /// # }
+    /// let runtime = Runtime::<MyApp>::try_new((), 60).expect("frame rate must be valid");
+    /// ```
+    pub fn try_new(
+        flags: App::Flags,
+        frame_rate: u32,
+    ) -> std::result::Result<Self, FrameRateError> {
+        Ok(Self::new(flags, FrameRate::try_new(frame_rate)?))
     }
 
     /// Processes a batch of messages that arrive in quick succession (micro-batching).
@@ -364,7 +396,7 @@ impl<App: Application> Runtime<App> {
     /// async fn main() -> Result<()> {
     ///     let mut terminal = ratatui::init();
     ///
-    ///     let runtime = Runtime::<MyApp>::new((), 60);
+    ///     let runtime = Runtime::<MyApp>::try_new((), 60)?;
     ///     runtime.run(&mut terminal).await?;
     ///
     ///     ratatui::restore();
@@ -526,6 +558,10 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
     use tokio::time::{Duration, sleep};
+
+    fn frame_rate(value: u32) -> FrameRate {
+        FrameRate::try_new(value).expect("frame rate must be valid")
+    }
 
     // Simple test application
     #[derive(Debug)]
@@ -869,7 +905,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_new() {
-        let runtime = Runtime::<TestApp>::new(0, 60);
+        let runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         // Runtime should be created successfully
         assert_eq!(runtime.state.app.counter, 0);
@@ -877,8 +913,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_new_with_different_frame_rates() {
-        let _runtime1 = Runtime::<TestApp>::new(0, 30);
-        let _runtime2 = Runtime::<TestApp>::new(0, 144);
+        let _runtime1 = Runtime::<TestApp>::new(0, frame_rate(30));
+        let _runtime2 = Runtime::<TestApp>::new(0, frame_rate(144));
 
         // Should handle different frame rates without panic
     }
@@ -888,7 +924,7 @@ mod tests {
         // 60 FPS should yield a ~16.667ms period. The previous integer
         // millisecond division (1000 / 60 = 16ms) truncated this, producing
         // an effective ~62.5 FPS.
-        let runtime = Runtime::<TestApp>::new(0, 60);
+        let runtime = Runtime::<TestApp>::new(0, frame_rate(60));
         let period = runtime.frame_interval.period();
         assert!(
             period >= Duration::from_micros(16_600) && period <= Duration::from_micros(16_700),
@@ -896,7 +932,7 @@ mod tests {
         );
 
         // 144 FPS should yield a ~6.944ms period (not the truncated 6ms).
-        let runtime = Runtime::<TestApp>::new(0, 144);
+        let runtime = Runtime::<TestApp>::new(0, frame_rate(144));
         let period = runtime.frame_interval.period();
         assert!(
             period >= Duration::from_micros(6_900) && period <= Duration::from_micros(6_950),
@@ -906,7 +942,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_message_batch_single_message() {
-        let mut runtime = Runtime::<TestApp>::new(0, 60);
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         // Initially no redraw needed (well, actually true for initial state)
         // Process a message
@@ -921,7 +957,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_message_batch_with_batching() {
-        let mut runtime = Runtime::<TestApp>::new(0, 60);
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         // Send multiple messages to the queue
         let _ = runtime.state.msg_tx.send(TestMessage::Increment);
@@ -940,7 +976,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_frame_tick_renders_when_needed() -> Result<()> {
-        let mut runtime = Runtime::<TestApp>::new(0, 60);
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
@@ -962,7 +998,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_frame_tick_skips_render_when_not_needed() -> Result<()> {
-        let mut runtime = Runtime::<TestApp>::new(0, 60);
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
@@ -984,7 +1020,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_frame_tick_detects_quit() -> Result<()> {
-        let mut runtime = Runtime::<TestApp>::new(0, 60);
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         // Send quit signal
         let _ = runtime.state.quit_tx.send(());
@@ -1039,7 +1075,7 @@ mod tests {
             }
         }
 
-        let mut runtime = Runtime::<DynamicApp>::new(true, 60);
+        let mut runtime = Runtime::<DynamicApp>::new(true, frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
@@ -1097,7 +1133,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let counter = Arc::new(AtomicUsize::new(0));
-        let mut runtime = Runtime::<SubCountingApp>::new(counter.clone(), 60);
+        let mut runtime = Runtime::<SubCountingApp>::new(counter.clone(), frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
@@ -1123,7 +1159,7 @@ mod tests {
         use std::sync::atomic::{AtomicUsize, Ordering};
 
         let counter = Arc::new(AtomicUsize::new(0));
-        let mut runtime = Runtime::<SubCountingApp>::new(counter.clone(), 60);
+        let mut runtime = Runtime::<SubCountingApp>::new(counter.clone(), frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;

--- a/tests/quit_handling.rs
+++ b/tests/quit_handling.rs
@@ -14,7 +14,7 @@ async fn test_quit_responsiveness_low_framerate() -> Result<()> {
     // This test uses InitQuitApp which sends quit from init command
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<InitQuitApp>::new((), 16);
+    let runtime = Runtime::<InitQuitApp>::try_new((), 16).expect("frame rate must be valid");
 
     let start = Instant::now();
     // Use low frame rate (16 FPS = 62.5ms per frame)
@@ -60,7 +60,7 @@ async fn test_quit_from_init_command() -> Result<()> {
     // Test that quit from init command is processed quickly
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<InitQuitApp>::new((), 60);
+    let runtime = Runtime::<InitQuitApp>::try_new((), 60).expect("frame rate must be valid");
 
     let start = Instant::now();
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
@@ -109,7 +109,7 @@ async fn test_quit_during_frame_wait() -> Result<()> {
     // Test that quit signal during frame wait is processed immediately
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<DelayedQuitApp>::new((), 10);
+    let runtime = Runtime::<DelayedQuitApp>::try_new((), 10).expect("frame rate must be valid");
 
     let start = Instant::now();
     // Use very low frame rate (10 FPS = 100ms per frame)
@@ -177,7 +177,8 @@ async fn test_quit_after_multiple_messages() -> Result<()> {
     // Test that quit is processed quickly even after multiple messages
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<MultiMessageQuitApp>::new((), 60);
+    let runtime =
+        Runtime::<MultiMessageQuitApp>::try_new((), 60).expect("frame rate must be valid");
 
     let start = Instant::now();
     let result = timeout(Duration::from_millis(500), runtime.run(&mut terminal)).await?;

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -101,7 +101,7 @@ async fn test_runtime_run_end_to_end_basic() -> Result<()> {
     // End-to-end: Basic application lifecycle
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<CounterApp>::new(0, 60); // Quit immediately
+    let runtime = Runtime::<CounterApp>::try_new(0, 60).expect("frame rate must be valid"); // Quit immediately
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
@@ -148,7 +148,7 @@ async fn test_runtime_run_end_to_end_with_commands() -> Result<()> {
 
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<MessageApp>::new((), 60);
+    let runtime = Runtime::<MessageApp>::try_new((), 60).expect("frame rate must be valid");
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
@@ -162,7 +162,7 @@ async fn test_runtime_run_end_to_end_with_subscriptions() -> Result<()> {
     // End-to-end: Subscription message processing
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<SubApp>::new((), 60);
+    let runtime = Runtime::<SubApp>::try_new((), 60).expect("frame rate must be valid");
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 


### PR DESCRIPTION
## Summary

- Add `FrameRate` and `FrameRateError` for validated runtime FPS values
- Change `Runtime::new` to accept `FrameRate` instead of raw `u32`
- Add `Runtime::try_new(flags, u32)` for convenient construction from raw FPS
- Reject `0` and frame rates too high to produce a non-zero Tokio interval
- Update examples, README, tests, and changelog for the new API

## Motivation

`Runtime::new(flags, frame_rate)` previously accepted any `u32`.

This caused two invalid cases to panic later during interval construction:

- `frame_rate == 0` divided by zero
- extremely high frame rates rounded the frame duration down to zero

Since the next release is `0.9.0` and can include breaking changes, this makes the invalid states explicit in the API.

## Testing

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo test --doc`
- `cargo clippy --all-targets --all-features`
- `cargo test --all-features`