### PR TITLE
refactor(command): add runtime command parts

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -26,10 +26,14 @@
 
 mod effect;
 mod runtime_directives;
+mod runtime_parts;
 
 use effect::Effect;
-use futures::{FutureExt, Stream, StreamExt, stream::BoxStream};
+#[cfg(test)]
+use futures::stream::BoxStream;
+use futures::{FutureExt, Stream, StreamExt};
 use runtime_directives::RuntimeDirectives;
+pub(crate) use runtime_parts::RuntimeCommandParts;
 
 /// An action that can be performed by a command.
 pub enum Action<Msg> {
@@ -134,12 +138,20 @@ impl<Msg: Send + 'static> Command<Msg> {
         self.effect.is_some()
     }
 
+    #[cfg(test)]
     pub(super) const fn requests_redraw(&self) -> bool {
         self.directives.requests_redraw()
     }
 
+    #[cfg(test)]
     pub(super) fn into_stream(self) -> Option<BoxStream<'static, Action<Msg>>> {
         self.effect.into_stream()
+    }
+
+    /// Decompose this command into the runtime-facing parts that must be
+    /// observed together.
+    pub(super) fn into_runtime_parts(self) -> RuntimeCommandParts<Msg> {
+        RuntimeCommandParts::new(self.directives, self.effect.into_stream())
     }
 
     /// Declare that the update returning this command did not change the
@@ -432,6 +444,88 @@ mod tests {
 
         assert!(cmd.is_none());
         assert!(!cmd.requests_redraw());
+    }
+
+    #[test]
+    fn test_into_runtime_parts_none_requests_redraw_without_stream() {
+        let parts = Command::<i32>::none().into_runtime_parts();
+
+        assert!(parts.requests_redraw());
+        assert!(parts.into_stream().is_none());
+    }
+
+    #[test]
+    fn test_into_runtime_parts_without_redraw_has_no_stream() {
+        let parts = Command::<i32>::none().without_redraw().into_runtime_parts();
+
+        assert!(!parts.requests_redraw());
+        assert!(parts.into_stream().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_into_runtime_parts_message_requests_redraw_and_yields_message() {
+        let parts = Command::message(42).into_runtime_parts();
+
+        assert!(parts.requests_redraw());
+
+        let mut stream = parts.into_stream().expect("stream should exist");
+        let action = stream.next().await.expect("should have action");
+
+        assert!(matches!(action, Action::Message(msg) if msg == 42));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_into_runtime_parts_effect_quit_yields_quit() {
+        let parts = Command::<i32>::effect(Action::Quit).into_runtime_parts();
+
+        assert!(parts.requests_redraw());
+
+        let mut stream = parts.into_stream().expect("stream should exist");
+        let action = stream.next().await.expect("should have action");
+
+        assert!(matches!(action, Action::Quit));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_into_runtime_parts_batch_preserves_redraw_and_stream() {
+        let cmd = Command::batch(vec![
+            Command::message(2).without_redraw(),
+            Command::none().without_redraw(),
+            Command::message(1).without_redraw(),
+        ]);
+        let parts = cmd.into_runtime_parts();
+
+        assert!(!parts.requests_redraw());
+
+        let mut stream = parts.into_stream().expect("stream should exist");
+        let mut results = vec![];
+
+        while let Some(action) = stream.next().await {
+            match action {
+                Action::Message(msg) => results.push(msg),
+                Action::Quit => break,
+            }
+        }
+
+        results.sort_unstable();
+        assert_eq!(results, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_map_preserves_directives_through_runtime_parts() {
+        let parts = Command::message(21)
+            .without_redraw()
+            .map(|value| value * 2)
+            .into_runtime_parts();
+
+        assert!(!parts.requests_redraw());
+
+        let mut stream = parts.into_stream().expect("stream should exist");
+        let action = stream.next().await.expect("should have action");
+
+        assert!(matches!(action, Action::Message(msg) if msg == 42));
     }
 
     #[tokio::test]

--- a/src/command/runtime_parts.rs
+++ b/src/command/runtime_parts.rs
@@ -1,0 +1,30 @@
+use futures::stream::BoxStream;
+
+use super::{Action, RuntimeDirectives};
+
+/// Internal command decomposition consumed by the runtime.
+///
+/// Keeps command-owned directives paired with the action stream so runtime code
+/// has a single lowering boundary for command execution.
+#[must_use = "Runtime command parts may contain side effects and directives that must be handled by the runtime."]
+pub struct RuntimeCommandParts<Msg: Send + 'static> {
+    directives: RuntimeDirectives,
+    stream: Option<BoxStream<'static, Action<Msg>>>,
+}
+
+impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
+    pub(super) const fn new(
+        directives: RuntimeDirectives,
+        stream: Option<BoxStream<'static, Action<Msg>>>,
+    ) -> Self {
+        Self { directives, stream }
+    }
+
+    pub(crate) const fn requests_redraw(&self) -> bool {
+        self.directives.requests_redraw()
+    }
+
+    pub(crate) fn into_stream(self) -> Option<BoxStream<'static, Action<Msg>>> {
+        self.stream
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -96,7 +96,7 @@ use tokio::time::{Interval, MissedTickBehavior, interval};
 
 use crate::{
     application::Application,
-    command::{Action, Command},
+    command::{Action, Command, RuntimeCommandParts},
     frame_rate::{FrameRate, FrameRateError},
     subscription::SubscriptionManager,
 };
@@ -321,8 +321,9 @@ impl<App: Application> Runtime<App> {
     }
 
     fn dispatch_update_command(&mut self, cmd: Command<App::Message>) {
-        self.needs_redraw |= cmd.requests_redraw();
-        self.state.enqueue_command(cmd);
+        let parts = cmd.into_runtime_parts();
+        self.needs_redraw |= parts.requests_redraw();
+        self.state.enqueue_command(parts);
     }
 
     /// Whether the frame tick has pending work (a redraw or a subscription
@@ -538,24 +539,25 @@ impl<App: Application> ApplicationState<App> {
         };
 
         // Enqueue the initial command
-        runtime.enqueue_command(init_cmd);
+        runtime.enqueue_command(init_cmd.into_runtime_parts());
 
         runtime
     }
 
-    /// Enqueues a command for asynchronous execution.
+    /// Enqueues decomposed command parts for asynchronous execution.
     ///
-    /// Spawns a tokio task that executes the command's action stream. Messages are sent
-    /// to the message channel, and quit signals are sent to the quit channel. The task
-    /// terminates when the stream completes or a quit action is received.
+    /// Spawns a tokio task that executes the command's action stream, if one exists.
+    /// Messages are sent to the message channel, and quit signals are sent to the quit
+    /// channel. The task terminates when the stream completes or a quit action is
+    /// received.
     ///
     /// The task is tracked in [`command_tasks`](Self::command_tasks) so it can be aborted
     /// on shutdown (or when the runtime is dropped). If the command's stream panics, the
     /// panic is caught and logged rather than silently lost.
     ///
     /// Send failures are silently ignored as they only occur during application shutdown.
-    fn enqueue_command(&mut self, cmd: Command<App::Message>) {
-        if let Some(stream) = cmd.into_stream() {
+    fn enqueue_command(&mut self, parts: RuntimeCommandParts<App::Message>) {
+        if let Some(stream) = parts.into_stream() {
             let msg_tx = self.msg_tx.clone();
             let quit_tx = self.quit_tx.clone();
 
@@ -794,7 +796,7 @@ mod tests {
         let mut runtime = ApplicationState::<TestApp>::new(0);
 
         // Enqueue a none command (should not panic)
-        runtime.enqueue_command(Command::none());
+        runtime.enqueue_command(Command::none().into_runtime_parts());
     }
 
     #[tokio::test]
@@ -803,7 +805,7 @@ mod tests {
 
         // Enqueue a command that sends a message
         let cmd = Command::future(async { TestMessage::Increment });
-        runtime.enqueue_command(cmd);
+        runtime.enqueue_command(cmd.into_runtime_parts());
 
         // Give time for message to be sent
         sleep(Duration::from_millis(50)).await;
@@ -817,7 +819,7 @@ mod tests {
 
         // Enqueue a quit command
         let cmd = Command::effect(Action::Quit);
-        runtime.enqueue_command(cmd);
+        runtime.enqueue_command(cmd.into_runtime_parts());
 
         // Give time for quit signal to be sent
         sleep(Duration::from_millis(50)).await;
@@ -1161,11 +1163,14 @@ mod tests {
         tracing::subscriber::with_default(counter, || {
             rt.block_on(async {
                 let mut state = ApplicationState::<TestApp>::new(0);
-                state.enqueue_command(Command::future(async {
-                    panic!("boom");
-                    #[allow(unreachable_code)]
-                    TestMessage::Increment
-                }));
+                state.enqueue_command(
+                    Command::future(async {
+                        panic!("boom");
+                        #[allow(unreachable_code)]
+                        TestMessage::Increment
+                    })
+                    .into_runtime_parts(),
+                );
                 // Run the command task to completion (it panics and is caught).
                 state.command_tasks.join_next().await;
             });
@@ -1199,10 +1204,13 @@ mod tests {
             let guard = AbortGuard(aborted.clone());
             // A command that owns the guard and never completes, so its task
             // stays parked until aborted.
-            state.enqueue_command(Command::future(async move {
-                let _guard = guard;
-                std::future::pending::<TestMessage>().await
-            }));
+            state.enqueue_command(
+                Command::future(async move {
+                    let _guard = guard;
+                    std::future::pending::<TestMessage>().await
+                })
+                .into_runtime_parts(),
+            );
 
             // Let the task start and park.
             sleep(Duration::from_millis(10)).await;


### PR DESCRIPTION
## Summary

- Add internal `RuntimeCommandParts` as the runtime-facing decomposition of `Command`
- Route update and initialization commands through `Command::into_runtime_parts()`
- Update runtime command enqueueing to consume decomposed parts instead of reading `Command` directly
- Add command-unit coverage for redraw directives and stream behavior through the new boundary

## Testing

- `cargo test`
- `just clippy`