### PR TITLE
test(runtime): cover command-task panic logging end-to-end

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1097,58 +1097,6 @@ mod tests {
         );
     }
 
-    #[test]
-    #[allow(
-        clippy::panic,
-        reason = "the test intentionally panics inside a command"
-    )]
-    fn test_command_task_panic_is_logged() {
-        use std::sync::atomic::Ordering;
-
-        // Serialize against other tests that observe the global panic hook, so
-        // this test's caught panic cannot pollute their recorded hook activity.
-        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-        let counter = EventCounter::default();
-        let errors = counter.errors.clone();
-
-        // Drive the panicking command task to completion on the current thread,
-        // inside the subscriber scope, so its `catch_unwind` error event is seen.
-        //
-        // The panic is caught by `catch_unwind`, so the default hook only prints
-        // the panic message to stderr — harmless test noise. We deliberately do
-        // not swap the panic hook here: it is process-global, so a no-op hook
-        // would suppress panics in other tests running in parallel and could
-        // leak if this test panicked before restoring it.
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("test runtime should build");
-
-        tracing::subscriber::with_default(counter, || {
-            rt.block_on(async {
-                let mut state = ApplicationState::<TestApp>::new(0);
-                state.enqueue_command(
-                    Command::future(async {
-                        panic!("boom");
-                        #[allow(unreachable_code)]
-                        TestMessage::Increment
-                    })
-                    .into_runtime_parts(),
-                );
-                // Run the command task to completion (it panics and is caught).
-                state.command_tasks.join_next().await;
-            });
-        });
-
-        assert!(
-            errors.load(Ordering::SeqCst) >= 1,
-            "a panicking command task should log an error event"
-        );
-    }
-
     #[tokio::test]
     async fn test_dropping_state_aborts_command_tasks() {
         use std::sync::Arc;

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -4,6 +4,9 @@
 
 mod common;
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use color_eyre::eyre::Result;
 use ratatui::Frame;
 use tears::prelude::*;
@@ -96,6 +99,35 @@ impl Application for SubApp {
     }
 }
 
+// Counts runtime ERROR events so command-task panic handling can be verified
+// through the public run() pipeline.
+#[derive(Clone, Default)]
+struct RuntimeErrorCounter {
+    errors: Arc<AtomicUsize>,
+}
+
+impl tracing::Subscriber for RuntimeErrorCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        metadata.target() == "tears::runtime" && *metadata.level() == tracing::Level::ERROR
+    }
+
+    fn new_span(&self, _span: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
+
+    fn event(&self, _event: &tracing::Event<'_>) {
+        self.errors.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn enter(&self, _span: &tracing::span::Id) {}
+
+    fn exit(&self, _span: &tracing::span::Id) {}
+}
+
 #[tokio::test]
 async fn test_runtime_run_end_to_end_basic() -> Result<()> {
     // End-to-end: Basic application lifecycle
@@ -106,6 +138,66 @@ async fn test_runtime_run_end_to_end_basic() -> Result<()> {
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
     assert!(result.is_ok(), "Runtime should not error");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[allow(
+    clippy::panic,
+    reason = "the test intentionally panics inside a command"
+)]
+async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
+    struct PanicCommandApp;
+
+    #[derive(Clone)]
+    enum Message {
+        Quit,
+    }
+
+    impl Application for PanicCommandApp {
+        type Message = Message;
+        type Flags = ();
+
+        fn new((): ()) -> (Self, Command<Message>) {
+            let cmd = Command::future(async {
+                panic!("boom");
+                #[allow(unreachable_code)]
+                Message::Quit
+            });
+
+            (Self, cmd)
+        }
+
+        fn update(&mut self, _msg: Message) -> Command<Message> {
+            Command::effect(Action::Quit)
+        }
+
+        fn view(&self, _frame: &mut Frame<'_>) {}
+
+        fn subscriptions(&self) -> Vec<Subscription<Message>> {
+            use tears::subscription::time::Timer;
+
+            vec![
+                Subscription::new(Timer::try_new(10).expect("timer interval must be non-zero"))
+                    .map(|_| Message::Quit),
+            ]
+        }
+    }
+
+    let counter = RuntimeErrorCounter::default();
+    let errors = counter.errors.clone();
+    let _guard = tracing::subscriber::set_default(counter);
+
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<PanicCommandApp>::try_new((), 60).expect("frame rate must be valid");
+
+    timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await??;
+
+    assert!(
+        errors.load(Ordering::SeqCst) >= 1,
+        "a panicking command task should log a tears::runtime error event"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Angle 1 from the `runtime.rs` review: migrate `test_command_task_panic_is_logged` from a white-box unit test to a black-box e2e test that verifies command-task panic logging through the public `run()` pipeline.

The panic-caught-and-logged path is inherently a whole-pipeline behavior (spawn → panic → `catch_unwind` → `tracing::error!`), so driving it through `Runtime::run` and observing via a `tracing` subscriber fits the existing `tests/` convention (cf. the `FrameTickCounter` in `tests/idle_wakeup.rs`) better than reaching into `ApplicationState::enqueue_command` / `command_tasks`.

## Changes

- **Removed** `test_command_task_panic_is_logged` (white-box) from `src/runtime.rs`.
- **Added** `test_runtime_run_logs_command_task_panic` to `tests/runtime_run.rs`:
  - An app whose **init command panics** (`panic!("boom")`) before producing a message.
  - A short **Timer(10ms) subscription** supplies the quit so `run()` returns (the panicking command never does).
  - A `RuntimeErrorCounter` subscriber counts `tears::runtime` ERROR events; the test asserts ≥ 1.
  - Wrapped in a 1s `timeout` to guard against a hang.

## Why this is simpler

Running in its own test binary drops two workarounds the unit test needed:

- the `PANIC_HOOK_GUARD` serialization against other panic-hook-observing tests (process-global hook), and
- the hand-built current-thread `tokio::runtime`.

`PANIC_HOOK_GUARD` is still used by `src/panic.rs`, so it is not dead code.

## Note on `flavor = "current_thread"`

This is load-bearing: `tracing::subscriber::set_default` installs a **thread-local** default, and only on a current-thread runtime does the spawned command task run on the same thread, so its error event is observed. A multi-thread flavor could run the task on a worker thread without the subscriber and miss the event.

## Verification

`cargo test` (incl. the new e2e), `cargo clippy --all-targets --all-features`, and `cargo fmt --check` are clean. Independent of #142; targets `main` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)