### PR TITLE
refactor(runtime): fold the frame timer into a FrameScheduler

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -90,7 +90,6 @@ use futures::stream::StreamExt;
 use ratatui::prelude::Backend;
 use tokio::sync::mpsc;
 use tokio::task::JoinSet;
-use tokio::time::{Interval, MissedTickBehavior, interval};
 
 use crate::{
     application::Application,
@@ -100,10 +99,11 @@ use crate::{
 };
 
 mod app_input;
+mod frame_scheduler;
 mod pending_work;
 
 use app_input::{AppInput, AppInputs};
-use pending_work::PendingWork;
+use frame_scheduler::FrameScheduler;
 
 /// Application state that manages the application lifecycle.
 ///
@@ -164,10 +164,8 @@ struct ApplicationState<App: Application> {
 pub struct Runtime<App: Application> {
     /// Application state and message routing
     state: ApplicationState<App>,
-    /// Timer for frame rate regulation
-    frame_interval: Interval,
-    /// Tracks pending render/subscription work and gates the frame branch
-    pending: PendingWork,
+    /// Schedules frame work and gates idle wake-ups
+    scheduler: FrameScheduler,
 }
 
 impl<App: Application> Runtime<App> {
@@ -212,18 +210,9 @@ impl<App: Application> Runtime<App> {
     pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self {
         let state = ApplicationState::new(flags);
 
-        // Divide a one-second `Duration` directly so the period is exact (e.g.
-        // 60 FPS -> 16.667ms) instead of truncating to whole milliseconds (the
-        // old `1000 / frame_rate` gave 16ms, an effective ~62.5 FPS).
-        let frame_duration = frame_rate.frame_duration();
-        let mut frame_interval = interval(frame_duration);
-        // Skip missed frames rather than trying to catch up
-        frame_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
         Self {
             state,
-            frame_interval,
-            pending: PendingWork::new(),
+            scheduler: FrameScheduler::new(frame_rate),
         }
     }
 
@@ -295,7 +284,7 @@ impl<App: Application> Runtime<App> {
         tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
 
         // Mark that subscriptions may have changed even when redraw is suppressed.
-        self.pending.mark_subscriptions_dirty();
+        self.scheduler.mark_subscriptions_dirty();
     }
 
     fn process_app_input(&mut self, input: AppInput<App::Message>) {
@@ -309,13 +298,13 @@ impl<App: Application> Runtime<App> {
 
     fn dispatch_update_command(&mut self, cmd: Command<App::Message>) {
         let parts = cmd.into_runtime_parts();
-        self.pending.record_redraw(parts.requests_redraw());
+        self.scheduler.record_redraw(parts.requests_redraw());
         self.state.enqueue_command(parts);
     }
 
     /// Processes a frame tick: renders if needed and updates subscriptions.
     ///
-    /// Only renders when [`PendingWork`] has a pending redraw (conditional
+    /// Only renders when [`FrameScheduler`] has a pending redraw (conditional
     /// rendering optimization). Only re-evaluates subscriptions when it has marked
     /// them dirty, i.e. when a message has been processed since the last
     /// evaluation.
@@ -333,7 +322,7 @@ impl<App: Application> Runtime<App> {
         tracing::trace!(target: "tears::runtime::frame", "frame tick");
 
         // Render only if state has changed
-        if self.pending.take_redraw() {
+        if self.scheduler.take_redraw() {
             self.state.render(terminal)?;
             tracing::trace!(target: "tears::runtime", "frame rendered");
         }
@@ -342,7 +331,7 @@ impl<App: Application> Runtime<App> {
         // Since `subscriptions()` is a pure function of the application state,
         // an idle frame (no messages processed) cannot change the subscription
         // set, so we skip the (potentially costly) evaluation entirely.
-        if self.pending.take_subscriptions_dirty() {
+        if self.scheduler.take_subscriptions_dirty() {
             self.update_subscriptions();
         }
 
@@ -450,14 +439,13 @@ impl<App: Application> Runtime<App> {
                     self.process_input_batch(input);
                 }
 
-                // Frame tick: render if needed and update subscriptions.
-                //
-                // Gated on pending work so an idle loop does not wake at the frame
-                // rate just to do nothing. When a message re-enables the branch, the
-                // timer deadline has already elapsed, so `tick()` is ready on the
-                // next poll and adds no render latency. `MissedTickBehavior::Skip`
-                // only controls where the following tick lands (no catch-up burst).
-                _ = self.frame_interval.tick(), if self.pending.has_pending_work() => {
+                // Frame tick: render if needed and update subscriptions. The
+                // scheduler parks while idle, so the loop does not wake at the
+                // frame rate just to do nothing. When a message re-enables frame
+                // work, the elapsed timer is ready on the next poll and adds no
+                // render latency; `MissedTickBehavior::Skip` only controls where
+                // the following tick lands (no catch-up burst).
+                () = self.scheduler.next_work_frame() => {
                     self.process_frame_tick(terminal)?;
                 }
 
@@ -973,12 +961,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_runtime_frame_interval_period_is_accurate() {
+    async fn test_runtime_frame_scheduler_period_is_accurate() {
         // 60 FPS should yield a ~16.667ms period. The previous integer
         // millisecond division (1000 / 60 = 16ms) truncated this, producing
         // an effective ~62.5 FPS.
         let runtime = Runtime::<TestApp>::new(0, frame_rate(60));
-        let period = runtime.frame_interval.period();
+        let period = runtime.scheduler.frame_period();
         assert!(
             period >= Duration::from_micros(16_600) && period <= Duration::from_micros(16_700),
             "60 FPS period should be ~16.667ms, got {period:?}",
@@ -986,7 +974,7 @@ mod tests {
 
         // 144 FPS should yield a ~6.944ms period (not the truncated 6ms).
         let runtime = Runtime::<TestApp>::new(0, frame_rate(144));
-        let period = runtime.frame_interval.period();
+        let period = runtime.scheduler.frame_period();
         assert!(
             period >= Duration::from_micros(6_900) && period <= Duration::from_micros(6_950),
             "144 FPS period should be ~6.944ms, got {period:?}",
@@ -1005,20 +993,20 @@ mod tests {
         assert_eq!(runtime.state.app.counter, 1);
 
         // Redraw should be needed
-        assert!(runtime.pending.needs_redraw);
+        assert!(runtime.scheduler.pending.needs_redraw);
     }
 
     #[tokio::test]
     async fn test_process_message_batch_without_redraw_leaves_redraw_unchanged() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.pending.needs_redraw = false;
-        runtime.pending.subscriptions_dirty = false;
+        runtime.scheduler.pending.needs_redraw = false;
+        runtime.scheduler.pending.subscriptions_dirty = false;
 
         runtime.process_message_batch(RedrawControlMessage::Skip);
 
-        assert!(!runtime.pending.needs_redraw);
+        assert!(!runtime.scheduler.pending.needs_redraw);
         assert!(
-            runtime.pending.subscriptions_dirty,
+            runtime.scheduler.pending.subscriptions_dirty,
             "redraw suppression must not suppress subscription re-evaluation"
         );
     }
@@ -1026,29 +1014,29 @@ mod tests {
     #[tokio::test]
     async fn test_process_message_batch_mixed_commands_redraws() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.pending.needs_redraw = false;
-        runtime.pending.subscriptions_dirty = false;
+        runtime.scheduler.pending.needs_redraw = false;
+        runtime.scheduler.pending.subscriptions_dirty = false;
 
         let _ = runtime.state.msg_tx.send(RedrawControlMessage::Redraw);
         runtime.process_message_batch(RedrawControlMessage::Skip);
 
-        assert!(runtime.pending.needs_redraw);
-        assert!(runtime.pending.subscriptions_dirty);
+        assert!(runtime.scheduler.pending.needs_redraw);
+        assert!(runtime.scheduler.pending.subscriptions_dirty);
     }
 
     #[tokio::test]
     async fn test_process_message_batch_redraw_recovers_after_suppression() {
         let mut runtime = Runtime::<RedrawControlApp>::new((), frame_rate(60));
-        runtime.pending.needs_redraw = false;
+        runtime.scheduler.pending.needs_redraw = false;
 
         runtime.process_message_batch(RedrawControlMessage::Skip);
-        assert!(!runtime.pending.needs_redraw);
+        assert!(!runtime.scheduler.pending.needs_redraw);
 
-        runtime.pending.subscriptions_dirty = false;
+        runtime.scheduler.pending.subscriptions_dirty = false;
         runtime.process_message_batch(RedrawControlMessage::Redraw);
 
-        assert!(runtime.pending.needs_redraw);
-        assert!(runtime.pending.subscriptions_dirty);
+        assert!(runtime.scheduler.pending.needs_redraw);
+        assert!(runtime.scheduler.pending.subscriptions_dirty);
     }
 
     // A minimal `tracing::Subscriber` that counts emitted events (total, and
@@ -1247,7 +1235,7 @@ mod tests {
         }
 
         let mut runtime = Runtime::<BatchOrderApp>::new((), frame_rate(60));
-        runtime.pending.subscriptions_dirty = false;
+        runtime.scheduler.pending.subscriptions_dirty = false;
 
         runtime
             .state
@@ -1263,7 +1251,7 @@ mod tests {
         runtime.process_input_batch(AppInput::Shared(1));
 
         assert_eq!(runtime.state.app.messages, vec![1, 2, 3]);
-        assert!(runtime.pending.subscriptions_dirty);
+        assert!(runtime.scheduler.pending.subscriptions_dirty);
     }
 
     #[tokio::test]
@@ -1274,13 +1262,13 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Initially needs_redraw is true
-        assert!(runtime.pending.needs_redraw);
+        assert!(runtime.scheduler.pending.needs_redraw);
 
         // Process frame tick
         runtime.process_frame_tick(&mut terminal)?;
 
         // Redraw flag should be cleared
-        assert!(!runtime.pending.needs_redraw);
+        assert!(!runtime.scheduler.pending.needs_redraw);
 
         Ok(())
     }
@@ -1293,13 +1281,13 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Clear the needs_redraw flag
-        runtime.pending.needs_redraw = false;
+        runtime.scheduler.pending.needs_redraw = false;
 
         // Process frame tick
         runtime.process_frame_tick(&mut terminal)?;
 
         // Redraw flag should still be false
-        assert!(!runtime.pending.needs_redraw);
+        assert!(!runtime.scheduler.pending.needs_redraw);
 
         Ok(())
     }
@@ -1371,9 +1359,10 @@ mod tests {
 
     // --- Idle frame wake-up elision -----------------------------------------
     //
-    // The event loop gates its frame branch on `PendingWork::has_pending_work()`
+    // The scheduler gates its frame branch on `PendingWork::has_pending_work()`
     // so an idle loop stops waking at the frame rate. The predicate's pure logic
-    // is unit-tested in `pending_work`; these tests cover the Runtime-level
+    // is unit-tested in `pending_work`; the scheduler's idle parking is unit-
+    // tested in `frame_scheduler`; these tests cover the Runtime-level
     // integration — that a real frame tick drains the pending work and a processed
     // message re-arms the branch. The end-to-end behavior (zero idle wake-ups, and
     // an immediate render once a message re-enables the branch) is covered by
@@ -1386,7 +1375,7 @@ mod tests {
 
         // Draining the initial pending work leaves both flags false: idle.
         runtime.process_frame_tick(&mut terminal)?;
-        assert!(!runtime.pending.has_pending_work());
+        assert!(!runtime.scheduler.pending.has_pending_work());
 
         Ok(())
     }
@@ -1397,11 +1386,11 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
 
         runtime.process_frame_tick(&mut terminal)?;
-        assert!(!runtime.pending.has_pending_work());
+        assert!(!runtime.scheduler.pending.has_pending_work());
 
         // A processed message re-enables the frame branch.
         runtime.process_message_batch(TestMessage::Increment);
-        assert!(runtime.pending.has_pending_work());
+        assert!(runtime.scheduler.pending.has_pending_work());
 
         Ok(())
     }
@@ -1468,20 +1457,20 @@ mod tests {
         let mut terminal = Terminal::new(backend)?;
 
         // Clear needs_redraw so only the subscription path exercises the tick.
-        runtime.pending.needs_redraw = false;
+        runtime.scheduler.pending.needs_redraw = false;
 
         // Not yet applied: no frame tick has run.
         assert_eq!(spawns.load(Ordering::SeqCst), 0);
 
         // Subscriptions are only re-evaluated when marked dirty (after a
         // message). Simulate that here.
-        runtime.pending.subscriptions_dirty = true;
+        runtime.scheduler.pending.subscriptions_dirty = true;
 
         // Process frame tick: it must re-evaluate and actually start the
         // subscription, and clear the dirty flag.
         runtime.process_frame_tick(&mut terminal)?;
 
-        assert!(!runtime.pending.subscriptions_dirty);
+        assert!(!runtime.scheduler.pending.subscriptions_dirty);
         for _ in 0..100 {
             if spawns.load(Ordering::SeqCst) == 1 {
                 break;

--- a/src/runtime/frame_scheduler.rs
+++ b/src/runtime/frame_scheduler.rs
@@ -1,0 +1,142 @@
+//! Frame scheduling for runtime work.
+//!
+//! This module combines the frame timer with [`PendingWork`], so it owns both
+//! *when* the runtime may process a frame and *whether* there is any frame work
+//! to do. The runtime still owns what a frame means: draining pending flags,
+//! rendering, and re-evaluating subscriptions.
+
+use std::future::pending;
+
+use tokio::time::{Interval, MissedTickBehavior, interval};
+
+use crate::frame_rate::FrameRate;
+
+use super::pending_work::PendingWork;
+
+/// Schedules runtime frame work at the configured frame rate.
+///
+/// The scheduler parks while there is no pending work, so the runtime's event
+/// loop remains event-driven while idle instead of waking at the frame rate to
+/// do nothing.
+pub(super) struct FrameScheduler {
+    interval: Interval,
+    pub(super) pending: PendingWork,
+}
+
+impl FrameScheduler {
+    /// Creates a frame scheduler with the given target frame rate.
+    pub(super) fn new(frame_rate: FrameRate) -> Self {
+        // Divide a one-second `Duration` directly so the period is exact (e.g.
+        // 60 FPS -> 16.667ms) instead of truncating to whole milliseconds.
+        let frame_duration = frame_rate.frame_duration();
+        let mut interval = interval(frame_duration);
+        // Skip missed frames rather than trying to catch up.
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        Self {
+            interval,
+            pending: PendingWork::new(),
+        }
+    }
+
+    /// Returns the scheduler's frame period.
+    #[cfg(test)]
+    pub(super) fn frame_period(&self) -> std::time::Duration {
+        self.interval.period()
+    }
+
+    /// Records whether a processed command requested a redraw.
+    pub(super) const fn record_redraw(&mut self, requested: bool) {
+        self.pending.record_redraw(requested);
+    }
+
+    /// Marks that subscriptions may have changed and should be re-evaluated.
+    pub(super) const fn mark_subscriptions_dirty(&mut self) {
+        self.pending.mark_subscriptions_dirty();
+    }
+
+    /// Whether a redraw or subscription re-evaluation is pending.
+    pub(super) const fn has_pending_work(&self) -> bool {
+        self.pending.has_pending_work()
+    }
+
+    /// Returns whether a redraw is pending and clears the flag.
+    pub(super) const fn take_redraw(&mut self) -> bool {
+        self.pending.take_redraw()
+    }
+
+    /// Returns whether subscriptions need re-evaluation and clears the flag.
+    pub(super) const fn take_subscriptions_dirty(&mut self) -> bool {
+        self.pending.take_subscriptions_dirty()
+    }
+
+    /// Resolves at the next frame boundary, but only when work is pending.
+    ///
+    /// If no work is pending, this future parks forever. In the runtime's
+    /// `select!` loop that is intentional: another branch processes a message,
+    /// marks work pending, the loop iterates, and this future is recreated so it
+    /// re-checks the pending flags before awaiting the interval.
+    ///
+    /// This relies on the runtime's current single-task ownership invariant:
+    /// only the runtime task mutates [`PendingWork`] while handling another
+    /// `select!` branch. A future parked here does not register a wake for later
+    /// pending-flag changes. If pending work is ever allowed to be marked from a
+    /// different task, this implementation would risk losing that wake and must
+    /// be replaced with an explicitly notified design.
+    pub(super) async fn next_work_frame(&mut self) {
+        if !self.has_pending_work() {
+            pending::<()>().await;
+        }
+
+        self.interval.tick().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::{Duration, Instant, timeout};
+
+    use super::*;
+
+    fn frame_rate(value: u32) -> FrameRate {
+        FrameRate::try_new(value).expect("frame rate must be valid")
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn next_work_frame_parks_while_idle() {
+        let mut scheduler = FrameScheduler::new(frame_rate(60));
+        scheduler.take_redraw();
+
+        let result = timeout(Duration::from_secs(1), scheduler.next_work_frame()).await;
+
+        assert!(
+            result.is_err(),
+            "an idle scheduler must park instead of waking on the interval"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn next_work_frame_is_ready_immediately_after_idle_work_arrives() {
+        let mut scheduler = FrameScheduler::new(frame_rate(60));
+
+        // Consume the initial redraw frame and drain it so the scheduler reaches
+        // the idle state under test.
+        scheduler.next_work_frame().await;
+        scheduler.take_redraw();
+
+        let result = timeout(Duration::from_secs(1), scheduler.next_work_frame()).await;
+        assert!(result.is_err(), "scheduler should be parked while idle");
+
+        scheduler.mark_subscriptions_dirty();
+        let before = Instant::now();
+        timeout(Duration::from_secs(1), scheduler.next_work_frame())
+            .await
+            .expect("elapsed interval should make the re-armed frame ready");
+
+        assert_eq!(
+            Instant::now(),
+            before,
+            "re-arming after idle should not wait an extra frame period"
+        );
+    }
+}

--- a/src/runtime/pending_work.rs
+++ b/src/runtime/pending_work.rs
@@ -2,13 +2,13 @@
 //!
 //! The runtime renders conditionally (only when the view may have changed) and
 //! re-evaluates subscriptions only after a message has been processed. This
-//! module owns those two flags and the [`PendingWork::has_pending_work`] query
-//! that the event loop uses to gate its frame branch, keeping that bookkeeping
-//! out of the main loop.
+//! module owns those two flags and the [`PendingWork::has_pending_work`] query,
+//! keeping that bookkeeping out of the scheduler and main loop.
 //!
 //! This type tracks *whether* there is work; it does not own the frame timer or
-//! decide *when* to run — the runtime still owns the `Interval` and the
-//! `take` → render/update ordering.
+//! decide *when* to run. [`super::frame_scheduler::FrameScheduler`] owns the
+//! timer and idle parking, while the runtime owns the `take` → render/update
+//! ordering.
 
 /// Tracks whether the runtime has pending render or subscription work.
 ///
@@ -58,10 +58,10 @@ impl PendingWork {
     /// Whether the frame tick has pending work (a redraw or a subscription
     /// re-evaluation) to do.
     ///
-    /// Gates the frame branch of the event loop's `select!`: when the application
-    /// is idle (no message processed since the last frame), both flags are false
+    /// Used by the frame scheduler to park while the application is idle. When
+    /// no message has been processed since the last frame, both flags are false
     /// and a frame tick would do nothing, so the loop can skip waking at the
-    /// frame rate entirely — making it event-driven and saving CPU/battery.
+    /// frame rate entirely.
     ///
     /// Must use `||` (not `&&`): the initial state has `needs_redraw == true` and
     /// `subscriptions_dirty == false`, and the first frame must still render.
@@ -170,7 +170,7 @@ mod tests {
         pending.mark_subscriptions_dirty();
 
         // Draining both kinds of pending work leaves the tracker idle, so the
-        // event loop's frame branch is gated off.
+        // scheduler's frame branch is gated off.
         pending.take_redraw();
         pending.take_subscriptions_dirty();
         assert!(!pending.has_pending_work());


### PR DESCRIPTION
## Summary

Stage 2 follow-up to #141. #141 extracted `PendingWork`, which tracks *whether* there is frame work — but the frame timer (`Interval`) and the idle-gating still lived in `Runtime`, split between a struct field and a `select!` guard. This folds them together into a type that genuinely **schedules** frames: it owns both *when* a frame may run and *whether* there is work to do.

This resolves the naming discussion from #141: the type is now accurately a `FrameScheduler` because it owns timing + gating, not just flags.

## Changes

`runtime::frame_scheduler`:

- **`FrameScheduler { interval, pending: PendingWork }`** owns the timer and delegates the pending-work transitions (`record_redraw`, `mark_subscriptions_dirty`, `take_*`, `has_pending_work`) to the inner `PendingWork`.
- **`next_work_frame()`** resolves at the next frame boundary but **parks while no work is pending**, moving the idle-wake-up gate off the `select!` guard and into the scheduler. The event loop's frame branch becomes an unguarded `() = self.scheduler.next_work_frame() => { ... }`.
- The parking relies on the runtime's **single-task ownership** of the flags: a parked future does not register a wake for later flag changes, so it is only correct because only the runtime task mutates `PendingWork` while handling another branch. This invariant is documented on `next_work_frame` as a footgun for any future cross-task flag marking.

`PendingWork` stays a pure, synchronously-testable inner type (its flag-logic unit tests are unchanged). Interval construction moves from `Runtime::new` into `FrameScheduler::new` — not a new constraint, since `Runtime::new` already required a Tokio runtime to build the interval.

## Equivalence to the old `select!` guard

- **Re-check timing:** the old `if has_pending_work()` was evaluated on each `select!` entry; `next_work_frame` re-checks the flags each time the future is recreated (once per loop iteration) — identical.
- **Zero re-arm latency:** while idle the interval is never polled, so its deadline elapses; on re-arm `tick()` is ready immediately (`MissedTickBehavior::Skip` only moves the *following* tick). Guarded by the new `start_paused` test asserting `Instant::now() == before`.
- **Cancel safety:** if another branch wins, the dropped future loses no state (parked = stateless; `Interval::tick` keeps its deadline in the `Interval`).
- **No idle frame ticks:** `process_frame_tick` runs only when `next_work_frame` resolves, which only happens with pending work — so `tests/idle_wakeup.rs` (zero idle wake-ups) still holds.

## Tests

- Two new `start_paused` unit tests for the scheduler: idle parking, and zero-added-latency re-arm after idle. These unit-test the park/wake property that was previously only covered end-to-end.
- All existing suites pass: `cargo test --all-features`, `tests/idle_wakeup.rs`, `tests/quit_handling.rs`, `tests/runtime_run.rs`.
- `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean.

## No behavior change

The frame period, the initial flag state (`needs_redraw = true`, `subscriptions_dirty = false`), and the idle-gating predicate are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)