### PR TITLE
feat(command): add redraw suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Command::without_redraw()` for updates that handled a message without
+  changing the visible view
+  - The default behavior is unchanged: commands still request redraws unless
+    explicitly opted out
+  - Redraw suppression does not suppress subscription re-evaluation
+
 ### Changed
 
 - Consolidated quit detection into the event loop's dedicated quit branch

--- a/docs/rfcs/0002-redraw-suppression.md
+++ b/docs/rfcs/0002-redraw-suppression.md
@@ -1,6 +1,6 @@
 # RFC 0002: Redraw Suppression (message / redraw separation)
 
-- Status: Approved
+- Status: Implemented
 - Target: additive, non-breaking (next minor)
 - Scope: an opt-out API for an `update` to declare "this message does not need a redraw"
 - Feature flag: none (core runtime)

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,8 +1,10 @@
-//! Commands for performing asynchronous side effects.
+//! Commands for performing asynchronous side effects and returning runtime
+//! directives.
 //!
-//! Commands represent asynchronous operations that produce messages or actions.
-//! They are the primary way to perform side effects in the Elm Architecture,
-//! such as HTTP requests, file I/O, or any other async operation.
+//! Commands represent asynchronous operations that produce messages or actions,
+//! plus attributes that tell the runtime how to handle the update that returned
+//! them. They are the primary way to perform side effects in the Elm
+//! Architecture, such as HTTP requests, file I/O, or any other async operation.
 //!
 //! # Examples
 //!
@@ -36,10 +38,13 @@ pub enum Action<Msg> {
     Quit,
 }
 
-/// A command that can be executed to perform side effects.
+/// A command that can be executed to perform side effects and carry runtime
+/// directives.
 ///
 /// Commands represent asynchronous operations that produce messages,
-/// such as HTTP requests, file I/O, or background computations.
+/// such as HTTP requests, file I/O, or background computations. They may also
+/// carry runtime attributes, such as [`Command::without_redraw`], independently
+/// of whether they have a side-effect stream.
 ///
 /// # Examples
 ///
@@ -50,13 +55,27 @@ pub enum Action<Msg> {
 ///
 /// let cmd = Command::perform(async { 42 }, Message::GotResult);
 /// ```
-#[must_use = "Commands represent side effects in the Elm Architecture and must be handled by the runtime. Ignoring a command means the intended side effect will not occur."]
+#[must_use = "Commands represent side effects and runtime directives in the Elm Architecture and must be handled by the runtime."]
 pub struct Command<Msg: Send + 'static> {
     pub(super) stream: Option<BoxStream<'static, Action<Msg>>>,
+    pub(super) redraw: bool,
 }
 
 impl<Msg: Send + 'static> Command<Msg> {
-    /// Create a command that does nothing.
+    const DEFAULT_REDRAW: bool = true;
+
+    fn with_stream(stream: BoxStream<'static, Action<Msg>>) -> Self {
+        Self {
+            stream: Some(stream),
+            redraw: Self::DEFAULT_REDRAW,
+        }
+    }
+
+    /// Create a command with no side-effect stream.
+    ///
+    /// A stream-less command may still carry runtime attributes after applying
+    /// modifiers such as [`Command::without_redraw`], so it should not be
+    /// treated as having no effect on runtime behavior.
     ///
     /// # Examples
     ///
@@ -66,10 +85,17 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// let cmd: Command<i32> = Command::none();
     /// ```
     pub const fn none() -> Self {
-        Self { stream: None }
+        Self {
+            stream: None,
+            redraw: Self::DEFAULT_REDRAW,
+        }
     }
 
-    /// Returns `true` if the command does nothing (is `none`).
+    /// Returns `true` if the command has no side-effect stream.
+    ///
+    /// This only reflects whether the runtime has a stream to spawn. A command
+    /// with no stream may still carry runtime attributes such as
+    /// [`Command::without_redraw`].
     ///
     /// # Examples
     ///
@@ -87,7 +113,10 @@ impl<Msg: Send + 'static> Command<Msg> {
         self.stream.is_none()
     }
 
-    /// Returns `true` if the command will perform some action.
+    /// Returns `true` if the command has a side-effect stream.
+    ///
+    /// This is the inverse of [`Command::is_none`] and does not inspect runtime
+    /// attributes such as [`Command::without_redraw`].
     ///
     /// # Examples
     ///
@@ -103,6 +132,19 @@ impl<Msg: Send + 'static> Command<Msg> {
     #[must_use]
     pub fn is_some(&self) -> bool {
         self.stream.is_some()
+    }
+
+    /// Declare that the update returning this command did not change the
+    /// visible view, so the runtime may skip the redraw it would otherwise
+    /// perform.
+    ///
+    /// Side effects still run. This is an optimization hint rather than a
+    /// guarantee: the runtime may still redraw for other reasons, such as an
+    /// initial frame or another message in the same batch.
+    #[must_use = "without_redraw returns a modified command and does not mutate in place"]
+    pub const fn without_redraw(mut self) -> Self {
+        self.redraw = false;
+        self
     }
 
     /// Perform an asynchronous operation and convert its result to a message.
@@ -135,9 +177,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// let cmd = Command::future(async { 42 });
     /// ```
     pub fn future(future: impl Future<Output = Msg> + Send + 'static) -> Self {
-        Self {
-            stream: Some(future.into_stream().map(Action::Message).boxed()),
-        }
+        Self::with_stream(future.into_stream().map(Action::Message).boxed())
     }
 
     /// Send a message to the application immediately.
@@ -171,14 +211,16 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// let cmd = Command::effect(Action::Message(42));
     /// ```
     pub fn effect(action: Action<Msg>) -> Self {
-        Self {
-            stream: Some(stream::once(async move { action }).boxed()),
-        }
+        Self::with_stream(stream::once(async move { action }).boxed())
     }
 
     /// Batch multiple commands into a single command.
     ///
-    /// All commands execute concurrently. `Command::none()` is filtered out.
+    /// All command streams execute concurrently. Commands with no side-effect
+    /// stream do not contribute work to spawn, but their runtime attributes are
+    /// still folded into the combined command. The combined command redraws if
+    /// any child command redraws; only an empty input uses the default redraw
+    /// behavior.
     ///
     /// # Examples
     ///
@@ -193,14 +235,25 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// ]);
     /// ```
     pub fn batch(commands: impl IntoIterator<Item = Self>) -> Self {
-        let streams: Vec<_> = commands.into_iter().filter_map(|cmd| cmd.stream).collect();
+        let mut redraw = false;
+        let mut any_child = false;
+        let mut streams = Vec::new();
 
-        if streams.is_empty() {
-            Self::none()
-        } else {
-            Self {
-                stream: Some(select_all(streams).boxed()),
+        for cmd in commands {
+            any_child = true;
+            redraw |= cmd.redraw;
+            if let Some(stream) = cmd.stream {
+                streams.push(stream);
             }
+        }
+
+        if any_child {
+            Self {
+                stream: (!streams.is_empty()).then(|| select_all(streams).boxed()),
+                redraw,
+            }
+        } else {
+            Self::none()
         }
     }
 
@@ -216,9 +269,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// let cmd = Command::stream(messages);
     /// ```
     pub fn stream(stream: impl Stream<Item = Msg> + Send + 'static) -> Self {
-        Self {
-            stream: Some(stream.map(Action::Message).boxed()),
-        }
+        Self::with_stream(stream.map(Action::Message).boxed())
     }
 
     /// Run a stream and convert each item to a message.
@@ -295,15 +346,17 @@ impl<Msg: Send + 'static> Command<Msg> {
     where
         T: Send + 'static,
     {
-        self.stream.map_or_else(Command::none, |stream| {
-            let mapped = stream.map(move |action| match action {
-                Action::Message(msg) => Action::Message(f(msg)),
-                Action::Quit => Action::Quit,
-            });
-            Command {
-                stream: Some(mapped.boxed()),
-            }
-        })
+        let redraw = self.redraw;
+        let stream = self.stream.map(|stream| {
+            stream
+                .map(move |action| match action {
+                    Action::Message(msg) => Action::Message(f(msg)),
+                    Action::Quit => Action::Quit,
+                })
+                .boxed()
+        });
+
+        Command { stream, redraw }
     }
 }
 
@@ -313,6 +366,74 @@ mod tests {
     use futures::StreamExt;
     use futures::stream;
     use tokio::time::{Duration, sleep};
+
+    #[test]
+    fn test_redraw_defaults_to_true_for_constructors() {
+        assert!(Command::<i32>::none().redraw);
+        assert!(Command::message(1).redraw);
+        assert!(Command::future(async { 1 }).redraw);
+        assert!(Command::perform(async { 1 }, |value| value).redraw);
+        assert!(Command::<i32>::effect(Action::Quit).redraw);
+        assert!(Command::stream(stream::iter(vec![1])).redraw);
+        assert!(Command::run(stream::iter(vec![1]), |value| value).redraw);
+        assert!(Command::batch(vec![Command::<i32>::none()]).redraw);
+        assert!(Command::<i32>::batch(vec![]).redraw);
+    }
+
+    #[test]
+    fn test_without_redraw_flips_redraw() {
+        let cmd = Command::<i32>::none().without_redraw();
+        assert!(!cmd.redraw);
+    }
+
+    #[test]
+    fn test_batch_redraw_is_or_over_children() {
+        let cmd = Command::batch(vec![
+            Command::none().without_redraw(),
+            Command::future(async { 1 }),
+        ]);
+        assert!(cmd.redraw);
+
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }).without_redraw(),
+            Command::future(async { 2 }).without_redraw(),
+        ]);
+        assert!(!cmd.redraw);
+    }
+
+    #[test]
+    fn test_batch_all_opted_out_streamless_children_stays_opted_out() {
+        let cmd = Command::batch(vec![Command::<i32>::none().without_redraw()]);
+
+        assert!(cmd.is_none());
+        assert!(!cmd.redraw);
+    }
+
+    #[test]
+    fn test_map_preserves_redraw_for_stream_command() {
+        let cmd = Command::future(async { 1 })
+            .without_redraw()
+            .map(|value| value * 2);
+        assert!(!cmd.redraw);
+    }
+
+    #[test]
+    fn test_map_preserves_redraw_for_streamless_command() {
+        let cmd = Command::<i32>::none()
+            .without_redraw()
+            .map(|value| value * 2);
+
+        assert!(cmd.is_none());
+        assert!(!cmd.redraw);
+    }
+
+    #[test]
+    fn test_is_none_is_independent_of_redraw() {
+        let cmd = Command::<i32>::none().without_redraw();
+
+        assert!(cmd.is_none());
+        assert!(!cmd.redraw);
+    }
 
     #[tokio::test]
     async fn test_batch_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,13 @@
 //! 3. **Update**: Function that processes messages and updates the model
 //! 4. **View**: Function that renders the UI based on the current model
 //! 5. **Subscriptions**: External event sources (keyboard, timers, etc.)
-//! 6. **Commands**: Asynchronous operations that produce messages
+//! 6. **Commands**: Asynchronous operations and runtime directives
 //!
 //! ## Core Components
 //!
 //! - [`application::Application`]: The main trait that defines your application
 //! - [`runtime::Runtime`]: Manages the application lifecycle and event loop
-//! - [`command::Command`]: Represents asynchronous side effects
+//! - [`command::Command`]: Represents asynchronous side effects and runtime directives
 //! - [`subscription::Subscription`]: Represents ongoing event sources
 //! - [`install_panic_hook`]: Restores the terminal if the application panics
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,7 +7,7 @@
 //! # What's included
 //!
 //! - [`Application`] - The main application trait
-//! - [`Command`] - For performing side effects
+//! - [`Command`] - For side effects and runtime directives
 //! - [`Action`] - Actions that commands can perform
 //! - [`Subscription`] - For handling event sources
 //! - [`Runtime`] - The runtime for running applications

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -277,11 +277,12 @@ impl<App: Application> Runtime<App> {
     /// that arrived within 100μs. This reduces overhead by batching rapid message sequences
     /// (e.g., keyboard input, rapid timers) while maintaining responsiveness.
     ///
-    /// Always sets `needs_redraw` and `subscriptions_dirty` to true after processing.
+    /// Sets `needs_redraw` if any processed command requests a redraw, and
+    /// always sets `subscriptions_dirty` after processing.
     fn process_message_batch(&mut self, first_msg: App::Message) {
         // Process the first message
         let cmd = self.state.app.update(first_msg);
-        self.state.enqueue_command(cmd);
+        self.dispatch_update_command(cmd);
         let mut processed = 1usize;
 
         // Micro-batching: process additional messages that arrived during a short window
@@ -290,7 +291,7 @@ impl<App: Application> Runtime<App> {
             match self.state.msg_rx.try_recv() {
                 Ok(msg) => {
                     let cmd = self.state.app.update(msg);
-                    self.state.enqueue_command(cmd);
+                    self.dispatch_update_command(cmd);
                     processed += 1;
                 }
                 Err(_) => break, // No more messages available
@@ -299,9 +300,13 @@ impl<App: Application> Runtime<App> {
 
         tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
 
-        // Mark that a redraw is needed and that subscriptions may have changed
-        self.needs_redraw = true;
+        // Mark that subscriptions may have changed even when redraw is suppressed.
         self.subscriptions_dirty = true;
+    }
+
+    fn dispatch_update_command(&mut self, cmd: Command<App::Message>) {
+        self.needs_redraw |= cmd.redraw;
+        self.state.enqueue_command(cmd);
     }
 
     /// Whether the frame tick has pending work (a redraw or a subscription
@@ -677,6 +682,36 @@ mod tests {
         }
     }
 
+    struct RedrawControlApp;
+
+    #[derive(Debug, Clone)]
+    enum RedrawControlMessage {
+        Redraw,
+        Suppress,
+    }
+
+    impl Application for RedrawControlApp {
+        type Message = RedrawControlMessage;
+        type Flags = ();
+
+        fn new((): ()) -> (Self, Command<Self::Message>) {
+            (Self, Command::none())
+        }
+
+        fn update(&mut self, msg: Self::Message) -> Command<Self::Message> {
+            match msg {
+                RedrawControlMessage::Redraw => Command::none(),
+                RedrawControlMessage::Suppress => Command::none().without_redraw(),
+            }
+        }
+
+        fn view(&self, _frame: &mut Frame<'_>) {}
+
+        fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+            vec![]
+        }
+    }
+
     #[test]
     fn test_runtime_new() {
         let runtime = ApplicationState::<TestApp>::new(42);
@@ -985,6 +1020,49 @@ mod tests {
 
         // Redraw should be needed
         assert!(runtime.needs_redraw);
+    }
+
+    #[tokio::test]
+    async fn test_process_message_batch_without_redraw_leaves_redraw_unchanged() {
+        let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
+        runtime.needs_redraw = false;
+        runtime.subscriptions_dirty = false;
+
+        runtime.process_message_batch(RedrawControlMessage::Suppress);
+
+        assert!(!runtime.needs_redraw);
+        assert!(
+            runtime.subscriptions_dirty,
+            "redraw suppression must not suppress subscription re-evaluation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_process_message_batch_mixed_commands_redraws() {
+        let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
+        runtime.needs_redraw = false;
+        runtime.subscriptions_dirty = false;
+
+        let _ = runtime.state.msg_tx.send(RedrawControlMessage::Redraw);
+        runtime.process_message_batch(RedrawControlMessage::Suppress);
+
+        assert!(runtime.needs_redraw);
+        assert!(runtime.subscriptions_dirty);
+    }
+
+    #[tokio::test]
+    async fn test_process_message_batch_redraw_recovers_after_suppression() {
+        let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
+        runtime.needs_redraw = false;
+
+        runtime.process_message_batch(RedrawControlMessage::Suppress);
+        assert!(!runtime.needs_redraw);
+
+        runtime.subscriptions_dirty = false;
+        runtime.process_message_batch(RedrawControlMessage::Redraw);
+
+        assert!(runtime.needs_redraw);
+        assert!(runtime.subscriptions_dirty);
     }
 
     // A minimal `tracing::Subscriber` that counts emitted events (total, and


### PR DESCRIPTION
## Summary

Implements RFC0002 redraw suppression by adding `Command::without_redraw()` as an opt-out runtime directive.

By default, all commands continue to request redraws exactly as before. An update can now return a command with `.without_redraw()` to indicate that handling the message did not change the visible view, allowing the runtime to skip forcing a redraw for that message batch.

## Changes

- Add a private redraw directive to `Command`
- Add `Command::without_redraw()`
- Preserve redraw directives through `Command::batch` and `Command::map`
- Gate `Runtime::process_message_batch` redraw marking on the command directive
- Keep subscription re-evaluation unconditional after processed messages
- Update command docs to distinguish “no side-effect stream” from “no runtime directive”
- Mark RFC0002 as implemented
- Add contract tests for default behavior, opt-out behavior, batch/map propagation, and runtime gating

## Compatibility

This is additive and non-breaking.

Existing commands still request redraws by default, including `Command::none()`, `Command::future()`, `Command::perform()`, `Command::message()`, `Command::effect()`, `Command::stream()`, `Command::run()`, and ordinary `Command::batch(...)`.

## Testing

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets --all-features`