### PR TITLE
feat: add tracing for subscription sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The runtime emits events for message batches, subscription updates, command
     spawns, renders, and shutdown under the `tears::runtime` and
     `tears::subscription` targets
+  - WebSocket subscriptions now emit connection, disconnection, read/write
+    error, and message-type/size events under
+    `tears::subscription::websocket`
+  - HTTP query subscriptions now emit invalidation, cell reuse, fetch
+    lifecycle, and cache GC events under `tears::subscription::http`
+  - Terminal, timer, and signal subscriptions now emit source-specific events
+    under `tears::subscription::terminal`, `tears::subscription::time`, and
+    `tears::subscription::signal`
+  - Subscription instrumentation avoids logging payloads, query key values,
+    pasted text, key presses, and error strings that may contain sensitive data
   - Events are inert unless a `tracing` subscriber is installed
   - Panics inside command and subscription tasks are now caught and logged at
     the `error` level instead of being silently lost

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -58,13 +58,14 @@
 //! }
 //! ```
 
-use std::any::TypeId;
+use std::any::{TypeId, type_name};
 use std::fmt;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
+use std::time::Instant;
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
@@ -171,12 +172,23 @@ impl QueryClient {
         K: Into<QueryKey>,
     {
         let query_key = key.into();
+        let key_hash = trace_key_hash(&query_key);
+        let mut matched_cells = 0usize;
 
         for entry in self.cells.iter() {
             if entry.key().1 == query_key {
+                matched_cells += 1;
                 entry.value().invalidate(&self.config);
             }
         }
+
+        tracing::debug!(
+            target: "tears::subscription::http",
+            client_id = self.client_id,
+            key_hash,
+            matched_cells,
+            "query invalidated"
+        );
     }
 
     /// Removes retained data that has outlived `cache_time`.
@@ -185,8 +197,18 @@ impl QueryClient {
     /// (for example when no further fetches are expected for a while).
     fn gc_expired(&self) {
         let cache_time = self.config.cache_time;
+        let cells_before = self.cells.len();
         self.cells
             .retain(|_, cell| !cell.gc_inactive_data_and_should_evict(cache_time));
+        let evicted_cells = cells_before.saturating_sub(self.cells.len());
+        if evicted_cells > 0 {
+            tracing::trace!(
+                target: "tears::subscription::http",
+                client_id = self.client_id,
+                evicted_cells,
+                "query cache gc evicted cells"
+            );
+        }
     }
 
     /// Removes retained query data that has outlived the configured `cache_time`.
@@ -220,15 +242,33 @@ impl QueryClient {
     where
         T: Clone + Send + Sync + 'static,
     {
-        let cell_key = (TypeId::of::<T>(), key.into());
+        let query_key = key.into();
+        let key_hash = trace_key_hash(&query_key);
+        let cell_key = (TypeId::of::<T>(), query_key);
 
         match self.cells.entry(cell_key) {
             Entry::Occupied(entry) => {
+                tracing::trace!(
+                    target: "tears::subscription::http",
+                    client_id = self.client_id,
+                    key_hash,
+                    value_type = type_name::<T>(),
+                    reused = true,
+                    "query cell subscribed"
+                );
                 let cell = downcast_cell(entry.get().clone());
                 let subscription = cell.subscribe();
                 (cell, subscription)
             }
             Entry::Vacant(entry) => {
+                tracing::trace!(
+                    target: "tears::subscription::http",
+                    client_id = self.client_id,
+                    key_hash,
+                    value_type = type_name::<T>(),
+                    reused = false,
+                    "query cell subscribed"
+                );
                 let (cell, subscription) = Cell::<T>::new_subscribed();
                 let new_cell: Arc<dyn AnyCell> = cell.clone();
                 entry.insert(new_cell);
@@ -360,11 +400,17 @@ where
         let key = self.key.clone();
         let fetcher = self.fetcher.clone();
         let client = self.client.clone();
+        let trace = QueryTrace {
+            client_id: self.client.client_id,
+            key_hash: trace_key_hash(&self.key),
+            value_type: type_name::<V>(),
+        };
 
         stream::unfold(State::Initial, move |state| {
             let key = key.clone();
             let fetcher = fetcher.clone();
             let client = client.clone();
+            let trace = trace;
 
             async move {
                 match state {
@@ -377,6 +423,15 @@ where
                             subscription.mark_seen_version(version);
                         }
                         let next = if let Some(generation) = generation {
+                            tracing::trace!(
+                                target: "tears::subscription::http",
+                                client_id = trace.client_id,
+                                key_hash = trace.key_hash,
+                                value_type = trace.value_type,
+                                generation,
+                                reason = "initial_observe",
+                                "query fetch scheduled"
+                            );
                             State::Fetching {
                                 subscription,
                                 cell,
@@ -399,6 +454,7 @@ where
                             client.config(),
                             generation,
                             subscription,
+                            trace,
                         )
                         .await;
                         client.gc_expired();
@@ -406,7 +462,7 @@ where
                     }
 
                     State::Watching { subscription, cell } => {
-                        watch_cell(subscription, cell, client.config()).await
+                        watch_cell(subscription, cell, client.config(), trace).await
                     }
                 }
             }
@@ -429,6 +485,13 @@ impl<V> Hash for Query<V> {
         self.client.client_id.hash(hasher);
         self.key.hash(hasher);
     }
+}
+
+#[derive(Clone, Copy)]
+struct QueryTrace {
+    client_id: u64,
+    key_hash: u64,
+    value_type: &'static str,
 }
 
 /// Internal state machine for the Query subscription.
@@ -454,13 +517,33 @@ async fn perform_fetch<V>(
     config: &QueryConfig,
     generation: u64,
     mut subscription: CellSubscription<V>,
+    trace: QueryTrace,
 ) -> (QueryResult<V>, State<V>)
 where
     V: Clone + Send + Sync + 'static,
 {
+    tracing::debug!(
+        target: "tears::subscription::http",
+        client_id = trace.client_id,
+        key_hash = trace.key_hash,
+        value_type = trace.value_type,
+        generation,
+        "query fetch started"
+    );
+    let started_at = Instant::now();
     let (result, generation) = match fetcher().await {
         Ok(data) => {
             let (result, committed, sent_version) = cell.complete_success(generation, data, config);
+            tracing::debug!(
+                target: "tears::subscription::http",
+                client_id = trace.client_id,
+                key_hash = trace.key_hash,
+                value_type = trace.value_type,
+                generation,
+                committed,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                "query fetch succeeded"
+            );
             if committed {
                 subscription.mark_seen_version(sent_version);
                 (result, None)
@@ -470,11 +553,34 @@ where
                 if let Some(version) = sent_version {
                     subscription.mark_seen_version(version);
                 }
+                if let Some(next_generation) = generation {
+                    tracing::trace!(
+                        target: "tears::subscription::http",
+                        client_id = trace.client_id,
+                        key_hash = trace.key_hash,
+                        value_type = trace.value_type,
+                        generation = next_generation,
+                        reason = "stale_success_completion",
+                        "query fetch scheduled"
+                    );
+                }
                 (result, generation)
             }
         }
         Err(error) => {
+            let error_kind = trace_query_error_kind(&error);
             let (result, committed, sent_version) = cell.complete_error(generation, error, config);
+            tracing::debug!(
+                target: "tears::subscription::http",
+                client_id = trace.client_id,
+                key_hash = trace.key_hash,
+                value_type = trace.value_type,
+                generation,
+                committed,
+                error_kind,
+                elapsed_ms = started_at.elapsed().as_millis(),
+                "query fetch failed"
+            );
             if committed {
                 subscription.mark_seen_version(sent_version);
                 (result, None)
@@ -483,6 +589,17 @@ where
                     cell.reconcile(ReconcileReason::WatchChanged, config);
                 if let Some(version) = sent_version {
                     subscription.mark_seen_version(version);
+                }
+                if let Some(next_generation) = generation {
+                    tracing::trace!(
+                        target: "tears::subscription::http",
+                        client_id = trace.client_id,
+                        key_hash = trace.key_hash,
+                        value_type = trace.value_type,
+                        generation = next_generation,
+                        reason = "stale_error_completion",
+                        "query fetch scheduled"
+                    );
                 }
                 (result, generation)
             }
@@ -505,6 +622,7 @@ async fn watch_cell<V>(
     mut subscription: CellSubscription<V>,
     cell: Arc<Cell<V>>,
     config: &QueryConfig,
+    trace: QueryTrace,
 ) -> Option<(QueryResult<V>, State<V>)>
 where
     V: Clone + Send + Sync + 'static,
@@ -523,6 +641,15 @@ where
             cell.reconcile(ReconcileReason::WatchChanged, config);
         subscription.mark_seen_version(sent_version.unwrap_or(changed_version));
         let next = if let Some(generation) = generation {
+            tracing::trace!(
+                target: "tears::subscription::http",
+                client_id = trace.client_id,
+                key_hash = trace.key_hash,
+                value_type = trace.value_type,
+                generation,
+                reason = "watch_changed",
+                "query fetch scheduled"
+            );
             State::Fetching {
                 subscription,
                 cell,
@@ -532,6 +659,19 @@ where
             State::Watching { subscription, cell }
         };
         return Some((result, next));
+    }
+}
+
+fn trace_key_hash(key: &QueryKey) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+const fn trace_query_error_kind(error: &QueryError) -> &'static str {
+    match error {
+        QueryError::FetchError(_) => "fetch",
+        QueryError::NetworkError(_) => "network",
     }
 }
 

--- a/src/subscription/signal.rs
+++ b/src/subscription/signal.rs
@@ -125,15 +125,44 @@ mod unix_signal {
                 let mut sig = match state {
                     None => {
                         // First call: initialize the signal handler
-                        signal(kind)?
+                        match signal(kind) {
+                            Ok(sig) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = ?kind,
+                                    "signal handler installed"
+                                );
+                                sig
+                            }
+                            Err(error) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = ?kind,
+                                    error_kind = ?error.kind(),
+                                    "signal handler installation failed"
+                                );
+                                return Err(error);
+                            }
+                        }
                     }
                     Some(sig) => sig,
                 };
 
                 // Wait for signals
-                match sig.recv().await {
-                    Some(()) => Ok(Some(((), Some(sig)))),
-                    None => Ok(None), // End the stream
+                if sig.recv().await == Some(()) {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = ?kind,
+                        "signal received"
+                    );
+                    Ok(Some(((), Some(sig))))
+                } else {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = ?kind,
+                        "signal stream ended"
+                    );
+                    Ok(None)
                 }
             })
             .boxed()
@@ -263,15 +292,44 @@ mod windows_signal {
                 let mut sig = match state {
                     None => {
                         // First call: initialize the signal handler
-                        ctrl_c()?
+                        match ctrl_c() {
+                            Ok(sig) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = "ctrl_c",
+                                    "signal handler installed"
+                                );
+                                sig
+                            }
+                            Err(error) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = "ctrl_c",
+                                    error_kind = ?error.kind(),
+                                    "signal handler installation failed"
+                                );
+                                return Err(error);
+                            }
+                        }
                     }
                     Some(sig) => sig,
                 };
 
                 // Wait for signals
-                match sig.recv().await {
-                    Some(()) => Ok(Some(((), Some(sig)))),
-                    None => Ok(None), // End the stream
+                if sig.recv().await == Some(()) {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = "ctrl_c",
+                        "signal received"
+                    );
+                    Ok(Some(((), Some(sig))))
+                } else {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = "ctrl_c",
+                        "signal stream ended"
+                    );
+                    Ok(None)
                 }
             })
             .boxed()
@@ -353,15 +411,44 @@ mod windows_signal {
                 let mut sig = match state {
                     None => {
                         // First call: initialize the signal handler
-                        ctrl_break()?
+                        match ctrl_break() {
+                            Ok(sig) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = "ctrl_break",
+                                    "signal handler installed"
+                                );
+                                sig
+                            }
+                            Err(error) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::signal",
+                                    signal_kind = "ctrl_break",
+                                    error_kind = ?error.kind(),
+                                    "signal handler installation failed"
+                                );
+                                return Err(error);
+                            }
+                        }
                     }
                     Some(sig) => sig,
                 };
 
                 // Wait for signals
-                match sig.recv().await {
-                    Some(()) => Ok(Some(((), Some(sig)))),
-                    None => Ok(None), // End the stream
+                if sig.recv().await == Some(()) {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = "ctrl_break",
+                        "signal received"
+                    );
+                    Ok(Some(((), Some(sig))))
+                } else {
+                    tracing::debug!(
+                        target: "tears::subscription::signal",
+                        signal_kind = "ctrl_break",
+                        "signal stream ended"
+                    );
+                    Ok(None)
                 }
             })
             .boxed()

--- a/src/subscription/terminal.rs
+++ b/src/subscription/terminal.rs
@@ -114,7 +114,25 @@ impl SubscriptionSource for TerminalEvents {
             // NOTE: EventStream::next() returns Result<Event, io::Error>
             // We pass the Result directly to the application, allowing users to
             // decide how to handle errors (log, retry, show error UI, etc.)
-            stream.next().await.map(|result| (result, stream))
+            stream.next().await.map(|result| {
+                match &result {
+                    Ok(event) => {
+                        tracing::trace!(
+                            target: "tears::subscription::terminal",
+                            event_type = trace_event_type(event),
+                            "terminal event received"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            target: "tears::subscription::terminal",
+                            error_kind = ?error.kind(),
+                            "terminal event read failed"
+                        );
+                    }
+                }
+                (result, stream)
+            })
         })
         .boxed()
     }
@@ -124,6 +142,17 @@ impl SubscriptionSource for TerminalEvents {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         SubscriptionId::of::<Self>(hasher.finish())
+    }
+}
+
+const fn trace_event_type(event: &Event) -> &'static str {
+    match event {
+        Event::FocusGained => "focus_gained",
+        Event::FocusLost => "focus_lost",
+        Event::Key(_) => "key",
+        Event::Mouse(_) => "mouse",
+        Event::Paste(_) => "paste",
+        Event::Resize(_, _) => "resize",
     }
 }
 

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -114,6 +114,11 @@ impl SubscriptionSource for Timer {
         // This is appropriate for UI applications where we want
         // to maintain a consistent tick rate rather than processing old ticks.
         let duration = Duration::from_millis(self.interval_ms.get());
+        tracing::trace!(
+            target: "tears::subscription::time",
+            interval_ms = self.interval_ms.get(),
+            "timer stream created"
+        );
         let mut interval = interval(duration);
         interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -218,6 +218,7 @@ enum WsStreamState {
 impl SubscriptionSource for WebSocket {
     type Output = WebSocketMessage;
 
+    #[allow(clippy::too_many_lines)]
     fn stream(&self) -> BoxStream<'static, WebSocketMessage> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 
@@ -230,20 +231,39 @@ impl SubscriptionSource for WebSocket {
             |state| async move {
                 match state {
                     WsStreamState::Connecting { url, cmd_tx, cmd_rx } => {
+                        let trace_url = trace_url(&url);
+                        tracing::debug!(
+                            target: "tears::subscription::websocket",
+                            url = %trace_url,
+                            "websocket connecting"
+                        );
                         match connect_async(&url).await {
                             Ok((ws, _)) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::websocket",
+                                    url = %trace_url,
+                                    "websocket connected"
+                                );
                                 let (write, read) = ws.split();
                                 Some((
                                     WebSocketMessage::Connected { sender: cmd_tx },
                                     WsStreamState::Running { write, read, cmd_rx },
                                 ))
                             }
-                            Err(e) => Some((
-                                WebSocketMessage::Error {
-                                    error: format!("Connection failed: {e}"),
-                                },
-                                WsStreamState::Done,
-                            )),
+                            Err(e) => {
+                                tracing::debug!(
+                                    target: "tears::subscription::websocket",
+                                    url = %trace_url,
+                                    error = %e,
+                                    "websocket connection failed"
+                                );
+                                Some((
+                                    WebSocketMessage::Error {
+                                        error: format!("Connection failed: {e}"),
+                                    },
+                                    WsStreamState::Done,
+                                ))
+                            }
                         }
                     }
                     // FIXME(#103): when the outer task is aborted (e.g. via
@@ -272,6 +292,7 @@ impl SubscriptionSource for WebSocket {
                             msg = read.next() => {
                                 match msg {
                                     Some(Ok(Message::Close(_))) => {
+                                        tracing::debug!(target: "tears::subscription::websocket", reason = "server_close", "websocket disconnected");
                                         let _ = write.close().await;
                                         break Some((WebSocketMessage::Disconnected, WsStreamState::Done));
                                     }
@@ -287,12 +308,23 @@ impl SubscriptionSource for WebSocket {
                                         // here would close that narrow window but
                                         // would couple read progress to write
                                         // backpressure on every Ping, so we don't.
+                                        tracing::trace!(
+                                            target: "tears::subscription::websocket",
+                                            message_type = trace_message_type(&message),
+                                            message_size = trace_message_size(&message),
+                                            "websocket message received"
+                                        );
                                         break Some((
                                             WebSocketMessage::Received(message),
                                             WsStreamState::Running { write, read, cmd_rx },
                                         ));
                                     }
                                     Some(Err(e)) => {
+                                        tracing::debug!(
+                                            target: "tears::subscription::websocket",
+                                            error = %e,
+                                            "websocket read failed"
+                                        );
                                         let _ = write.close().await;
                                         break Some((
                                             WebSocketMessage::Error { error: e.to_string() },
@@ -300,6 +332,7 @@ impl SubscriptionSource for WebSocket {
                                         ));
                                     }
                                     None => {
+                                        tracing::debug!(target: "tears::subscription::websocket", reason = "read_stream_ended", "websocket disconnected");
                                         break Some((WebSocketMessage::Disconnected, WsStreamState::Done));
                                     }
                                 }
@@ -307,12 +340,25 @@ impl SubscriptionSource for WebSocket {
                             cmd = cmd_rx.recv() => {
                                 match cmd {
                                     Some(WebSocketCommand::Close(frame)) => {
+                                        tracing::debug!(target: "tears::subscription::websocket", reason = "close_command", "websocket disconnecting");
                                         let _ = write.send(Message::Close(frame)).await;
                                         let _ = write.close().await;
                                         break Some((WebSocketMessage::Disconnected, WsStreamState::Done));
                                     }
                                     Some(WebSocketCommand::SendText(text)) => {
+                                        tracing::trace!(
+                                            target: "tears::subscription::websocket",
+                                            message_type = "text",
+                                            message_size = text.len(),
+                                            "websocket message sending"
+                                        );
                                         if let Err(e) = write.send(Message::Text(text.into())).await {
+                                            tracing::debug!(
+                                                target: "tears::subscription::websocket",
+                                                error = %e,
+                                                message_type = "text",
+                                                "websocket write failed"
+                                            );
                                             // Report the error but stay Running: the read half may
                                             // still deliver buffered frames (e.g. a server Close).
                                             break Some((
@@ -322,7 +368,19 @@ impl SubscriptionSource for WebSocket {
                                         }
                                     }
                                     Some(WebSocketCommand::SendBinary(data)) => {
+                                        tracing::trace!(
+                                            target: "tears::subscription::websocket",
+                                            message_type = "binary",
+                                            message_size = data.len(),
+                                            "websocket message sending"
+                                        );
                                         if let Err(e) = write.send(Message::Binary(data.into())).await {
+                                            tracing::debug!(
+                                                target: "tears::subscription::websocket",
+                                                error = %e,
+                                                message_type = "binary",
+                                                "websocket write failed"
+                                            );
                                             break Some((
                                                 WebSocketMessage::Error { error: e.to_string() },
                                                 WsStreamState::Running { write, read, cmd_rx },
@@ -331,6 +389,7 @@ impl SubscriptionSource for WebSocket {
                                     }
                                     None => {
                                         // Application dropped the command sender.
+                                        tracing::debug!(target: "tears::subscription::websocket", reason = "command_sender_dropped", "websocket disconnected");
                                         let _ = write.close().await;
                                         break Some((WebSocketMessage::Disconnected, WsStreamState::Done));
                                     }
@@ -349,6 +408,48 @@ impl SubscriptionSource for WebSocket {
         let mut hasher = DefaultHasher::new();
         self.hash(&mut hasher);
         SubscriptionId::of::<Self>(hasher.finish())
+    }
+}
+
+const fn trace_message_type(message: &Message) -> &'static str {
+    match message {
+        Message::Text(_) => "text",
+        Message::Binary(_) => "binary",
+        Message::Ping(_) => "ping",
+        Message::Pong(_) => "pong",
+        Message::Close(_) => "close",
+        Message::Frame(_) => "frame",
+    }
+}
+
+fn trace_message_size(message: &Message) -> usize {
+    match message {
+        Message::Text(text) => text.len(),
+        Message::Binary(data) | Message::Ping(data) | Message::Pong(data) => data.len(),
+        Message::Close(_) => 0,
+        Message::Frame(frame) => frame.payload().len(),
+    }
+}
+
+fn trace_url(url: &str) -> String {
+    let base = url.split_once(['?', '#']).map_or(url, |(base, _)| base);
+
+    let Some((scheme, rest)) = base.split_once("://") else {
+        return base.to_string();
+    };
+
+    let (authority, path) = rest
+        .split_once('/')
+        .map_or((rest, ""), |(authority, path)| (authority, path));
+
+    let Some((_, host)) = authority.split_once('@') else {
+        return base.to_string();
+    };
+
+    if path.is_empty() {
+        format!("{scheme}://<redacted>@{host}")
+    } else {
+        format!("{scheme}://<redacted>@{host}/{path}")
     }
 }
 
@@ -379,6 +480,18 @@ mod tests {
 
         // Different urls should produce different IDs
         assert_ne!(ws1.id(), ws2.id());
+    }
+
+    #[test]
+    fn test_trace_url_redacts_userinfo_only_in_authority() {
+        assert_eq!(
+            trace_url("wss://user:password@example.com/socket?token=secret#fragment"),
+            "wss://<redacted>@example.com/socket"
+        );
+        assert_eq!(
+            trace_url("wss://example.com/@user/feed?token=secret"),
+            "wss://example.com/@user/feed"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add source-specific `tracing` instrumentation for WebSocket, HTTP query, terminal, timer, and signal subscriptions.
- Avoid logging sensitive values such as payloads, query key contents, pasted text, key presses, and error strings.
- Update the changelog to document the expanded subscription observability.

## Details

WebSocket subscriptions now emit connection, disconnection, read/write error, and message type/size events.

HTTP query subscriptions now emit invalidation, cell reuse, fetch lifecycle, and cache GC events using metadata such as `client_id`, `key_hash`, `value_type`, `generation`, and `error_kind`.

Terminal, timer, and signal subscriptions now emit low-risk source-specific events without exposing user input or sensitive error details.

## Verification

- `cargo fmt --check`
- `cargo check --features http,ws`
- `cargo clippy --features http,ws -- -D warnings`
- `cargo test --features http,ws subscription::`
- `git diff --check`