### PR TITLE
ci: run loom concurrency model tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,22 @@ jobs:
       - name: Run tests
         run: cargo test --all-targets --all-features
 
+  loom:
+    name: Loom
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # `--cfg loom` reconfigures tokio (dropping modules like `signal`), so the
+      # loom model checks are scoped to the `--lib` unit tests for the isolated
+      # `cell_core` primitives rather than the whole suite.
+      - name: Run loom tests
+        run: cargo test --features loom-core --lib -- cell_core
+        env:
+          RUSTFLAGS: --cfg loom
+          LOOM_MAX_PREEMPTIONS: 3
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ test-integration:
 test-doc:
     cargo test --doc
 
+# Run loom concurrency model tests (scoped to the isolated cell_core primitives)
+test-loom:
+    RUSTFLAGS="--cfg loom" LOOM_MAX_PREEMPTIONS=3 cargo test --features loom-core --lib -- cell_core
+
 # Build the library
 build:
     cargo build


### PR DESCRIPTION
## Summary

The crate ships loom model checks for the query cell's concurrency primitives (the `loom-core` feature and the `cell_core` tests in `src/subscription/http/cell_core.rs`), but CI never ran them. A regression in those invariants — single-flight, compare-and-commit, in-flight release, post-error retry suppression — could land silently.

This PR adds a `loom` CI job that runs the model checks, plus a matching `just test-loom` recipe for running them locally.

## Changes

- **CI**: new `loom` job running `cargo test --features loom-core --lib -- cell_core` under `RUSTFLAGS=--cfg loom` (with `LOOM_MAX_PREEMPTIONS=3`)
- **justfile**: new `test-loom` recipe mirroring the CI invocation

## Notes

- `--cfg loom` reconfigures tokio (dropping modules such as `signal`), which breaks the plain-lib build. The run is therefore scoped to the `--lib` unit tests for the isolated `cell_core` primitives rather than the whole suite — this matches how the loom mirror is intentionally isolated from async plumbing.
- CI-only / tooling change; no library code or public API is touched (non-breaking).

## Testing

- `just test-loom` (and the exact CI command) run locally: 4 loom model tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uodFKV5h9rpTL4GkYJ9zF