### PR TITLE
docs(subscription): use canonical root import in SubscriptionId::of example

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -294,7 +294,7 @@ impl SubscriptionId {
     /// # Examples
     ///
     /// ```
-    /// use tears::subscription::SubscriptionId;
+    /// use tears::SubscriptionId;
     /// use std::hash::{Hash, Hasher};
     /// use std::collections::hash_map::DefaultHasher;
     ///


### PR DESCRIPTION
## Summary
- `SubscriptionId` is re-exported at the crate root (`tears::SubscriptionId`), but the rustdoc example on `SubscriptionId::of` imported it via the deeper `tears::subscription::SubscriptionId` path.
- Switched the example to `use tears::SubscriptionId;` to match the crate's convention of using the canonical root path for core API types.

## Test plan
- [x] `cargo test --doc subscription::SubscriptionId` passes
- [x] `cargo fmt --check` passes