### PR TITLE
refactor(runtime): extract PendingWork for frame gating

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -100,8 +100,10 @@ use crate::{
 };
 
 mod app_input;
+mod pending_work;
 
 use app_input::{AppInput, AppInputs};
+use pending_work::PendingWork;
 
 /// Application state that manages the application lifecycle.
 ///
@@ -164,15 +166,8 @@ pub struct Runtime<App: Application> {
     state: ApplicationState<App>,
     /// Timer for frame rate regulation
     frame_interval: Interval,
-    /// Whether the UI needs to be re-rendered (conditional rendering optimization)
-    needs_redraw: bool,
-    /// Whether subscriptions may have changed and should be re-evaluated.
-    ///
-    /// `subscriptions()` is a pure function of the application state, which only
-    /// changes when a message is processed. This flag is set after each message
-    /// batch so that subscriptions are re-evaluated only when the state may have
-    /// changed, rather than on every frame.
-    subscriptions_dirty: bool,
+    /// Tracks pending render/subscription work and gates the frame branch
+    pending: PendingWork,
 }
 
 impl<App: Application> Runtime<App> {
@@ -228,10 +223,7 @@ impl<App: Application> Runtime<App> {
         Self {
             state,
             frame_interval,
-            needs_redraw: true, // Initial draw is always needed
-            // Initial subscriptions are started by `initialize_subscriptions`,
-            // so no re-evaluation is needed until a message is processed.
-            subscriptions_dirty: false,
+            pending: PendingWork::new(),
         }
     }
 
@@ -282,8 +274,8 @@ impl<App: Application> Runtime<App> {
     /// inputs that arrived within 100μs. This reduces overhead by batching rapid
     /// input sequences while maintaining responsiveness.
     ///
-    /// Sets `needs_redraw` if any processed command requests a redraw, and
-    /// always sets `subscriptions_dirty` after processing.
+    /// Records a redraw request if any processed command wants one, and always
+    /// marks subscriptions dirty after processing.
     fn process_input_batch(&mut self, first_input: AppInput<App::Message>) {
         self.process_app_input(first_input);
         let mut processed = 1usize;
@@ -303,7 +295,7 @@ impl<App: Application> Runtime<App> {
         tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
 
         // Mark that subscriptions may have changed even when redraw is suppressed.
-        self.subscriptions_dirty = true;
+        self.pending.mark_subscriptions_dirty();
     }
 
     fn process_app_input(&mut self, input: AppInput<App::Message>) {
@@ -317,30 +309,16 @@ impl<App: Application> Runtime<App> {
 
     fn dispatch_update_command(&mut self, cmd: Command<App::Message>) {
         let parts = cmd.into_runtime_parts();
-        self.needs_redraw |= parts.requests_redraw();
+        self.pending.record_redraw(parts.requests_redraw());
         self.state.enqueue_command(parts);
-    }
-
-    /// Whether the frame tick has pending work (a redraw or a subscription
-    /// re-evaluation) to do.
-    ///
-    /// Used to gate the frame branch of the event loop's `select!`: when the
-    /// application is idle (no message has been processed since the last frame),
-    /// both flags are false and there is nothing for a frame tick to do. Skipping
-    /// the tick entirely means the loop no longer wakes up at the frame rate while
-    /// idle, turning the loop event-driven and saving CPU/battery.
-    ///
-    /// Must use `||` (not `&&`): the initial state has `needs_redraw == true` and
-    /// `subscriptions_dirty == false`, and the first frame must still render.
-    const fn should_process_frame(&self) -> bool {
-        self.needs_redraw || self.subscriptions_dirty
     }
 
     /// Processes a frame tick: renders if needed and updates subscriptions.
     ///
-    /// Only renders when `needs_redraw` is true (conditional rendering optimization).
-    /// Only re-evaluates subscriptions when `subscriptions_dirty` is true, i.e. when
-    /// a message has been processed since the last evaluation.
+    /// Only renders when [`PendingWork`] has a pending redraw (conditional
+    /// rendering optimization). Only re-evaluates subscriptions when it has marked
+    /// them dirty, i.e. when a message has been processed since the last
+    /// evaluation.
     ///
     /// Quit is not detected here: the event loop's `select!` has a dedicated
     /// `quit_rx.recv()` branch that handles it, so this method only renders and
@@ -355,9 +333,8 @@ impl<App: Application> Runtime<App> {
         tracing::trace!(target: "tears::runtime::frame", "frame tick");
 
         // Render only if state has changed
-        if self.needs_redraw {
+        if self.pending.take_redraw() {
             self.state.render(terminal)?;
-            self.needs_redraw = false;
             tracing::trace!(target: "tears::runtime", "frame rendered");
         }
 
@@ -365,9 +342,8 @@ impl<App: Application> Runtime<App> {
         // Since `subscriptions()` is a pure function of the application state,
         // an idle frame (no messages processed) cannot change the subscription
         // set, so we skip the (potentially costly) evaluation entirely.
-        if self.subscriptions_dirty {
+        if self.pending.take_subscriptions_dirty() {
             self.update_subscriptions();
-            self.subscriptions_dirty = false;
         }
 
         Ok(())
@@ -481,7 +457,7 @@ impl<App: Application> Runtime<App> {
                 // timer deadline has already elapsed, so `tick()` is ready on the
                 // next poll and adds no render latency. `MissedTickBehavior::Skip`
                 // only controls where the following tick lands (no catch-up burst).
-                _ = self.frame_interval.tick(), if self.should_process_frame() => {
+                _ = self.frame_interval.tick(), if self.pending.has_pending_work() => {
                     self.process_frame_tick(terminal)?;
                 }
 
@@ -1029,20 +1005,20 @@ mod tests {
         assert_eq!(runtime.state.app.counter, 1);
 
         // Redraw should be needed
-        assert!(runtime.needs_redraw);
+        assert!(runtime.pending.needs_redraw);
     }
 
     #[tokio::test]
     async fn test_process_message_batch_without_redraw_leaves_redraw_unchanged() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.needs_redraw = false;
-        runtime.subscriptions_dirty = false;
+        runtime.pending.needs_redraw = false;
+        runtime.pending.subscriptions_dirty = false;
 
         runtime.process_message_batch(RedrawControlMessage::Skip);
 
-        assert!(!runtime.needs_redraw);
+        assert!(!runtime.pending.needs_redraw);
         assert!(
-            runtime.subscriptions_dirty,
+            runtime.pending.subscriptions_dirty,
             "redraw suppression must not suppress subscription re-evaluation"
         );
     }
@@ -1050,29 +1026,29 @@ mod tests {
     #[tokio::test]
     async fn test_process_message_batch_mixed_commands_redraws() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.needs_redraw = false;
-        runtime.subscriptions_dirty = false;
+        runtime.pending.needs_redraw = false;
+        runtime.pending.subscriptions_dirty = false;
 
         let _ = runtime.state.msg_tx.send(RedrawControlMessage::Redraw);
         runtime.process_message_batch(RedrawControlMessage::Skip);
 
-        assert!(runtime.needs_redraw);
-        assert!(runtime.subscriptions_dirty);
+        assert!(runtime.pending.needs_redraw);
+        assert!(runtime.pending.subscriptions_dirty);
     }
 
     #[tokio::test]
     async fn test_process_message_batch_redraw_recovers_after_suppression() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.needs_redraw = false;
+        runtime.pending.needs_redraw = false;
 
         runtime.process_message_batch(RedrawControlMessage::Skip);
-        assert!(!runtime.needs_redraw);
+        assert!(!runtime.pending.needs_redraw);
 
-        runtime.subscriptions_dirty = false;
+        runtime.pending.subscriptions_dirty = false;
         runtime.process_message_batch(RedrawControlMessage::Redraw);
 
-        assert!(runtime.needs_redraw);
-        assert!(runtime.subscriptions_dirty);
+        assert!(runtime.pending.needs_redraw);
+        assert!(runtime.pending.subscriptions_dirty);
     }
 
     // A minimal `tracing::Subscriber` that counts emitted events (total, and
@@ -1271,7 +1247,7 @@ mod tests {
         }
 
         let mut runtime = Runtime::<BatchOrderApp>::new((), frame_rate(60));
-        runtime.subscriptions_dirty = false;
+        runtime.pending.subscriptions_dirty = false;
 
         runtime
             .state
@@ -1287,7 +1263,7 @@ mod tests {
         runtime.process_input_batch(AppInput::Shared(1));
 
         assert_eq!(runtime.state.app.messages, vec![1, 2, 3]);
-        assert!(runtime.subscriptions_dirty);
+        assert!(runtime.pending.subscriptions_dirty);
     }
 
     #[tokio::test]
@@ -1298,13 +1274,13 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Initially needs_redraw is true
-        assert!(runtime.needs_redraw);
+        assert!(runtime.pending.needs_redraw);
 
         // Process frame tick
         runtime.process_frame_tick(&mut terminal)?;
 
         // Redraw flag should be cleared
-        assert!(!runtime.needs_redraw);
+        assert!(!runtime.pending.needs_redraw);
 
         Ok(())
     }
@@ -1317,13 +1293,13 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Clear the needs_redraw flag
-        runtime.needs_redraw = false;
+        runtime.pending.needs_redraw = false;
 
         // Process frame tick
         runtime.process_frame_tick(&mut terminal)?;
 
         // Redraw flag should still be false
-        assert!(!runtime.needs_redraw);
+        assert!(!runtime.pending.needs_redraw);
 
         Ok(())
     }
@@ -1352,7 +1328,7 @@ mod tests {
     }
 
     // Quit must terminate the loop even while idle, i.e. after the initial frame
-    // has rendered and the frame branch is gated off by `should_process_frame()`.
+    // has rendered and the frame branch is gated off by `has_pending_work()`.
     // This is the exact safety property the frame-branch gating relies on: the
     // `quit_rx.recv()` branch is always armed, so a quit arriving with no pending
     // redraw or subscription work is still received.
@@ -1395,42 +1371,37 @@ mod tests {
 
     // --- Idle frame wake-up elision -----------------------------------------
     //
-    // The event loop gates its frame branch on `should_process_frame()` so an
-    // idle loop stops waking at the frame rate. These unit tests cover the gate
-    // predicate in isolation; the end-to-end behavior (zero idle wake-ups, and
+    // The event loop gates its frame branch on `PendingWork::has_pending_work()`
+    // so an idle loop stops waking at the frame rate. The predicate's pure logic
+    // is unit-tested in `pending_work`; these tests cover the Runtime-level
+    // integration — that a real frame tick drains the pending work and a processed
+    // message re-arms the branch. The end-to-end behavior (zero idle wake-ups, and
     // an immediate render once a message re-enables the branch) is covered by
     // `tests/idle_wakeup.rs`.
 
     #[tokio::test]
-    async fn test_should_process_frame_initial_state_allows_first_frame() {
-        // Fresh runtime: `needs_redraw == true`, so the first frame must render.
-        let runtime = Runtime::<TestApp>::new(0, frame_rate(60));
-        assert!(runtime.should_process_frame());
-    }
-
-    #[tokio::test]
-    async fn test_should_process_frame_is_gated_off_when_idle() -> Result<()> {
+    async fn test_frame_branch_gated_off_when_idle() -> Result<()> {
         let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
 
         // Draining the initial pending work leaves both flags false: idle.
         runtime.process_frame_tick(&mut terminal)?;
-        assert!(!runtime.should_process_frame());
+        assert!(!runtime.pending.has_pending_work());
 
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_should_process_frame_reenabled_after_message() -> Result<()> {
+    async fn test_frame_branch_reenabled_after_message() -> Result<()> {
         let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
 
         runtime.process_frame_tick(&mut terminal)?;
-        assert!(!runtime.should_process_frame());
+        assert!(!runtime.pending.has_pending_work());
 
         // A processed message re-enables the frame branch.
         runtime.process_message_batch(TestMessage::Increment);
-        assert!(runtime.should_process_frame());
+        assert!(runtime.pending.has_pending_work());
 
         Ok(())
     }
@@ -1497,20 +1468,20 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Clear needs_redraw so only the subscription path exercises the tick.
-        runtime.needs_redraw = false;
+        runtime.pending.needs_redraw = false;
 
         // Not yet applied: no frame tick has run.
         assert_eq!(spawns.load(Ordering::SeqCst), 0);
 
         // Subscriptions are only re-evaluated when marked dirty (after a
         // message). Simulate that here.
-        runtime.subscriptions_dirty = true;
+        runtime.pending.subscriptions_dirty = true;
 
         // Process frame tick: it must re-evaluate and actually start the
         // subscription, and clear the dirty flag.
         runtime.process_frame_tick(&mut terminal)?;
 
-        assert!(!runtime.subscriptions_dirty);
+        assert!(!runtime.pending.subscriptions_dirty);
         for _ in 0..100 {
             if spawns.load(Ordering::SeqCst) == 1 {
                 break;

--- a/src/runtime/pending_work.rs
+++ b/src/runtime/pending_work.rs
@@ -1,0 +1,182 @@
+//! Pending render/subscription work tracking for the runtime event loop.
+//!
+//! The runtime renders conditionally (only when the view may have changed) and
+//! re-evaluates subscriptions only after a message has been processed. This
+//! module owns those two flags and the [`PendingWork::has_pending_work`] query
+//! that the event loop uses to gate its frame branch, keeping that bookkeeping
+//! out of the main loop.
+//!
+//! This type tracks *whether* there is work; it does not own the frame timer or
+//! decide *when* to run — the runtime still owns the `Interval` and the
+//! `take` → render/update ordering.
+
+/// Tracks whether the runtime has pending render or subscription work.
+///
+/// Fields are `pub(super)` so the parent `runtime` module (and its tests) can
+/// inspect them directly; the methods express the intended transitions.
+pub(super) struct PendingWork {
+    /// Whether the UI needs to be re-rendered (conditional rendering optimization).
+    pub(super) needs_redraw: bool,
+    /// Whether subscriptions may have changed and should be re-evaluated.
+    ///
+    /// `subscriptions()` is a pure function of the application state, which only
+    /// changes when a message is processed. This flag is set after each message
+    /// batch so that subscriptions are re-evaluated only when the state may have
+    /// changed, rather than on every frame.
+    pub(super) subscriptions_dirty: bool,
+}
+
+impl PendingWork {
+    /// Creates the tracker in the initial state.
+    ///
+    /// The first frame must always render, so `needs_redraw` starts `true`. No
+    /// subscription re-evaluation is pending: the initial subscriptions are
+    /// started by the runtime before the loop begins, so `subscriptions_dirty`
+    /// starts `false`.
+    pub(super) const fn new() -> Self {
+        Self {
+            needs_redraw: true,
+            subscriptions_dirty: false,
+        }
+    }
+
+    /// Records whether a processed command requested a redraw.
+    ///
+    /// Uses `|=` so that a command opting out of a redraw cannot clear a redraw
+    /// already requested by another command in the same batch.
+    pub(super) const fn record_redraw(&mut self, requested: bool) {
+        self.needs_redraw |= requested;
+    }
+
+    /// Marks that subscriptions may have changed and should be re-evaluated on
+    /// the next frame. Called after each processed message batch, even when the
+    /// batch suppressed a redraw.
+    pub(super) const fn mark_subscriptions_dirty(&mut self) {
+        self.subscriptions_dirty = true;
+    }
+
+    /// Whether the frame tick has pending work (a redraw or a subscription
+    /// re-evaluation) to do.
+    ///
+    /// Gates the frame branch of the event loop's `select!`: when the application
+    /// is idle (no message processed since the last frame), both flags are false
+    /// and a frame tick would do nothing, so the loop can skip waking at the
+    /// frame rate entirely — making it event-driven and saving CPU/battery.
+    ///
+    /// Must use `||` (not `&&`): the initial state has `needs_redraw == true` and
+    /// `subscriptions_dirty == false`, and the first frame must still render.
+    pub(super) const fn has_pending_work(&self) -> bool {
+        self.needs_redraw || self.subscriptions_dirty
+    }
+
+    /// Returns whether a redraw is pending and clears the flag.
+    pub(super) const fn take_redraw(&mut self) -> bool {
+        let pending = self.needs_redraw;
+        self.needs_redraw = false;
+        pending
+    }
+
+    /// Returns whether subscriptions need re-evaluation and clears the flag.
+    pub(super) const fn take_subscriptions_dirty(&mut self) -> bool {
+        let pending = self.subscriptions_dirty;
+        self.subscriptions_dirty = false;
+        pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_starts_with_a_pending_first_frame() {
+        let pending = PendingWork::new();
+        assert!(pending.needs_redraw, "the first frame must render");
+        assert!(
+            !pending.subscriptions_dirty,
+            "initial subscriptions are started outside the frame loop"
+        );
+        assert!(pending.has_pending_work());
+    }
+
+    #[test]
+    fn has_pending_work_is_the_or_of_both_flags() {
+        // Exhaustive truth table: the gate must fire when either flag is set,
+        // and only go idle when both are clear.
+        for (needs_redraw, subscriptions_dirty, expected) in [
+            (false, false, false),
+            (true, false, true),
+            (false, true, true),
+            (true, true, true),
+        ] {
+            let pending = PendingWork {
+                needs_redraw,
+                subscriptions_dirty,
+            };
+            assert_eq!(
+                pending.has_pending_work(),
+                expected,
+                "needs_redraw={needs_redraw}, subscriptions_dirty={subscriptions_dirty}"
+            );
+        }
+    }
+
+    #[test]
+    fn record_redraw_never_clears_an_existing_request() {
+        let mut pending = PendingWork::new();
+        pending.take_redraw(); // clear the initial pending frame
+
+        // A command that does not request a redraw leaves the flag clear.
+        pending.record_redraw(false);
+        assert!(!pending.needs_redraw);
+
+        // A command that requests a redraw sets it.
+        pending.record_redraw(true);
+        assert!(pending.needs_redraw);
+
+        // A later opt-out cannot clear an already-requested redraw.
+        pending.record_redraw(false);
+        assert!(pending.needs_redraw);
+    }
+
+    #[test]
+    fn mark_subscriptions_dirty_sets_the_flag() {
+        let mut pending = PendingWork::new();
+        assert!(!pending.subscriptions_dirty);
+        pending.mark_subscriptions_dirty();
+        assert!(pending.subscriptions_dirty);
+    }
+
+    #[test]
+    fn take_redraw_returns_then_clears() {
+        let mut pending = PendingWork::new();
+        assert!(pending.take_redraw(), "initial state has a pending redraw");
+        assert!(!pending.needs_redraw);
+        assert!(!pending.take_redraw(), "already taken");
+    }
+
+    #[test]
+    fn take_subscriptions_dirty_returns_then_clears() {
+        let mut pending = PendingWork::new();
+        pending.mark_subscriptions_dirty();
+        assert!(pending.take_subscriptions_dirty());
+        assert!(!pending.subscriptions_dirty);
+        assert!(!pending.take_subscriptions_dirty(), "already taken");
+    }
+
+    #[test]
+    fn goes_idle_once_pending_work_is_drained() {
+        let mut pending = PendingWork::new();
+        pending.mark_subscriptions_dirty();
+
+        // Draining both kinds of pending work leaves the tracker idle, so the
+        // event loop's frame branch is gated off.
+        pending.take_redraw();
+        pending.take_subscriptions_dirty();
+        assert!(!pending.has_pending_work());
+
+        // A new message batch re-arms the frame branch.
+        pending.mark_subscriptions_dirty();
+        assert!(pending.has_pending_work());
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #140 (work item (b) from the `runtime.rs` responsibility review). `Runtime` mixed the pending render/subscription bookkeeping into the event loop: two loose flags (`needs_redraw`, `subscriptions_dirty`), the frame-branch gate predicate, and inline flag mutations scattered across the update/dispatch/frame paths.

This extracts that concern into a new `runtime::pending_work` module.

## Naming

An earlier revision of this branch called the type `FrameScheduler`, but it does **not** schedule: it neither owns the frame timer (`Interval`) nor decides *when* to run — it only tracks *whether* there is pending work. Naming it `PendingWork` keeps the abstraction honest. (A later PR may fold the `Interval` in and introduce a genuine `FrameScheduler` that owns `PendingWork` + timing + the idle-gating future; this PR is the pure-tracker foundation for that.)

## Changes

- **`PendingWork`** (`src/runtime/pending_work.rs`) owns the two flags and exposes named transitions:
  - `record_redraw(bool)` — OR-in a command's redraw request (an opt-out can't clear an existing request)
  - `mark_subscriptions_dirty()` — after each message batch
  - `take_redraw()` / `take_subscriptions_dirty()` — return-and-clear, used by the frame tick
  - `has_pending_work()` — the idle-gating predicate
- **`Runtime`** holds a `PendingWork` and delegates. The frame timer and the `take` → render/update ordering stay in `Runtime` — a deliberate boundary: the tracker knows *whether* there is work, the runtime decides *what* the frame does.
- **Tests distributed with the code:** the flag-logic unit tests (predicate truth table, `record_redraw` OR-semantics, take/reset behavior) live in the new module as pure tests. Runtime-level tests still cover the integration (a real frame tick drains the work; a message re-arms the branch), and `tests/idle_wakeup.rs` still covers end-to-end.

## No behavior change

The flags, their initial values (`needs_redraw = true`, `subscriptions_dirty = false`), and the `||` gating predicate are identical.

`cargo test --all-features`, `cargo clippy --all-targets --all-features`, and `cargo fmt --check` are all clean.

## Deferred

- **Interval integration** (fold `Interval` into a real `FrameScheduler { interval, pending: PendingWork }` with a parked-future `next_work_frame()` that internalizes the idle gate) — separate PR, to keep this mechanical extraction reviewable.
- Angle 1 (tracing-based e2e for the command-panic test) and Angle 2 (`RuntimeHandle`, RFC-gated) remain separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)