### PR TITLE
feat: add install_panic_hook for terminal recovery on panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `install_panic_hook()` for restoring the terminal on panic
+  - Wraps the current panic hook so the terminal leaves raw mode and the
+    alternate screen *before* the previously installed hook (e.g. `color_eyre`)
+    prints its report
+  - Call it once during startup, after the reporter is installed and the
+    terminal is initialized
+  - See the new `panic_hook` example for a demonstration
+
 ## [0.9.0] - 2026-07-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -163,11 +163,15 @@ async fn main() -> Result<()> {
     // Setup terminal
     let mut terminal = ratatui::init();
 
+    // Restore the terminal on panic before the color_eyre report runs.
+    // Installed after `color_eyre::install()` so it wraps that hook.
+    tears::install_panic_hook();
+
     // Run application at 60 FPS
     let runtime = Runtime::<Counter>::try_new((), 60)?;
     let result = runtime.run(&mut terminal).await;
 
-    // Restore terminal
+    // Restore terminal (normal exit path)
     ratatui::restore();
 
     result
@@ -224,6 +228,7 @@ Create custom subscriptions by implementing the `SubscriptionSource` trait.
 Check out the [`examples/`](examples/) directory for more examples:
 
 - [`counter.rs`](examples/counter.rs) - A simple counter with timer and keyboard input
+- [`panic_hook.rs`](examples/panic_hook.rs) - Restoring the terminal on panic with `install_panic_hook`
 - [`views.rs`](examples/views.rs) - Multiple view states with navigation and conditional subscriptions
 - [`dashboard.rs`](examples/dashboard.rs) - Structured state management with nested state and child messages
 - [`signals.rs`](examples/signals.rs) - OS signal handling with graceful shutdown (SIGINT, SIGTERM, etc.)
@@ -234,6 +239,7 @@ Run an example:
 
 ```bash
 cargo run --example counter
+cargo run --example panic_hook
 cargo run --example views
 cargo run --example dashboard
 cargo run --example signals

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -1,0 +1,106 @@
+//! Demonstrates terminal recovery on panic via [`tears::install_panic_hook`].
+//!
+//! A TUI puts the terminal into raw mode and an alternate screen. If the
+//! application panics, the stack unwinds past the `ratatui::restore()` call that
+//! would normally run after [`Runtime::run`], leaving the terminal broken.
+//!
+//! [`tears::install_panic_hook`] wraps the current panic hook so the terminal is
+//! restored *before* the original hook runs, so the `color_eyre` report prints
+//! on a clean, usable terminal.
+//!
+//! Try it:
+//! - Press `p` to trigger a panic. The terminal is restored and a `color_eyre`
+//!   report is printed normally (no leftover raw mode / alternate screen).
+//! - Press `q` to quit normally.
+//!
+//! To see the broken behavior for comparison, comment out the
+//! `tears::install_panic_hook()` call in `main` and press `p`: the report is
+//! printed into the alternate screen and the terminal is left in raw mode.
+//!
+//! Run with: `cargo run --example panic_hook`
+
+use std::io;
+
+use color_eyre::eyre::Result;
+use crossterm::event::{Event, KeyCode};
+use ratatui::Frame;
+use ratatui::text::Text;
+use tears::prelude::*;
+use tears::subscription::terminal::TerminalEvents;
+
+/// Messages that the application can receive
+#[derive(Debug)]
+enum Message {
+    /// Terminal input event (keyboard, mouse, resize)
+    Terminal(Event),
+    /// Terminal event stream error
+    TerminalError(io::Error),
+}
+
+/// Application state
+#[derive(Debug, Default)]
+struct PanicDemo;
+
+impl Application for PanicDemo {
+    type Message = Message;
+    type Flags = ();
+
+    fn new(_flags: Self::Flags) -> (Self, Command<Self::Message>) {
+        (Self, Command::none())
+    }
+
+    fn update(&mut self, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            Message::Terminal(Event::Key(key)) => match key.code {
+                // Intentionally panic to demonstrate terminal recovery.
+                #[allow(clippy::panic, reason = "demonstrating panic recovery")]
+                KeyCode::Char('p') => panic!("intentional panic triggered by 'p'"),
+                // Quit normally.
+                KeyCode::Char('q') => Command::effect(Action::Quit),
+                _ => Command::none(),
+            },
+            Message::Terminal(_) => Command::none(),
+            Message::TerminalError(e) => {
+                eprintln!("Terminal error: {e}");
+                Command::effect(Action::Quit)
+            }
+        }
+    }
+
+    fn view(&self, frame: &mut Frame<'_>) {
+        let text = Text::raw("Press 'p' to panic (terminal should recover), 'q' to quit");
+        frame.render_widget(text, frame.area());
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        vec![
+            Subscription::new(TerminalEvents::new()).map(|result| match result {
+                Ok(event) => Message::Terminal(event),
+                Err(e) => Message::TerminalError(e),
+            }),
+        ]
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    // Setup terminal
+    let mut terminal = ratatui::init();
+
+    // Restore the terminal on panic before the color_eyre report runs.
+    // Installed after `color_eyre::install()` so it wraps that hook.
+    tears::install_panic_hook();
+
+    // Run the application at 60 FPS
+    let runtime = Runtime::<PanicDemo>::try_new((), 60)?;
+    let result = runtime.run(&mut terminal).await;
+
+    // Restore terminal (normal exit path)
+    ratatui::restore();
+
+    result?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 //! - [`runtime::Runtime`]: Manages the application lifecycle and event loop
 //! - [`command::Command`]: Represents asynchronous side effects
 //! - [`subscription::Subscription`]: Represents ongoing event sources
+//! - [`install_panic_hook`]: Restores the terminal if the application panics
 //!
 //! ## Example
 //!
@@ -84,6 +85,7 @@
 pub mod application;
 pub mod command;
 mod frame_rate;
+pub mod panic;
 pub mod prelude;
 pub mod runtime;
 pub mod subscription;
@@ -93,5 +95,6 @@ pub use application::Application;
 pub use command::{Action, Command};
 pub use frame_rate::{FrameRate, FrameRateError};
 pub use futures::stream::BoxStream;
+pub use panic::install_panic_hook;
 pub use runtime::Runtime;
 pub use subscription::{Subscription, SubscriptionId, SubscriptionSource};

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,0 +1,117 @@
+//! Panic handling helpers for restoring the terminal on unwind.
+//!
+//! A TUI application puts the terminal into raw mode and an alternate screen.
+//! If the application panics, the stack unwinds straight out of
+//! [`Runtime::run`](crate::Runtime::run) and the `ratatui::restore()` call that
+//! would normally run afterwards is skipped, leaving the user's terminal in a
+//! broken state (no echo, no line editing, stuck on the alternate screen).
+//!
+//! [`install_panic_hook`] wraps the current panic hook so that the terminal is
+//! restored *before* the original hook runs. Because it chains into the existing
+//! hook rather than replacing it, panic reporters such as `color_eyre` still
+//! print their report — now on a restored, readable terminal.
+//!
+//! # Usage
+//!
+//! Call it once during startup, after any reporter is installed and after the
+//! terminal is initialized:
+//!
+//! ```rust,no_run
+//! # use color_eyre::eyre::Result;
+//! # fn main() -> Result<()> {
+//! color_eyre::install()?;
+//! let mut terminal = ratatui::init();
+//! tears::install_panic_hook();
+//! // ... run the application ...
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Call it only once. Each call wraps the previous hook, so repeated calls would
+//! restore the terminal multiple times (harmless, but pointless).
+
+/// The boxed panic hook type used by [`std::panic::set_hook`].
+type PanicHook = Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Installs a panic hook that restores the terminal before delegating to the
+/// previously installed hook.
+///
+/// This should be called once, after initializing the terminal (and after
+/// installing any panic reporter such as `color_eyre`). See the
+/// [module documentation](self) for details and usage.
+pub fn install_panic_hook() {
+    let original = std::panic::take_hook();
+    std::panic::set_hook(compose_hook(
+        || {
+            // Restore the terminal to its normal state (leave raw mode and the
+            // alternate screen). Errors are ignored: we are already panicking and
+            // there is nothing useful to do with a restore failure.
+            ratatui::restore();
+        },
+        original,
+    ));
+}
+
+/// Composes a panic hook that runs `restore` and then delegates to `next`.
+///
+/// Extracted from [`install_panic_hook`] so the chaining order can be tested
+/// without touching a real terminal.
+fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook) -> PanicHook {
+    Box::new(move |info| {
+        restore();
+        next(info);
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    // A single test, because `set_hook`/`take_hook` mutate process-global state.
+    // Running multiple hook-swapping tests in parallel would let them clobber
+    // each other's hooks, so both properties are asserted here in one go.
+    #[test]
+    #[allow(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_compose_hook_restores_then_delegates_once() {
+        // Records the order (and therefore the count) of the two stages.
+        // `restore` must run first so the terminal is usable before the
+        // delegated reporter prints.
+        let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
+
+        let restore_order = order.clone();
+        let next_order = order.clone();
+        let next: PanicHook = Box::new(move |_info| {
+            next_order
+                .lock()
+                .expect("order mutex should not be poisoned")
+                .push("next");
+        });
+        let hook = compose_hook(
+            move || {
+                restore_order
+                    .lock()
+                    .expect("order mutex should not be poisoned")
+                    .push("restore");
+            },
+            next,
+        );
+
+        // `PanicHookInfo` cannot be constructed directly, so drive the composed
+        // hook through the real panic runtime and catch the unwind.
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(hook);
+        let _ = std::panic::catch_unwind(|| panic!("trigger"));
+        std::panic::set_hook(previous);
+
+        let recorded = order
+            .lock()
+            .expect("order mutex should not be poisoned")
+            .clone();
+        assert_eq!(
+            recorded,
+            vec!["restore", "next"],
+            "restore must run exactly once, before the delegated hook"
+        );
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -73,6 +73,8 @@
 //! async fn main() -> Result<()> {
 //!     let runtime = Runtime::<CounterApp>::try_new((), 60)?;
 //!     let mut terminal = ratatui::init();
+//!     // Restore the terminal if the application panics.
+//!     tears::install_panic_hook();
 //!     runtime.run(&mut terminal).await?;
 //!     ratatui::restore();
 //!     Ok(())
@@ -395,6 +397,8 @@ impl<App: Application> Runtime<App> {
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
     ///     let mut terminal = ratatui::init();
+    ///     // Restore the terminal if the application panics.
+    ///     tears::install_panic_hook();
     ///
     ///     let runtime = Runtime::<MyApp>::try_new((), 60)?;
     ///     runtime.run(&mut terminal).await?;


### PR DESCRIPTION
## Summary

When a TUI application panics, the stack unwinds straight past the `ratatui::restore()` call that normally runs after `Runtime::run`, leaving the user's terminal in a broken state (no echo, no line editing, stuck on the alternate screen). `color_eyre` prints its report but does not restore the terminal, so the report ends up on the corrupted alternate screen.

This PR adds `install_panic_hook()`, which wraps the current panic hook so the terminal is restored **before** the previously installed hook (e.g. `color_eyre`) runs. Because it chains into the existing hook rather than replacing it, the panic report still prints — now on a clean, readable terminal.

## Changes

- New `panic` module with `install_panic_hook()`
  - Re-exported at the crate root as `tears::install_panic_hook`
  - **Not** added to the prelude, to avoid glob-import name conflicts (keeps this fully non-breaking)
- New `panic_hook` example demonstrating recovery (press `p` to panic, `q` to quit)
- Document the recommended setup order (`color_eyre::install()` → `ratatui::init()` → `install_panic_hook()`) in the runtime module/`run` docs, the crate-level docs, and the README

## Notes

- Purely additive; no existing public API changed. Under 0.x semver this is a patch-level change (`0.9.x`). No version bump is included here — that is handled at release time.
- Scope is limited to terminal recovery. Aborting leaked subscription/command tasks on panic (via `Drop`) is tracked separately.

## Testing

- `cargo test` (unit + doctests) — passing
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- Manually verified: running the `panic_hook` example and pressing `p` restores the terminal and prints the `color_eyre` report normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uodFKV5h9rpTL4GkYJ9zF