### PR TITLE
docs(rfc): place CommandId/CancelPolicy and Retry* under tears::command

### DIFF
--- a/docs/rfcs/0003-command-cancellation.md
+++ b/docs/rfcs/0003-command-cancellation.md
@@ -140,6 +140,15 @@ This RFC accepts a keyed command-output lifecycle with these decisions:
 
 ## 3. Public API Details
 
+`CommandId` and `CancelPolicy` are re-exported from `tears::command`
+(`tears::command::CommandId`, `tears::command::CancelPolicy`), not the crate
+root. Per `docs/api-guidelines.md`'s root promotion criteria, cancellation is
+opt-in vocabulary: it is not named in an `Application` skeleton that doesn't
+use it, and it is not the extension contract behind a skeleton item the way
+`SubscriptionSource` is for `Subscription`. `Command::cancellable`,
+`Command::cancellable_with`, and `Command::cancel` stay on `Command` itself
+and need no separate import.
+
 ### 3.1 `CommandId`
 
 `CommandId` is structural, not a pre-hashed surrogate. It stores an erased
@@ -243,6 +252,8 @@ impl<Msg: Send + 'static> Command<Msg> {
 Examples:
 
 ```rust
+use tears::command::{CancelPolicy, CommandId};
+
 Command::perform(fetch(query.clone()), Msg::Loaded)
     .cancellable(CommandId::new(RequestId::Search));
 

--- a/docs/rfcs/0004-command-timeout-retry.md
+++ b/docs/rfcs/0004-command-timeout-retry.md
@@ -117,8 +117,12 @@ retry must accept a repeatable operation factory.
    independently.
 4. **Non-panicking constructors.** Invalid public input uses `Option` or
    builders, following the crate's `panic = "warn"` policy.
-5. **Minimal prelude.** Retry support types are exported from the crate root,
-   not from `src/prelude.rs`.
+5. **Minimal prelude and root.** Retry support types are exported from
+   `tears::command`, not the crate root and not from `src/prelude.rs`. Per
+   `docs/api-guidelines.md`'s root promotion criteria, retry is opt-in
+   vocabulary: it is not named in an `Application` skeleton that doesn't use
+   it, and it is not the extension contract behind a skeleton item the way
+   `SubscriptionSource` is for `Subscription`.
 6. **No new dependencies.** The implementation uses the existing `tokio`,
    `futures`, and `tokio-stream` dependencies.
 7. **Deterministic contract verification.** Every T/R contract must be pinned
@@ -280,7 +284,8 @@ allows the caller to stop based on the error and current attempt.
 ```rust
 use std::num::NonZeroUsize;
 use std::time::Duration;
-use tears::{Command, RetryError, RetryPolicy};
+use tears::Command;
+use tears::command::{RetryError, RetryPolicy};
 
 struct Todo;
 struct FetchError;
@@ -381,11 +386,15 @@ repeatable operation second, and the message mapper remains last. Public
 rustdoc must state that reading order explicitly: configuration → operation →
 message conversion.
 
-Retry support types are imported explicitly from the crate root and are not
-added to the prelude. The prelude is deliberately small—it does not include
-`Timer`—and `RetryPolicy` / `RetryError` are common, collision-prone ecosystem
-names. Adding them later is non-breaking; removing them after inclusion would
-be breaking.
+Retry support types are imported explicitly from `tears::command` and are not
+added to the prelude or the crate root. The prelude is deliberately
+small—it does not include `Timer`—and `RetryPolicy` / `RetryError` are
+common, collision-prone ecosystem names, which is also why they stay off
+the crate root: retry is opt-in vocabulary a `Command`-using app may never
+touch, not skeleton vocabulary or a `Subscription`-style extension
+contract (see `docs/api-guidelines.md`). Adding them to the prelude or
+promoting them to the crate root later is non-breaking; removing them
+after inclusion would be breaking.
 
 ## 4. Composition and Runtime Cancellation
 
@@ -630,8 +639,11 @@ dependencies.
 ### C.1 Suggested order
 
 1. Add `Effect::timeout` and `Command::timeout` with unit tests and rustdoc.
-2. Add retry support types in `src/command/retry.rs` and re-export them from
-   `src/command.rs` and `src/lib.rs`, but not the prelude.
+2. Add retry support types in `src/command/retry.rs` (private `mod retry;`)
+   and re-export them from `src/command.rs` only (`tears::command::RetryPolicy`
+   etc.), not from `src/lib.rs` or the prelude. Re-exporting from both
+   `command.rs` and `lib.rs` would give every type two public paths, which
+   `docs/api-guidelines.md`'s single-canonical-path rule treats as a defect.
 3. Add `Command::retry`, `retry_if`, and a `run_retry` helper.
 4. Add runtime integration smoke tests.
 5. Update CHANGELOG, README, and rustdoc.


### PR DESCRIPTION
## Summary
- Applies `docs/api-guidelines.md`'s root promotion criteria (merged in #166) to RFC 0003 and RFC 0004, the two Accepted-but-unimplemented RFCs that introduce command-scoped opt-in vocabulary.
- RFC 0003: adds an explicit `tears::command::{CommandId, CancelPolicy}` path statement to §3 (it previously had no import example at all) and adds a `use` line to the `Command::cancellable` example.
- RFC 0004: revises Constraint 5, the §3.2 usage example, §3.5's prelude rationale, and Appendix C.1's suggested re-export order so `RetryPolicy`/`RetryBackoff`/`RetryContext`/`RetryError`/`RetryStopReason` live at `tears::command::` instead of the crate root, and Appendix C.1 now re-exports from `src/command.rs` only (not also `src/lib.rs`) to avoid a dual path.

Neither `CommandId`/`CancelPolicy` nor `Retry*` pass the skeleton-literal test (only apps that opt into cancellation or retry name them) or the extension-contract test (`Command` has no trait-based extension point the way `Subscription` has `SubscriptionSource`), so both belong at a domain path rather than root — matching how `subscription::http::Query` stays off the root for the same reason.

Both RFCs are Accepted but unimplemented and unreleased, so this changes no shipped API. The actual `feat/command-timeout-retry` implementation branch (unmerged) will be updated separately to match.

## Test plan
- Doc-only change; no code affected.