### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
Potential fix for [https://github.com/akiomik/tears/security/code-scanning/1](https://github.com/akiomik/tears/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access by default.

Best fix here (without changing functionality): add

```yml
permissions:
  contents: read
```

near the top of the workflow (after `on:` is a common placement). None of the shown jobs appear to require write permissions, so this should preserve behavior while resolving the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
