### PR TITLE
test(runtime): drop EventCounter's unused errors counter

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -571,12 +571,11 @@ mod tests {
         assert!(runtime.scheduler.pending.subscriptions_dirty);
     }
 
-    // A minimal `tracing::Subscriber` that counts emitted events (total, and
-    // those at ERROR level), used to assert that instrumentation actually fires.
+    // A minimal `tracing::Subscriber` that counts emitted events, used to assert
+    // that instrumentation actually fires.
     #[derive(Clone, Default)]
     struct EventCounter {
         events: std::sync::Arc<std::sync::atomic::AtomicUsize>,
-        errors: std::sync::Arc<std::sync::atomic::AtomicUsize>,
     }
 
     impl tracing::Subscriber for EventCounter {
@@ -588,12 +587,9 @@ mod tests {
         }
         fn record(&self, _span: &tracing::span::Id, _values: &tracing::span::Record<'_>) {}
         fn record_follows_from(&self, _span: &tracing::span::Id, _follows: &tracing::span::Id) {}
-        fn event(&self, event: &tracing::Event<'_>) {
+        fn event(&self, _event: &tracing::Event<'_>) {
             use std::sync::atomic::Ordering;
             self.events.fetch_add(1, Ordering::SeqCst);
-            if *event.metadata().level() == tracing::Level::ERROR {
-                self.errors.fetch_add(1, Ordering::SeqCst);
-            }
         }
         fn enter(&self, _span: &tracing::span::Id) {}
         fn exit(&self, _span: &tracing::span::Id) {}


### PR DESCRIPTION
## Summary

`EventCounter` (a test-only `tracing::Subscriber` in `runtime.rs`) counted ERROR-level events into a separate `errors` field, originally read by `test_command_task_panic_is_logged`. That test was migrated to a black-box e2e in `tests/runtime_run.rs` (#143), which uses its own `RuntimeErrorCounter`. Since then `errors` has been written on every ERROR event but read by nobody.

This drops the `errors` field and the ERROR-level branch in `event()` (the `event` argument becomes `_event`). The sole remaining user, `test_process_message_batch_emits_tracing_event`, only reads `events`.

Not compiler-flagged (the field was "used" via `fetch_add`), so this is a semantic dead-code cleanup.

`cargo test`, `cargo clippy --all-targets --all-features`, and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)