### PR TITLE
perf(runtime): elide frame wake-ups while idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Panics inside command and subscription tasks are now caught and logged at
     the `error` level instead of being silently lost
 
+### Changed
+
+- The runtime no longer wakes at the frame rate while idle
+  - The event loop skips its frame tick when there is no pending redraw or
+    subscription update, so an idle application consumes no CPU at the frame
+    rate instead of waking (e.g. 60 times per second) only to do nothing
+  - Rendering latency is unaffected: when a message re-enables the frame tick,
+    the timer deadline has already elapsed, so the tick is ready on the next poll
+    (`MissedTickBehavior::Skip` only controls where the following tick lands,
+    avoiding a catch-up burst)
+  - Each frame tick now emits a `tracing` event under the new
+    `tears::runtime::frame` target
+
 ### Fixed
 
 - Subscription tasks are now aborted when the `SubscriptionManager` is dropped

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ tracing = "0.1"
 criterion = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# `test-util` (not part of `full`) provides paused virtual time for the idle
+# frame wake-up tests.
+tokio = { version = "1", features = ["test-util"] }
+# Used by `tests/idle_wakeup.rs` to count frame-tick tracing events; `tracing`
+# is a normal dependency, but integration tests need it as a direct dev-dep.
+tracing = "0.1"
 
 [target.'cfg(not(loom))'.dev-dependencies]
 reqwest = { version = "0.13", features = ["json", "query"] }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -145,6 +145,8 @@ struct ApplicationState<App: Application> {
 /// - **Frame Rate Control**: Regulates rendering at the specified FPS (e.g., 60 FPS)
 /// - **Micro-batching**: Processes messages arriving within 100μs together, reducing overhead
 /// - **Conditional Rendering**: Only renders when state changes, saving CPU cycles
+/// - **Idle Wake-up Elision**: Skips frame ticks entirely while idle, so the loop is
+///   event-driven and does not consume CPU at the frame rate with nothing to render
 /// - **Subscription Caching**: Re-evaluates subscriptions only after a message is processed,
 ///   and updates the subscription manager only when their IDs change
 ///
@@ -302,6 +304,21 @@ impl<App: Application> Runtime<App> {
         self.subscriptions_dirty = true;
     }
 
+    /// Whether the frame tick has pending work (a redraw or a subscription
+    /// re-evaluation) to do.
+    ///
+    /// Used to gate the frame branch of the event loop's `select!`: when the
+    /// application is idle (no message has been processed since the last frame),
+    /// both flags are false and there is nothing for a frame tick to do. Skipping
+    /// the tick entirely means the loop no longer wakes up at the frame rate while
+    /// idle, turning the loop event-driven and saving CPU/battery.
+    ///
+    /// Must use `||` (not `&&`): the initial state has `needs_redraw == true` and
+    /// `subscriptions_dirty == false`, and the first frame must still render.
+    const fn should_process_frame(&self) -> bool {
+        self.needs_redraw || self.subscriptions_dirty
+    }
+
     /// Processes a frame tick: renders if needed and updates subscriptions.
     ///
     /// Only renders when `needs_redraw` is true (conditional rendering optimization).
@@ -315,6 +332,11 @@ impl<App: Application> Runtime<App> {
         &mut self,
         terminal: &mut ratatui::Terminal<B>,
     ) -> Result<bool, <B as Backend>::Error> {
+        // Emitted on every frame branch wake-up (before the redraw check), so the
+        // event loop's idle behavior is observable via `tracing`. A dedicated
+        // target lets subscribers count wake-ups without matching the message.
+        tracing::trace!(target: "tears::runtime::frame", "frame tick");
+
         // Render only if state has changed
         if self.needs_redraw {
             self.state.render(terminal)?;
@@ -378,7 +400,9 @@ impl<App: Application> Runtime<App> {
     /// 1. **Message Channel**: Processes messages through [`Application::update`]. Messages
     ///    arriving within 100μs are batched together for efficiency.
     /// 2. **Frame Timer**: Renders UI via [`Application::view`] (only when state changed)
-    ///    and updates subscriptions at the specified frame rate.
+    ///    and updates subscriptions at the specified frame rate. The frame branch is
+    ///    skipped while the application is idle (no pending redraw or subscription
+    ///    update), so the loop does not wake at the frame rate with nothing to do.
     /// 3. **Quit Channel**: Terminates the loop when quit signal is received.
     ///
     /// Commands returned from [`Application::update`] are executed asynchronously as
@@ -442,8 +466,14 @@ impl<App: Application> Runtime<App> {
                     self.process_message_batch(msg);
                 }
 
-                // Frame tick: render if needed and update subscriptions
-                _ = self.frame_interval.tick() => {
+                // Frame tick: render if needed and update subscriptions.
+                //
+                // Gated on pending work so an idle loop does not wake at the frame
+                // rate just to do nothing. When a message re-enables the branch, the
+                // timer deadline has already elapsed, so `tick()` is ready on the
+                // next poll and adds no render latency. `MissedTickBehavior::Skip`
+                // only controls where the following tick lands (no catch-up burst).
+                _ = self.frame_interval.tick(), if self.should_process_frame() => {
                     if self.process_frame_tick(terminal)? {
                         break;
                     }
@@ -1225,6 +1255,48 @@ mod tests {
 
         // Should detect quit
         assert!(should_quit);
+
+        Ok(())
+    }
+
+    // --- Idle frame wake-up elision -----------------------------------------
+    //
+    // The event loop gates its frame branch on `should_process_frame()` so an
+    // idle loop stops waking at the frame rate. These unit tests cover the gate
+    // predicate in isolation; the end-to-end behavior (zero idle wake-ups, and
+    // an immediate render once a message re-enables the branch) is covered by
+    // `tests/idle_wakeup.rs`.
+
+    #[tokio::test]
+    async fn test_should_process_frame_initial_state_allows_first_frame() {
+        // Fresh runtime: `needs_redraw == true`, so the first frame must render.
+        let runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        assert!(runtime.should_process_frame());
+    }
+
+    #[tokio::test]
+    async fn test_should_process_frame_is_gated_off_when_idle() -> Result<()> {
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        // Draining the initial pending work leaves both flags false: idle.
+        runtime.process_frame_tick(&mut terminal)?;
+        assert!(!runtime.should_process_frame());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_should_process_frame_reenabled_after_message() -> Result<()> {
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        runtime.process_frame_tick(&mut terminal)?;
+        assert!(!runtime.should_process_frame());
+
+        // A processed message re-enables the frame branch.
+        runtime.process_message_batch(TestMessage::Increment);
+        assert!(runtime.should_process_frame());
 
         Ok(())
     }

--- a/tests/idle_wakeup.rs
+++ b/tests/idle_wakeup.rs
@@ -1,0 +1,162 @@
+// Integration tests for the idle frame wake-up elision.
+// These verify end-to-end that the event loop stops waking at the frame rate
+// while idle, and that re-enabling the frame branch after idle renders without
+// added latency. The gate predicate itself is unit-tested in src/runtime.rs.
+
+mod common;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use color_eyre::eyre::Result;
+use ratatui::Frame;
+use tears::prelude::*;
+use tokio::time::{Duration, Instant, sleep};
+
+// Idle window: one second is ~60 frame periods at 60 FPS, so an ungated loop
+// would wake ~60 times before the message arrives.
+const IDLE_WINDOW: Duration = Duration::from_secs(1);
+
+// 60 FPS frame period, computed the same way the runtime does (dividing a
+// one-second `Duration`), so the latency assertion stays exact.
+const FRAME_PERIOD: Duration = Duration::from_nanos(1_000_000_000 / 60);
+
+// A `tracing::Subscriber` that counts only frame-tick wake-ups, identified by
+// the dedicated `tears::runtime::frame` target. Filtering in `enabled` means
+// `event` is called for those events only.
+#[derive(Clone, Default)]
+struct FrameTickCounter {
+    ticks: Arc<AtomicUsize>,
+}
+
+impl tracing::Subscriber for FrameTickCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.target() == "tears::runtime::frame"
+    }
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+    fn event(&self, _event: &tracing::Event<'_>) {
+        self.ticks.fetch_add(1, Ordering::SeqCst);
+    }
+    fn enter(&self, _span: &tracing::span::Id) {}
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
+// App for both tests: its init command idles for `IDLE_WINDOW`, then emits a
+// message whose `update` quits. `view` records the virtual instant of every
+// render so latency can be asserted.
+struct IdleThenQuitApp {
+    renders: Arc<Mutex<Vec<Instant>>>,
+}
+
+#[derive(Clone)]
+struct Wake;
+
+impl Application for IdleThenQuitApp {
+    type Message = Wake;
+    type Flags = Arc<Mutex<Vec<Instant>>>;
+
+    fn new(renders: Self::Flags) -> (Self, Command<Self::Message>) {
+        let cmd = Command::future(async {
+            sleep(IDLE_WINDOW).await;
+            Wake
+        });
+        (Self { renders }, cmd)
+    }
+
+    fn update(&mut self, _msg: Wake) -> Command<Self::Message> {
+        Command::effect(Action::Quit)
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {
+        self.renders
+            .lock()
+            .expect("render log mutex should not be poisoned")
+            .push(Instant::now());
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        vec![]
+    }
+}
+
+// With paused virtual time, an ungated loop would auto-advance in frame-sized
+// steps and wake ~60 times during the idle window; the gated loop has no armed
+// frame timer while idle, so time jumps straight to the message.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn idle_loop_does_not_wake_at_frame_rate() -> Result<()> {
+    let counter = FrameTickCounter::default();
+    let ticks = counter.ticks.clone();
+    // `set_default` is thread-local; on a current-thread runtime the spawned
+    // tasks run on this same thread and so observe the subscriber.
+    let _guard = tracing::subscriber::set_default(counter);
+
+    let renders = Arc::new(Mutex::new(Vec::new()));
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<IdleThenQuitApp>::try_new(renders, 60)?;
+    runtime.run(&mut terminal).await?;
+
+    // Only the initial render and the single post-message render wake the frame
+    // branch. A count near the frame rate means the gate is missing.
+    let count = ticks.load(Ordering::SeqCst);
+    assert!(
+        (1..=2).contains(&count),
+        "idle loop should wake at most twice (initial + post-message render), \
+         but woke {count} times; a value near the frame rate means the frame \
+         branch is not gated on pending work",
+    );
+
+    Ok(())
+}
+
+// The message arrives at `IDLE_WINDOW`. Re-enabling the frame branch polls an
+// interval whose deadline has already elapsed, so `tick()` is ready at once and
+// the render happens at that same virtual instant rather than on the next frame
+// boundary. (The immediate readiness comes from polling a past deadline;
+// `MissedTickBehavior::Skip` only re-aligns the *following* tick.)
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn message_after_idle_renders_without_extra_frame_delay() -> Result<()> {
+    // Install a subscriber here too so no test thread ever emits the
+    // `tears::runtime::frame` callsite under `NoSubscriber`, which would poison
+    // its cached interest for the parallel wake-up test.
+    let _guard = tracing::subscriber::set_default(FrameTickCounter::default());
+
+    let start = Instant::now();
+
+    let renders = Arc::new(Mutex::new(Vec::new()));
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<IdleThenQuitApp>::try_new(renders.clone(), 60)?;
+    runtime.run(&mut terminal).await?;
+
+    let times: Vec<Duration> = renders
+        .lock()
+        .expect("render log mutex should not be poisoned")
+        .iter()
+        .map(|instant| *instant - start)
+        .collect();
+
+    // Initial render at startup, then one render for the post-idle message.
+    assert_eq!(
+        times.len(),
+        2,
+        "expected an initial render and one post-message render, got {times:?}",
+    );
+    assert_eq!(
+        times[0],
+        Duration::ZERO,
+        "initial render should be at startup"
+    );
+
+    let post = times[1];
+    assert!(
+        post >= IDLE_WINDOW && post < IDLE_WINDOW + FRAME_PERIOD,
+        "a message arriving after idle should render at ~{IDLE_WINDOW:?} (got \
+         {post:?}); a delay of a full frame period would mean the loop waited for \
+         the next grid tick instead of the already-elapsed one",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The event loop drove `frame_interval` unconditionally, so it woke at the frame rate (e.g. 60 times per second) even when the application was idle — finding no pending redraw or subscription update, and going straight back to sleep. This wasted CPU and battery for no observable benefit.

This gates the `select!` frame branch on a new `should_process_frame()` predicate (`needs_redraw || subscriptions_dirty`). While idle the branch is disabled and the loop parks; when a message re-enables it, the interval's deadline has already elapsed, so `tick()` is ready on the next poll and the render happens without delay. `MissedTickBehavior::Skip` only governs where the *following* tick lands (re-aligning to the period grid and avoiding a catch-up burst), so **rendering latency is unchanged**.

### Why it's safe

`subscriptions()` and `view()` are pure functions of the application state, and state only changes when a message is processed. So an idle frame (no message since the last one) can neither need a redraw nor change the subscription set — skipping it is a no-op. Terminal events (including resize) arrive as messages via `TerminalEvents`, which wake the loop through the message channel, not the frame timer.

## Changes

- Gate the frame branch on `should_process_frame()` (`needs_redraw || subscriptions_dirty`; must be `||` so the initial frame still renders).
- Emit a per-tick `tracing` event under the new `tears::runtime::frame` target so wake-ups are observable.
- Add the tokio `test-util` and `tracing` dev-dependencies (paused virtual time; event counting in integration tests).

## Tests

- **Gate predicate (unit, `src/runtime.rs`):** `should_process_frame()` across initial / idle / post-message states.
- **Idle wake-ups (integration, `tests/idle_wakeup.rs`, paused time):** an idle loop wakes at most twice (initial + post-message render) instead of ~60×/s, counted via the `tears::runtime::frame` target. Verified this fails (~61 wake-ups) when the gate is removed.
- **Latency (integration, `tests/idle_wakeup.rs`, paused time):** a message arriving after idle renders at the same virtual instant, with no extra frame-period delay.

End-to-end tests that drive `run()` through the public API live under `tests/`, matching the existing convention (see `tests/runtime_run.rs`); the white-box predicate test stays in `src/runtime.rs`.

## Measurements

Idle for 10s at 1000 FPS, fix vs. gate removed:

| Metric | With fix | Without gate |
|---|---:|---:|
| Frame wake-ups (counted) | **2** | 9,838 |
| CPU time (user+sys) | **0.00s** | 0.26s |
| samply on-CPU samples | **29** | 19,524 |
| Instructions retired | **22.4M** | 413.9M |

Timer-driven counter rate is unaffected (10 ticks / 10s, 20 / 20s, identical with and without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)