### PR TITLE
refactor(command): hold effect leaves until into_stream boundary

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -1011,7 +1011,7 @@ mod tests {
     // and `map` application to pin the two concerns apart.
     #[test]
     fn test_redraw_preserved_across_effect_and_map_matrix() {
-        // stream-ful command: redraw survives map, without_redraw survives map.
+        // Command with a stream: redraw survives map, without_redraw survives map.
         assert!(
             Command::future(async { 1 })
                 .map(|v| v * 2)
@@ -1043,7 +1043,7 @@ mod tests {
         assert!(cmd.is_some());
         assert!(cmd.requests_redraw());
 
-        // All opted out, both stream-ful and stream-less: stays opted out.
+        // All opted out, both with and without a stream: stays opted out.
         let cmd = Command::batch(vec![
             Command::future(async { 1 }).without_redraw(),
             Command::none().without_redraw(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -1006,6 +1006,44 @@ mod tests {
         assert_eq!(cmd.effect.leaf_count(), 3);
     }
 
+    // `map` promises to accept any `Fn + Send` mapper without also requiring
+    // `Sync`. On the multi-leaf batch path the mapper is shared across leaves,
+    // and it is `Arc<Mutex<F>>` (not `Arc<F>`, which would demand `F: Sync`)
+    // that upholds that contract. This test pins the contract down: a mapper
+    // that is `Send` but not `Sync` (it captures a `Cell`) must still compile
+    // and run through a batched `map`, so a regression to `Arc<F>` fails to
+    // build.
+    #[tokio::test]
+    async fn test_batch_map_accepts_send_non_sync_mapper() {
+        use std::cell::Cell;
+
+        fn assert_send<F: Send>(_: &F) {}
+
+        // `Cell<i32>` is `Send` but not `Sync`, so this closure is too.
+        let offset = Cell::new(10);
+        let mapper = move |value: i32| value + offset.get();
+        assert_send(&mapper);
+
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }),
+            Command::future(async { 2 }),
+        ])
+        .map(mapper);
+        assert_eq!(cmd.effect.leaf_count(), 2);
+
+        let mut stream = cmd.into_stream().expect("stream should exist");
+        let mut results = vec![];
+        while let Some(action) = stream.next().await {
+            match action {
+                Action::Message(msg) => results.push(msg),
+                Action::Quit => break,
+            }
+        }
+
+        results.sort_unstable();
+        assert_eq!(results, vec![11, 12]);
+    }
+
     // Directives (`without_redraw`) travel a path independent of the effect
     // leaves, so exercise the redraw flag across the matrix of effect presence
     // and `map` application to pin the two concerns apart.

--- a/src/command.rs
+++ b/src/command.rs
@@ -962,4 +962,108 @@ mod tests {
         assert!(mapped.is_some());
         assert!(!mapped.is_none());
     }
+
+    #[test]
+    fn test_batch_flattens_nested_batches_into_flat_leaves() {
+        let batch1 = Command::batch(vec![
+            Command::future(async { 1 }),
+            Command::future(async { 2 }),
+        ]);
+        let batch2 = Command::batch(vec![
+            Command::future(async { 3 }),
+            Command::future(async { 4 }),
+        ]);
+        let cmd = Command::batch(vec![batch1, batch2, Command::future(async { 5 })]);
+
+        // batch(batch(a, b), batch(c, d), e) collapses to a single flat leaf
+        // sequence [a, b, c, d, e] rather than a nested structure.
+        assert_eq!(cmd.effect.leaf_count(), 5);
+    }
+
+    #[test]
+    fn test_batch_drops_streamless_children_from_leaves() {
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }),
+            Command::none(),
+            Command::none().without_redraw(),
+            Command::future(async { 2 }),
+        ]);
+
+        // Stream-less children contribute no leaves even though their redraw
+        // directives are still folded in.
+        assert_eq!(cmd.effect.leaf_count(), 2);
+    }
+
+    #[test]
+    fn test_map_over_batch_preserves_leaf_count() {
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }),
+            Command::future(async { 2 }),
+            Command::future(async { 3 }),
+        ])
+        .map(|value| value * 10);
+
+        assert_eq!(cmd.effect.leaf_count(), 3);
+    }
+
+    // Directives (`without_redraw`) travel a path independent of the effect
+    // leaves, so exercise the redraw flag across the matrix of effect presence
+    // and `map` application to pin the two concerns apart.
+    #[test]
+    fn test_redraw_preserved_across_effect_and_map_matrix() {
+        // stream-ful command: redraw survives map, without_redraw survives map.
+        assert!(
+            Command::future(async { 1 })
+                .map(|v| v * 2)
+                .requests_redraw()
+        );
+        assert!(
+            !Command::future(async { 1 })
+                .without_redraw()
+                .map(|v| v * 2)
+                .requests_redraw()
+        );
+
+        // stream-less command: same, and it stays stream-less.
+        let cmd = Command::<i32>::none().map(|v| v * 2);
+        assert!(cmd.is_none());
+        assert!(cmd.requests_redraw());
+        let cmd = Command::<i32>::none().without_redraw().map(|v| v * 2);
+        assert!(cmd.is_none());
+        assert!(!cmd.requests_redraw());
+    }
+
+    #[test]
+    fn test_batch_redraw_matrix_over_effect_and_map() {
+        // Mixed children: OR over redraw flags holds regardless of effects.
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }).without_redraw(),
+            Command::none(),
+        ]);
+        assert!(cmd.is_some());
+        assert!(cmd.requests_redraw());
+
+        // All opted out, both stream-ful and stream-less: stays opted out.
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }).without_redraw(),
+            Command::none().without_redraw(),
+        ]);
+        assert!(cmd.is_some());
+        assert!(!cmd.requests_redraw());
+
+        // Mapping the batch does not disturb the folded redraw directive.
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }).without_redraw(),
+            Command::future(async { 2 }).without_redraw(),
+        ])
+        .map(|v| v * 2);
+        assert!(!cmd.requests_redraw());
+
+        let cmd = Command::batch(vec![
+            Command::future(async { 1 }),
+            Command::future(async { 2 }).without_redraw(),
+        ])
+        .map(|v| v * 2);
+        assert!(cmd.requests_redraw());
+    }
 }

--- a/src/command/effect.rs
+++ b/src/command/effect.rs
@@ -1,3 +1,5 @@
+use std::sync::{Arc, Mutex};
+
 use futures::{
     FutureExt, Stream, StreamExt,
     stream::{self, BoxStream, select_all},
@@ -7,18 +9,45 @@ use super::Action;
 
 // Effects own and compose the asynchronous action stream; runtime directives
 // stay separate because they describe how the runtime treats the update result.
-pub(super) struct Effect<Msg: Send + 'static> {
-    stream: Option<BoxStream<'static, Action<Msg>>>,
+//
+// Rather than folding children into a single opaque stream at construction
+// time, an effect keeps the flat sequence of leaf streams and only folds them
+// (via `select_all`) at the `into_stream()` boundary. Keeping the leaves apart
+// preserves each leaf's identity through `Command` composition, which is what a
+// future per-leaf cancellation id would attach to.
+//
+// The empty case is a distinct `None` variant rather than an empty `Vec` so
+// that `is_none()`/`is_some()` stay `const fn` (these back the public
+// `Command::is_none`/`is_some`); `Vec::is_empty` only became usable in `const`
+// in Rust 1.87, past this crate's MSRV. The invariant is therefore that
+// `Leaves` is always non-empty.
+//
+// TODO(msrv >= 1.87): collapse this back to a plain
+// `Vec<BoxStream<'static, Action<Msg>>>` and implement the `const`
+// `is_none()`/`is_some()` with `Vec::is_empty`, dropping the `None` variant and
+// its non-empty invariant.
+//
+// Future room: to carry per-leaf metadata, `Leaves` could hold
+// `Vec<(LeafMeta, BoxStream<'static, Action<Msg>>)>` without reworking the fold
+// at the `into_stream()` boundary.
+pub(super) enum Effect<Msg: Send + 'static> {
+    None,
+    Leaves(Vec<BoxStream<'static, Action<Msg>>>),
 }
 
 impl<Msg: Send + 'static> Effect<Msg> {
     pub(super) const fn none() -> Self {
-        Self { stream: None }
+        Self::None
     }
 
     fn from_stream(stream: BoxStream<'static, Action<Msg>>) -> Self {
-        Self {
-            stream: Some(stream),
+        Self::Leaves(vec![stream])
+    }
+
+    fn into_leaves(self) -> Vec<BoxStream<'static, Action<Msg>>> {
+        match self {
+            Self::None => Vec::new(),
+            Self::Leaves(leaves) => leaves,
         }
     }
 
@@ -35,15 +64,16 @@ impl<Msg: Send + 'static> Effect<Msg> {
     }
 
     pub(super) fn batch(effects: impl IntoIterator<Item = Self>) -> Self {
-        let streams: Vec<_> = effects
-            .into_iter()
-            .filter_map(|effect| effect.stream)
-            .collect();
+        // Concatenate the children's leaves. Because every effect already holds
+        // a flat leaf sequence, nested batches flatten automatically and
+        // stream-less children contribute nothing. Collapse to `None` when no
+        // child had a leaf so the non-empty `Leaves` invariant holds.
+        let leaves: Vec<_> = effects.into_iter().flat_map(Self::into_leaves).collect();
 
-        if streams.is_empty() {
-            Self::none()
+        if leaves.is_empty() {
+            Self::None
         } else {
-            Self::from_stream(select_all(streams).boxed())
+            Self::Leaves(leaves)
         }
     }
 
@@ -51,28 +81,77 @@ impl<Msg: Send + 'static> Effect<Msg> {
     where
         T: Send + 'static,
     {
-        let stream = self.stream.map(|stream| {
-            stream
-                .map(move |action| match action {
-                    Action::Message(msg) => Action::Message(f(msg)),
-                    Action::Quit => Action::Quit,
-                })
-                .boxed()
-        });
+        fn map_leaf<Msg, T>(
+            leaf: BoxStream<'static, Action<Msg>>,
+            f: impl Fn(Msg) -> T + Send + 'static,
+        ) -> BoxStream<'static, Action<T>>
+        where
+            Msg: Send + 'static,
+            T: Send + 'static,
+        {
+            leaf.map(move |action| match action {
+                Action::Message(msg) => Action::Message(f(msg)),
+                Action::Quit => Action::Quit,
+            })
+            .boxed()
+        }
 
-        Effect { stream }
+        // Map each leaf on its own to preserve leaf count and order. A single
+        // leaf moves `f` straight into its closure with no shared-ownership
+        // cost (the pre-refactor path). Several leaves must share `f`: `Arc<F>`
+        // alone would require `F: Sync`, but the public `map` bound is only
+        // `Fn + Send`, so a `Mutex` supplies the needed `Sync`.
+        match self {
+            Self::None => Effect::None,
+            Self::Leaves(mut leaves) if leaves.len() == 1 => {
+                let leaf = leaves.pop().expect("length checked to be 1");
+                Effect::Leaves(vec![map_leaf(leaf, f)])
+            }
+            Self::Leaves(leaves) => {
+                let f = Arc::new(Mutex::new(f));
+                let mapped = leaves
+                    .into_iter()
+                    .map(|leaf| {
+                        let f = Arc::clone(&f);
+                        map_leaf(leaf, move |msg| {
+                            let guard = f.lock().expect("map closure mutex poisoned");
+                            (*guard)(msg)
+                        })
+                    })
+                    .collect();
+                Effect::Leaves(mapped)
+            }
+        }
     }
 
     pub(super) const fn is_none(&self) -> bool {
-        self.stream.is_none()
+        matches!(self, Self::None)
     }
 
     pub(super) const fn is_some(&self) -> bool {
-        self.stream.is_some()
+        matches!(self, Self::Leaves(_))
+    }
+
+    // Observe the leaf count so tests in `command.rs` can pin down nested-batch
+    // flattening. Not needed by non-test builds.
+    #[cfg(test)]
+    pub(super) fn leaf_count(&self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Leaves(leaves) => leaves.len(),
+        }
     }
 
     pub(super) fn into_stream(self) -> Option<BoxStream<'static, Action<Msg>>> {
-        self.stream
+        // Fold the leaves back into one stream here, at the boundary. A single
+        // leaf is returned as-is (a `select_all` over one stream is observably
+        // identical); `None` yields no stream, which the runtime treats as no
+        // work to spawn. `Leaves` is always non-empty by invariant.
+        match self {
+            Self::None => None,
+            Self::Leaves(mut leaves) if leaves.len() == 1 => leaves.pop(),
+            Self::Leaves(leaves) => Some(select_all(leaves).boxed()),
+        }
     }
 }
 
@@ -81,13 +160,99 @@ mod tests {
     use super::*;
     use futures::StreamExt;
 
+    async fn drain<Msg>(stream: BoxStream<'static, Action<Msg>>) -> (Vec<Msg>, bool) {
+        let mut messages = Vec::new();
+        let mut quit = false;
+        let mut stream = stream;
+        while let Some(action) = stream.next().await {
+            match action {
+                Action::Message(msg) => messages.push(msg),
+                Action::Quit => quit = true,
+            }
+        }
+        (messages, quit)
+    }
+
     #[test]
     fn test_effect_none_has_no_stream() {
         let effect = Effect::<i32>::none();
 
         assert!(effect.is_none());
         assert!(!effect.is_some());
+        assert_eq!(effect.leaf_count(), 0);
         assert!(effect.into_stream().is_none());
+    }
+
+    #[test]
+    fn test_effect_empty_batch_is_none() {
+        let effect = Effect::<i32>::batch(Vec::new());
+
+        assert!(effect.is_none());
+        assert_eq!(effect.leaf_count(), 0);
+    }
+
+    #[test]
+    fn test_effect_batch_of_all_none_is_none() {
+        let effect = Effect::<i32>::batch(vec![Effect::none(), Effect::none()]);
+
+        assert!(effect.is_none());
+        assert!(!effect.is_some());
+        assert_eq!(effect.leaf_count(), 0);
+    }
+
+    #[test]
+    fn test_effect_map_over_none_is_none() {
+        let effect = Effect::<i32>::none().map(|value| value * 2);
+
+        assert!(effect.is_none());
+        assert_eq!(effect.leaf_count(), 0);
+    }
+
+    #[test]
+    fn test_effect_batch_drops_none_children_from_leaves() {
+        let effect = Effect::batch(vec![
+            Effect::none(),
+            Effect::future(async { 1 }),
+            Effect::none(),
+            Effect::future(async { 2 }),
+        ]);
+
+        assert_eq!(effect.leaf_count(), 2);
+    }
+
+    #[test]
+    fn test_effect_nested_batch_is_flattened() {
+        let inner = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::future(async { 2 }),
+        ]);
+        let effect = Effect::batch(vec![inner, Effect::future(async { 3 })]);
+
+        // batch(batch(a, b), c) collapses to the flat leaf sequence [a, b, c].
+        assert_eq!(effect.leaf_count(), 3);
+    }
+
+    #[test]
+    fn test_effect_map_preserves_leaf_count() {
+        let effect = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::future(async { 2 }),
+        ])
+        .map(|value| value * 10);
+
+        assert_eq!(effect.leaf_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_effect_single_leaf_into_stream() {
+        let effect = Effect::future(async { 1 });
+
+        assert_eq!(effect.leaf_count(), 1);
+        let stream = effect.into_stream().expect("stream should exist");
+        let (messages, quit) = drain(stream).await;
+
+        assert_eq!(messages, vec![1]);
+        assert!(!quit);
     }
 
     #[tokio::test]
@@ -99,6 +264,52 @@ mod tests {
 
         assert!(matches!(action, Action::Message(1)));
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_effect_batch_delivers_all_leaves() {
+        let effect = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::future(async { 2 }),
+            Effect::future(async { 3 }),
+        ]);
+
+        let stream = effect.into_stream().expect("stream should exist");
+        let (mut messages, quit) = drain(stream).await;
+
+        messages.sort_unstable();
+        assert_eq!(messages, vec![1, 2, 3]);
+        assert!(!quit);
+    }
+
+    #[tokio::test]
+    async fn test_effect_map_over_batch_applies_to_every_leaf() {
+        let effect = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::future(async { 2 }),
+            Effect::future(async { 3 }),
+        ])
+        .map(|value| value * 10);
+
+        let stream = effect.into_stream().expect("stream should exist");
+        let (mut messages, _) = drain(stream).await;
+
+        messages.sort_unstable();
+        assert_eq!(messages, vec![10, 20, 30]);
+    }
+
+    #[tokio::test]
+    async fn test_effect_map_over_batch_preserves_quit() {
+        let effect = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::action(Action::Quit),
+        ])
+        .map(|value: i32| value * 10);
+
+        let stream = effect.into_stream().expect("stream should exist");
+        let (_, quit) = drain(stream).await;
+
+        assert!(quit, "Quit should pass through map over a batch");
     }
 
     #[tokio::test]

--- a/src/command/effect.rs
+++ b/src/command/effect.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 
 use futures::{
     FutureExt, Stream, StreamExt,
@@ -114,7 +114,13 @@ impl<Msg: Send + 'static> Effect<Msg> {
                     .map(|leaf| {
                         let f = Arc::clone(&f);
                         map_leaf(leaf, move |msg| {
-                            let guard = f.lock().expect("map closure mutex poisoned");
+                            // The mutex only lends `Sync` to the shared `Fn`; it
+                            // guards no mutable state, so a poisoned lock carries
+                            // no corrupted invariant. Recover the guard rather
+                            // than panicking, which would otherwise turn one
+                            // leaf's panic into a misleading "mutex poisoned"
+                            // cascade across its sibling leaves.
+                            let guard = f.lock().unwrap_or_else(PoisonError::into_inner);
                             (*guard)(msg)
                         })
                     })


### PR DESCRIPTION
## Summary

Internal refactor of `Effect` — the prerequisite for RFC 0003 (command cancellation, #136). No public API change, no observable behavior change, `src/runtime.rs` untouched.

Previously `Effect::batch` folded child streams into a single opaque stream with `select_all` **at construction time**, so a child's identity was lost at the earliest point of `Command` composition. RFC 0003's review flagged this as a structural problem: identity was erased and then the runtime tried to reconstruct strong semantics on top of it.

This PR moves the fold from construction time to the `into_stream()` boundary. `Effect` now keeps a **flat sequence of leaf streams** internally. As a result:

- child identity survives `Command` composition (`map`, `batch`);
- future per-leaf metadata (e.g. cancellation ids) can be added without reworking the representation;
- the current unkeyed behavior is fully preserved — the fold still happens at the boundary with the same `select_all`.

Cancellation itself (`CommandId` / `CancelPolicy` / `cancellable` / `cancel`) is **not** part of this PR — that is the follow-up implementation work.

## Changes

- `src/command/effect.rs`: internal representation reworked to a flat leaf sequence; behavior-pinning tests added.
- `src/command.rs`: retention-matrix tests added (test-only; no production code change).

## Design decisions

| Topic | Decision | Rationale |
|---|---|---|
| Internal representation | `enum { None, Leaves(Vec<BoxStream>) }` | A plain `Vec` was the natural choice, but `Command::is_none`/`is_some` are public `const fn` and `Vec::is_empty` only became `const` in Rust 1.87, past this crate's MSRV (1.86). The `None` variant keeps a `const`-inspectable emptiness discriminant. Invariant: `Leaves` is always non-empty. A `TODO(msrv >= 1.87)` marks the simplification back to a plain `Vec`. |
| `map` sharing | Single leaf moves `f` directly; multiple leaves share `f` via `Arc<Mutex<F>>` | The public `map` bound is `Fn + Send` (not `Sync`); `Arc<F>` alone would require `Sync`, so a `Mutex` supplies it. The common single-leaf path keeps the pre-refactor zero-overhead behavior. |
| `None`-child filtering | Dropped at `batch` time | Keeps `is_none()` O(1) / trivial. |
| Single-leaf fast path | `into_stream()` returns the sole leaf directly | A `select_all` over one stream is observably identical. |

## Behavior preserved

- `is_none()`/`is_some()`: `batch([none, none])` → none, `none().map(f)` → none, `batch([])` → none.
- `batch` delivers all child outputs (order-independent), unchanged `select_all` semantics.
- `map` applies to `Action::Message`, passes `Action::Quit` through.
- Nested `batch` flattens to a single flat leaf sequence (directly asserted via a test-only leaf-count helper).
- `RuntimeDirectives` (`without_redraw`) travel their independent path; a redraw × effect × map matrix pins the two concerns apart.

## Testing

- `cargo test` — 153 lib + 43 doc tests pass.
- `cargo clippy --all-targets` — clean (including MSRV lints).
- `cargo fmt --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)