### PR TITLE
docs: enable missing_docs lint and fill in missing doc comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ required-features = ["ws", "rustls"]
 name = "http_todo"
 required-features = ["http"]
 
+[lints.rust]
+missing_docs = "warn"
+
 [lints.clippy]
 cargo = { level = "warn", priority = -1 }
 complexity = { level = "warn", priority = -1 }

--- a/src/subscription/http/key.rs
+++ b/src/subscription/http/key.rs
@@ -13,9 +13,13 @@ pub struct QueryKey(Arc<[QueryKeyPart]>);
 #[non_exhaustive]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum QueryKeyPart {
+    /// A string component.
     Str(String),
+    /// A signed 64-bit integer component.
     I64(i64),
+    /// An unsigned 64-bit integer component.
     U64(u64),
+    /// A boolean component.
     Bool(bool),
 }
 

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -89,9 +89,11 @@ static NEXT_QUERY_CLIENT_ID: AtomicU64 = AtomicU64::new(1);
 /// Error type for query operations.
 #[derive(Error, Debug, Clone)]
 pub enum QueryError {
+    /// The fetcher returned an application-level failure.
     #[error("Fetch failed: {0}")]
     FetchError(String),
 
+    /// The fetcher failed due to a network-level issue.
     #[error("Network error: {0}")]
     NetworkError(String),
 }
@@ -294,6 +296,9 @@ impl Default for QueryClient {
     }
 }
 
+/// A shared, reusable async fetcher producing a query's value.
+type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Send + Sync>;
+
 /// A query subscription that monitors and fetches retained data.
 ///
 /// `Query` is a subscription that automatically manages data fetching and retention.
@@ -340,9 +345,6 @@ impl Default for QueryClient {
 /// ))
 /// .map(Message::UserQuery);
 /// ```
-/// A shared, reusable async fetcher producing a query's value.
-type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Send + Sync>;
-
 pub struct Query<V> {
     key: QueryKey,
     fetcher: Fetcher<V>,

--- a/src/subscription/http/result.rs
+++ b/src/subscription/http/result.rs
@@ -4,8 +4,11 @@ use super::query::QueryError;
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum QueryStatus {
+    /// No successful data has been observed yet.
     Pending,
+    /// The query currently has successful data.
     Success,
+    /// The latest fetch failed.
     Error,
 }
 
@@ -13,7 +16,9 @@ pub enum QueryStatus {
 #[non_exhaustive]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum FetchStatus {
+    /// No fetch is currently in progress.
     Idle,
+    /// A fetch is currently in progress.
     Fetching,
 }
 

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -78,6 +78,7 @@ pub enum WebSocketCommand {
 pub enum WebSocketMessage {
     /// Successfully connected to the WebSocket server, provides command sender
     Connected {
+        /// Sends commands (text/binary messages, close requests) to the connection.
         sender: mpsc::UnboundedSender<WebSocketCommand>,
     },
     /// Disconnected from the WebSocket server (normal closure)
@@ -85,7 +86,10 @@ pub enum WebSocketMessage {
     /// A message received from the WebSocket server
     Received(Message),
     /// An error occurred (connection failure or communication error)
-    Error { error: String },
+    Error {
+        /// A description of the connection failure or communication error.
+        error: String,
+    },
 }
 
 /// A WebSocket subscription that connects to a WebSocket server and provides

--- a/tests/idle_wakeup.rs
+++ b/tests/idle_wakeup.rs
@@ -1,7 +1,7 @@
-// Integration tests for the idle frame wake-up elision.
-// These verify end-to-end that the event loop stops waking at the frame rate
-// while idle, and that re-enabling the frame branch after idle renders without
-// added latency. The gate predicate itself is unit-tested in src/runtime.rs.
+//! Integration tests for the idle frame wake-up elision.
+//! These verify end-to-end that the event loop stops waking at the frame rate
+//! while idle, and that re-enabling the frame branch after idle renders without
+//! added latency. The gate predicate itself is unit-tested in src/runtime.rs.
 
 mod common;
 #[path = "common/trace_recorder.rs"]

--- a/tests/quit_handling.rs
+++ b/tests/quit_handling.rs
@@ -1,3 +1,5 @@
+//! Integration tests for quit handling.
+
 mod common;
 
 use color_eyre::eyre::Result;

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -1,6 +1,6 @@
-// Integration tests for Runtime::run
-// These tests verify end-to-end scenarios.
-// Unit tests for individual methods are in src/runtime.rs
+//! Integration tests for `Runtime::run`
+//! These tests verify end-to-end scenarios.
+//! Unit tests for individual methods are in src/runtime.rs
 
 mod common;
 #[path = "common/trace_recorder.rs"]


### PR DESCRIPTION
## Summary
- Enables `missing_docs = "warn"` under `[lints.rust]` in Cargo.toml
- Adds the doc comments the lint flagged: `QueryKeyPart` variants, `QueryError` variants, `QueryStatus`/`FetchStatus` variants, `WebSocketMessage::Connected.sender` and `WebSocketMessage::Error.error` struct fields, and crate-level docs for the three integration test files that lacked one (`tests/idle_wakeup.rs`, `tests/quit_handling.rs`, `tests/runtime_run.rs`)
- Fixes a pre-existing doc placement bug in `src/subscription/http/query.rs`: the large `Query` doc comment had no blank line before the `Fetcher` type alias, so rustdoc attached the whole block to `Fetcher` instead of `Query`, leaving `Query` undocumented

## Test plan
- [x] `cargo build --all-features` — no `missing documentation` warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --all-targets --all-features` — all tests pass
- [x] `cargo doc --all-features --no-deps` — builds without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)