### PR TITLE
fix(runtime): restart finished subscriptions on every re-evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Finished subscriptions are now restarted on every re-evaluation while still
+  requested
+  - The runtime cached a hash of the subscription IDs and skipped
+    `SubscriptionManager::update` whenever the ID set was unchanged, which
+    suppressed the manager's documented restart of subscriptions whose tasks had
+    finished (e.g. a finite source completing, or a WebSocket disconnecting)
+  - **Behavior change:** while a subscription ID keeps appearing in
+    `subscriptions()`, a finished stream is restarted after the next message. To
+    stop a source once it finishes, drop it from the returned set; keeping a
+    finished WebSocket subscription in the set is now an implicit reconnect
+
 ### Added
 
 - `Command::without_redraw()` for updates that handled a message without

--- a/benches/subscription.rs
+++ b/benches/subscription.rs
@@ -2,9 +2,6 @@
 //!
 //! These establish a regression baseline for the runtime's subscription work:
 //!
-//! - **id hashing**: the hash the runtime computes over subscription IDs each
-//!   time it decides whether the subscription set changed
-//!   ([`Runtime::update_subscriptions`](../src/runtime.rs)).
 //! - **reconcile (steady)**: [`SubscriptionManager::update`] when the requested
 //!   set is unchanged — the common per-message case, which must diff cheaply and
 //!   keep the existing tasks running.
@@ -13,12 +10,8 @@
 //!
 //! Run with `cargo bench --bench subscription`.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::stream::{self, StreamExt};
-use std::hint::black_box;
 use tears::BoxStream;
 use tears::subscription::{Subscription, SubscriptionId, SubscriptionManager, SubscriptionSource};
 
@@ -44,27 +37,6 @@ fn subscriptions(ids: impl IntoIterator<Item = u64>) -> Vec<Subscription<()>> {
     ids.into_iter()
         .map(|id| Subscription::new(BenchSource { id }))
         .collect()
-}
-
-fn subscription_ids(count: u64) -> Vec<SubscriptionId> {
-    (0..count).map(SubscriptionId::of::<BenchSource>).collect()
-}
-
-fn bench_id_hashing(c: &mut Criterion) {
-    let mut group = c.benchmark_group("subscription_id_hashing");
-    for count in [1u64, 8, 64, 256] {
-        let ids = subscription_ids(count);
-        group.bench_with_input(BenchmarkId::from_parameter(count), &ids, |b, ids| {
-            b.iter(|| {
-                let mut hasher = DefaultHasher::new();
-                for id in ids {
-                    id.hash(&mut hasher);
-                }
-                black_box(hasher.finish())
-            });
-        });
-    }
-    group.finish();
 }
 
 fn bench_reconcile_steady(c: &mut Criterion) {
@@ -123,10 +95,5 @@ fn bench_reconcile_churn(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_id_hashing,
-    bench_reconcile_steady,
-    bench_reconcile_churn
-);
+criterion_group!(benches, bench_reconcile_steady, bench_reconcile_churn);
 criterion_main!(benches);

--- a/src/application.rs
+++ b/src/application.rs
@@ -142,6 +142,18 @@ pub trait Application: Sized {
     /// tasks mutating shared state) that affects the returned subscription IDs may
     /// not be detected. Express such changes as messages handled in `update` instead.
     ///
+    /// # Restart of finished subscriptions
+    ///
+    /// A subscription is identified by its ID. While an ID keeps appearing in the
+    /// returned set, the runtime treats it as *requested*: if its stream has ended
+    /// (a finite source completing, or a WebSocket disconnecting), the runtime
+    /// **restarts it** on the next re-evaluation (i.e. after the next message).
+    /// To stop a source permanently once it finishes, drop it from the returned
+    /// set — for example by tracking completion in state updated via `update` and
+    /// returning `vec![]` (or omitting that subscription) thereafter. Keeping a
+    /// finished WebSocket subscription in the set is therefore an implicit
+    /// auto-reconnect.
+    ///
     /// # Examples
     ///
     /// ```

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -22,9 +22,9 @@
 //!   batched together for processing, reducing overhead and improving responsiveness
 //! - **Conditional Rendering**: The UI is only re-rendered when the application state
 //!   changes, skipping unnecessary draw operations
-//! - **Subscription Caching**: Subscriptions are only re-evaluated after a message is
-//!   processed (idle frames are skipped), and the subscription manager is only updated
-//!   when their IDs change, using hash-based comparison for efficiency
+//! - **Subscription Re-evaluation Gating**: Subscriptions are only re-evaluated after a
+//!   message is processed (idle frames are skipped), since `subscriptions()` is a pure
+//!   function of the application state
 //!
 //! # Example
 //!
@@ -81,8 +81,6 @@
 //! }
 //! ```
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::panic::AssertUnwindSafe;
 use std::time::{Duration, Instant};
 
@@ -151,8 +149,8 @@ struct ApplicationState<App: Application> {
 /// - **Conditional Rendering**: Only renders when state changes, saving CPU cycles
 /// - **Idle Wake-up Elision**: Skips frame ticks entirely while idle, so the loop is
 ///   event-driven and does not consume CPU at the frame rate with nothing to render
-/// - **Subscription Caching**: Re-evaluates subscriptions only after a message is processed,
-///   and updates the subscription manager only when their IDs change
+/// - **Subscription Re-evaluation Gating**: Re-evaluates subscriptions only after a message
+///   is processed, since the subscription set is a pure function of application state
 ///
 /// # Type Parameters
 ///
@@ -175,8 +173,6 @@ pub struct Runtime<App: Application> {
     /// batch so that subscriptions are re-evaluated only when the state may have
     /// changed, rather than on every frame.
     subscriptions_dirty: bool,
-    /// Cached hash of subscription IDs from previous frame (subscription caching optimization)
-    subscription_ids_hash: Option<u64>,
 }
 
 impl<App: Application> Runtime<App> {
@@ -236,7 +232,6 @@ impl<App: Application> Runtime<App> {
             // Initial subscriptions are started by `initialize_subscriptions`,
             // so no re-evaluation is needed until a message is processed.
             subscriptions_dirty: false,
-            subscription_ids_hash: None, // No subscriptions cached yet
         }
     }
 
@@ -371,8 +366,6 @@ impl<App: Application> Runtime<App> {
         // an idle frame (no messages processed) cannot change the subscription
         // set, so we skip the (potentially costly) evaluation entirely.
         if self.subscriptions_dirty {
-            // NOTE: Uses hash-based caching to skip the manager update when the
-            // subscription IDs haven't actually changed.
             self.update_subscriptions();
             self.subscriptions_dirty = false;
         }
@@ -380,28 +373,23 @@ impl<App: Application> Runtime<App> {
         Ok(())
     }
 
-    /// Updates subscriptions if they have changed (uses hash-based caching).
+    /// Re-evaluates the application's subscriptions and applies them.
     ///
-    /// Computes a hash of subscription IDs and only calls [`SubscriptionManager::update`]
-    /// if the hash differs from the previous frame. This optimization avoids unnecessary
-    /// subscription updates when the application's subscription set hasn't changed.
+    /// Calls [`Application::subscriptions`] and hands the result to
+    /// [`SubscriptionManager::update`], which diffs against the running set: it
+    /// starts new subscriptions, cancels removed ones, and — crucially —
+    /// restarts subscriptions whose tasks have finished but are still requested.
+    ///
+    /// The manager's diff is already ID-keyed and cheap, so this is called on
+    /// every dirty frame without an additional caching layer. An earlier
+    /// hash-of-IDs cache here skipped the manager update whenever the ID set was
+    /// unchanged, which suppressed the restart of finished subscriptions and
+    /// violated the manager's documented contract.
     fn update_subscriptions(&mut self) {
         let subscriptions = self.state.app.subscriptions();
-
-        // Compute hash of subscription IDs
-        let mut hasher = DefaultHasher::new();
-        for sub in &subscriptions {
-            sub.id.hash(&mut hasher);
-        }
-        let current_hash = hasher.finish();
-
-        // Only update if subscriptions have changed
-        if self.subscription_ids_hash != Some(current_hash) {
-            let count = subscriptions.len();
-            self.state.subscription_manager.update(subscriptions);
-            self.subscription_ids_hash = Some(current_hash);
-            tracing::debug!(target: "tears::runtime", count, "subscriptions updated");
-        }
+        let count = subscriptions.len();
+        self.state.subscription_manager.update(subscriptions);
+        tracing::debug!(target: "tears::runtime", count, "subscriptions updated");
     }
 
     /// Runs the runtime until the application quits.
@@ -1487,18 +1475,15 @@ mod tests {
         // Clear needs_redraw
         runtime.needs_redraw = false;
 
-        // Initially no hash
-        assert_eq!(runtime.subscription_ids_hash, None);
-
         // Subscriptions are only re-evaluated when marked dirty (after a
         // message). Simulate that here.
         runtime.subscriptions_dirty = true;
 
-        // Process frame tick (should update subscriptions)
+        // Process frame tick (should re-evaluate and apply subscriptions).
         runtime.process_frame_tick(&mut terminal)?;
 
-        // Hash should be set
-        assert!(runtime.subscription_ids_hash.is_some());
+        // The dirty flag is cleared once subscriptions have been re-evaluated.
+        assert!(!runtime.subscriptions_dirty);
 
         Ok(())
     }
@@ -1583,6 +1568,117 @@ mod tests {
         runtime.process_frame_tick(&mut terminal)?;
         runtime.process_frame_tick(&mut terminal)?;
         assert_eq!(counter.load(Ordering::SeqCst), 1);
+
+        Ok(())
+    }
+
+    // Regression test: a finished subscription must be restarted on every
+    // re-evaluation even when its ID is unchanged.
+    //
+    // `SubscriptionManager::update` documents that "subscriptions whose tasks
+    // have finished will be restarted if still present". An earlier hash-of-IDs
+    // cache in `update_subscriptions` skipped the manager update whenever the ID
+    // set was unchanged. The skip only bit on the *second* re-evaluation: the
+    // first cached the hash (and did restart), but every later re-evaluation
+    // with the same ID set was elided, so a finite subscription that finished
+    // again was never restarted. This test therefore drives two message-gated
+    // re-evaluations and asserts the subscription restarts each time. Removing
+    // the cache means every dirty frame calls `update`, restoring the restart.
+    #[tokio::test]
+    async fn test_finished_subscription_restarted_with_unchanged_id() -> Result<()> {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures::stream::{self, BoxStream};
+
+        use crate::subscription::{SubscriptionId, SubscriptionSource};
+
+        // A subscription with a fixed ID whose stream emits one value and then
+        // ends. It counts how many times its stream is spawned so a restart is
+        // observable.
+        struct OneshotSource {
+            spawns: Arc<AtomicUsize>,
+        }
+
+        impl SubscriptionSource for OneshotSource {
+            type Output = ();
+
+            fn stream(&self) -> BoxStream<'static, ()> {
+                self.spawns.fetch_add(1, Ordering::SeqCst);
+                stream::once(async {}).boxed()
+            }
+
+            fn id(&self) -> SubscriptionId {
+                // A constant ID: the set of IDs never changes across frames,
+                // which is exactly the case the removed hash cache skipped.
+                SubscriptionId::of::<Self>(0)
+            }
+        }
+
+        struct RestartApp {
+            spawns: Arc<AtomicUsize>,
+        }
+
+        impl Application for RestartApp {
+            type Message = ();
+            type Flags = Arc<AtomicUsize>;
+
+            fn new(spawns: Arc<AtomicUsize>) -> (Self, Command<Self::Message>) {
+                (Self { spawns }, Command::none())
+            }
+
+            fn update(&mut self, (): ()) -> Command<Self::Message> {
+                Command::none()
+            }
+
+            fn view(&self, _frame: &mut Frame<'_>) {}
+
+            fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+                vec![Subscription::new(OneshotSource {
+                    spawns: self.spawns.clone(),
+                })]
+            }
+        }
+
+        // Polls the spawn counter until it reaches `target`, or fails after a
+        // bounded wait so a regression cannot hang the suite.
+        async fn wait_for_spawns(spawns: &AtomicUsize, target: usize) {
+            for _ in 0..100 {
+                if spawns.load(Ordering::SeqCst) >= target {
+                    return;
+                }
+                sleep(Duration::from_millis(5)).await;
+            }
+            assert!(
+                spawns.load(Ordering::SeqCst) >= target,
+                "expected at least {target} spawns, saw {}",
+                spawns.load(Ordering::SeqCst)
+            );
+        }
+
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let mut runtime = Runtime::<RestartApp>::new(spawns.clone(), frame_rate(60));
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        // Start subscriptions the way `run()` does: the first spawn happens here.
+        runtime.state.initialize_subscriptions();
+        wait_for_spawns(&spawns, 1).await;
+
+        // Drive two message-gated re-evaluations. The ID never changes, so the
+        // removed hash cache would have skipped the manager update from the
+        // second round onward, leaving the finished subscription dead. Each
+        // round must restart it, so the spawn count must keep climbing.
+        for round in 2..=3 {
+            // Let the current one-shot task finish so the manager sees it as
+            // completed before the next re-evaluation.
+            sleep(Duration::from_millis(10)).await;
+
+            // A message marks subscriptions dirty; the next frame re-evaluates.
+            runtime.process_message_batch(());
+            runtime.process_frame_tick(&mut terminal)?;
+
+            wait_for_spawns(&spawns, round).await;
+        }
 
         Ok(())
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -389,7 +389,10 @@ impl<App: Application> Runtime<App> {
         let subscriptions = self.state.app.subscriptions();
         let count = subscriptions.len();
         self.state.subscription_manager.update(subscriptions);
-        tracing::debug!(target: "tears::runtime", count, "subscriptions updated");
+        // Fires on every dirty frame regardless of whether the set actually
+        // changed; the accurate change signals are the manager's
+        // "subscription started"/"subscription stopped" events.
+        tracing::debug!(target: "tears::runtime", count, "subscriptions re-evaluated");
     }
 
     /// Runs the runtime until the application quits.
@@ -1434,17 +1437,44 @@ mod tests {
 
     #[tokio::test]
     async fn test_event_loop_process_frame_tick_updates_subscriptions() -> Result<()> {
-        // App with dynamic subscriptions
-        struct DynamicApp {
-            enabled: bool,
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use futures::stream::{self, BoxStream};
+
+        use crate::subscription::{SubscriptionId, SubscriptionSource};
+
+        // A subscription whose stream stays parked (never yields), so once
+        // started its task stays alive. Counts how many times it is spawned so
+        // that "the frame tick actually applied the subscriptions" is
+        // observable rather than merely inferred from the dirty flag.
+        struct ParkedSource {
+            spawns: Arc<AtomicUsize>,
         }
 
-        impl Application for DynamicApp {
-            type Message = ();
-            type Flags = bool;
+        impl SubscriptionSource for ParkedSource {
+            type Output = ();
 
-            fn new(enabled: bool) -> (Self, Command<Self::Message>) {
-                (Self { enabled }, Command::none())
+            fn stream(&self) -> BoxStream<'static, ()> {
+                self.spawns.fetch_add(1, Ordering::SeqCst);
+                stream::pending().boxed()
+            }
+
+            fn id(&self) -> SubscriptionId {
+                SubscriptionId::of::<Self>(0)
+            }
+        }
+
+        struct App {
+            spawns: Arc<AtomicUsize>,
+        }
+
+        impl Application for App {
+            type Message = ();
+            type Flags = Arc<AtomicUsize>;
+
+            fn new(spawns: Arc<AtomicUsize>) -> (Self, Command<Self::Message>) {
+                (Self { spawns }, Command::none())
             }
 
             fn update(&mut self, (): ()) -> Command<Self::Message> {
@@ -1454,36 +1484,44 @@ mod tests {
             fn view(&self, _frame: &mut Frame<'_>) {}
 
             fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
-                if self.enabled {
-                    vec![
-                        Subscription::new(
-                            Timer::try_new(100).expect("timer interval must be non-zero"),
-                        )
-                        .map(|_| ()),
-                    ]
-                } else {
-                    vec![]
-                }
+                vec![Subscription::new(ParkedSource {
+                    spawns: self.spawns.clone(),
+                })]
             }
         }
 
-        let mut runtime = Runtime::<DynamicApp>::new(true, frame_rate(60));
+        let spawns = Arc::new(AtomicUsize::new(0));
+        let mut runtime = Runtime::<App>::new(spawns.clone(), frame_rate(60));
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
 
-        // Clear needs_redraw
+        // Clear needs_redraw so only the subscription path exercises the tick.
         runtime.needs_redraw = false;
+
+        // Not yet applied: no frame tick has run.
+        assert_eq!(spawns.load(Ordering::SeqCst), 0);
 
         // Subscriptions are only re-evaluated when marked dirty (after a
         // message). Simulate that here.
         runtime.subscriptions_dirty = true;
 
-        // Process frame tick (should re-evaluate and apply subscriptions).
+        // Process frame tick: it must re-evaluate and actually start the
+        // subscription, and clear the dirty flag.
         runtime.process_frame_tick(&mut terminal)?;
 
-        // The dirty flag is cleared once subscriptions have been re-evaluated.
         assert!(!runtime.subscriptions_dirty);
+        for _ in 0..100 {
+            if spawns.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            sleep(Duration::from_millis(5)).await;
+        }
+        assert_eq!(
+            spawns.load(Ordering::SeqCst),
+            1,
+            "a dirty frame tick must actually start the requested subscription"
+        );
 
         Ok(())
     }

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -15,6 +15,17 @@
 //! sending, see the "Design Philosophy" section in the [`subscription`](crate::subscription)
 //! module documentation.
 //!
+//! # Disconnection and reconnection
+//!
+//! The subscription's stream ends when the connection closes (server close,
+//! transport error, etc.). While the application keeps returning this
+//! subscription from [`Application::subscriptions`](crate::Application::subscriptions),
+//! the runtime restarts the finished stream on the next re-evaluation — i.e. it
+//! reconnects automatically after the next message. To stop reconnecting, drop
+//! the subscription from the returned set once you observe
+//! [`WebSocketMessage::Disconnected`]. See the "Restart of finished
+//! subscriptions" note on [`Application::subscriptions`](crate::Application::subscriptions).
+//!
 //! # Feature Flag
 //!
 //! This module is only available when the `ws` feature is enabled:


### PR DESCRIPTION
## Summary

`Runtime::update_subscriptions` kept a hash of the subscription IDs from the previous re-evaluation and skipped `SubscriptionManager::update` whenever the ID set was unchanged. Because the hash was seeded on the *first* re-evaluation, every later re-evaluation with the same ID set was elided and the manager was never consulted.

This silently broke the manager's documented contract (`src/subscription.rs`):

> Subscriptions whose tasks have finished will be restarted if still present

A finite subscription (e.g. one backed by `stream::once`) that completed was never restarted, even though the application still requested it — the manager only saw it again on the first re-evaluation.

## Fix

The manager's diff is already ID-keyed and cheap, and `subscriptions()` is still only re-evaluated on dirty frames (after a message via `subscriptions_dirty`), so the hash layer saved almost nothing while introducing the bug. This removes the `subscription_ids_hash` field and its hashing logic, letting every dirty frame call `update` and restoring the restart. The re-evaluation gating (`subscriptions_dirty`) is unchanged.

## Verification

Added a regression test (`test_finished_subscription_restarted_with_unchanged_id`) that drives two message-gated re-evaluations of a fixed-ID one-shot subscription and asserts it restarts each time.

- ✅ passes with the fix
- ❌ fails with the hash cache reintroduced (confirmed by temporarily restoring the old behavior)
- The skip only bit on the *second* re-evaluation, which is why the test drives two rounds rather than one.

`cargo test`, `cargo clippy --all-targets`, and `cargo fmt --check` are all clean.

## Scope

Bug fix only — the broader `runtime.rs` refactor (render/subscription scheduler extraction, e2e test migration) is intentionally deferred to follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)