### PR TITLE
docs: record why RFC 0002 keeps without_redraw() over with_redraw(bool)

### DIFF
--- a/docs/rfcs/0002-redraw-suppression.md
+++ b/docs/rfcs/0002-redraw-suppression.md
@@ -230,6 +230,26 @@ to keep the API predictable ("Simple & Predictable"):
 - A dedicated no-side-effect constructor (e.g. `Command::quiet()`) was rejected:
   it does not compose with `perform`/`message`, so it would force a second
   mechanism for the "effect + no redraw" case, against the minimal-API goal.
+- A parameterized **`with_redraw(bool)`** was rejected as a *dominated middle
+  option*. Because the default is `true`, `with_redraw(true)` is a no-op, so the
+  argument only ever meaningfully takes `false` — a single-valued bool parameter,
+  which is the signal to make it a niladic method, and `with_redraw(false)` reads
+  as boolean-blind at the call site (`false` carries no clue what is toggled).
+  Its one genuine advantage over `without_redraw()` is the *dynamic* case, where
+  the policy is computed from state (e.g. an off-screen relay event whose
+  redraw depends on whether it targets the active tab): `cmd.with_redraw(cond)`
+  avoids a call-site `if`. But for that case a clearer-polarity `redraw_if(cond)`
+  beats `with_redraw(cond)` (the `if` marks the bool as a *condition*, not a
+  config value), while `redraw_if(false)` is silly for the static case that
+  dominates here (Tick-style unconditional suppression, §1.1). So `with_redraw`
+  loses on both ends: `without_redraw()` is clearer for the static majority and
+  `redraw_if()` would be clearer for the dynamic minority. `without_redraw()` is
+  also the coherent opt-out vocabulary shared with the future
+  `without_subscription_update()` (§9). Should the dynamic case prove common in
+  practice, `redraw_if(bool)` can be **added additively** later (the `redraw`
+  field is private and `without_redraw()` is a consuming builder, so a
+  parameterized sibling is non-breaking) — there is no need to trade the clearer
+  static form for it now.
 
 Once a redraw attribute exists, a `Command` is no longer *only* a side-effect
 stream: `Command::none().without_redraw()` has no stream yet still carries a


### PR DESCRIPTION
## Summary

§5.1.1 recorded only the `silent()` / `quiet()` rejections. This adds the `with_redraw(bool)` comparison — the alternative the approved name implicitly settled but never wrote down — so the naming decision is fully justified in the doc.

Points added:

- **Single-valued bool.** The default is `true`, so `with_redraw(true)` is a no-op and the argument only ever meaningfully takes `false` — a signal to make it a niladic method. `with_redraw(false)` also reads boolean-blind at the call site.
- **Dominated middle option.** Its one real edge over `without_redraw()` is the dynamic case (redraw computed from state, e.g. an off-screen event keyed on the active tab). But there a clearer-polarity `redraw_if(cond)` beats `with_redraw(cond)`, while `redraw_if(false)` is silly for the static majority (Tick-style suppression). So `with_redraw` loses on both ends.
- **Family consistency + reversibility.** `without_redraw()` matches the opt-out vocabulary of the future `without_subscription_update()` (§9); and `redraw_if(bool)` can be added additively later (private field + consuming builder) if the dynamic case proves common — no need to trade the clearer static form now.

## Scope

Docs only. The approved API name (`without_redraw()`) is unchanged; this only records the rejected alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)