### PR TITLE
feat: add tracing instrumentation for runtime hot paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Call it once during startup, after the reporter is installed and the
     terminal is initialized
   - See the new `panic_hook` example for a demonstration
+- `tracing` instrumentation for the runtime hot paths
+  - The runtime emits events for message batches, subscription updates, command
+    spawns, renders, and shutdown under the `tears::runtime` and
+    `tears::subscription` targets
+  - Events are inert unless a `tracing` subscriber is installed
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2810,7 +2811,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-tungstenite = { version = "0.29", default-features = false, optional = true }
 tokio-util = "0.7"
+tracing = "0.1"
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,15 @@
 //! }
 //! ```
 //!
+//! ## Observability
+//!
+//! The runtime emits [`tracing`](https://docs.rs/tracing) events for its hot
+//! paths — message batches, subscription updates, command spawns, renders, and
+//! shutdown — under the `tears::runtime` and `tears::subscription` targets.
+//! Events are inert unless a `tracing` subscriber is installed, so there is no
+//! setup required to ignore them. To see them, install any subscriber (e.g.
+//! `tracing_subscriber::fmt()`) before running the app.
+//!
 //! ## Optional Features
 //!
 //! ### WebSocket Support

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -270,6 +270,7 @@ impl<App: Application> Runtime<App> {
         // Process the first message
         let cmd = self.state.app.update(first_msg);
         self.state.enqueue_command(cmd);
+        let mut processed = 1usize;
 
         // Micro-batching: process additional messages that arrived during a short window
         let batch_deadline = Instant::now() + Duration::from_micros(100);
@@ -278,10 +279,13 @@ impl<App: Application> Runtime<App> {
                 Ok(msg) => {
                     let cmd = self.state.app.update(msg);
                     self.state.enqueue_command(cmd);
+                    processed += 1;
                 }
                 Err(_) => break, // No more messages available
             }
         }
+
+        tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
 
         // Mark that a redraw is needed and that subscriptions may have changed
         self.needs_redraw = true;
@@ -305,6 +309,7 @@ impl<App: Application> Runtime<App> {
         if self.needs_redraw {
             self.state.render(terminal)?;
             self.needs_redraw = false;
+            tracing::trace!(target: "tears::runtime", "frame rendered");
         }
 
         // Re-evaluate subscriptions only when the state may have changed.
@@ -319,7 +324,11 @@ impl<App: Application> Runtime<App> {
         }
 
         // Check for quit signal (non-blocking)
-        Ok(self.state.check_quit())
+        let quit = self.state.check_quit();
+        if quit {
+            tracing::debug!(target: "tears::runtime", "quit signal received");
+        }
+        Ok(quit)
     }
 
     /// Updates subscriptions if they have changed (uses hash-based caching).
@@ -339,8 +348,10 @@ impl<App: Application> Runtime<App> {
 
         // Only update if subscriptions have changed
         if self.subscription_ids_hash != Some(current_hash) {
+            let count = subscriptions.len();
             self.state.subscription_manager.update(subscriptions);
             self.subscription_ids_hash = Some(current_hash);
+            tracing::debug!(target: "tears::runtime", count, "subscriptions updated");
         }
     }
 
@@ -412,6 +423,7 @@ impl<App: Application> Runtime<App> {
         terminal: &mut ratatui::Terminal<B>,
     ) -> Result<(), <B as Backend>::Error> {
         self.state.initialize_subscriptions();
+        tracing::debug!(target: "tears::runtime", "runtime started");
 
         loop {
             tokio::select! {
@@ -429,11 +441,13 @@ impl<App: Application> Runtime<App> {
 
                 // Quit signal received
                 _ = self.state.quit_rx.recv() => {
+                    tracing::debug!(target: "tears::runtime", "quit signal received");
                     break;
                 }
             }
         }
 
+        tracing::debug!(target: "tears::runtime", "runtime shutting down");
         self.state.shutdown();
 
         Ok(())
@@ -484,6 +498,8 @@ impl<App: Application> ApplicationState<App> {
         if let Some(stream) = cmd.stream {
             let msg_tx = self.msg_tx.clone();
             let quit_tx = self.quit_tx.clone();
+
+            tracing::trace!(target: "tears::runtime", "command spawned");
 
             tokio::spawn(async move {
                 futures::pin_mut!(stream);
@@ -957,6 +973,50 @@ mod tests {
 
         // Redraw should be needed
         assert!(runtime.needs_redraw);
+    }
+
+    // A minimal `tracing::Subscriber` that only counts emitted events, used to
+    // assert that instrumentation actually fires.
+    struct EventCounter {
+        events: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl tracing::Subscriber for EventCounter {
+        fn enabled(&self, _metadata: &tracing::Metadata<'_>) -> bool {
+            true
+        }
+        fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+            tracing::span::Id::from_u64(1)
+        }
+        fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+        fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+        fn event(&self, _event: &tracing::Event<'_>) {
+            self.events
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+        fn enter(&self, _span: &tracing::span::Id) {}
+        fn exit(&self, _span: &tracing::span::Id) {}
+    }
+
+    #[tokio::test]
+    async fn test_process_message_batch_emits_tracing_event() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let events = Arc::new(AtomicUsize::new(0));
+        let subscriber = EventCounter {
+            events: events.clone(),
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+            runtime.process_message_batch(TestMessage::Increment);
+        });
+
+        assert!(
+            events.load(Ordering::SeqCst) >= 1,
+            "processing a message batch should emit a tracing event"
+        );
     }
 
     #[tokio::test]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -376,6 +376,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
             let keep = new_ids.contains(id);
             if !keep {
                 running.handle.abort();
+                tracing::debug!(target: "tears::subscription", "subscription stopped");
             }
             keep
         });
@@ -386,6 +387,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
                 let stream = spawn();
                 let handle = self.spawn_subscription(stream);
                 self.running.insert(id, RunningSubscription { handle });
+                tracing::debug!(target: "tears::subscription", "subscription started");
             }
         }
     }


### PR DESCRIPTION
## Summary

There was no built-in way to observe where a tears app spends time or why a subscription/command behaves unexpectedly. This PR adds `tracing` instrumentation to the runtime's hot paths, so they can be inspected with the standard `tracing` ecosystem.

This is the first of two PRs for backlog task **S3** (measurement foundation). The criterion benchmark baseline is a separate follow-up PR.

## Changes

- Add `tracing` as a normal (always-on) dependency
- Emit events at the runtime hot paths:
  - `tears::runtime`: message batch processed (with count), subscriptions updated (with count), command spawned, frame rendered, runtime started / shutting down, quit signal received
  - `tears::subscription`: subscription started / stopped
- Document observability in the crate-level docs and CHANGELOG
- Add a contract test (minimal counting `Subscriber`) proving instrumentation actually fires

## Design note

`tracing` is always-on rather than feature-gated, matching ecosystem-standard crates (tokio, hyper, reqwest). Events are inert unless a subscriber is installed, so the overhead without one is a cached atomic load per callsite — this avoids the cfg/no-op-shim complexity of feature-gating.

## Notes

- Additive / non-breaking: one new dependency, no public API signature changes. No version bump (handled at release time).

## Testing

- `cargo test` — 120 lib tests pass, including the new `test_process_message_batch_emits_tracing_event`
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uodFKV5h9rpTL4GkYJ9zF