### PR TITLE
test: add criterion benchmarks for subscription hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
@@ -160,6 +181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +224,58 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
@@ -304,6 +383,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +487,12 @@ checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -803,6 +942,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1449,6 +1599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1661,16 @@ name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1647,6 +1813,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1901,6 +2095,26 @@ dependencies = [
  "time",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2467,6 +2681,7 @@ name = "tears"
 version = "0.9.0"
 dependencies = [
  "color-eyre",
+ "criterion",
  "crossterm 0.29.0",
  "dashmap",
  "futures",
@@ -2650,6 +2865,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = [
     "src/**/*",
     "examples/**/*",
     "tests/**/*",
+    "benches/**/*",
     "Cargo.toml",
     "LICENSE",
     "README.md",
@@ -49,11 +50,16 @@ tokio-util = "0.7"
 tracing = "0.1"
 
 [dev-dependencies]
+criterion = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [target.'cfg(not(loom))'.dev-dependencies]
 reqwest = { version = "0.13", features = ["json", "query"] }
+
+[[bench]]
+name = "subscription"
+harness = false
 
 [[example]]
 name = "websocket"

--- a/benches/subscription.rs
+++ b/benches/subscription.rs
@@ -1,0 +1,132 @@
+//! Benchmarks for subscription hot paths.
+//!
+//! These establish a regression baseline for the runtime's subscription work:
+//!
+//! - **id hashing**: the hash the runtime computes over subscription IDs each
+//!   time it decides whether the subscription set changed
+//!   ([`Runtime::update_subscriptions`](../src/runtime.rs)).
+//! - **reconcile (steady)**: [`SubscriptionManager::update`] when the requested
+//!   set is unchanged — the common per-message case, which must diff cheaply and
+//!   keep the existing tasks running.
+//! - **reconcile (churn)**: `update` when the whole set is replaced — measures
+//!   the abort + spawn bookkeeping.
+//!
+//! Run with `cargo bench --bench subscription`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::stream::{self, StreamExt};
+use std::hint::black_box;
+use tears::BoxStream;
+use tears::subscription::{Subscription, SubscriptionId, SubscriptionManager, SubscriptionSource};
+
+/// A minimal source with a caller-controlled ID whose stream never yields, so
+/// its spawned task stays parked (alive) until the manager aborts it.
+struct BenchSource {
+    id: u64,
+}
+
+impl SubscriptionSource for BenchSource {
+    type Output = ();
+
+    fn stream(&self) -> BoxStream<'static, ()> {
+        stream::pending().boxed()
+    }
+
+    fn id(&self) -> SubscriptionId {
+        SubscriptionId::of::<Self>(self.id)
+    }
+}
+
+fn subscriptions(ids: impl IntoIterator<Item = u64>) -> Vec<Subscription<()>> {
+    ids.into_iter()
+        .map(|id| Subscription::new(BenchSource { id }))
+        .collect()
+}
+
+fn subscription_ids(count: u64) -> Vec<SubscriptionId> {
+    (0..count).map(SubscriptionId::of::<BenchSource>).collect()
+}
+
+fn bench_id_hashing(c: &mut Criterion) {
+    let mut group = c.benchmark_group("subscription_id_hashing");
+    for count in [1u64, 8, 64, 256] {
+        let ids = subscription_ids(count);
+        group.bench_with_input(BenchmarkId::from_parameter(count), &ids, |b, ids| {
+            b.iter(|| {
+                let mut hasher = DefaultHasher::new();
+                for id in ids {
+                    id.hash(&mut hasher);
+                }
+                black_box(hasher.finish())
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_reconcile_steady(c: &mut Criterion) {
+    // `SubscriptionManager::update` spawns tasks, so it must run inside a Tokio
+    // runtime context. The tasks park immediately on the pending stream.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .expect("bench runtime should build");
+    let _guard = rt.enter();
+
+    let mut group = c.benchmark_group("subscription_reconcile_steady");
+    for count in [1u64, 8, 64, 256] {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+            let mut manager = SubscriptionManager::new(tx);
+            // Prime the manager so subsequent updates hit the steady-state path
+            // (same IDs, tasks already running -> no spawns, just the diff).
+            manager.update(subscriptions(0..count));
+
+            b.iter(|| {
+                manager.update(subscriptions(0..count));
+            });
+
+            manager.shutdown();
+        });
+    }
+    group.finish();
+}
+
+fn bench_reconcile_churn(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .expect("bench runtime should build");
+    let _guard = rt.enter();
+
+    let mut group = c.benchmark_group("subscription_reconcile_churn");
+    for count in [1u64, 8, 64, 256] {
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+            let mut manager = SubscriptionManager::new(tx);
+
+            // Alternate between two disjoint ID sets so every update aborts the
+            // previous set and spawns a whole new one.
+            let mut toggle = false;
+            b.iter(|| {
+                let ids = if toggle { count..count * 2 } else { 0..count };
+                toggle = !toggle;
+                manager.update(subscriptions(ids));
+            });
+
+            manager.shutdown();
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_id_hashing,
+    bench_reconcile_steady,
+    bench_reconcile_churn
+);
+criterion_main!(benches);

--- a/justfile
+++ b/justfile
@@ -44,6 +44,10 @@ test-doc:
 test-loom:
     RUSTFLAGS="--cfg loom" LOOM_MAX_PREEMPTIONS=3 cargo test --features loom-core --lib -- cell_core
 
+# Run criterion benchmarks
+bench:
+    cargo bench
+
 # Build the library
 build:
     cargo build


### PR DESCRIPTION
## Summary

The runtime had no benchmark baseline, so performance regressions in the subscription hot paths could land undetected. This PR adds criterion benchmarks for the subscription work, completing backlog task **S3** (measurement foundation) alongside the tracing instrumentation from #119.

## Changes

- Add `criterion` dev-dependency and a `benches/subscription.rs` bench target (`harness = false`)
- Benchmarks (parameterized over 1 / 8 / 64 / 256 subscriptions):
  - `subscription_id_hashing` — the hash the runtime computes over subscription IDs to decide whether the set changed
  - `subscription_reconcile_steady` — `SubscriptionManager::update` when the set is unchanged (the common per-message case: cheap diff, tasks kept running)
  - `subscription_reconcile_churn` — `update` when the whole set is replaced (abort + spawn bookkeeping)
- Add a `just bench` recipe
- Include `benches/` in the package `include` list so the `[[bench]]` target stays consistent with the published manifest (matching how `tests/` is already included)

## Notes

- The benches drive only the public subscription API. Private hot paths (`process_message_batch`, `render`) are not directly reachable from an external bench crate and are covered indirectly; instrumenting them would require exposing internals, so they are left for a future integration-style harness if needed.
- No CI job runs the benches: timing in CI is noisy without baseline tracking, and `cargo test --all-targets --all-features` already compile-checks the bench. The baseline is for local/manual regression checks via `just bench`.
- Dev-only / non-breaking: no library code or public API changes. No version bump.

## Testing

- `cargo bench --bench subscription` runs all three groups and produces stable numbers
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uodFKV5h9rpTL4GkYJ9zF