### PR TITLE
docs: document testing guidelines

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,108 @@
+# Testing Guidelines
+
+This document describes repository-wide test structure and async test
+synchronization rules.
+
+## Test Placement
+
+Place crate-internal, white-box tests next to the code they exercise under
+`src/**/*.rs`. These tests may use private modules, inspect internal state, and
+share helpers from `src/test_support.rs`.
+
+Place black-box integration tests under `tests/`. These tests should exercise
+the public API the way downstream users would. Shared integration-test helpers
+belong in `tests/common/`; keep them focused so each integration test only
+imports what it needs.
+
+When a behavior can be tested either way, prefer the narrowest layer that proves
+the contract:
+
+- Use unit tests for pure logic, internal state transitions, and edge cases that
+  need private access.
+- Use integration tests for end-to-end runtime behavior, public API contracts,
+  and interactions between runtime components.
+
+## Do Not Use Sleep For Synchronization
+
+Tests should not use `tokio::time::sleep(Duration::from_millis(...))` to wait
+for another task, subscription, stream, or command to reach a state. Sleeping
+makes the test depend on scheduler timing and CI load, so the test can become
+both flaky and unnecessarily slow.
+
+Prefer explicit synchronization:
+
+- `oneshot` for a single gate or milestone.
+- `watch` for state that changes over time.
+- `Notify` for repeated readiness events where no value needs to be carried.
+- Atomic wait helpers for counters and drop/abort observations.
+- `timeout` only as a failure bound around an explicit condition, not as the
+  condition itself.
+
+Real time is still valid when time is the behavior under test. Timer accuracy
+tests, delayed command behavior, and paused-time event-loop tests may use
+`sleep` or `timeout` when the assertion is about elapsed time, virtual time, or
+timer ordering.
+
+## Tracing Assertions
+
+Use `TraceRecorder` when a test asserts `tracing` output. Crate-internal unit
+tests should import `crate::test_support::TraceRecorder`; integration tests
+that need tracing assertions should import the local helper from
+`tests/common/trace_recorder.rs` with an explicit `#[path]` module:
+
+```rust
+#[path = "common/trace_recorder.rs"]
+mod trace_recorder;
+
+use trace_recorder::TraceRecorder;
+```
+
+`tests/common/mod.rs` does not re-export this helper. Importing it explicitly
+keeps unused tracing code out of integration-test targets that do not assert
+tracing output.
+
+Prefer filtering the recorder to the event being asserted, for example with
+`.with_target("tears::runtime")` and `.with_level(tracing::Level::DEBUG)`.
+Avoid ad hoc subscribers that filter by returning `false` from `enabled()`:
+`tracing` caches callsite interest process-wide, so one test can accidentally
+make a callsite invisible to another parallel test. `TraceRecorder` keeps
+interest open and filters in `event()` instead.
+
+The unit-test and integration-test recorders are intentionally duplicated for
+now. Keep their structure aligned when changing shared behavior so fixes are
+easy to compare across the two copies.
+
+## Process-Global Panic Hook Tests
+
+Use `crate::test_support::PANIC_HOOK_GUARD` for crate-internal tests that call
+`std::panic::set_hook`, `std::panic::take_hook`, or deliberately trigger a panic
+while a recording hook is installed. The panic hook is process-global and tests
+run in parallel by default, so hook-swapping tests can otherwise clobber each
+other or observe an unrelated panic.
+
+Hold the guard for the full critical section: install or take the hook, trigger
+and catch the panic if needed, restore the previous hook, and then inspect any
+recorded hook state. Ordinary tests that do not mutate the panic hook do not
+need the guard.
+
+If an integration test ever needs to mutate the panic hook, add a focused local
+guard under `tests/common/` rather than exposing the crate-internal test helper
+as public API.
+
+## Sleep Audit Notes
+
+Keep this document focused on durable policy rather than a complete inventory of
+individual tests. Exact cleanup history belongs in PRs and git log, where it can
+age with the code that changed.
+
+When auditing sleeps, classify each use into one of these buckets:
+
+- **Remove immediately** when the awaited work is already synchronized, such as
+  synchronous channel sends that can be drained directly.
+- **Replace with explicit observation** when a spawned task is expected to send
+  a message, emit a quit signal, drop a guard, or update a counter.
+- **Keep intentionally** when elapsed time, virtual time, timer ordering, or
+  command delay is the behavior under test.
+- **Defer to async helper work** when several tests need the same wait pattern;
+  move those cases to helpers such as `wait_until_atomic`,
+  `assert_pending_until`, or source-specific gates instead of open-coding loops.


### PR DESCRIPTION
## Summary

- Add `docs/testing.md`
- Document unit vs integration test placement
- Document the policy against using `sleep` for async test synchronization
- Document when to use `TraceRecorder`
- Document when to use `PANIC_HOOK_GUARD`

## Rationale

Recent flaky-test fixes exposed a few implicit testing rules around async synchronization, tracing assertions, and process-global panic hook tests. This document makes those rules explicit so future tests follow the same patterns.

The document also records the current audit of sleep usage:
- cases already cleaned up
- cases intentionally kept because they test time itself
- candidates for follow-up async test utilities

## Verification

Docs-only change. Reviewed rendered Markdown/source text.