### PR TITLE
fix: abort subscription tasks when SubscriptionManager is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     terminal is initialized
   - See the new `panic_hook` example for a demonstration
 
+### Fixed
+
+- Subscription tasks are now aborted when the `SubscriptionManager` is dropped
+  - Previously, dropping the manager without calling `shutdown()` (for example
+    while unwinding from a panic) detached the running tasks instead of
+    cancelling them, leaking any parked subscription tasks
+
 ## [0.9.0] - 2026-07-03
 
 ### Changed

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -407,9 +407,30 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
     /// This cancels all running subscription tasks. Called automatically
     /// when the runtime shuts down.
     pub fn shutdown(&mut self) {
-        for (_, running) in self.running.drain() {
+        self.abort_running();
+        self.running.clear();
+    }
+}
+
+impl<Msg> SubscriptionManager<Msg> {
+    /// Abort every running subscription task without removing the map entries.
+    ///
+    /// Shared by [`shutdown`](SubscriptionManager::shutdown) and [`Drop`], so a
+    /// manager that is dropped without a clean shutdown (e.g. during a panic
+    /// unwind) still cancels its tasks instead of detaching them.
+    fn abort_running(&self) {
+        for running in self.running.values() {
             running.handle.abort();
         }
+    }
+}
+
+impl<Msg> Drop for SubscriptionManager<Msg> {
+    fn drop(&mut self) {
+        // `JoinHandle` does not abort on drop (it detaches), so a manager that
+        // is dropped without `shutdown()` — for instance while unwinding from a
+        // panic — would otherwise leak its subscription tasks.
+        self.abort_running();
     }
 }
 
@@ -580,6 +601,72 @@ mod tests {
 
         // Should not receive more messages after shutdown
         // The channel might have some buffered messages, but stream should stop
+    }
+
+    #[tokio::test]
+    async fn test_drop_aborts_running_subscriptions() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::task::Poll;
+
+        use futures::stream;
+
+        // A guard that records, via its `Drop`, that the task's future was
+        // dropped. The runtime only drops an aborted task's future, so the flag
+        // flipping to `true` proves the task was cancelled rather than detached.
+        struct AbortGuard(Arc<AtomicBool>);
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        // A subscription whose stream owns the guard and never yields, so its
+        // task stays parked until it is aborted.
+        struct ParkedSource {
+            aborted: Arc<AtomicBool>,
+        }
+        impl SubscriptionSource for ParkedSource {
+            type Output = i32;
+
+            fn stream(&self) -> BoxStream<'static, i32> {
+                let guard = AbortGuard(self.aborted.clone());
+                stream::poll_fn(move |_cx| {
+                    let _keep_alive = &guard;
+                    Poll::Pending
+                })
+                .boxed()
+            }
+
+            fn id(&self) -> SubscriptionId {
+                SubscriptionId::of::<Self>(0)
+            }
+        }
+
+        let aborted = Arc::new(AtomicBool::new(false));
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        {
+            let mut manager = SubscriptionManager::new(tx);
+            manager.update(vec![Subscription::new(ParkedSource {
+                aborted: aborted.clone(),
+            })]);
+
+            // Let the task start and park on the pending stream.
+            sleep(Duration::from_millis(10)).await;
+            assert!(
+                !aborted.load(Ordering::SeqCst),
+                "task should still be running before the manager is dropped"
+            );
+            // `manager` is dropped here.
+        }
+
+        // Give the runtime a chance to process the abort and drop the future.
+        sleep(Duration::from_millis(10)).await;
+        assert!(
+            aborted.load(Ordering::SeqCst),
+            "dropping the manager should abort running subscription tasks"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`tokio::task::JoinHandle` does not abort its task when dropped — it detaches it. So when a `SubscriptionManager` was dropped without a prior `shutdown()` (for example while unwinding from a panic in `Runtime::run`), its running subscription tasks were leaked rather than cancelled. Tasks parked on a stream that never yields (a slow HTTP request, an idle WebSocket, a long timer interval) would linger instead of being cleaned up.

This is the first step of backlog task **S0**: guarantee subscription tasks are aborted even on the panic-unwind path. The command-side abort (which requires tracking the currently-discarded command `JoinHandle`s) is deferred to the batch that lands alongside S2/S3.

## Changes

- Add `impl Drop for SubscriptionManager` that aborts every running subscription task
- Extract a shared `abort_running` helper used by both `Drop` and `shutdown()` (no double-abort: `shutdown()` still clears the map afterwards)
- Add a contract test that proves an aborted task's future is actually dropped — an `AbortGuard` whose own `Drop` sets a flag, held by a stream that stays `Pending` until cancelled

## Notes

- Non-breaking: adds a `Drop` impl to an internal manager type; no public API signature changes. No code moves fields out of `SubscriptionManager`, so the new `Drop` introduces no partial-move breakage.
- No version bump (handled at release time).

## Testing

- `cargo test` — 119 lib tests pass, including the new `test_drop_aborts_running_subscriptions`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uodFKV5h9rpTL4GkYJ9zF