### PR TITLE
test: add async test synchronization helpers

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,12 @@ Prefer explicit synchronization:
 - `oneshot` for a single gate or milestone.
 - `watch` for state that changes over time.
 - `Notify` for repeated readiness events where no value needs to be carried.
-- Atomic wait helpers for counters and drop/abort observations.
+- `crate::test_support::wait_until` for bounded condition waits in
+  crate-internal tests.
+- `crate::test_support::assert_pending_until` for futures that must stay
+  pending until a gated condition is observed.
+- `crate::test_support::gate_fetches` for query tests that need deterministic
+  in-flight fetch windows.
 - `timeout` only as a failure bound around an explicit condition, not as the
   condition itself.
 
@@ -104,5 +109,5 @@ When auditing sleeps, classify each use into one of these buckets:
 - **Keep intentionally** when elapsed time, virtual time, timer ordering, or
   command delay is the behavior under test.
 - **Defer to async helper work** when several tests need the same wait pattern;
-  move those cases to helpers such as `wait_until_atomic`,
-  `assert_pending_until`, or source-specific gates instead of open-coding loops.
+  move those cases to `crate::test_support` helpers instead of open-coding
+  loops.

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -435,7 +435,7 @@ mod tests {
     use crate::application::Application;
     use crate::command::Command;
     use crate::subscription::Subscription;
-    use crate::test_support::{TestApp, TestMessage};
+    use crate::test_support::{TestApp, TestMessage, wait_until};
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
     use tokio::time::{Duration, sleep};
@@ -869,17 +869,11 @@ mod tests {
         runtime.process_frame_tick(&mut terminal)?;
 
         assert!(!runtime.scheduler.pending.subscriptions_dirty);
-        for _ in 0..100 {
-            if spawns.load(Ordering::SeqCst) == 1 {
-                break;
-            }
-            sleep(Duration::from_millis(5)).await;
-        }
-        assert_eq!(
-            spawns.load(Ordering::SeqCst),
-            1,
-            "a dirty frame tick must actually start the requested subscription"
-        );
+        wait_until(
+            || spawns.load(Ordering::SeqCst) == 1,
+            "a dirty frame tick must actually start the requested subscription",
+        )
+        .await;
 
         Ok(())
     }
@@ -989,19 +983,37 @@ mod tests {
 
         use crate::subscription::{SubscriptionId, SubscriptionSource};
 
-        // A subscription with a fixed ID whose stream emits one value and then
-        // ends. It counts how many times its stream is spawned so a restart is
-        // observable.
-        struct OneshotSource {
+        #[derive(Clone)]
+        struct RestartCounters {
             spawns: Arc<AtomicUsize>,
+            completions: Arc<AtomicUsize>,
+        }
+
+        // A subscription with a fixed ID whose stream emits one value and then
+        // ends. It counts spawns and completions so restarts are observable
+        // without sleeping for the previous task to finish.
+        struct OneshotSource {
+            counters: RestartCounters,
         }
 
         impl SubscriptionSource for OneshotSource {
             type Output = ();
 
             fn stream(&self) -> BoxStream<'static, ()> {
-                self.spawns.fetch_add(1, Ordering::SeqCst);
-                stream::once(async {}).boxed()
+                self.counters.spawns.fetch_add(1, Ordering::SeqCst);
+                let completions = self.counters.completions.clone();
+                stream::unfold(false, move |emitted| {
+                    let completions = completions.clone();
+                    async move {
+                        if emitted {
+                            completions.fetch_add(1, Ordering::SeqCst);
+                            None
+                        } else {
+                            Some(((), true))
+                        }
+                    }
+                })
+                .boxed()
             }
 
             fn id(&self) -> SubscriptionId {
@@ -1012,15 +1024,15 @@ mod tests {
         }
 
         struct RestartApp {
-            spawns: Arc<AtomicUsize>,
+            counters: RestartCounters,
         }
 
         impl Application for RestartApp {
             type Message = ();
-            type Flags = Arc<AtomicUsize>;
+            type Flags = RestartCounters;
 
-            fn new(spawns: Arc<AtomicUsize>) -> (Self, Command<Self::Message>) {
-                (Self { spawns }, Command::none())
+            fn new(counters: RestartCounters) -> (Self, Command<Self::Message>) {
+                (Self { counters }, Command::none())
             }
 
             fn update(&mut self, (): ()) -> Command<Self::Message> {
@@ -1031,49 +1043,46 @@ mod tests {
 
             fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
                 vec![Subscription::new(OneshotSource {
-                    spawns: self.spawns.clone(),
+                    counters: self.counters.clone(),
                 })]
             }
         }
 
-        // Polls the spawn counter until it reaches `target`, or fails after a
-        // bounded wait so a regression cannot hang the suite.
-        async fn wait_for_spawns(spawns: &AtomicUsize, target: usize) {
-            for _ in 0..100 {
-                if spawns.load(Ordering::SeqCst) >= target {
-                    return;
-                }
-                sleep(Duration::from_millis(5)).await;
-            }
-            assert!(
-                spawns.load(Ordering::SeqCst) >= target,
-                "expected at least {target} spawns, saw {}",
-                spawns.load(Ordering::SeqCst)
-            );
-        }
-
-        let spawns = Arc::new(AtomicUsize::new(0));
-        let mut runtime = Runtime::<RestartApp>::new(spawns.clone(), frame_rate(60));
+        let counters = RestartCounters {
+            spawns: Arc::new(AtomicUsize::new(0)),
+            completions: Arc::new(AtomicUsize::new(0)),
+        };
+        let mut runtime = Runtime::<RestartApp>::new(counters.clone(), frame_rate(60));
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
 
         // Start subscriptions the way `run()` does: the first spawn happens here.
         runtime.core.initialize_subscriptions();
-        wait_for_spawns(&spawns, 1).await;
+        wait_until(
+            || counters.spawns.load(Ordering::SeqCst) >= 1,
+            "initial subscription spawn should start before the timeout",
+        )
+        .await;
 
         // Drive two message-gated re-evaluations. The ID never changes, so the
         // removed hash cache would have skipped the manager update from the
         // second round onward, leaving the finished subscription dead. Each
         // round must restart it, so the spawn count must keep climbing.
         for round in 2..=3 {
-            // Let the current one-shot task finish so the manager sees it as
-            // completed before the next re-evaluation.
-            sleep(Duration::from_millis(10)).await;
+            wait_until(
+                || counters.completions.load(Ordering::SeqCst) >= round - 1,
+                "current one-shot subscription should finish before re-evaluation",
+            )
+            .await;
 
             // A message marks subscriptions dirty; the next frame re-evaluates.
             runtime.process_message_batch(());
             runtime.process_frame_tick(&mut terminal)?;
 
-            wait_for_spawns(&spawns, round).await;
+            wait_until(
+                || counters.spawns.load(Ordering::SeqCst) >= round,
+                "finished subscription should restart before the timeout",
+            )
+            .await;
         }
 
         Ok(())

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -196,11 +196,12 @@ mod tests {
     use crate::command::{Action, Command};
     use crate::subscription::Subscription;
     use crate::subscription::time::Timer;
-    use crate::test_support::{TestApp, TestMessage};
+    use crate::test_support::{TestApp, TestMessage, wait_until};
     use futures::stream::StreamExt;
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
-    use tokio::time::{Duration, sleep, timeout};
+    use tokio::sync::oneshot;
+    use tokio::time::{Duration, timeout};
 
     #[test]
     fn test_new() {
@@ -483,18 +484,22 @@ mod tests {
         {
             let mut core = RuntimeCore::<TestApp>::new(0);
             let guard = AbortGuard(aborted.clone());
+            let (started_tx, started_rx) = oneshot::channel();
             // A command that owns the guard and never completes, so its task
             // stays parked until aborted.
             core.enqueue_command(
                 Command::future(async move {
                     let _guard = guard;
+                    let _ = started_tx.send(());
                     std::future::pending::<TestMessage>().await
                 })
                 .into_runtime_parts(),
             );
 
-            // Let the task start and park.
-            sleep(Duration::from_millis(10)).await;
+            timeout(Duration::from_secs(1), started_rx)
+                .await
+                .expect("command task should start before the timeout")
+                .expect("command task should signal that it started");
             assert!(
                 !aborted.load(Ordering::SeqCst),
                 "command task should still be running before the core is dropped"
@@ -502,11 +507,10 @@ mod tests {
             // `core` (and its `command_tasks` JoinSet) is dropped here.
         }
 
-        // Give the runtime a chance to process the abort and drop the future.
-        sleep(Duration::from_millis(10)).await;
-        assert!(
-            aborted.load(Ordering::SeqCst),
-            "dropping the core should abort running command tasks"
-        );
+        wait_until(
+            || aborted.load(Ordering::SeqCst),
+            "dropping the core should abort running command tasks",
+        )
+        .await;
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -458,6 +458,7 @@ impl<Msg> Drop for SubscriptionManager<Msg> {
 mod tests {
     use super::*;
     use crate::subscription::mock::MockSource;
+    use crate::test_support::wait_until;
     use color_eyre::eyre::Result;
     use tokio::time::{Duration, sleep, timeout};
 
@@ -487,8 +488,16 @@ mod tests {
         let first = timeout(Duration::from_millis(100), rx.recv()).await?;
         assert_eq!(first, Some(1));
 
-        // Give the task time to reach the finished state.
-        sleep(Duration::from_millis(10)).await;
+        wait_until(
+            || {
+                manager
+                    .running
+                    .values()
+                    .all(|running| running.handle.is_finished())
+            },
+            "one-shot subscription should finish before restart",
+        )
+        .await;
 
         // Update with the same subscription ID. Because the previous task
         // finished, it must be restarted rather than silently skipped.
@@ -497,6 +506,14 @@ mod tests {
         assert_eq!(second, Some(2), "finished subscription should be restarted");
 
         Ok(())
+    }
+
+    async fn wait_for_mock_receivers<T: Clone + 'static>(mock: &MockSource<T>, expected: usize) {
+        wait_until(
+            || mock.receiver_count() == expected,
+            "mock receiver count should reach the expected value",
+        )
+        .await;
     }
 
     #[test]
@@ -604,7 +621,7 @@ mod tests {
         let sub = Subscription::new(mock.clone());
 
         manager.update(vec![sub]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
 
         // Emit values
         mock.emit(10)?;
@@ -654,11 +671,7 @@ mod tests {
         // Shutdown should cancel all subscriptions
         manager.shutdown();
 
-        // Wait a bit
-        sleep(Duration::from_millis(50)).await;
-
-        // Should not receive more messages after shutdown
-        // The channel might have some buffered messages, but stream should stop
+        assert_eq!(manager.running.len(), 0);
     }
 
     #[tokio::test]
@@ -682,14 +695,17 @@ mod tests {
         // A subscription whose stream owns the guard and never yields, so its
         // task stays parked until it is aborted.
         struct ParkedSource {
+            started: Arc<AtomicBool>,
             aborted: Arc<AtomicBool>,
         }
         impl SubscriptionSource for ParkedSource {
             type Output = i32;
 
             fn stream(&self) -> BoxStream<'static, i32> {
+                let started = self.started.clone();
                 let guard = AbortGuard(self.aborted.clone());
                 stream::poll_fn(move |_cx| {
+                    started.store(true, Ordering::SeqCst);
                     let _keep_alive = &guard;
                     Poll::Pending
                 })
@@ -701,17 +717,22 @@ mod tests {
             }
         }
 
+        let started = Arc::new(AtomicBool::new(false));
         let aborted = Arc::new(AtomicBool::new(false));
         let (tx, _rx) = mpsc::unbounded_channel();
 
         {
             let mut manager = SubscriptionManager::new(tx);
             manager.update(vec![Subscription::new(ParkedSource {
+                started: started.clone(),
                 aborted: aborted.clone(),
             })]);
 
-            // Let the task start and park on the pending stream.
-            sleep(Duration::from_millis(10)).await;
+            wait_until(
+                || started.load(Ordering::SeqCst),
+                "subscription task should start before the manager is dropped",
+            )
+            .await;
             assert!(
                 !aborted.load(Ordering::SeqCst),
                 "task should still be running before the manager is dropped"
@@ -719,12 +740,11 @@ mod tests {
             // `manager` is dropped here.
         }
 
-        // Give the runtime a chance to process the abort and drop the future.
-        sleep(Duration::from_millis(10)).await;
-        assert!(
-            aborted.load(Ordering::SeqCst),
-            "dropping the manager should abort running subscription tasks"
-        );
+        wait_until(
+            || aborted.load(Ordering::SeqCst),
+            "dropping the manager should abort running subscription tasks",
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -741,7 +761,8 @@ mod tests {
             Subscription::new(mock1.clone()),
             Subscription::new(mock2.clone()),
         ]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock1, 1).await;
+        wait_for_mock_receivers(&mock2, 1).await;
 
         // Emit from both subscriptions
         mock1.emit(1)?;
@@ -808,11 +829,10 @@ mod tests {
 
         // Initially no subscriptions
         manager.update(Vec::<Subscription<i32>>::new());
-        sleep(Duration::from_millis(10)).await;
 
         // Enable subscription
         manager.update(vec![Subscription::new(mock.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
 
         // Emit event
         mock.emit(42)?;
@@ -833,7 +853,7 @@ mod tests {
 
         // Start with subscription enabled
         manager.update(vec![Subscription::new(mock.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
 
         // Emit event - should be received
         mock.emit(1)?;
@@ -842,11 +862,10 @@ mod tests {
 
         // Disable subscription
         manager.update(Vec::<Subscription<i32>>::new());
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 0).await;
 
         // Emit event - should NOT be received
-        let _ = mock.emit(2); // May fail if no receivers
-        sleep(Duration::from_millis(10)).await;
+        assert!(mock.emit(2).is_err());
 
         // Channel should be empty
         assert!(rx.try_recv().is_err());
@@ -864,7 +883,7 @@ mod tests {
 
         // Start with subscription 1
         manager.update(vec![Subscription::new(mock1.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock1, 1).await;
 
         mock1.emit(100)?;
         let msg = timeout(Duration::from_millis(100), rx.recv()).await?;
@@ -872,7 +891,8 @@ mod tests {
 
         // Switch to subscription 2
         manager.update(vec![Subscription::new(mock2.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock1, 0).await;
+        wait_for_mock_receivers(&mock2, 1).await;
 
         // mock1 should no longer work (no receivers)
         let _ = mock1.emit(200);
@@ -932,7 +952,16 @@ mod tests {
         // Start and let the task finish.
         manager.update(vec![Subscription::new(OneshotSource)]);
         let _ = timeout(Duration::from_millis(100), rx.recv()).await?;
-        sleep(Duration::from_millis(10)).await;
+        wait_until(
+            || {
+                manager
+                    .running
+                    .values()
+                    .all(|running| running.handle.is_finished())
+            },
+            "one-shot subscription should finish before cleanup",
+        )
+        .await;
 
         // Update without any subscriptions — the stale map entry must be removed.
         manager.update(Vec::<Subscription<i32>>::new());
@@ -955,7 +984,7 @@ mod tests {
 
         // Enable
         manager.update(vec![Subscription::new(mock.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
         mock.emit(1)?;
         assert_eq!(
             timeout(Duration::from_millis(100), rx.recv()).await?,
@@ -964,11 +993,11 @@ mod tests {
 
         // Disable
         manager.update(Vec::<Subscription<i32>>::new());
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 0).await;
 
         // Re-enable
         manager.update(vec![Subscription::new(mock.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
         mock.emit(2)?;
         assert_eq!(
             timeout(Duration::from_millis(100), rx.recv()).await?,
@@ -977,11 +1006,11 @@ mod tests {
 
         // Disable again
         manager.update(Vec::<Subscription<i32>>::new());
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 0).await;
 
         // Re-enable again
         manager.update(vec![Subscription::new(mock.clone())]);
-        sleep(Duration::from_millis(10)).await;
+        wait_for_mock_receivers(&mock, 1).await;
         mock.emit(3)?;
         assert_eq!(
             timeout(Duration::from_millis(100), rx.recv()).await?,

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -1050,20 +1050,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_cell_invalidate_without_data_emits_pending_fetching_not_stale() {
-        use std::collections::VecDeque;
+        use crate::test_support::{assert_pending_until, gate_fetches};
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
         let config = QueryConfig::new(Duration::from_secs(3600), Duration::from_secs(3600));
         let client = Arc::new(QueryClient::with_config(config));
         let fetch_count = Arc::new(AtomicUsize::new(0));
-        let (release_first, wait_first) = oneshot::channel::<()>();
-        let (release_second, wait_second) = oneshot::channel::<()>();
-        let gates = Arc::new(std::sync::Mutex::new(VecDeque::from([
-            wait_first,
-            wait_second,
-        ])));
+        let (mut releases, gates) = gate_fetches(2);
 
         let fetch_count_clone = fetch_count.clone();
         let gates_clone = gates.clone();
@@ -1074,12 +1068,7 @@ mod tests {
                 let gates = gates_clone.clone();
                 Box::pin(async move {
                     let fetch_number = count.fetch_add(1, Ordering::SeqCst) + 1;
-                    let receiver = gates
-                        .lock()
-                        .expect("fetch gate mutex should not be poisoned")
-                        .pop_front()
-                        .expect("test should provide a gate for each expected fetch");
-                    receiver.await.expect("fetch gate should be released");
+                    gates.next().await.expect("fetch gate should be released");
                     Ok::<i32, QueryError>(
                         i32::try_from(fetch_number).expect("test fetch count should fit in i32"),
                     )
@@ -1094,23 +1083,16 @@ mod tests {
 
         let invalidated_poll = stream.next();
         tokio::pin!(invalidated_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut invalidated_poll => panic!("first fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 1 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("first fetch should start");
+        assert_pending_until(
+            &mut invalidated_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 1,
+            "first fetch completed before its gate was released",
+            "first fetch should start",
+        )
+        .await;
 
         client.invalidate("key");
-        release_first
-            .send(())
-            .expect("first fetch gate receiver should still be waiting");
+        releases.release(0);
 
         let pending = timeout(Duration::from_millis(100), invalidated_poll)
             .await
@@ -1122,22 +1104,15 @@ mod tests {
 
         let success_poll = stream.next();
         tokio::pin!(success_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut success_poll => panic!("second fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 2 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("second fetch should start");
+        assert_pending_until(
+            &mut success_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 2,
+            "second fetch completed before its gate was released",
+            "second fetch should start",
+        )
+        .await;
 
-        release_second
-            .send(())
-            .expect("second fetch gate receiver should still be waiting");
+        releases.release(1);
         let success = timeout(Duration::from_millis(100), success_poll)
             .await
             .expect("second fetch should complete");
@@ -1315,30 +1290,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_same_identity_streams_share_single_in_flight_fetch() {
+        use crate::test_support::{assert_pending_until, gate_fetches};
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));
-        let (release_fetch, wait_for_release) = oneshot::channel::<()>();
-        let wait_for_release = Arc::new(std::sync::Mutex::new(Some(wait_for_release)));
+        let (mut releases, gates) = gate_fetches(1);
 
         let fetch_count_clone = fetch_count.clone();
-        let wait_for_release_clone = wait_for_release.clone();
+        let gates_clone = gates.clone();
         let query = Query::new(
             "key",
             move || {
                 let count = fetch_count_clone.clone();
-                let wait = wait_for_release_clone.clone();
+                let gates = gates_clone.clone();
                 Box::pin(async move {
                     count.fetch_add(1, Ordering::SeqCst);
-                    let receiver = wait
-                        .lock()
-                        .expect("fetch gate mutex should not be poisoned")
-                        .take()
-                        .expect("single-flight should call the fetcher only once");
-                    receiver.await.expect("fetch gate should be released");
+                    gates.next().await.expect("fetch gate should be released");
                     Ok::<i32, QueryError>(7)
                 })
             },
@@ -1353,18 +1322,13 @@ mod tests {
 
         let first_success_poll = first_stream.next();
         tokio::pin!(first_success_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut first_success_poll => panic!("first fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 1 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("first fetch should start");
+        assert_pending_until(
+            &mut first_success_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 1,
+            "first fetch completed before its gate was released",
+            "first fetch should start",
+        )
+        .await;
 
         let second_loading = second_stream.next().await;
         assert!(matches!(second_loading, Some(ref result) if result.is_loading()));
@@ -1374,9 +1338,7 @@ mod tests {
             "same identity streams must share the cell in-flight fetch"
         );
 
-        release_fetch
-            .send(())
-            .expect("fetch gate receiver should still be waiting");
+        releases.release(0);
 
         let first_success = timeout(Duration::from_millis(100), first_success_poll)
             .await
@@ -1402,19 +1364,13 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::too_many_lines)]
     async fn test_invalidations_during_one_fetch_window_coalesce_to_one_refetch() {
-        use std::collections::VecDeque;
+        use crate::test_support::{assert_pending_until, gate_fetches};
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));
-        let (release_first, wait_first) = oneshot::channel::<()>();
-        let (release_second, wait_second) = oneshot::channel::<()>();
-        let gates = Arc::new(std::sync::Mutex::new(VecDeque::from([
-            wait_first,
-            wait_second,
-        ])));
+        let (mut releases, gates) = gate_fetches(2);
 
         let fetch_count_clone = fetch_count.clone();
         let gates_clone = gates.clone();
@@ -1425,12 +1381,7 @@ mod tests {
                 let gates = gates_clone.clone();
                 Box::pin(async move {
                     let fetch_number = count.fetch_add(1, Ordering::SeqCst) + 1;
-                    let receiver = gates
-                        .lock()
-                        .expect("fetch gate mutex should not be poisoned")
-                        .pop_front()
-                        .expect("test should provide a gate for each expected fetch");
-                    receiver.await.expect("fetch gate should be released");
+                    gates.next().await.expect("fetch gate should be released");
                     Ok::<i32, QueryError>(
                         i32::try_from(fetch_number).expect("test fetch count should fit in i32"),
                     )
@@ -1446,27 +1397,20 @@ mod tests {
 
         let refetching_poll = stream.next();
         tokio::pin!(refetching_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut refetching_poll => panic!("first fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 1 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("first fetch should start");
+        assert_pending_until(
+            &mut refetching_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 1,
+            "first fetch completed before its gate was released",
+            "first fetch should start",
+        )
+        .await;
         assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
 
         client.invalidate("key");
         client.invalidate("key");
         client.invalidate("key");
 
-        release_first
-            .send(())
-            .expect("first fetch gate receiver should still be waiting");
+        releases.release(0);
 
         let refetching = timeout(Duration::from_millis(100), refetching_poll)
             .await
@@ -1484,27 +1428,20 @@ mod tests {
 
         let second_poll = stream.next();
         tokio::pin!(second_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 2 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-                result = &mut second_poll => panic!("second fetch completed before its gate was released: {result:?}"),
-            }
-        })
-        .await
-        .expect("second fetch should start");
+        assert_pending_until(
+            &mut second_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 2,
+            "second fetch completed before its gate was released",
+            "second fetch should start",
+        )
+        .await;
         assert_eq!(
             fetch_count.load(Ordering::SeqCst),
             2,
             "multiple invalidations in one in-flight window should coalesce to one additional fetch"
         );
 
-        release_second
-            .send(())
-            .expect("second fetch gate receiver should still be waiting");
+        releases.release(1);
         let success = timeout(Duration::from_millis(100), second_poll)
             .await
             .expect("second fetch should complete")
@@ -1621,30 +1558,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_loser_observes_shared_fetch_error_without_retrying() {
+        use crate::test_support::{assert_pending_until, gate_fetches};
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));
-        let (release_fetch, wait_for_release) = oneshot::channel::<()>();
-        let wait_for_release = Arc::new(std::sync::Mutex::new(Some(wait_for_release)));
+        let (mut releases, gates) = gate_fetches(1);
 
         let fetch_count_clone = fetch_count.clone();
-        let wait_for_release_clone = wait_for_release.clone();
+        let gates_clone = gates.clone();
         let query = Query::new(
             "key",
             move || {
                 let count = fetch_count_clone.clone();
-                let wait = wait_for_release_clone.clone();
+                let gates = gates_clone.clone();
                 Box::pin(async move {
                     count.fetch_add(1, Ordering::SeqCst);
-                    let receiver = wait
-                        .lock()
-                        .expect("fetch gate mutex should not be poisoned")
-                        .take()
-                        .expect("single-flight should call the fetcher only once");
-                    receiver.await.expect("fetch gate should be released");
+                    gates.next().await.expect("fetch gate should be released");
                     Err::<i32, QueryError>(QueryError::FetchError("boom".to_string()))
                 })
             },
@@ -1659,26 +1590,19 @@ mod tests {
 
         let first_error_poll = first_stream.next();
         tokio::pin!(first_error_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut first_error_poll => panic!("first fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 1 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("first fetch should start");
+        assert_pending_until(
+            &mut first_error_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 1,
+            "first fetch completed before its gate was released",
+            "first fetch should start",
+        )
+        .await;
 
         let second_loading = second_stream.next().await;
         assert!(matches!(second_loading, Some(ref result) if result.is_loading()));
         assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
 
-        release_fetch
-            .send(())
-            .expect("fetch gate receiver should still be waiting");
+        releases.release(0);
 
         let first_error = timeout(Duration::from_millis(100), first_error_poll)
             .await
@@ -1716,20 +1640,14 @@ mod tests {
     /// `State::Watching` until the next explicit invalidation.
     #[tokio::test]
     async fn test_invalidation_during_fetch_triggers_refetch() {
-        use std::collections::VecDeque;
+        use crate::test_support::{assert_pending_until, gate_fetches};
         use std::sync::Arc;
         use std::sync::atomic::{AtomicUsize, Ordering};
-        use tokio::sync::oneshot;
         use tokio::time::{Duration, timeout};
 
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));
-        let (release_first, wait_first) = oneshot::channel::<()>();
-        let (release_second, wait_second) = oneshot::channel::<()>();
-        let gates = Arc::new(std::sync::Mutex::new(VecDeque::from([
-            wait_first,
-            wait_second,
-        ])));
+        let (mut releases, gates) = gate_fetches(2);
 
         let fetch_count_clone = fetch_count.clone();
         let gates_clone = gates.clone();
@@ -1740,12 +1658,7 @@ mod tests {
                 let gates = gates_clone.clone();
                 Box::pin(async move {
                     let fetch_number = count.fetch_add(1, Ordering::SeqCst) + 1;
-                    let receiver = gates
-                        .lock()
-                        .expect("fetch gate mutex should not be poisoned")
-                        .pop_front()
-                        .expect("test should provide a gate for each expected fetch");
-                    receiver.await.expect("fetch gate should be released");
+                    gates.next().await.expect("fetch gate should be released");
                     Ok::<i32, QueryError>(
                         i32::try_from(fetch_number).expect("test fetch count should fit in i32"),
                     )
@@ -1763,25 +1676,18 @@ mod tests {
         // Gate the fetcher instead of sleeping so CI timing cannot miss the in-flight window.
         let refetching_poll = stream.next();
         tokio::pin!(refetching_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                result = &mut refetching_poll => panic!("first fetch completed before its gate was released: {result:?}"),
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 1 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-            }
-        })
-        .await
-        .expect("first fetch should start");
+        assert_pending_until(
+            &mut refetching_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 1,
+            "first fetch completed before its gate was released",
+            "first fetch should start",
+        )
+        .await;
 
         // Inject an invalidation while the first fetch is still gated.
         client.invalidate("key");
 
-        release_first
-            .send(())
-            .expect("first fetch gate receiver should still be waiting");
+        releases.release(0);
 
         // The first fetch completes after it has already been invalidated, so
         // the stale completion is discarded and the stream immediately starts
@@ -1798,22 +1704,15 @@ mod tests {
         // second fetch that produces the visible success.
         let success_poll = stream.next();
         tokio::pin!(success_poll);
-        timeout(Duration::from_millis(100), async {
-            tokio::select! {
-                () = async {
-                    while fetch_count.load(Ordering::SeqCst) < 2 {
-                        tokio::task::yield_now().await;
-                    }
-                } => {}
-                result = &mut success_poll => panic!("second fetch completed before its gate was released: {result:?}"),
-            }
-        })
-        .await
-        .expect("second fetch should start");
+        assert_pending_until(
+            &mut success_poll,
+            || fetch_count.load(Ordering::SeqCst) >= 2,
+            "second fetch completed before its gate was released",
+            "second fetch should start",
+        )
+        .await;
 
-        release_second
-            .send(())
-            .expect("second fetch gate receiver should still be waiting");
+        releases.release(1);
         let third = timeout(Duration::from_millis(100), success_poll)
             .await
             .expect("second fetch should complete");

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -13,8 +13,10 @@ use crate::application::Application;
 use crate::command::{Action, Command};
 use crate::subscription::Subscription;
 
+pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
 pub use trace_recorder::TraceRecorder;
 
+mod async_utils;
 mod trace_recorder;
 
 /// Serializes tests that install a process-global panic hook or deliberately

--- a/src/test_support/async_utils.rs
+++ b/src/test_support/async_utils.rs
@@ -1,0 +1,176 @@
+use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// Waits until a test-observed condition becomes true.
+///
+/// This hides the common `timeout + yield_now` polling loop used by tests that
+/// observe state updated by spawned tasks.
+pub async fn wait_until(mut condition: impl FnMut() -> bool, timeout_message: &str) {
+    timeout(DEFAULT_WAIT_TIMEOUT, async {
+        while !condition() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect(timeout_message);
+}
+
+/// Asserts that `future` remains pending until `condition` becomes true.
+///
+/// Use this when a test needs to prove a gated future has started but must not
+/// complete before the gate is released.
+pub async fn assert_pending_until<Fut, Condition>(
+    future: &mut Pin<&mut Fut>,
+    mut condition: Condition,
+    completed_message: &str,
+    timeout_message: &str,
+) where
+    Fut: Future,
+    Fut::Output: Debug,
+    Condition: FnMut() -> bool,
+{
+    timeout(DEFAULT_WAIT_TIMEOUT, async {
+        tokio::select! {
+            result = future.as_mut() => panic!("{completed_message}: {result:?}"),
+            () = async {
+                while !condition() {
+                    tokio::task::yield_now().await;
+                }
+            } => {}
+        }
+    })
+    .await
+    .expect(timeout_message);
+}
+
+/// Creates one-shot gates for a fixed number of expected fetches.
+pub fn gate_fetches(count: usize) -> (FetchGateReleases, FetchGateQueue) {
+    let mut releases = Vec::with_capacity(count);
+    let mut receivers = VecDeque::with_capacity(count);
+
+    for _ in 0..count {
+        let (release, wait) = oneshot::channel();
+        releases.push(Some(release));
+        receivers.push_back(wait);
+    }
+
+    (
+        FetchGateReleases { releases },
+        FetchGateQueue {
+            receivers: Arc::new(Mutex::new(receivers)),
+        },
+    )
+}
+
+/// Release handles returned by [`gate_fetches`].
+pub struct FetchGateReleases {
+    releases: Vec<Option<oneshot::Sender<()>>>,
+}
+
+impl FetchGateReleases {
+    /// Releases the zero-based gate at `index`.
+    pub fn release(&mut self, index: usize) {
+        let release = self
+            .releases
+            .get_mut(index)
+            .and_then(Option::take)
+            .expect("fetch gate release should exist");
+        assert!(
+            release.send(()).is_ok(),
+            "fetch gate receiver should still be waiting"
+        );
+    }
+}
+
+/// Receiver queue cloned into fetch closures by [`gate_fetches`].
+#[derive(Clone)]
+pub struct FetchGateQueue {
+    receivers: Arc<Mutex<VecDeque<oneshot::Receiver<()>>>>,
+}
+
+impl FetchGateQueue {
+    /// Returns the next expected fetch gate.
+    pub fn next(&self) -> oneshot::Receiver<()> {
+        self.receivers
+            .lock()
+            .expect("fetch gate mutex should not be poisoned")
+            .pop_front()
+            .expect("test should provide a gate for each expected fetch")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use tokio::time::timeout;
+
+    use crate::test_support::{assert_pending_until, gate_fetches, wait_until};
+
+    #[tokio::test]
+    async fn test_wait_until_observes_condition() {
+        let ready = Arc::new(AtomicBool::new(false));
+        let ready_clone = ready.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            ready_clone.store(true, Ordering::SeqCst);
+        });
+
+        wait_until(
+            || ready.load(Ordering::SeqCst),
+            "condition should become true",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_assert_pending_until_observes_condition() {
+        let ready = Arc::new(AtomicBool::new(false));
+        let ready_clone = ready.clone();
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            ready_clone.store(true, Ordering::SeqCst);
+        });
+
+        let pending = std::future::pending::<usize>();
+        tokio::pin!(pending);
+        assert_pending_until(
+            &mut pending,
+            || ready.load(Ordering::SeqCst),
+            "future should remain pending",
+            "condition should become true",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_gate_fetches_releases_expected_receivers() {
+        let (mut releases, gates) = gate_fetches(2);
+        let first = gates.next();
+        let second = gates.next();
+
+        releases.release(0);
+        timeout(super::DEFAULT_WAIT_TIMEOUT, first)
+            .await
+            .expect("first gate should complete")
+            .expect("first release should be delivered");
+
+        releases.release(1);
+        timeout(super::DEFAULT_WAIT_TIMEOUT, second)
+            .await
+            .expect("second gate should complete")
+            .expect("second release should be delivered");
+    }
+}


### PR DESCRIPTION
## Summary

- Add crate-internal async test helpers for bounded condition waits, pending-future assertions, and gated query fetches.
- Replace open-coded `timeout + select + yield_now` loops in HTTP query race tests with shared helpers.
- Replace synchronization sleeps in runtime/subscription tests with explicit state observation.
- Document the new helper usage in the testing guidelines.

## Notes

The helper timeout is intentionally a failure bound, not the synchronization mechanism itself. Successful waits still complete as soon as the observed condition becomes true.

Remaining `sleep(Duration::from_millis(...))` usages are left where elapsed time or delayed behavior is the behavior under test.

The observed `test_process_message_batch_emits_tracing_event` tracing flake is treated as existing parallel-sensitivity in tracing tests and should be followed up separately.

## Verification

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`
