### PR TITLE
feat(command): add timeout and retry controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Command::timeout()` for applying an overall deadline to each effect leaf,
+  with at most one timeout message emitted per modifier call
+- `Command::retry()` and `Command::retry_if()` for repeatable fallible
+  operations, with non-zero attempt policies, optional fixed backoff, retry
+  context, and structured terminal errors
 - Subscription start tracing events now include a `restarted` field so initial
   starts and restarts can be distinguished.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,47 @@ async fn main() -> Result<()> {
 }
 ```
 
+### Command timeouts and retries
+
+Commands can enforce an overall deadline without changing their message type:
+
+```rust
+use std::time::Duration;
+use tears::prelude::*;
+
+enum Message {
+    Loaded(String),
+    TimedOut,
+}
+
+let command = Command::perform(async { "data".to_string() }, Message::Loaded)
+    .timeout(Duration::from_secs(5), || Message::TimedOut);
+```
+
+Retrying commands take a factory so every attempt receives a fresh future.
+Retry support types are imported explicitly from `tears::command` rather than
+from the crate root or prelude:
+
+```rust
+use std::time::Duration;
+use tears::Command;
+use tears::command::{RetryError, RetryPolicy};
+
+enum Message {
+    Loaded(Result<String, RetryError<&'static str>>),
+}
+
+let policy = RetryPolicy::try_new(3)
+    .expect("attempt count must be non-zero")
+    .with_fixed_backoff(Duration::from_millis(200));
+
+let command = Command::retry(
+    policy,
+    |_| async { Ok::<_, &'static str>("data".to_string()) },
+    Message::Loaded,
+);
+```
+
 ## Architecture
 
 Tears follows **The Elm Architecture (TEA)** pattern:

--- a/docs/rfcs/0004-command-timeout-retry.md
+++ b/docs/rfcs/0004-command-timeout-retry.md
@@ -1,6 +1,6 @@
 # RFC 0004: Command Timeout / Retry
 
-- Status: Accepted
+- Status: Implemented
 - Target: 0.9.3 (the next non-breaking patch at acceptance), additive public
   API only
 - Scope: timeout / retry lifecycle control confined to a single effect's

--- a/src/command.rs
+++ b/src/command.rs
@@ -24,7 +24,10 @@
 //! let cmd = Command::perform(load_data(), Message::DataLoaded);
 //! ```
 
+use std::time::Duration;
+
 mod effect;
+mod retry;
 mod runtime_directives;
 mod runtime_parts;
 
@@ -32,6 +35,7 @@ use effect::Effect;
 #[cfg(test)]
 use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt};
+pub use retry::{RetryBackoff, RetryContext, RetryError, RetryPolicy, RetryStopReason};
 use runtime_directives::RuntimeDirectives;
 pub(crate) use runtime_parts::RuntimeCommandParts;
 
@@ -165,6 +169,111 @@ impl<Msg: Send + 'static> Command<Msg> {
     pub const fn without_redraw(mut self) -> Self {
         self.directives = self.directives.without_redraw();
         self
+    }
+
+    /// Add an overall deadline to every effect leaf in this command.
+    ///
+    /// The deadline for each leaf starts when that leaf is first polled. A
+    /// single call emits at most one timeout message across all of the
+    /// command's leaves, while messages produced before the deadline continue
+    /// to flow normally. Applying a timeout to [`Command::none`] is inert.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::time::Duration;
+    /// use tears::prelude::*;
+    ///
+    /// enum Message {
+    ///     Loaded(String),
+    ///     TimedOut,
+    /// }
+    ///
+    /// let cmd = Command::perform(async { "data".to_string() }, Message::Loaded)
+    ///     .timeout(Duration::from_secs(5), || Message::TimedOut);
+    /// ```
+    #[must_use = "timeout returns a modified command and does not mutate in place"]
+    pub fn timeout(
+        mut self,
+        duration: Duration,
+        on_timeout: impl FnOnce() -> Msg + Send + 'static,
+    ) -> Self {
+        self.effect = self.effect.timeout(duration, on_timeout);
+        self
+    }
+
+    /// Retry an operation after every error while attempts remain.
+    ///
+    /// Arguments read as configuration → repeatable operation → message
+    /// conversion. `policy.max_attempts()` includes the first execution, and
+    /// the operation receives a 1-based [`RetryContext`] for every attempt.
+    /// Processing emits one final message containing either the successful
+    /// value or a [`RetryError`].
+    ///
+    /// # Repetition safety
+    ///
+    /// The operation may run up to `policy.max_attempts()` times. Callers must
+    /// ensure repetition is safe: a non-idempotent external side effect can
+    /// occur more than once, including when an attempt performs the side
+    /// effect and later returns an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tears::Command;
+    /// use tears::command::{RetryError, RetryPolicy};
+    ///
+    /// enum Message {
+    ///     Loaded(Result<String, RetryError<&'static str>>),
+    /// }
+    ///
+    /// let policy = RetryPolicy::try_new(3).expect("attempt count is non-zero");
+    /// let command = Command::retry(
+    ///     policy,
+    ///     |_| async { Ok::<_, &'static str>("data".to_string()) },
+    ///     Message::Loaded,
+    /// );
+    /// ```
+    pub fn retry<A, E, Fut, Op, F>(policy: RetryPolicy, operation: Op, f: F) -> Self
+    where
+        A: Send + 'static,
+        E: Send + 'static,
+        Fut: Future<Output = Result<A, E>> + Send + 'static,
+        Op: FnMut(RetryContext) -> Fut + Send + 'static,
+        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static,
+    {
+        Self::retry_if(policy, operation, |_, _| true, f)
+    }
+
+    /// Retry an operation when its error is accepted by a predicate.
+    ///
+    /// Arguments read as configuration → repeatable operation → retry
+    /// predicate → message conversion. The predicate is called only when an
+    /// error occurs while another attempt remains. Rejecting that error
+    /// produces [`RetryStopReason::StoppedByPredicate`]; an error on the final
+    /// attempt produces [`RetryStopReason::Exhausted`] without invoking the
+    /// predicate.
+    ///
+    /// The operation may run up to `policy.max_attempts()` times, so callers
+    /// are responsible for ensuring that repetition is safe.
+    pub fn retry_if<A, E, Fut, Op, P, F>(
+        policy: RetryPolicy,
+        operation: Op,
+        should_retry: P,
+        f: F,
+    ) -> Self
+    where
+        A: Send + 'static,
+        E: Send + 'static,
+        Fut: Future<Output = Result<A, E>> + Send + 'static,
+        Op: FnMut(RetryContext) -> Fut + Send + 'static,
+        P: FnMut(&E, RetryContext) -> bool + Send + 'static,
+        F: FnOnce(Result<A, RetryError<E>>) -> Msg + Send + 'static,
+    {
+        Self::future(async move {
+            let result = retry::run_retry(policy, operation, should_retry).await;
+            f(result)
+        })
     }
 
     /// Perform an asynchronous operation and convert its result to a message.
@@ -375,10 +484,10 @@ impl<Msg: Send + 'static> Command<Msg> {
 mod tests {
     use super::*;
 
-    use std::cell::Cell;
+    use std::{cell::Cell, future::pending};
 
     use futures::stream;
-    use tokio::time::{Duration, sleep};
+    use tokio::time::{advance, sleep};
 
     #[test]
     fn test_redraw_defaults_to_true_for_constructors() {
@@ -446,6 +555,40 @@ mod tests {
 
         assert!(cmd.is_none());
         assert!(!cmd.requests_redraw());
+    }
+
+    #[test]
+    fn test_timeout_preserves_runtime_directives_and_streamless_shape() {
+        let cmd = Command::<i32>::none()
+            .without_redraw()
+            .timeout(Duration::from_secs(1), || 99);
+
+        assert!(cmd.is_none());
+        assert!(!cmd.requests_redraw());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_composes_with_map_on_either_side() {
+        let before = Command::future(pending::<i32>())
+            .map(|value| value.to_string())
+            .timeout(Duration::from_secs(1), || "before".to_string());
+        let after = Command::future(pending::<i32>())
+            .timeout(Duration::from_secs(1), || 99)
+            .map(|value| value.to_string());
+        let command = Command::batch([before, after]);
+        let mut stream = command.into_stream().expect("stream should exist");
+
+        assert!(futures::poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+
+        let mut messages = Vec::new();
+        while let Some(action) = stream.next().await {
+            if let Action::Message(message) = action {
+                messages.push(message);
+            }
+        }
+        messages.sort();
+        assert_eq!(messages, vec!["99", "before"]);
     }
 
     #[test]

--- a/src/command/effect.rs
+++ b/src/command/effect.rs
@@ -1,11 +1,143 @@
-use std::sync::{Arc, Mutex, PoisonError};
+use std::{
+    pin::Pin,
+    sync::{Arc, Mutex, PoisonError},
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use futures::{
     FutureExt, Stream, StreamExt,
     stream::{self, BoxStream, select_all},
 };
+use tokio::time::{Sleep, sleep};
 
 use super::Action;
+
+/// Wraps one effect leaf with a lazily started overall deadline and terminal
+/// timeout handling.
+struct TimeoutLeaf<Msg, F>
+where
+    Msg: Send + 'static,
+{
+    inner: Option<BoxStream<'static, Action<Msg>>>,
+    sleep: Option<Pin<Box<Sleep>>>,
+    duration: Duration,
+    on_timeout: Arc<Mutex<Option<F>>>,
+    deadline_observed: bool,
+}
+
+impl<Msg, F> TimeoutLeaf<Msg, F>
+where
+    Msg: Send + 'static,
+    F: FnOnce() -> Msg,
+{
+    fn new(
+        inner: BoxStream<'static, Action<Msg>>,
+        duration: Duration,
+        on_timeout: Arc<Mutex<Option<F>>>,
+    ) -> Self {
+        Self {
+            inner: Some(inner),
+            sleep: None,
+            duration,
+            on_timeout,
+            deadline_observed: false,
+        }
+    }
+
+    fn finish(&mut self) {
+        self.inner = None;
+        self.sleep = None;
+    }
+
+    fn take_deadline_path(&mut self) -> Poll<Option<Action<Msg>>> {
+        self.finish();
+        let on_timeout = self
+            .on_timeout
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .take();
+
+        Poll::Ready(on_timeout.map(|on_timeout| Action::Message(on_timeout())))
+    }
+}
+
+impl<Msg, F> Stream for TimeoutLeaf<Msg, F>
+where
+    Msg: Send + 'static,
+    F: FnOnce() -> Msg + Send + 'static,
+{
+    type Item = Action<Msg>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let state = &mut *self;
+
+        if state.inner.is_none() {
+            return Poll::Ready(None);
+        }
+
+        // Constructing the sleep on the first poll makes the timeout an
+        // execution deadline rather than a construction deadline.
+        if state.sleep.is_none() {
+            state.sleep = Some(Box::pin(sleep(state.duration)));
+        }
+
+        // If a deadline/item tie previously passed through a message, inspect
+        // the inner stream once more only so termination can retain priority.
+        // Any other result takes the already-observed deadline path.
+        if state.deadline_observed {
+            let inner_poll = state
+                .inner
+                .as_mut()
+                .expect("checked above")
+                .as_mut()
+                .poll_next(cx);
+
+            if matches!(inner_poll, Poll::Ready(None)) {
+                state.finish();
+                return Poll::Ready(None);
+            }
+
+            return state.take_deadline_path();
+        }
+
+        // Poll both sides before choosing an outcome. This lets inner
+        // termination deterministically win while bounding a continuously
+        // ready inner stream to one item after the deadline becomes ready.
+        let inner_poll = state
+            .inner
+            .as_mut()
+            .expect("checked above")
+            .as_mut()
+            .poll_next(cx);
+        let deadline_ready = state
+            .sleep
+            .as_mut()
+            .expect("initialized above")
+            .as_mut()
+            .poll(cx)
+            .is_ready();
+
+        match inner_poll {
+            Poll::Ready(None) => {
+                state.finish();
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Action::Quit)) => {
+                state.finish();
+                Poll::Ready(Some(Action::Quit))
+            }
+            Poll::Ready(Some(action @ Action::Message(_))) => {
+                if deadline_ready {
+                    state.deadline_observed = true;
+                }
+                Poll::Ready(Some(action))
+            }
+            Poll::Pending if deadline_ready => state.take_deadline_path(),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
 
 // Effects own and compose the asynchronous action stream; runtime directives
 // stay separate because they describe how the runtime treats the update result.
@@ -74,6 +206,23 @@ impl<Msg: Send + 'static> Effect<Msg> {
             Self::None
         } else {
             Self::Leaves(leaves)
+        }
+    }
+
+    pub(super) fn timeout<F>(self, duration: Duration, on_timeout: F) -> Self
+    where
+        F: FnOnce() -> Msg + Send + 'static,
+    {
+        match self {
+            Self::None => Self::None,
+            Self::Leaves(leaves) => {
+                let on_timeout = Arc::new(Mutex::new(Some(on_timeout)));
+                let leaves = leaves
+                    .into_iter()
+                    .map(|leaf| TimeoutLeaf::new(leaf, duration, Arc::clone(&on_timeout)).boxed())
+                    .collect();
+                Self::Leaves(leaves)
+            }
         }
     }
 
@@ -164,7 +313,13 @@ impl<Msg: Send + 'static> Effect<Msg> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::StreamExt;
+    use std::{
+        future::pending,
+        sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    use futures::{StreamExt, poll};
+    use tokio::time::advance;
 
     async fn drain<Msg>(stream: BoxStream<'static, Action<Msg>>) -> (Vec<Msg>, bool) {
         let mut messages = Vec::new();
@@ -326,5 +481,263 @@ mod tests {
         let action = stream.next().await.expect("should have action");
 
         assert!(matches!(action, Action::Quit));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_deadline_starts_on_first_poll() {
+        let effect = Effect::future(pending::<i32>()).timeout(Duration::from_secs(1), || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        advance(Duration::from_secs(10)).await;
+        assert!(poll!(stream.next()).is_pending());
+
+        advance(Duration::from_millis(999)).await;
+        assert!(poll!(stream.next()).is_pending());
+
+        advance(Duration::from_millis(1)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(99))));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_factory_is_shared_across_batch_and_accepts_move_only_state() {
+        let effect = Effect::batch(vec![
+            Effect::future(pending::<String>()),
+            Effect::future(pending::<String>()),
+        ])
+        .timeout(Duration::from_secs(1), {
+            let timeout = String::from("timed out");
+            move || timeout
+        });
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Action::Message(message)) if message == "timed out"
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_completion_does_not_consume_factory() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_by_timeout = Arc::clone(&called);
+        let effect = Effect::future(async { 42 }).timeout(Duration::ZERO, move || {
+            called_by_timeout.store(true, Ordering::SeqCst);
+            99
+        });
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(matches!(stream.next().await, Some(Action::Message(42))));
+        assert!(stream.next().await.is_none());
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_completed_batch_leaf_leaves_timeout_factory_for_pending_sibling() {
+        let effect = Effect::batch([
+            Effect::future(async { 42 }),
+            Effect::future(pending::<i32>()),
+        ])
+        .timeout(Duration::from_secs(1), || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(matches!(stream.next().await, Some(Action::Message(42))));
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+
+        assert!(matches!(stream.next().await, Some(Action::Message(99))));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_passes_through_messages_before_deadline() {
+        let effect = Effect::stream(stream::iter([1, 2, 3])).timeout(Duration::from_secs(1), || 99);
+        let stream = effect.into_stream().expect("stream should exist");
+        let (messages, quit) = drain(stream).await;
+
+        assert_eq!(messages, vec![1, 2, 3]);
+        assert!(!quit);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_quit_is_terminal_and_does_not_consume_factory() {
+        let called = Arc::new(AtomicBool::new(false));
+        let called_by_timeout = Arc::clone(&called);
+        let effect =
+            Effect::<i32>::action(Action::Quit).timeout(Duration::from_secs(1), move || {
+                called_by_timeout.store(true, Ordering::SeqCst);
+                99
+            });
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(matches!(stream.next().await, Some(Action::Quit)));
+        assert!(stream.next().await.is_none());
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_quit_batch_leaf_leaves_timeout_factory_for_pending_sibling() {
+        let effect = Effect::batch([
+            Effect::<i32>::action(Action::Quit),
+            Effect::future(pending::<i32>()),
+        ])
+        .timeout(Duration::from_secs(1), || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(matches!(stream.next().await, Some(Action::Quit)));
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+
+        assert!(matches!(stream.next().await, Some(Action::Message(99))));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timeout_drops_inner_stream_and_never_polls_it_again() {
+        struct DropMarker(Arc<AtomicBool>);
+
+        impl Drop for DropMarker {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let polls = Arc::new(AtomicUsize::new(0));
+        let marker = DropMarker(Arc::clone(&dropped));
+        let polls_by_stream = Arc::clone(&polls);
+        let pending = stream::poll_fn(move |_| {
+            let _marker = &marker;
+            polls_by_stream.fetch_add(1, Ordering::SeqCst);
+            Poll::Pending::<Option<i32>>
+        });
+        let effect = Effect::stream(pending).timeout(Duration::from_secs(1), || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(99))));
+
+        let polls_at_timeout = polls.load(Ordering::SeqCst);
+        assert!(dropped.load(Ordering::SeqCst));
+        assert!(stream.next().await.is_none());
+        assert_eq!(polls.load(Ordering::SeqCst), polls_at_timeout);
+    }
+
+    #[test]
+    fn test_timeout_over_none_is_inert_and_preserves_leaf_shape() {
+        let effect = Effect::<i32>::none().timeout(Duration::ZERO, || 99);
+
+        assert!(effect.is_none());
+        assert_eq!(effect.leaf_count(), 0);
+        assert!(effect.into_stream().is_none());
+    }
+
+    #[test]
+    fn test_timeout_and_map_preserve_leaf_count() {
+        let effect = Effect::batch(vec![
+            Effect::future(async { 1 }),
+            Effect::future(async { 2 }),
+        ])
+        .timeout(Duration::from_secs(1), || 99)
+        .map(|message| message.to_string());
+
+        assert_eq!(effect.leaf_count(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_child_timeouts_in_a_batch_are_independent() {
+        let first = Effect::future(pending::<i32>()).timeout(Duration::from_secs(1), || 10);
+        let second = Effect::future(pending::<i32>()).timeout(Duration::from_secs(2), || 20);
+        let effect = Effect::batch([first, second]);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(10))));
+        advance(Duration::from_secs(1)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(20))));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_nested_timeout_emits_only_the_earlier_message() {
+        let effect = Effect::future(pending::<i32>())
+            .timeout(Duration::from_secs(1), || 10)
+            .timeout(Duration::from_secs(2), || 20);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(10))));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_nested_simultaneous_timeouts_emit_exactly_one_message() {
+        let effect = Effect::future(pending::<i32>())
+            .timeout(Duration::from_secs(1), || 10)
+            .timeout(Duration::from_secs(1), || 20);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        advance(Duration::from_secs(1)).await;
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Action::Message(10 | 20))
+        ));
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_elapsed_deadline_bounds_continuously_ready_stream_progress() {
+        let effect = Effect::stream(stream::repeat(1)).timeout(Duration::from_secs(1), || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(matches!(stream.next().await, Some(Action::Message(1))));
+        advance(Duration::from_secs(1)).await;
+
+        let tied_output = stream.next().await;
+        let item_won = matches!(tied_output.as_ref(), Some(Action::Message(1)));
+        let deadline_won = matches!(tied_output.as_ref(), Some(Action::Message(99)));
+        assert!(item_won || deadline_won);
+
+        if item_won {
+            // Passing through the tied item requires the deadline transition
+            // on the very next poll, before another inner item can escape.
+            assert!(matches!(stream.next().await, Some(Action::Message(99))));
+        }
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_deadline_quit_tie_allows_either_terminal_outcome() {
+        let timeout_called = Arc::new(AtomicBool::new(false));
+        let called_by_timeout = Arc::clone(&timeout_called);
+        let effect = Effect::<i32>::action(Action::Quit).timeout(Duration::ZERO, move || {
+            called_by_timeout.store(true, Ordering::SeqCst);
+            99
+        });
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        let output = stream.next().await;
+        let quit_won = matches!(output.as_ref(), Some(Action::Quit));
+        let deadline_won = matches!(output.as_ref(), Some(Action::Message(99)));
+        assert!(quit_won || deadline_won);
+        assert_eq!(timeout_called.load(Ordering::SeqCst), deadline_won);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_zero_timeout_is_non_panicking_and_termination_wins() {
+        let effect = Effect::stream(stream::empty::<i32>()).timeout(Duration::ZERO, || 99);
+        let mut stream = effect.into_stream().expect("stream should exist");
+
+        assert!(stream.next().await.is_none());
     }
 }

--- a/src/command/retry.rs
+++ b/src/command/retry.rs
@@ -1,0 +1,512 @@
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+    future::Future,
+    num::NonZeroUsize,
+    time::Duration,
+};
+use tokio::time::sleep;
+
+/// Configuration for a retrying command.
+///
+/// `max_attempts` includes the first execution. The default backoff performs
+/// the next attempt immediately.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetryPolicy {
+    max_attempts: NonZeroUsize,
+    backoff: RetryBackoff,
+}
+
+impl RetryPolicy {
+    /// Create a retry policy with no delay between attempts.
+    #[must_use]
+    pub const fn new(max_attempts: NonZeroUsize) -> Self {
+        Self {
+            max_attempts,
+            backoff: RetryBackoff::None,
+        }
+    }
+
+    /// Create a retry policy from a raw attempt count.
+    ///
+    /// Returns `None` when `max_attempts` is zero.
+    #[must_use]
+    pub const fn try_new(max_attempts: usize) -> Option<Self> {
+        match NonZeroUsize::new(max_attempts) {
+            Some(max_attempts) => Some(Self::new(max_attempts)),
+            None => None,
+        }
+    }
+
+    /// Return the maximum number of executions, including the first attempt.
+    #[must_use]
+    pub const fn max_attempts(&self) -> NonZeroUsize {
+        self.max_attempts
+    }
+
+    /// Return the delay strategy used between retriable failures.
+    #[must_use]
+    pub const fn backoff(&self) -> &RetryBackoff {
+        &self.backoff
+    }
+
+    /// Replace the delay strategy.
+    #[must_use = "with_backoff returns a modified policy and does not mutate in place"]
+    pub const fn with_backoff(mut self, backoff: RetryBackoff) -> Self {
+        self.backoff = backoff;
+        self
+    }
+
+    /// Use the same delay before every subsequent attempt.
+    #[must_use = "with_fixed_backoff returns a modified policy and does not mutate in place"]
+    pub const fn with_fixed_backoff(self, delay: Duration) -> Self {
+        self.with_backoff(RetryBackoff::fixed(delay))
+    }
+}
+
+/// Delay strategy applied between retry attempts.
+///
+/// This enum and its field-bearing variants are non-exhaustive. Downstream
+/// matches must include `..` in variant patterns and a wildcard arm for future
+/// strategies.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RetryBackoff {
+    /// Start the next attempt without sleeping.
+    None,
+
+    /// Wait the same duration after every retriable failure.
+    #[non_exhaustive]
+    Fixed {
+        /// Delay before the next attempt.
+        delay: Duration,
+    },
+}
+
+impl RetryBackoff {
+    /// Create a strategy with no delay between attempts.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self::None
+    }
+
+    /// Create a fixed-delay strategy.
+    #[must_use]
+    pub const fn fixed(delay: Duration) -> Self {
+        Self::Fixed { delay }
+    }
+}
+
+/// Information about the currently executing retry attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct RetryContext {
+    attempt: NonZeroUsize,
+}
+
+impl RetryContext {
+    pub(crate) const fn new(attempt: NonZeroUsize) -> Self {
+        Self { attempt }
+    }
+
+    /// Return the 1-based attempt number.
+    #[must_use]
+    pub const fn attempt(&self) -> NonZeroUsize {
+        self.attempt
+    }
+}
+
+/// The final failure of a retrying command.
+#[derive(Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct RetryError<E> {
+    attempts: NonZeroUsize,
+    last_error: E,
+    reason: RetryStopReason,
+}
+
+impl<E> RetryError<E> {
+    /// Return the number of attempts that completed.
+    #[must_use]
+    pub const fn attempts(&self) -> NonZeroUsize {
+        self.attempts
+    }
+
+    /// Borrow the error returned by the final attempt.
+    #[must_use]
+    pub const fn last_error(&self) -> &E {
+        &self.last_error
+    }
+
+    /// Return why no further attempt was started.
+    #[must_use]
+    pub const fn reason(&self) -> RetryStopReason {
+        self.reason
+    }
+
+    /// Consume this retry error and return the final operation error.
+    #[must_use]
+    pub fn into_last_error(self) -> E {
+        self.last_error
+    }
+}
+
+impl<E: Display> Display for RetryError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let reason = match self.reason {
+            RetryStopReason::Exhausted => "retry policy exhausted",
+            RetryStopReason::StoppedByPredicate => "retry stopped by predicate",
+        };
+
+        write!(
+            f,
+            "{reason} after {} attempt(s): {}",
+            self.attempts, self.last_error
+        )
+    }
+}
+
+impl<E: Error + 'static> Error for RetryError<E> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.last_error)
+    }
+}
+
+/// Why a failed retrying command did not start another attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum RetryStopReason {
+    /// The final allowed attempt failed.
+    Exhausted,
+
+    /// The retry predicate rejected an error while attempts remained.
+    StoppedByPredicate,
+}
+
+pub(super) async fn run_retry<A, E, Fut, Op, P>(
+    policy: RetryPolicy,
+    mut operation: Op,
+    mut should_retry: P,
+) -> Result<A, RetryError<E>>
+where
+    Fut: Future<Output = Result<A, E>>,
+    Op: FnMut(RetryContext) -> Fut,
+    P: FnMut(&E, RetryContext) -> bool,
+{
+    let mut attempt = NonZeroUsize::MIN;
+
+    loop {
+        let context = RetryContext::new(attempt);
+
+        match operation(context).await {
+            Ok(value) => return Ok(value),
+            Err(error) if attempt == policy.max_attempts => {
+                return Err(RetryError {
+                    attempts: attempt,
+                    last_error: error,
+                    reason: RetryStopReason::Exhausted,
+                });
+            }
+            Err(error) if !should_retry(&error, context) => {
+                return Err(RetryError {
+                    attempts: attempt,
+                    last_error: error,
+                    reason: RetryStopReason::StoppedByPredicate,
+                });
+            }
+            Err(_) => {
+                match policy.backoff() {
+                    RetryBackoff::None => {}
+                    RetryBackoff::Fixed { delay, .. } => sleep(*delay).await,
+                }
+
+                // The final-attempt branch above guarantees `attempt < max`,
+                // so incrementing cannot overflow and cannot produce zero.
+                attempt = NonZeroUsize::new(attempt.get() + 1)
+                    .expect("attempt remains non-zero and within max_attempts");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use futures::{StreamExt, poll};
+    use tokio::time::advance;
+
+    use crate::command::{Action, Command};
+
+    async fn final_result<A, E>(
+        command: Command<Result<A, RetryError<E>>>,
+    ) -> Result<A, RetryError<E>>
+    where
+        A: Send + 'static,
+        E: Send + 'static,
+    {
+        let mut stream = command.into_stream().expect("stream should exist");
+        let action = stream.next().await.expect("retry should emit one message");
+        assert!(stream.next().await.is_none());
+
+        match action {
+            Action::Message(result) => result,
+            Action::Quit => unreachable!("retry commands never emit Quit"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_succeeds_on_the_first_attempt_and_emits_once() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_by_operation = Arc::clone(&attempts);
+        let command = Command::retry(
+            RetryPolicy::try_new(3).expect("valid policy"),
+            move |context| {
+                let attempts = Arc::clone(&attempts_by_operation);
+                async move {
+                    attempts.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(context.attempt(), NonZeroUsize::MIN);
+                    Ok::<_, &'static str>(42)
+                }
+            },
+            |result| result,
+        );
+
+        assert_eq!(final_result(command).await, Ok(42));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn retry_recreates_the_operation_until_success() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_by_operation = Arc::clone(&attempts);
+        let command = Command::retry(
+            RetryPolicy::try_new(3).expect("valid policy"),
+            move |context| {
+                let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    assert_eq!(context.attempt().get(), attempt);
+                    if attempt == 2 {
+                        Ok(42)
+                    } else {
+                        Err("transient")
+                    }
+                }
+            },
+            |result| result,
+        );
+
+        assert_eq!(final_result(command).await, Ok(42));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn final_attempt_failure_is_exhausted_without_calling_predicate() {
+        let predicate_calls = Arc::new(AtomicUsize::new(0));
+        let calls_by_predicate = Arc::clone(&predicate_calls);
+        let command = Command::retry_if(
+            RetryPolicy::try_new(1).expect("valid policy"),
+            |_| async { Err::<i32, _>("failed") },
+            move |_, _| {
+                calls_by_predicate.fetch_add(1, Ordering::SeqCst);
+                true
+            },
+            |result| result,
+        );
+
+        let error = final_result(command)
+            .await
+            .expect_err("attempt should fail");
+        assert_eq!(error.attempts().get(), 1);
+        assert_eq!(error.reason(), RetryStopReason::Exhausted);
+        assert_eq!(predicate_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn predicate_stop_occurs_only_while_attempts_remain() {
+        let command = Command::retry_if(
+            RetryPolicy::try_new(3).expect("valid policy"),
+            |_| async { Err::<i32, _>("permanent") },
+            |_, context| {
+                assert_eq!(context.attempt().get(), 1);
+                false
+            },
+            |result| result,
+        );
+
+        let error = final_result(command)
+            .await
+            .expect_err("attempt should fail");
+        assert_eq!(error.attempts().get(), 1);
+        assert_eq!(error.reason(), RetryStopReason::StoppedByPredicate);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn no_backoff_starts_the_next_attempt_without_sleeping() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_by_operation = Arc::clone(&attempts);
+        let command = Command::retry(
+            RetryPolicy::try_new(2).expect("valid policy"),
+            move |_| {
+                let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if attempt == 2 {
+                        Ok(42)
+                    } else {
+                        Err("transient")
+                    }
+                }
+            },
+            |result| result,
+        );
+
+        assert_eq!(final_result(command).await, Ok(42));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fixed_backoff_waits_before_every_next_attempt() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let attempts_by_operation = Arc::clone(&attempts);
+        let command = Command::retry(
+            RetryPolicy::try_new(3)
+                .expect("valid policy")
+                .with_fixed_backoff(Duration::from_secs(2)),
+            move |_| {
+                let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
+                async move {
+                    if attempt == 3 {
+                        Ok(42)
+                    } else {
+                        Err("transient")
+                    }
+                }
+            },
+            |result| result,
+        );
+        let mut stream = command.into_stream().expect("stream should exist");
+
+        assert!(poll!(stream.next()).is_pending());
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+        advance(Duration::from_secs(2)).await;
+        assert!(poll!(stream.next()).is_pending());
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+
+        advance(Duration::from_secs(2)).await;
+        assert!(matches!(stream.next().await, Some(Action::Message(Ok(42)))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert!(stream.next().await.is_none());
+    }
+
+    #[test]
+    fn retry_policy_validates_attempts_and_preserves_them_in_builders() {
+        assert_eq!(RetryPolicy::try_new(0), None);
+
+        let max_attempts = NonZeroUsize::new(3).expect("non-zero");
+        let policy = RetryPolicy::new(max_attempts);
+        assert_eq!(policy.max_attempts(), max_attempts);
+        assert_eq!(policy.backoff(), &RetryBackoff::None);
+
+        let policy = policy.with_fixed_backoff(Duration::from_millis(50));
+        assert_eq!(policy.max_attempts(), max_attempts);
+        assert_eq!(
+            policy.backoff(),
+            &RetryBackoff::Fixed {
+                delay: Duration::from_millis(50)
+            }
+        );
+        assert_eq!(RetryBackoff::none(), RetryBackoff::None);
+        assert_eq!(
+            RetryBackoff::fixed(Duration::from_secs(1)),
+            RetryBackoff::Fixed {
+                delay: Duration::from_secs(1)
+            }
+        );
+    }
+
+    #[test]
+    fn retry_error_exposes_last_error_through_display_and_source() {
+        #[derive(Debug, Eq, PartialEq)]
+        struct TestError(&'static str);
+
+        impl Display for TestError {
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+
+        impl Error for TestError {}
+
+        let error = RetryError {
+            attempts: NonZeroUsize::new(2).expect("non-zero"),
+            last_error: TestError("boom"),
+            reason: RetryStopReason::StoppedByPredicate,
+        };
+
+        assert_eq!(error.attempts().get(), 2);
+        assert_eq!(error.last_error(), &TestError("boom"));
+        assert_eq!(error.reason(), RetryStopReason::StoppedByPredicate);
+        assert!(error.to_string().contains("boom"));
+        assert_eq!(
+            error.source().map(ToString::to_string).as_deref(),
+            Some("boom")
+        );
+        assert_eq!(error.into_last_error(), TestError("boom"));
+    }
+
+    #[tokio::test]
+    async fn retry_composes_as_a_single_leaf_command() {
+        let retry = Command::retry(
+            RetryPolicy::try_new(1).expect("valid policy"),
+            |_| async { Ok::<_, &'static str>(20) },
+            |result| result.expect("operation should succeed"),
+        )
+        .without_redraw()
+        .map(|value| value * 2);
+
+        assert_eq!(retry.effect.leaf_count(), 1);
+        assert!(!retry.requests_redraw());
+
+        let command = Command::batch([retry, Command::message(1).without_redraw()]);
+        assert_eq!(command.effect.leaf_count(), 2);
+        assert!(!command.requests_redraw());
+
+        let mut stream = command.into_stream().expect("stream should exist");
+        let mut messages = Vec::new();
+        let mut quit = false;
+        while let Some(action) = stream.next().await {
+            match action {
+                Action::Message(message) => messages.push(message),
+                Action::Quit => quit = true,
+            }
+        }
+        messages.sort_unstable();
+        assert_eq!(messages, vec![1, 40]);
+        assert!(!quit);
+    }
+
+    #[tokio::test]
+    async fn retry_predicate_may_retain_mutable_local_state() {
+        let mut predicate_calls = 0;
+        let command = Command::retry_if(
+            RetryPolicy::try_new(4).expect("valid policy"),
+            |_| async { Err::<i32, _>("failed") },
+            move |_, _| {
+                predicate_calls += 1;
+                predicate_calls < 2
+            },
+            |result| result,
+        );
+
+        let error = final_result(command)
+            .await
+            .expect_err("attempt should fail");
+        assert_eq!(error.attempts().get(), 2);
+        assert_eq!(error.reason(), RetryStopReason::StoppedByPredicate);
+    }
+}

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -201,9 +201,9 @@ mod tests {
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
     use tokio::sync::oneshot;
-    use tokio::time::{Duration, timeout};
+    use tokio::time::{Duration, advance, timeout};
 
-    use crate::command::Command;
+    use crate::command::{Command, RetryPolicy};
     use crate::runtime::AppInput;
     use crate::subscription::Subscription;
     use crate::subscription::time::Timer;
@@ -287,6 +287,63 @@ mod tests {
         let input = timeout(Duration::from_secs(1), core.app_inputs.next())
             .await
             .expect("command should send a message before the timeout");
+
+        assert!(matches!(
+            input,
+            Some(AppInput::Shared(TestMessage::Increment))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_enqueue_command_delivers_timeout_message() {
+        let mut core = RuntimeCore::<TestApp>::new(0);
+        let (started_tx, started_rx) = oneshot::channel();
+        let command = Command::future(async move {
+            let _ = started_tx.send(());
+            pending::<TestMessage>().await
+        })
+        .timeout(Duration::from_secs(1), || TestMessage::Increment);
+        core.enqueue_command(command.into_runtime_parts());
+
+        timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("command should start before the timeout")
+            .expect("command should signal its first poll");
+        advance(Duration::from_secs(1)).await;
+
+        let input = timeout(Duration::from_secs(1), core.app_inputs.next())
+            .await
+            .expect("command should send its timeout message");
+        assert!(matches!(
+            input,
+            Some(AppInput::Shared(TestMessage::Increment))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_command_delivers_retry_final_message() {
+        let mut core = RuntimeCore::<TestApp>::new(0);
+        let mut attempts = 0;
+        let command = Command::retry(
+            RetryPolicy::try_new(2).expect("valid policy"),
+            move |_| {
+                attempts += 1;
+                let attempt = attempts;
+                async move {
+                    if attempt == 2 {
+                        Ok(TestMessage::Increment)
+                    } else {
+                        Err("transient")
+                    }
+                }
+            },
+            |result| result.expect("second attempt should succeed"),
+        );
+        core.enqueue_command(command.into_runtime_parts());
+
+        let input = timeout(Duration::from_secs(1), core.app_inputs.next())
+            .await
+            .expect("retry should send its final message before the timeout");
 
         assert!(matches!(
             input,

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -6,8 +6,17 @@ mod common;
 #[path = "common/trace_recorder.rs"]
 mod trace_recorder;
 
+use std::{
+    future::pending,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
+
 use color_eyre::eyre::Result;
 use ratatui::Frame;
+use tears::command::RetryPolicy;
 use tears::prelude::*;
 use tokio::time::{Duration, timeout};
 use trace_recorder::TraceRecorder;
@@ -217,6 +226,88 @@ async fn test_runtime_run_end_to_end_with_commands() -> Result<()> {
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
     assert!(result.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_runtime_run_delivers_timeout_and_retry_messages_to_update() -> Result<()> {
+    const TIMED_OUT: usize = 1;
+    const RETRIED: usize = 2;
+
+    struct LifecycleApp {
+        observed: Arc<AtomicUsize>,
+    }
+
+    #[derive(Clone)]
+    enum Message {
+        TimedOut,
+        Retried,
+    }
+
+    impl Application for LifecycleApp {
+        type Message = Message;
+        type Flags = Arc<AtomicUsize>;
+
+        fn new(observed: Self::Flags) -> (Self, Command<Self::Message>) {
+            let timeout_command =
+                Command::future(pending::<Message>()).timeout(Duration::ZERO, || Message::TimedOut);
+
+            let mut attempts = 0;
+            let retry_command = Command::retry(
+                RetryPolicy::try_new(2).expect("valid retry policy"),
+                move |_| {
+                    attempts += 1;
+                    let attempt = attempts;
+                    async move {
+                        if attempt == 2 {
+                            Ok(())
+                        } else {
+                            Err("transient")
+                        }
+                    }
+                },
+                |result| {
+                    result.expect("second retry attempt should succeed");
+                    Message::Retried
+                },
+            );
+
+            (
+                Self { observed },
+                Command::batch([timeout_command, retry_command]),
+            )
+        }
+
+        fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+            let bit = match message {
+                Message::TimedOut => TIMED_OUT,
+                Message::Retried => RETRIED,
+            };
+            let observed = self.observed.fetch_or(bit, Ordering::SeqCst) | bit;
+
+            if observed == (TIMED_OUT | RETRIED) {
+                Command::effect(Action::Quit)
+            } else {
+                Command::none()
+            }
+        }
+
+        fn view(&self, _frame: &mut Frame<'_>) {}
+
+        fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+            vec![]
+        }
+    }
+
+    let observed = Arc::new(AtomicUsize::new(0));
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<LifecycleApp>::try_new(Arc::clone(&observed), 60)
+        .expect("frame rate must be valid");
+
+    timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await??;
+
+    assert_eq!(observed.load(Ordering::SeqCst), TIMED_OUT | RETRIED);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements [RFC 0004: Command Timeout / Retry](docs/rfcs/0004-command-timeout-retry.md).

This adds effect-local timeout and retry controls without changing the runtime or introducing new dependencies.

## Changes

- Add `Command::timeout`
  - Applies an overall deadline to each effect leaf
  - Starts each deadline when the leaf is first polled
  - Emits at most one timeout message per `timeout` call, including across batches
  - Preserves runtime directives and stream-less command behavior
  - Handles completion, `Quit`, nested timeouts, and deadline/item ties

- Add `Command::retry` and `Command::retry_if`
  - Recreates the operation future for every attempt
  - Supports unconditional and predicate-controlled retries
  - Supports immediate and fixed-delay backoff
  - Emits exactly one final success or failure message

- Add retry support types under the canonical `tears::command` path
  - `RetryPolicy`
  - `RetryBackoff`
  - `RetryContext`
  - `RetryError`
  - `RetryStopReason`

- Add deterministic contract tests using Tokio's paused clock
  - Covers RFC timeout contracts T1–T10
  - Covers RFC retry contracts R1–R8
  - Verifies completed and pre-deadline `Quit` batch leaves preserve the shared timeout factory for pending siblings

- Add runtime integration coverage confirming timeout and retry messages reach `Application::update`

- Update README, rustdoc, and CHANGELOG documentation

## Testing

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`