### PR TITLE
docs(rfc): improve RFC 0004 structure and readability

### DIFF
--- a/docs/rfcs/0004-command-timeout-retry.md
+++ b/docs/rfcs/0004-command-timeout-retry.md
@@ -1,47 +1,75 @@
 # RFC 0004: Command Timeout / Retry
 
 - Status: Accepted
-- Target: 0.9.3 (next non-breaking patch), additive public API only
+- Target: 0.9.3 (the next non-breaking patch at acceptance), additive public
+  API only
 - Scope: timeout / retry lifecycle control confined to a single effect's
   execution; no runtime changes
 - Feature flag: none
-- CHANGELOG: `Added` (`Command::timeout`, `Command::retry`, `Command::retry_if`,
-  `RetryPolicy`, `RetryBackoff`, `RetryContext`, `RetryError`, `RetryStopReason`)
+- CHANGELOG: `Added` (`Command::timeout`, `Command::retry`,
+  `Command::retry_if`, `RetryPolicy`, `RetryBackoff`, `RetryContext`,
+  `RetryError`, `RetryStopReason`)
 
-> This RFC holds the observable contracts, invariants, and rationale, plus a
-> minimal implementation sketch (§9) for the mechanisms the contracts depend
-> on. Implementation details not fixed here are left to the implementer.
+> **Normative boundary.** The constraints in §1.3, the public API and observable
+> behavior in §§2–4 and Appendix A, and the "Contract" columns in Appendix B
+> are normative. Rationale and examples explain those contracts. Appendix C is
+> a non-normative implementation guide; where it cites a T/R contract, the
+> contract controls.
 
 ## Summary
 
-This RFC adds two lifecycle controls to `Command` that are confined to a single
-effect's execution.
+Long-running commands need two related but distinct lifecycle controls:
 
-- `Command::timeout(duration, on_timeout)`: attaches an overall deadline to
-  each effect leaf of the target command and emits a timeout message
-  **at most once per `.timeout()` call** when a deadline is reached.
-- `Command::retry(policy, operation, f)` / `Command::retry_if(policy,
-  operation, should_retry, f)`: constructors that take a repeatable future
-  factory and build a command that re-executes it according to a
-  `RetryPolicy`.
+- an overall deadline when an effect does not finish in time; and
+- re-execution when a repeatable operation fails transiently.
 
-Both are effect-local: they do not need the keyed, multi-update runtime state
-that RFC 0003 (command cancellation) introduces. The runtime (`src/runtime.rs`,
-`src/runtime/app_input.rs`) is not changed.
+This RFC adds both without changing the runtime:
 
-These two features were originally tagged "no RFC needed — they add no
-invariants" in the project backlog. Working out the design showed that they do
-carry (a) public contracts that are hard to walk back (the at-most-once
-guarantee, permanently claiming the `retry` name, treating `Quit` as terminal)
-and (b) integration contracts with RFC 0003, so the judgment was revised and
-this RFC records them. The original boundary judgment — that both features are
-effect-local — was correct and is kept here as a non-negotiable.
+| Feature | Public API shape | Execution scope | Terminal output |
+| --- | --- | --- | --- |
+| Timeout | `Command::timeout` modifier | Each effect leaf | At most one timeout message per `.timeout()` call |
+| Retry | `Command::retry` / `retry_if` constructors | One repeatable operation | On completion, one final success or error message |
 
-## 1. Context and Constraints
+Both controls are **effect-local**: they operate within one command execution
+and require no keyed state across updates. Keyed cancellation remains the
+runtime-level concern defined by
+[RFC 0003](./0003-command-cancellation.md).
 
-### 1.1 Background
+## 1. Motivation, Model, and Scope
 
-`Command<Msg>` is a two-layer structure of effect plus directives.
+### 1.1 Motivation
+
+A command that waits on I/O may remain pending indefinitely. The caller needs
+to turn that condition into an application message without changing the
+command's message type. Separately, an operation that can be safely repeated
+may need to retry a transient error and report only its final result.
+
+These cases need explicit contracts for composition, shutdown, and edge
+conditions. In particular:
+
+- a batched timeout needs a defined message count;
+- a retry needs a fresh future for every attempt;
+- `Quit` and cancellation need defined terminal behavior; and
+- time-dependent behavior needs deterministic contract tests.
+
+#### Why this requires an RFC
+
+Both features were originally tagged "no RFC needed — they add no invariants"
+in the project backlog. Design work exposed two kinds of decisions that would
+be difficult to reverse after release:
+
+1. public contracts such as the per-call at-most-once guarantee, permanently
+   claiming the `retry` name, and treating `Quit` as terminal; and
+2. integration contracts with
+   [RFC 0003](./0003-command-cancellation.md).
+
+That evidence reversed the original no-RFC decision. The original boundary
+assessment remains unchanged: timeout and retry are effect-local. Section 1.3
+keeps that boundary as a normative constraint.
+
+### 1.2 Model and terms
+
+`Command<Msg>` contains an effect and runtime directives:
 
 ```rust
 pub struct Command<Msg: Send + 'static> {
@@ -50,86 +78,61 @@ pub struct Command<Msg: Send + 'static> {
 }
 ```
 
-- `Effect<Msg>` is `None | Leaves(Vec<BoxStream<'static, Action<Msg>>>)`. It
-  keeps a flat sequence of leaf streams and only folds them (via `select_all`)
-  at the `into_stream()` boundary.
-- As noted in RFC 0002 §9 and RFC 0003, these concerns live in
-  separate layers:
-  - Output treatment (`without_redraw`): a directive over the whole update
-    result. Held as a field, folded by `batch`.
-  - Effect-local lifecycle (`timeout` / `retry`): `timeout` wraps effect leaf
-    streams, while `retry` is a constructor that closes over a repeatable
-    operation factory.
-  - Runtime lifecycle (`cancellable`): RFC 0003 represents cancellation as
-    runtime metadata (`cancels` / `key`) on `RuntimeCommandParts`, not as a
-    leaf-stream wrapper. Child keys inside `Command::batch` are intentionally
-    not preserved by RFC 0003.
-- `timeout` and `retry` close over a single effect. RFC 0003's cancellation
-  metadata is separate because cancellation needs keyed state spanning
-  multiple updates plus stale-output suppression.
-- Once an `Effect` has become a `BoxStream`, the information needed to
-  re-create the original async operation is gone. This constraint dictates the
-  shape of the retry API (constructor, not modifier).
+`Effect<Msg>` is either `None` or a flat sequence of leaf streams. The leaves
+are folded with `select_all` only at the `into_stream()` boundary.
 
-### 1.2 Non-Negotiables
+This RFC uses the following terms:
 
-1. **Effect-local boundary.** No new field on `RuntimeDirectives`. No new
-   `Action` variant. No changes to the runtime's keyed state machine.
-2. **Leaf identity is preserved.** `timeout` wraps leaves individually,
-   preserving leaf count and order. It must not close the door on future
-   per-leaf cancellation metadata beyond RFC 0003's top-level keyed task
-   model.
-3. **Per-child batch semantics hold.**
-   `Command::batch([a.timeout(1s), b.timeout(2s)])` times out per child,
+| Term | Meaning |
+| --- | --- |
+| Effect leaf | One independent stream stored in `Effect::Leaves` before folding |
+| Target command | The command consumed by a `.timeout()` call |
+| Per call | One contract shared by all leaves wrapped by that invocation |
+| Effect-local | State that exists only for one effect execution, not across updates |
+
+The relevant concerns remain in separate layers:
+
+| Layer | Examples | Representation |
+| --- | --- | --- |
+| Output treatment | `without_redraw` | Directive over the whole update result |
+| Effect-local lifecycle | `timeout`, `retry` | Leaf wrapper or repeatable operation factory |
+| Runtime lifecycle | `cancellable` | Keyed runtime metadata from RFC 0003 |
+
+RFC 0003 keeps cancellation metadata at the top-level keyed task boundary.
+Child keys inside `Command::batch` are intentionally not preserved.
+
+Once an effect has become a `BoxStream`, the original async operation can no
+longer be re-created. Timeout can therefore wrap an existing command, while
+retry must accept a repeatable operation factory.
+
+### 1.3 Constraints
+
+1. **Effect-local boundary.** There is no new `RuntimeDirectives` field,
+   `Action` variant, or runtime keyed state.
+2. **Leaf identity.** Timeout wraps leaves individually and preserves their
+   count and order. It must not preclude future per-leaf cancellation metadata
+   beyond RFC 0003's top-level keyed task model.
+3. **Per-child batch semantics.**
+   `Command::batch([a.timeout(1s), b.timeout(2s)])` times out each child
    independently.
-4. **Public constructors do not panic.** Following the crate's
-   `panic = "warn"` policy, invalid input is expressed via `Option` /
-   builders.
-5. **The prelude stays minimal.** Retry support types are re-exported from the
-   crate root only, not from `src/prelude.rs` (removing a name from the
-   prelude is a breaking change; adding one later is not).
-6. **No new dependencies.** Implemented with the existing `tokio` / `futures`
-   / `tokio-stream` dependencies.
+4. **Non-panicking constructors.** Invalid public input uses `Option` or
+   builders, following the crate's `panic = "warn"` policy.
+5. **Minimal prelude.** Retry support types are exported from the crate root,
+   not from `src/prelude.rs`.
+6. **No new dependencies.** The implementation uses the existing `tokio`,
+   `futures`, and `tokio-stream` dependencies.
+7. **Deterministic contract verification.** Every T/R contract must be pinned
+   by a deterministic test. Time-dependent tests use Tokio's paused clock.
 
-### 1.3 Goals and Non-Goals
+### 1.4 Out of scope
 
-#### Goals
+This RFC does not implement keyed cancellation, debounce, throttle, clock
+dependency injection, or runtime observability metrics. It also does not add
+stream re-subscription retry. Deferred API extensions are collected in §5.2.
 
-- Provide an overall deadline for a single effect (`timeout`) and
-  re-execution on failure (`retry`) as additive public API.
-- Fix the composition laws with `map` / `batch` / `without_redraw` as
-  contracts.
-- Pin every contract with deterministic tests on Tokio paused time.
-- Define up front the integration contracts that must still hold after
-  RFC 0003 is implemented.
+## 2. Timeout
 
-#### Non-Goals
-
-- Implementing RFC 0003 command cancellation.
-- Debounce / throttle.
-- Clock DI (generalizing deterministic effect testing is a separate item).
-- Exponential or jittered backoff in the initial release.
-- A retroactive `.retry(...)` modifier on an arbitrary `Command<Msg>`.
-- Re-subscription retry for `Command::stream`.
-- Runtime-level observability metrics for timeout / retry.
-
-## 2. Decision
-
-- `timeout` is a **modifier** that wraps each leaf stream of the `Effect` at
-  the `.timeout()` call. The deadline's `Sleep` is created on the leaf
-  stream's first poll, not at wrap time. The timeout message is emitted at
-  most once per `.timeout()` call.
-- `retry` is a **constructor** that takes a repeatable future factory and
-  rides on `Command::future`. `Effect` needs no changes, and `map` / `batch` /
-  `without_redraw` compose as they do for any existing command. After RFC 0003,
-  the constructor carries the default cancellation metadata.
-- Implementation order is `timeout` first (it touches `effect.rs`), `retry`
-  second (`Command::future(async move { ... })` suffices). The asymmetry is
-  deliberate.
-
-## 3. Public API Details
-
-### 3.1 `Command::timeout`
+### 2.1 Public API and usage
 
 ```rust
 impl<Msg: Send + 'static> Command<Msg> {
@@ -141,26 +144,312 @@ impl<Msg: Send + 'static> Command<Msg> {
 }
 ```
 
-Usage:
+`timeout` adds an overall deadline to the target command:
 
 ```rust
 Command::perform(fetch(query.clone()), Msg::SearchLoaded)
     .timeout(Duration::from_secs(5), || Msg::SearchTimedOut);
 ```
 
-Rationale for `on_timeout: FnOnce`:
+This is an overall deadline, not the per-item inactivity timeout provided by
+`tokio_stream::StreamExt::timeout`.
 
-- It matches the mental model of `tokio::time::timeout`: one `.timeout()`
-  call yields at most one timeout message.
-- Like the `Command::perform` mapper, it accepts closures that consume
-  move-only values.
-- The public bound does not require `Sync` (same reasoning as
-  `Command::map`).
+### 2.2 Core semantics
 
-A type-changing API (`timeout_result(duration) -> Command<Result<Msg,
-CommandTimeout>>` or similar) is not part of the initial implementation (§8).
+- Each leaf receives its own deadline. The deadline starts when that leaf is
+  first polled, not when `.timeout()` is called.
+- A `.timeout()` call emits **at most one timeout message**, even if it wraps
+  several leaves. The first leaf that takes its deadline path consumes
+  `on_timeout`. Other leaves still terminate at their own deadlines but emit no
+  timeout message.
+- A leaf that completes before its deadline does not consume `on_timeout`.
+  Inner termination wins when completion and an elapsed deadline are observed
+  in the same poll. Another pending leaf may still consume `on_timeout` later.
+- `Action::Message(msg)` observed before the deadline is delivered normally,
+  and the leaf continues.
+- `Action::Quit` observed before the deadline is delivered and terminates that
+  leaf without consuming `on_timeout`. At the runtime boundary, `Quit` stops
+  polling the entire command stream, so later sibling output is not delivered.
+  If `Quit` and an elapsed deadline are ready in the same poll, they follow the
+  same unspecified tie ordering as any other item: either `Quit` is delivered
+  and closes the leaf, or the deadline wins and `Quit` is not delivered.
+- When the wrapper takes the deadline path, the inner stream or future is
+  dropped and is never polled again. Already completed external side effects
+  are not rolled back.
+- A continuously ready stream cannot starve an elapsed deadline. A wrapper poll
+  in which the deadline is ready may pass through at most the simultaneously
+  ready inner item. If it does, no later inner item is delivered, and the
+  wrapper must take a terminal transition no later than its next poll. That
+  transition either observes inner termination or takes the deadline path and
+  may emit the timeout message; after any such terminal output, subsequent
+  polls return `None`. The exact ordering between the ready inner item and the
+  deadline is otherwise outside the contract.
 
-### 3.2 Retry support types
+### 2.3 Placement and composition
+
+Where timeout is attached determines how timeout messages are shared:
+
+| Shape | Deadline behavior | Timeout messages |
+| --- | --- | --- |
+| `single_leaf.timeout(d, f)` | One deadline | At most one |
+| `batch([a, b]).timeout(d, f)` | One deadline per leaf | At most one across the call |
+| `batch([a.timeout(d1, f1), b.timeout(d2, f2)])` | Each child is independent | At most one per child call |
+| `Command::none().timeout(d, f)` | No leaf, so no deadline | None |
+
+`Command::none().timeout(...)` remains stream-less and preserves runtime
+directives. `map` and `batch` preserve a timeout already wrapped into the leaf
+streams; `timeout` itself changes only the effect and preserves directives.
+
+On a `Command::stream`, messages flow before the deadline. A simultaneously
+ready item may also win the deadline tie once under §2.2's bounded-progress
+rule; the wrapper then takes a terminal transition, emitting the timeout
+message if still available unless inner termination wins, and closes. This also
+terminates an infinite stream, although `future` and `perform` are the primary
+use cases.
+
+### 2.4 Nested timeout edge cases
+
+For `a.timeout(d1, f1).timeout(d2, f2)`, the two calls retain independent
+at-most-once contracts:
+
+- On one leaf with strictly ordered deadlines, only the earlier wrapper emits
+  a message, then the leaf closes.
+- With simultaneous deadlines, exactly one of `f1` or `f2` is emitted; which
+  one is unspecified.
+- Across a batch, mutual exclusion is only per leaf. Different leaves may emit
+  messages belonging to different timeout calls.
+
+The ordering of a deadline and a simultaneously ready **item** is unspecified.
+Here, an item includes both `Action::Message` and `Action::Quit`. If `Quit`
+wins, it is delivered and closes the wrapper without consuming `on_timeout`; if
+the deadline wins, the inner stream is dropped and `Quit` is not delivered. If
+a non-terminal message wins, the wrapper must take a terminal transition no
+later than its next poll, as required by §2.2. Inner **termination** (`None`) is
+different: it deterministically wins and closes the wrapper without a timeout
+message.
+
+### 2.5 API rationale
+
+`on_timeout` is `FnOnce` because one `.timeout()` call can produce at most one
+timeout message. The bound also permits closures that consume move-only values
+and, like `Command::map`, does not expose a public `Sync` requirement.
+
+Timeout is a modifier because an existing leaf stream can be wrapped without
+reconstructing its source operation. Wrapping leaves individually preserves
+leaf identity and per-child batch behavior.
+
+## 3. Retry
+
+### 3.1 Public API
+
+```rust
+impl<Msg: Send + 'static> Command<Msg> {
+    pub fn retry<A, E, Fut, Op, F>(
+        policy: RetryPolicy,
+        operation: Op,
+        f: F,
+    ) -> Self
+    where
+        A: Send + 'static,
+        E: Send + 'static,
+        Fut: Future<Output = Result<A, E>> + Send + 'static,
+        Op: FnMut(RetryContext) -> Fut + Send + 'static,
+        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static;
+
+    pub fn retry_if<A, E, Fut, Op, P, F>(
+        policy: RetryPolicy,
+        operation: Op,
+        should_retry: P,
+        f: F,
+    ) -> Self
+    where
+        A: Send + 'static,
+        E: Send + 'static,
+        Fut: Future<Output = Result<A, E>> + Send + 'static,
+        Op: FnMut(RetryContext) -> Fut + Send + 'static,
+        P: FnMut(&E, RetryContext) -> bool + Send + 'static,
+        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static;
+}
+```
+
+`retry` retries every error while attempts remain. `retry_if` additionally
+allows the caller to stop based on the error and current attempt.
+
+### 3.2 Usage
+
+```rust
+use std::num::NonZeroUsize;
+use std::time::Duration;
+use tears::{Command, RetryError, RetryPolicy};
+
+struct Todo;
+struct FetchError;
+
+enum Msg {
+    TodoLoaded(Result<Todo, RetryError<FetchError>>),
+}
+
+async fn fetch_todo(
+    _todo_id: u64,
+    _attempt: NonZeroUsize,
+) -> Result<Todo, FetchError> {
+    Ok(Todo)
+}
+
+let policy = RetryPolicy::try_new(3)
+    .expect("max attempts must be non-zero")
+    .with_fixed_backoff(Duration::from_millis(200));
+
+let todo_id = 42;
+let command: Command<Msg> = Command::retry(
+    policy,
+    move |ctx| fetch_todo(todo_id, ctx.attempt()),
+    Msg::TodoLoaded,
+);
+```
+
+The public rustdoc must warn that the operation may run up to
+`policy.max_attempts()` times. Callers are responsible for ensuring that
+repetition is safe: non-idempotent external side effects may occur more than
+once, including when an attempt performs the side effect and later returns an
+error.
+
+### 3.3 Support model
+
+| Type | Purpose |
+| --- | --- |
+| `RetryPolicy` | Non-zero maximum attempt count plus backoff |
+| `RetryBackoff` | No delay or one fixed delay between attempts |
+| `RetryContext` | The current 1-based attempt number |
+| `RetryError<E>` | Attempt count, last error, and stop reason |
+| `RetryStopReason` | `Exhausted` or `StoppedByPredicate` |
+
+`RetryPolicy::new` accepts `NonZeroUsize`. The convenience
+`RetryPolicy::try_new(usize)` returns `None` for zero instead of panicking.
+The default backoff is `RetryBackoff::None`. Appendix A contains the complete
+support API and compatibility attributes.
+
+### 3.4 Core semantics
+
+- `max_attempts` includes the first execution, and
+  `RetryContext::attempt()` is 1-based. If a future backoff calculation needs
+  a 0-based exponent, that conversion remains inside the helper rather than
+  changing the public context.
+- If processing completes without cancellation or panic, `f` emits exactly one
+  final message: `Ok(A)` on success or
+  `Err(RetryError { attempts, last_error, reason })` on failure.
+- On `Err(E)` with attempts remaining, `retry_if` calls
+  `should_retry(&error, ctx)`. A true result continues after the configured
+  backoff; false returns `StoppedByPredicate`.
+- An error on the final attempt always returns `Exhausted`.
+  `should_retry` is not called on that attempt.
+- `RetryBackoff::None` starts the next attempt without sleeping.
+  `RetryBackoff::Fixed { delay }` waits the same delay after each retriable
+  failure and before the next attempt.
+- If the task is aborted before processing completes, no final message is
+  produced.
+
+For a per-attempt deadline, the operation can use
+`tokio::time::timeout(d, fetch()).await` and map the timeout to `Err`. An outer
+`.timeout(...)` instead applies one overall deadline to the complete retry
+process.
+
+### 3.5 API rationale and naming
+
+Retry is a constructor rather than a modifier because `Effect::Leaves` retains
+only streams, not the factory needed to create a new future. Each attempt must
+invoke the supplied operation again. In addition, an arbitrary `Command<Msg>`
+has no error channel from which retry could classify failures.
+
+`operation` and `should_retry` are `FnMut`. They run sequentially, so both may
+keep small local state without requiring synchronization. The final mapper `f`
+is `FnOnce` because it is invoked only for the final result.
+
+The name `Command::retry` permanently occupies that inherent constructor name;
+Rust does not permit a future inherent modifier with the same name. This
+tradeoff is accepted because a modifier cannot represent real re-execution
+under the current `Effect` model. If a future representation makes such a
+modifier possible, it must use another inherent name such as `with_retry` or
+`retry_with`. An extension-trait method could technically coexist even though
+the inherent `retry` name is closed.
+
+Arguments are ordered `policy, operation, f` (or
+`policy, operation, should_retry, f`). This is the crate's first intentional
+departure from the effectful-payload-first convention used by
+`perform(future, f)` and `run(stream, f)`. Configuration comes first, the
+repeatable operation second, and the message mapper remains last. Public
+rustdoc must state that reading order explicitly: configuration → operation →
+message conversion.
+
+Retry support types are imported explicitly from the crate root and are not
+added to the prelude. The prelude is deliberately small—it does not include
+`Timer`—and `RetryPolicy` / `RetryError` are common, collision-prone ecosystem
+names. Adding them later is non-breaking; removing them after inclusion would
+be breaking.
+
+## 4. Composition and Runtime Cancellation
+
+### 4.1 Existing command operations
+
+| Operation | Timeout | Retry |
+| --- | --- | --- |
+| `map` | Maps output while preserving wrapped leaves | Behaves like any `Command::future` result |
+| `batch` | Preserves leaf count, order, and placement semantics | Batches like any other command |
+| `without_redraw` | Directive is preserved | Directive is preserved |
+
+Retry is implemented through `Command::future` and therefore inherits its
+existing composition behavior. Timeout wraps only the effect and never removes
+directives.
+
+### 4.2 RFC 0003 integration
+
+[RFC 0003](./0003-command-cancellation.md) is implemented separately. Once its
+metadata exists, these forward-integration contracts apply:
+
+- `timeout` preserves cancellation metadata as well as directives.
+- `.timeout(...).cancellable(id)` and
+  `.cancellable(id).timeout(...)` both preserve the key.
+- Retry constructors carry the default cancellation metadata supplied by
+  `Command::future`.
+- Cancelling or superseding a keyed command suppresses both a pending timeout
+  message and a retry final message through private-receiver drop.
+- `Command::cancel(id).timeout(...)` remains stream-less, so timeout is inert
+  and the explicit cancellation remains.
+
+Verification of every contract in this subsection belongs to the RFC 0003
+implementation and is outside the 0.9.3 implementation scope of this RFC. Its
+runtime tests must additionally cover cancellation before a timeout,
+supersession during retry backoff, and `KeepInFlight` preventing a second
+retrying command from spawning under the same key.
+
+## 5. Alternatives and Deferred Work
+
+### 5.1 Alternatives not selected
+
+| Alternative | Reason |
+| --- | --- |
+| Fold leaves before applying timeout | Collapses leaf identity and prevents per-leaf lifecycle metadata |
+| Emit one timeout message per leaf | Conflicts with the one-call/one-message model; callers can attach timeout to each child instead |
+| Keep polling a leaf after `Quit` | Produces output after a terminal runtime request |
+| Use `tokio_stream::StreamExt::timeout` | Implements per-item inactivity, not an overall deadline |
+| Omit `RetryStopReason` | Makes predicate stop indistinguishable from exhausted attempts |
+| Accept `usize` and panic on zero | Violates the crate's non-panicking constructor policy |
+
+### 5.2 Deferred extensions
+
+| Extension | Reason for deferral |
+| --- | --- |
+| Type-changing `timeout_result` | Orthogonal to the message-preserving API and can be added later |
+| Exponential or jittered backoff | Factor representation, saturating arithmetic, and randomness need a separate reproducible design |
+| Retry modifier on arbitrary commands | Requires leaves to retain repeatable operation factories |
+| `Command::stream` re-subscription retry | Requires separate stream retry semantics |
+| Prelude re-exports | Can be added after observing usage; removal would be breaking |
+| Clock dependency injection | General deterministic effect testing is a separate concern |
+| Debounce / throttle | Belong to RFC 0003's keyed lifecycle model |
+
+## Appendix A. Retry Support API (Normative)
+
+### A.1 Types
 
 ```rust
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -201,9 +490,11 @@ pub enum RetryStopReason {
 }
 ```
 
-Constructors and accessors. The return-self builders carry message-bearing
-`#[must_use]`, mirroring `Command::without_redraw`; everything else clippy's
-`must_use_candidate` would flag carries a plain `#[must_use]`:
+### A.2 Constructors and accessors
+
+Return-self builders carry message-bearing `#[must_use]` attributes, matching
+`Command::without_redraw`. Other candidates identified by Clippy carry plain
+`#[must_use]`.
 
 ```rust
 impl RetryPolicy {
@@ -249,473 +540,176 @@ impl<E: std::fmt::Display> std::fmt::Display for RetryError<E>;
 impl<E: std::error::Error + 'static> std::error::Error for RetryError<E>;
 ```
 
-Design decisions:
+### A.3 Compatibility consequences
 
-- **`RetryPolicy::new` is an infallible API taking `NonZeroUsize`.** `usize`
-  input, which may be zero, goes through `try_new -> Option`. This matches
-  `Timer::try_new` (`Option`), which likewise has exactly one invalidity
-  reason. `FrameRate::try_new` returns `Result` because it has two failure
-  reasons (`Zero` / `TooHigh`), so its situation differs. A `new(usize)` that
-  panics on zero would violate the `panic = "warn"` policy and is not used.
-- **The default backoff is `RetryBackoff::None`.**
-- **`#[non_exhaustive]` strategy.** Both the enum itself and the variants with
-  fields carry `#[non_exhaustive]`, making future variant additions
-  (`Exponential` / `Jittered`) and field additions non-breaking. Enum variant
-  fields share the enum's visibility, so variant-level `#[non_exhaustive]`
-  achieves exactly: matching stays possible via `Fixed { delay, .. }`, while
-  construction is funneled through `RetryBackoff::fixed(...)` /
-  `RetryPolicy::with_*_backoff(...)`. The rustdoc must state that downstream
-  `match` expressions need a wildcard arm.
-- **Const-ness constrains drop glue.** Since `RetryPolicy::with_backoff` and
-  friends ship as `const fn`, future variant fields must stay free of drop
-  glue. Adding a field that needs `Drop` (a `Box`, a randomness source, etc.)
-  cannot keep const-ness and would require a separate API. This is one reason
-  exponential backoff is deferred: fixing the factor type (integer /
-  finite-guaranteeing newtype / `f64`) under this constraint is premature.
-- **Derived traits constrain future fields.** `RetryBackoff` ships with
-  derived `Clone, Debug, Eq, PartialEq`, and removing a derive later is
-  breaking. Future variant fields must therefore preserve all four (plus the
-  no-drop-glue constraint above). In particular, a bare `f64` multiplier can
-  never be stored (`f64` is not `Eq`): if a future constructor accepts `f64`,
-  it must convert it into an `Eq`-compatible finite representation for
-  storage, such as an integer-scaled multiplier or a finite-guaranteeing
-  newtype with a manual `Eq` impl. The same compatibility rule applies to
-  `RetryContext`: because it also derives `Copy`, every future field added
-  under `#[non_exhaustive]` must implement `Copy` as well as the other derived
-  traits.
-- **`RetryStopReason` exists.** A single-variant `RetryError::Exhausted` is
-  not enough: when the `retry_if` predicate returns false, attempts have not
-  been used up, so that case is represented separately as
-  `StoppedByPredicate`.
+- `RetryPolicy::new(NonZeroUsize)` is infallible, while
+  `try_new(usize) -> Option<Self>` represents the single invalid case. This
+  follows the `Timer::try_new` precedent; `FrameRate::try_new` uses `Result`
+  because it distinguishes multiple invalid cases.
+- `RetryBackoff` and its field-bearing variants are `#[non_exhaustive]`.
+  Enum variant fields share the enum's visibility, so variant-level
+  `#[non_exhaustive]` permits downstream matching with patterns such as
+  `Fixed { delay, .. }` while construction goes through public constructors
+  and builders. Enum-level `#[non_exhaustive]` leaves room for variants such as
+  `Exponential` and `Jittered`. Rustdoc must state that downstream matches
+  require a wildcard arm.
+- The shipped `const fn` builders constrain future backoff fields to values
+  without drop glue. A future representation requiring `Drop` needs a separate
+  API.
+- Removing the derived traits would be breaking. Future `RetryBackoff` fields
+  must preserve `Clone + Debug + Eq + PartialEq`; future `RetryContext` fields
+  must additionally preserve `Copy`. A bare `f64` therefore cannot be stored as
+  an `Eq` field, although a constructor could convert it to an `Eq`-compatible
+  finite representation.
+- `RetryStopReason` distinguishes an exhausted policy from a predicate stop
+  that occurs while attempts remain.
 
-### 3.3 `Command::retry` / `Command::retry_if`
+## Appendix B. Contract Checklist and Verification
 
-```rust
-impl<Msg: Send + 'static> Command<Msg> {
-    pub fn retry<A, E, Fut, Op, F>(
-        policy: RetryPolicy,
-        operation: Op,
-        f: F,
-    ) -> Self
-    where
-        A: Send + 'static,
-        E: Send + 'static,
-        Fut: Future<Output = Result<A, E>> + Send + 'static,
-        Op: FnMut(RetryContext) -> Fut + Send + 'static,
-        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static;
+As required by §1.3, every T/R contract below must be pinned by a deterministic
+test. The "Contract" columns and that coverage requirement are normative;
+exact test locations and representative cases are verification guidance.
 
-    pub fn retry_if<A, E, Fut, Op, P, F>(
-        policy: RetryPolicy,
-        operation: Op,
-        should_retry: P,
-        f: F,
-    ) -> Self
-    where
-        A: Send + 'static,
-        E: Send + 'static,
-        Fut: Future<Output = Result<A, E>> + Send + 'static,
-        Op: FnMut(RetryContext) -> Fut + Send + 'static,
-        P: FnMut(&E, RetryContext) -> bool + Send + 'static,
-        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static;
-}
-```
+### B.1 Timeout contracts
 
-- `retry` is the convenience wrapper that retries every error. `retry_if` is
-  the lower-level API that can stop based on the error kind or the attempt.
-- `should_retry` is `FnMut`. Like `operation`, it is called sequentially, so
-  the wider bound costs nothing and lets the predicate keep small local state
-  (e.g. a consecutive-failure counter) inside the closure.
-- The public rustdoc for both constructors must warn that `operation` can run
-  up to `policy.max_attempts()` times. Callers are responsible for ensuring
-  that repeating the operation is safe: non-idempotent external side effects
-  may occur more than once, including when an earlier attempt performs the
-  side effect and subsequently returns an error.
+| ID | Contract |
+| --- | --- |
+| T1 | Timeout changes only the effect and preserves runtime directives. |
+| T2 | Each deadline starts on the leaf's first poll, not at the `.timeout()` call. |
+| T3 | One `.timeout()` call emits at most one timeout message across all wrapped leaves; its `FnOnce` closure may consume move-only state. |
+| T4 | Completion before the deadline does not consume `on_timeout`; termination wins if both are observed together. |
+| T5 | Pre-deadline messages pass through; a pre-deadline `Quit` is delivered, closes the leaf, and does not consume `on_timeout`. At runtime, a delivered `Quit` stops sibling delivery. A deadline/`Quit` tie follows T10's unspecified item ordering. |
+| T6 | A timed-out inner stream is dropped and never polled again; no rollback is promised. |
+| T7 | Timeout on a stream-less command is inert and preserves `is_none()`. |
+| T8 | `map` and `batch` preserve leaf count, order, and placement semantics; child timeouts remain independent. |
+| T9 | Nested timeout emits only the earlier message on one leaf; a tie emits exactly one unspecified message. Different batch leaves may emit from different calls. |
+| T10 | Deadline/item tie ordering is unspecified and tests accept either outcome. `Item` includes `Message` and `Quit`. Termination (`None`) still wins. A poll in which the deadline is ready passes through at most the simultaneously ready inner item; if it does, no later inner item is delivered, the wrapper takes a terminal transition no later than its next poll, and it returns `None` after any terminal output. `Duration::ZERO` does not panic. |
 
-Usage:
+### B.2 Retry contracts
 
-```rust
-use std::num::NonZeroUsize;
-use std::time::Duration;
-use tears::{Command, RetryError, RetryPolicy};
+| ID | Contract |
+| --- | --- |
+| R1 | `max_attempts` includes the first attempt; completed processing emits exactly one final message. |
+| R2 | Final-attempt failure returns `Exhausted` without calling `should_retry`. |
+| R3 | `StoppedByPredicate` occurs only while attempts remain. |
+| R4 | `None` adds no delay; `Fixed` waits the same delay before every next attempt. |
+| R5 | `RetryError` retains `last_error` and exposes it through `Display` and `Error::source()`. |
+| R6 | `try_new(0)` is `None`; `new` defaults to no backoff; fixed-backoff builders preserve `max_attempts`. |
+| R7 | Retry uses `Command::future`, so `map`, `without_redraw`, and `batch` keep existing behavior. |
+| R8 | `should_retry` may retain local state through its `FnMut` bound. |
 
-struct Todo;
-struct FetchError;
+### B.3 Test strategy
 
-enum Msg {
-    TodoLoaded(Result<Todo, RetryError<FetchError>>),
-}
+Time-dependent tests use `#[tokio::test(start_paused = true)]` and
+`tokio::time::advance`. Tokio's `test-util` feature is already a
+dev-dependency.
 
-async fn fetch_todo(_todo_id: u64, _attempt: NonZeroUsize) -> Result<Todo, FetchError> {
-    Ok(Todo)
-}
+- Timeout unit tests in
+  [`src/command.rs`](../../src/command.rs) and
+  [`src/command/effect.rs`](../../src/command/effect.rs) cover T1–T10,
+  including pending and early-completing futures, multiple stream messages,
+  `map` on either side of timeout, batch factory consumption (completed and
+  pre-deadline `Quit` leaves do not consume the factory), deadline/`Quit` ties,
+  bounded progress after an elapsed deadline, nested timeout, and
+  `Duration::ZERO`.
+- Retry unit tests in `src/command/retry.rs` cover R1–R8, including first- and
+  second-attempt success, exhaustion, predicate stop, one allowed attempt,
+  policy validation, and backoff.
+- Runtime smoke tests verify that timeout and retry final messages reach
+  `update` and that pending timeouts or backoffs do not detach at shutdown.
+  Existing `JoinSet` abort behavior covers shutdown; add a `Notify`-based test
+  if that behavior needs an explicit assertion.
 
-let policy = RetryPolicy::try_new(3)
-    .expect("max attempts must be non-zero")
-    .with_fixed_backoff(Duration::from_millis(200));
+## Appendix C. Implementation Guide (Non-Normative)
 
-let todo_id = 42;
-let command: Command<Msg> = Command::retry(
-    policy,
-    move |ctx| fetch_todo(todo_id, ctx.attempt()),
-    Msg::TodoLoaded,
-);
-```
+Any implementation that satisfies the normative contracts is valid. The
+sketches below show how to realize the contracts with the existing
+dependencies.
 
-### 3.4 Naming decisions
+### C.1 Suggested order
 
-The following are deliberate decisions that become breaking to change once
-shipped.
+1. Add `Effect::timeout` and `Command::timeout` with unit tests and rustdoc.
+2. Add retry support types in `src/command/retry.rs` and re-export them from
+   `src/command.rs` and `src/lib.rs`, but not the prelude.
+3. Add `Command::retry`, `retry_if`, and a `run_retry` helper.
+4. Add runtime integration smoke tests.
+5. Update CHANGELOG, README, and rustdoc.
 
-1. **`Command::retry` permanently claims the constructor name.** In Rust,
-   items with the same name across inherent impls collide (E0592, duplicate
-   definitions), so this choice closes the door on ever adding an inherent
-   modifier method `retry(...)` to `impl<A, E> Command<Result<A, E>>`. A true
-   retry modifier on arbitrary commands would require a major redesign in
-   which `Effect` leaves hold repeatable operation factories — speculative —
-   so the short, natural constructor name wins. If a modifier is ever needed,
-   it takes another name such as `with_retry(...)` / `retry_with(...)` (the
-   inherent door closes, but an extension-trait method could technically
-   coexist). Retry semantics for `Command::stream` would also need their own
-   definition at that point.
-2. **Argument order is `policy, operation, f`.** This is the first API to
-   break the crate's own convention of "the effectful payload comes first"
-   (`perform(future, f)`, `run(stream, f)`), and the break is accepted
-   deliberately: `retry` can take two closures, and leading with the small
-   configuration value reads better. The mapper stays last, as in the existing
-   APIs, and the rustdoc spells out the reading order: configuration → what to
-   run → how to turn it into a message.
-3. **Retry support types are imported explicitly from the root**
-   (`tears::RetryPolicy`). They are not added to the prelude initially
-   (§1.2, item 5).
+Timeout comes first because it changes `effect.rs`. Retry can be built on
+`Command::future` without changing `Effect`.
 
-## 4. Semantics
+### C.2 Timeout sketch
 
-### 4.1 timeout
+`Effect::timeout(duration, on_timeout)` can return `Effect::None` unchanged and
+wrap every `Effect::Leaves` entry in a stateful `timeout_leaf` stream.
 
-- **An overall deadline, not an inter-item inactivity timeout.**
-  (`tokio_stream::StreamExt::timeout` is a per-item timeout and serves a
-  different purpose.)
-- The deadline applies **per leaf** of the target command. It starts at the
-  leaf stream's first poll (when the runtime starts executing the effect),
-  not at the `.timeout()` call.
-- **The timeout message is emitted at most once per `.timeout()` call.** Even
-  when the target has several leaves, as in
-  `Command::batch([a, b]).timeout(...)`, only the first leaf to reach its
-  deadline consumes `on_timeout` and emits the timeout message. The other
-  leaves terminate at their own deadlines without a message.
-- A leaf that completes before its deadline does not consume `on_timeout`.
-  This holds even when completion and the elapsed deadline are observed in the
-  same poll: inner termination wins over the wrapper's own elapsed deadline,
-  and the leaf closes without a timeout message (§9.2). If `a` completes early
-  and `b` is still pending inside a batch, `b` can still emit the timeout
-  message at its deadline.
-- An `Action::Message(msg)` before the deadline is delivered normally and the
-  leaf continues.
-- An `Action::Quit` before the deadline is delivered as `Quit` and
-  **terminates that leaf**. This is deliberate non-transparency: the timeout
-  wrapper treats `Quit` as a terminal action. Termination via `Quit` does not
-  consume `on_timeout`. At the runtime boundary, however, `Action::Quit`
-  stops polling the whole command stream, so later sibling output under the
-  same `.timeout()` is not delivered by the runtime.
-- When a deadline fires, the inner stream/future is dropped and never polled
-  again. As in RFC 0003, stopping the polling does not roll back external
-  side effects that already happened.
-- `Command::none().timeout(...)` is inert — there is no stream, so a timeout
-  message is never emitted. Runtime directives such as `without_redraw` are
-  preserved unchanged.
-- `map` / `batch` naturally preserve a timeout that is wrapped into the leaf
-  streams. `timeout` wraps only the `effect` and never drops `directives`.
-- Applying `.timeout(d1, f1).timeout(d2, f2)` twice: the two wrappers are
-  independent at-most-once contracts. For a single leaf, they do not emit both
-  messages: with strictly ordered deadlines, only the message of the wrapper
-  whose deadline fires first is emitted, then the leaf closes; with
-  simultaneous deadlines (equal durations, or nested `Duration::ZERO`),
-  exactly one of `f1` / `f2` is emitted, unspecified which. For a batched
-  command, this cross-wrapper exclusion is not a whole-command guarantee:
-  different leaves may still emit messages from different `.timeout()` calls,
-  for example one leaf emitting the outer timeout and another later emitting
-  the inner timeout. Each individual `.timeout()` call still emits at most
-  once.
-- The precise ordering when a deadline and a stream item become ready
-  simultaneously is **not part of the contract**.
-- On a `Command::stream`, messages flow until the deadline, then the timeout
-  message is emitted and the stream closes. An infinite stream is always
-  terminated at the deadline, so the primary use cases are `future` /
-  `perform`.
+One implementation shares `on_timeout` as `Arc<Mutex<Option<F>>>`. The first
+leaf to reach its deadline takes the `FnOnce`, satisfying T3. The mutex keeps
+the public bound at `FnOnce + Send` rather than exposing `Sync`. As in
+`Effect::map`, a poisoned lock can be recovered with
+`PoisonError::into_inner` so one sibling panic does not cascade.
 
-### 4.2 retry
-
-- `max_attempts` includes the first execution.
-- If retry processing completes without cancellation or panic, the final
-  message is emitted exactly once: `Ok(A)` on success, otherwise
-  `Err(RetryError { attempts, last_error, reason })`, both converted to a
-  message by `f`.
-- On `Err(E)` with attempts remaining and `should_retry(&error, ctx)` true,
-  the operation re-runs after the backoff.
-- **An `Err(E)` on the final attempt takes `RetryStopReason::Exhausted`
-  priority.** `should_retry` is not called on that attempt, so input for
-  which the predicate would return false still yields `Exhausted`, never
-  `StoppedByPredicate`. `StoppedByPredicate` occurs only when the predicate
-  returns false while attempts remain.
-- `RetryBackoff::None` proceeds to the next attempt without sleeping (no
-  virtual-time advance is needed). `RetryBackoff::Fixed { delay }` waits the
-  same `delay` after every failure, before the next attempt.
-- `RetryContext::attempt` is 1-based. If a backoff computation needs a 0-based
-  exponent index, that conversion stays inside the helper and the contract is
-  pinned by tests.
-- If the task is aborted before retry processing completes (runtime shutdown,
-  or future cancellation), no final message is produced.
-- For a per-attempt timeout, use `tokio::time::timeout(d, fetch()).await`
-  inside `operation` and map the timeout into an `Err`; that makes it subject
-  to retry. An outer `.timeout(...)` acts as a deadline over the whole retry.
-- No jitter in the initial implementation; deterministic tests and
-  reproducibility take priority.
-
-## 5. Invariants (contract tests)
-
-Each item is pinned by a test. Timeout (T), retry (R).
-
-- T1. `timeout` wraps only the `effect` and preserves `directives` (and,
-  later, cancellation metadata).
-- T2. The deadline starts at the leaf stream's first poll, not at the
-  `.timeout()` call.
-- T3. The timeout message is at-most-once per `.timeout()` call: even if
-  several leaves reach their deadlines, at most one message is emitted.
-- T4. A leaf that completes before its deadline does not consume
-  `on_timeout`; inner termination observed together with an elapsed deadline
-  still wins (no timeout message).
-- T5. Pre-deadline `Message`s pass through; `Quit` is delivered and closes the
-  leaf without consuming `on_timeout`. Once delivered to the runtime, `Quit`
-  stops polling the whole command stream, so later sibling output is not
-  runtime-delivered.
-- T6. When the timeout fires, the inner stream is dropped and never polled
-  again (no rollback is promised).
-- T7. Timeout on a stream-less command is inert and keeps `is_none()`.
-- T8. Composition with `map` / `batch` preserves leaf count, order, and
-  timeout behavior; `batch([a.timeout(..), b.timeout(..)])` times out per
-  child, independently.
-- T9. Double `.timeout()` on a single leaf: strictly ordered deadlines emit
-  only the earlier wrapper's message; simultaneous deadlines emit exactly one
-  of the two messages, unspecified which. Never both for that leaf. Batched
-  double timeouts do not have a cross-wrapper mutual-exclusion guarantee
-  across different leaves.
-- T10. Simultaneous readiness ordering between the deadline and a stream
-  *item* is out of contract. Tests must not depend on it (`Duration::ZERO`
-  must not panic; for a single-leaf double timeout, only assert that one of
-  the messages is emitted). Inner *termination*, by contrast,
-  deterministically wins over an elapsed deadline (T4, T9).
-- R1. `max_attempts` includes the first attempt; if retry processing completes
-  without cancellation or panic, the final message is emitted exactly once.
-- R2. Failure on the final attempt yields `Exhausted` and does not call
-  `should_retry` on that attempt.
-- R3. `StoppedByPredicate` occurs only while attempts remain.
-- R4. `RetryBackoff::None` advances no time before the next attempt; `Fixed`
-  waits the same delay after each failure.
-- R5. `RetryError` keeps `last_error` and exposes it through `Display` /
-  `Error::source()`.
-- R6. `RetryPolicy::try_new(0)` is `None`. `new` defaults the backoff to
-  `RetryBackoff::None`. `with_fixed_backoff` preserves `max_attempts`.
-- R7. The retry constructors go through `Command::future`, so `map` /
-  `without_redraw` / `batch` behave as they do for any existing command.
-- R8. `should_retry` can hold state as an `FnMut`; `on_timeout` can consume
-  move-only values as an `FnOnce` (compile-time contracts).
-
-## 6. Testing Strategy
-
-Time-dependent tests are made deterministic with
-`#[tokio::test(start_paused = true)]` and `tokio::time::advance` (`tokio`'s
-`test-util` is already a dev-dependency). Clock DI is future work; the tests in
-this RFC are fixed on Tokio paused time.
-
-- **Timeout unit tests** (`src/command.rs` / `src/command/effect.rs`): pin
-  T1–T10 directly. Representative cases: deadline firing on a pending future,
-  completion before the deadline, multiple messages passing through on a
-  `Command::stream`, `map` on both sides (`timeout.map` / `map.timeout`),
-  factory-consumption rules under batch × timeout (completed leaves and
-  `Quit` leaves do not consume), single-leaf double timeout, batched double
-  timeout without cross-wrapper mutual exclusion, `Duration::ZERO`.
-- **Retry unit tests** (`src/command/retry.rs`): R1–R8. Success on the first
-  attempt / success on the second (one backoff), exhaustion, predicate stop,
-  `max_attempts = 1`, policy validation, backoff computation.
-- **Integration smoke tests**: the timeout message and the retry final
-  message (success / exhausted) reach the runtime's `update`. That pending
-  timeouts / backoffs do not detach at shutdown rides on the existing
-  `JoinSet` abort behavior (add a `Notify`-based smoke test if needed).
-
-## 7. Interaction with RFC 0003 (command cancellation)
-
-RFC 0003 proceeds as a separate implementation, but the integration contracts
-are fixed now.
-
-- `timeout` wraps only the `effect` and preserves `directives` and
-  cancellation metadata (an extension of T1).
-- The retry constructors go through `Command::future` and therefore carry the
-  default cancellation metadata.
-- `.timeout(...).cancellable(id)` and `.cancellable(id).timeout(...)` both
-  preserve the key.
-- When a keyed command is cancelled or superseded, the timeout message and the
-  retry final message are not delivered, by virtue of the private-receiver
-  drop.
-- `Command::cancel(id).timeout(...)` is stream-less, so the timeout is inert;
-  the explicit cancel remains.
-
-Required RFC 0003 runtime coverage, outside the 0.9.3 implementation scope of
-this RFC:
-
-- Cancelling a keyed command before the timeout deadline suppresses the
-  timeout message.
-- Superseding a keyed command during a retry backoff suppresses the old retry
-  final message.
-- While a retrying command holds a key under `KeepInFlight`, a new retrying
-  command is not spawned.
-
-## 8. Alternatives Considered
-
-### Retry as a modifier (`Command::future(fetch()).retry(policy)`)
-
-Rejected. `Effect::Leaves` holds only `BoxStream`s, and a future cannot be
-re-used once polled, so a retroactive retry on an existing command cannot be a
-real re-execution. `Msg` has no error channel, so retry classification is also
-impossible. A constructor taking a repeatable factory is the only honest shape
-under the current `Effect` representation.
-
-### Fold first, then wrap a single timeout
-
-Rejected. Folding the leaves via `select_all` at `.timeout()` time and
-wrapping once is simpler, but it collapses leaf identity and closes the door
-on future per-leaf cancellation metadata beyond RFC 0003's top-level keyed
-task model (violates §1.2, item 2). Per-leaf wrapping with a shared factory
-keeps the per-call at-most-once message behavior while preserving the leaf
-structure.
-
-### Emit a timeout message per leaf
-
-Rejected. Multiple timeout messages out of one `.timeout()` call contradicts
-the "I attached one deadline" mental model. When per-child messages are
-wanted, attach `.timeout(...)` to each child command; that composes cleanly
-with the per-call at-most-once contract.
-
-### A `Quit`-transparent timeout wrapper
-
-Rejected. Continuing to poll the inner stream after `Quit` would be "fully
-transparent to the bare stream", but `Quit` is a terminal request to the
-runtime and later output has no meaning. The wrapper closing the leaf is made
-an explicit contract instead.
-
-### Type-changing timeout (`timeout_result`)
-
-Deferred. An API returning `Command<Result<Msg, CommandTimeout>>` can be added
-orthogonally to the message-preserving API, so it is left out of the initial
-implementation (§10).
-
-### `RetryError` as a single variant / without a reason
-
-Rejected. A predicate stop has not used up the attempts; if it were
-indistinguishable from `Exhausted`, callers could make wrong re-try decisions.
-
-### `RetryPolicy::new(usize)` panicking on zero
-
-Rejected. It violates the crate's `panic = "warn"` policy. Split into the
-infallible `new(NonZeroUsize)` and `try_new(usize) -> Option` (the same shape
-as `Timer::try_new`).
-
-### Exponential backoff in the initial release
-
-Deferred. Fixing the factor to `NonZeroU32` would make fractional multipliers
-like 1.5 hard to add later. `#[non_exhaustive]` makes adding the variant
-non-breaking, so the factor-type decision (integer / finite-guaranteeing
-newtype / `f64` constructor) is made when it is actually needed. If added, the
-`Duration` computation must saturate, and whatever the constructor accepts,
-the stored field must satisfy the derived-trait and drop-glue constraints of
-§3.2: `f64` may appear as constructor input only, converted to an
-`Eq`-compatible finite representation for storage.
-
-### Re-exporting the retry types from the prelude
-
-Deferred. The prelude is a glob-import surface, and removing a name later is a
-breaking change. The current prelude is deliberately small (it does not even
-include `Timer`), and `RetryPolicy` / `RetryError` are collision-prone common
-names in the ecosystem. Add later based on real-world usage of the root
-re-exports, if warranted.
-
-### Using `tokio_stream::StreamExt::timeout`
-
-Rejected. It is a per-item (inactivity) timeout, which differs from this RFC's
-overall-deadline semantics.
-
-## 9. Implementation Plan
-
-### 9.1 Order
-
-1. `Effect::timeout` / `Command::timeout` + unit tests + rustdoc.
-2. Retry support types in `src/command/retry.rs` + validation tests.
-   Re-exports from `src/command.rs` / `src/lib.rs` (not the prelude).
-3. `Command::retry` / `retry_if` + the `run_retry` helper + paused-time tests.
-4. Runtime integration smoke tests.
-5. CHANGELOG / README / rustdoc.
-
-Timeout comes first because it touches `effect.rs`; retry rides on
-`Command::future` and needs no `Effect` changes (§2).
-
-### 9.2 Timeout sketch
-
-The sketch below fixes the mechanisms that the contracts depend on (T2, T3,
-T4, T5). Anything not shown — state-struct layout, single-leaf fast paths,
-exact combinator choice — is up to the implementer.
-
-- `Effect::timeout(duration, on_timeout)` returns `Effect::None` unchanged and
-  wraps each leaf of `Effect::Leaves` in a `timeout_leaf` combinator.
-- `on_timeout` is shared across the leaves as `Arc<Mutex<Option<F>>>`; the
-  first leaf to reach its deadline `take()`s the `FnOnce` and emits the
-  message. This realizes the per-call at-most-once contract (T3). The mutex
-  only lends `Sync` so the public bound stays `FnOnce + Send`, and lock
-  recovery follows `Effect::map`: a poisoned lock is recovered via
-  `PoisonError::into_inner` rather than cascading a sibling leaf's panic.
-- `timeout_leaf` is a stateful stream whose state holds the inner stream and a
-  lazily created `Sleep`. The `Sleep` is created on the leaf's first poll
-  (T2), then raced against `inner.next()`:
+Each wrapper stores the inner stream and a lazily created `Sleep`:
 
 ```text
 timeout_leaf(inner, duration, shared_on_timeout):
-  state = { inner: Some(inner), sleep: None }
+  state = { inner: Some(inner), sleep: None, deadline_observed: false }
 
   loop per poll:
     if state.inner is None: end of stream
-    if state.sleep is None: state.sleep = sleep(duration)   # first poll (T2)
+    if state.sleep is None: state.sleep = sleep(duration)   # T2
 
-    race inner.next() against sleep:
-      inner yields None                  => end of stream (T4: factory untouched)
-      inner yields Action::Message(msg)  => emit Message(msg), continue
-      inner yields Action::Quit          => drop inner, emit Quit
-                                            (T5: factory untouched)
-      sleep fires                        => drop inner,
-                                            take shared_on_timeout:
-                                              Some(f) => emit Message(f()) (T3)
-                                              None    => end of stream
+    if state.deadline_observed:
+      poll inner once only to preserve termination priority:
+        inner yields None                => drop inner, end of stream
+        inner yields an item or Pending  => take deadline path
+
+    otherwise poll inner and sleep:
+      inner yields None                  => drop inner, end of stream
+      inner yields an item, sleep Pending:
+        Message(msg)                     => emit Message(msg), continue
+        Quit                             => drop inner, emit Quit
+      inner Pending, sleep fires         => take deadline path
+      inner yields an item, sleep fires  => choose either outcome:
+        deadline wins                    => take deadline path
+        Message(msg) wins                => state.deadline_observed = true,
+                                            emit Message(msg)
+        Quit wins                        => drop inner, emit Quit
+      inner Pending, sleep Pending       => Pending
+
+    deadline path:
+      drop inner
+      take shared_on_timeout:
+        Some(f)                          => emit Message(f())
+        None                             => end of stream
 ```
 
-- Every terminal transition (inner completion, `Quit`, deadline) drops the
-  inner stream, after which the leaf yields nothing (T6).
-- Two disambiguation rules are part of the mechanism, not implementer
-  freedom, because contracts depend on them:
-  1. **Termination wins.** When `inner.next()` yields `None`, the wrapper
-     closes without emitting its timeout message, even if its own deadline
-     has also elapsed (T4). A plain unbiased `select!` does not guarantee
-     this: after the inner wrapper of a double timeout emits its message and
-     terminates on a single leaf, an unbiased race between the observed
-     `None` and the outer wrapper's already-elapsed `Sleep` could emit the
-     second timeout message and violate T9. Check inner termination before
-     honoring the deadline.
-  2. **The deadline must not starve.** A continuously ready inner stream must
-     not keep an elapsed deadline from being honored, or an infinite stream
-     would never terminate at its deadline (§4.1). How ties between a ready
-     *item* and an elapsed deadline are broken is otherwise unspecified
-     (T10).
+Every terminal transition drops the inner stream. Three observable requirements
+constrain the implementation:
 
-### 9.3 Retry sketch
+1. **Termination wins (T4, T9).** If `inner.next()` returns `None` while the
+   wrapper's deadline is also elapsed, the wrapper closes without a timeout
+   message. An unbiased `select!` alone does not guarantee this for nested
+   timeouts.
+2. **The deadline has bounded progress (T10).** Once polling observes the sleep
+   ready, that poll may choose either the simultaneously ready item or the
+   deadline. If it chooses a non-terminal message, the wrapper records that the
+   deadline was observed. On the next poll it checks the inner stream only for
+   `None` so termination can still win; otherwise it takes the deadline path
+   without yielding another item. A chosen `Quit` is already terminal. Thus at
+   most one inner item is passed through after the deadline is ready and before
+   the wrapper takes a terminal transition. That transition may itself emit the
+   timeout message; the wrapper returns `None` on subsequent polls.
+3. **All item ties are unspecified (T5, T10).** Both `Action::Message` and
+   `Action::Quit` are items for this rule. If `Quit` wins, it is delivered and
+   closes the wrapper; if the deadline wins, the inner stream is dropped
+   without delivering `Quit`.
 
-`Command::retry` / `retry_if` do not construct an `Effect` directly; they ride
-on `Command::future` (R7):
+State layout, fast paths, and combinator choice remain implementation details.
+
+### C.3 Retry sketch
+
+`Command::retry` and `retry_if` can use `Command::future`:
 
 ```rust
 Command::future(async move {
@@ -732,39 +726,28 @@ run_retry(policy, operation, should_retry):
       Ok(value) =>
         return Ok(value)
       Err(error) =>
-        if attempt == policy.max_attempts:          # R2: predicate not called
+        if attempt == policy.max_attempts:          # R2
           return Err(RetryError { attempts: attempt, last_error: error,
                                   reason: Exhausted })
-        if !should_retry(&error, ctx):              # R3: attempts remain
+        if !should_retry(&error, ctx):              # R3
           return Err(RetryError { attempts: attempt, last_error: error,
                                   reason: StoppedByPredicate })
         sleep per policy.backoff                    # R4
         attempt += 1
 ```
 
-`RetryContext::new` stays `pub(crate)` so only `run_retry` can construct
+`RetryContext::new` remains `pub(crate)` so only crate code constructs retry
 contexts.
-
-## 10. Future Work
-
-- A type-changing timeout API (`timeout_result` or similar).
-- `RetryBackoff::Exponential` / jitter (factor-type decision and saturating
-  arithmetic; stored fields must keep the derived `Clone + Debug + Eq +
-  PartialEq` and stay free of drop glue, so `f64` may appear as constructor
-  input only — see §3.2).
-- A retry modifier on arbitrary commands (`with_retry` / `retry_with`),
-  contingent on `Effect` leaves holding repeatable operation factories.
-- Clock DI to generalize deterministic effect testing.
-- Debounce / throttle (as extensions of RFC 0003's keyed lifecycle).
 
 ## References
 
-- `docs/rfcs/0002-redraw-suppression.md` — the two modifier axes (output
-  treatment / execution lifecycle).
-- `docs/rfcs/0003-command-cancellation.md` — keyed lifecycle, private
-  receivers, the counterpart of the integration contracts.
-- `src/command.rs`, `src/command/effect.rs` — the current `Command` / `Effect`
-  representation.
-- `src/subscription/time.rs` (`Timer::try_new`),
-  `src/runtime/frame_rate.rs` (`FrameRate::try_new`) — precedents for the
-  validation APIs.
+- [RFC 0002: Redraw Suppression](./0002-redraw-suppression.md) — output
+  treatment versus execution lifecycle.
+- [RFC 0003: Command Cancellation](./0003-command-cancellation.md) — keyed
+  lifecycle and private receivers.
+- [`src/command.rs`](../../src/command.rs) and
+  [`src/command/effect.rs`](../../src/command/effect.rs) — current `Command`
+  and `Effect` representation.
+- [`src/subscription/time.rs`](../../src/subscription/time.rs) and
+  [`src/runtime/frame_rate.rs`](../../src/runtime/frame_rate.rs) — validation
+  API precedents.


### PR DESCRIPTION
## Summary

- Reorganize RFC 0004 into a feature-oriented structure for timeout and retry.
- Separate normative API and behavioral contracts from verification details and non-normative implementation guidance.
- Reduce duplication while preserving design rationale, compatibility constraints, and RFC 0003 integration requirements.

## What changed

- Added upfront motivation, terminology, and a decision overview.
- Grouped timeout and retry APIs, semantics, composition rules, and edge cases into self-contained sections.
- Moved the complete retry support API, T/R contract checklist, test strategy, and implementation sketches into focused appendices.
- Consolidated alternatives and deferred work, and converted repository references into links.
- Retained historical and forward-compatibility decisions, including argument-order rationale, retry naming constraints, per-leaf metadata compatibility, and deterministic test coverage.

## Validation

- `git diff --check`
- `typos docs/rfcs/0004-command-timeout-retry.md`

This is a documentation-only change. It does not modify runtime code or the accepted public API.