### PR TITLE
fix(tests): silence panic hook in command-task panic test

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -97,7 +97,32 @@ need the guard.
 
 If an integration test ever needs to mutate the panic hook, add a focused local
 guard under `tests/common/` rather than exposing the crate-internal test helper
-as public API.
+as public API. Because integration tests are async, that local guard should use
+`tokio::sync::Mutex` (not `std::sync::Mutex`) so it can be held across
+`.await` — see `tests/common/panic_hook.rs`.
+
+### Panic Hook Cost In Timing-Bound Tests
+
+A test that intentionally panics inside a spawned command (to assert
+`catch_unwind` logging, for example) still pays for the *default* panic hook:
+before `catch_unwind` regains control, the hook runs synchronously on the
+panicking thread and, under `RUST_BACKTRACE=1` (set repo-wide in CI),
+captures and symbolicates a full backtrace. On Windows that symbolication is
+markedly slower than on Linux/macOS and its duration is load-dependent, which
+makes it a source of flakiness rather than a fixed cost.
+
+This matters most when the panic happens on a `current_thread` runtime: the
+same thread that is blocked doing symbolication is also the thread driving
+any timer or subscription the test is relying on to reach its next state, so
+the hook cost eats directly into the test's `timeout` budget. A test that
+otherwise finishes in single-digit milliseconds can intermittently blow
+through a one-second timeout on a loaded Windows runner.
+
+If a test intentionally triggers a command-task panic under a bounded
+`timeout`, install a no-op panic hook for the duration (see
+`tests/common/panic_hook.rs::SilentPanicHook`) rather than only widening the
+timeout. Widening the timeout alone hides the same unbounded cost behind a
+larger number instead of removing it.
 
 ## Sleep Audit Notes
 

--- a/tests/common/panic_hook.rs
+++ b/tests/common/panic_hook.rs
@@ -1,0 +1,50 @@
+// Focused local guard for integration tests that mutate the process-global
+// panic hook, per docs/testing.md "Process-Global Panic Hook Tests". Kept
+// separate from `crate::test_support::PANIC_HOOK_GUARD` (crate-internal,
+// synchronous-only) because integration tests need to hold the guard across
+// `.await` while a spawned command panics.
+
+use std::panic::{self, PanicHookInfo};
+
+use tokio::sync::Mutex;
+
+/// Serializes integration tests that install a process-global panic hook.
+///
+/// The panic hook is process-global and tests in this binary can run
+/// concurrently on different threads, so a test that silences the hook must
+/// not overlap with another test that panics for real, or the latter's
+/// message and location would be lost.
+pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::const_new(());
+
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// Installs a no-op panic hook for as long as the guard is held, restoring
+/// the previous hook on drop.
+///
+/// The default hook synchronously captures and symbolicates a backtrace when
+/// `RUST_BACKTRACE=1` (set repo-wide in CI), on the panicking thread, before
+/// `catch_unwind` regains control. On Windows this symbolication can be slow
+/// enough to blow through a bounded `timeout`, especially when the panic
+/// happens on a `current_thread` runtime where the same thread also drives
+/// the timers/subscriptions the test is waiting on. See docs/testing.md.
+pub struct SilentPanicHook {
+    previous: Option<PanicHook>,
+}
+
+impl SilentPanicHook {
+    pub fn install() -> Self {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(|_info| {}));
+        Self {
+            previous: Some(previous),
+        }
+    }
+}
+
+impl Drop for SilentPanicHook {
+    fn drop(&mut self) {
+        if let Some(hook) = self.previous.take() {
+            panic::set_hook(hook);
+        }
+    }
+}

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -3,6 +3,8 @@
 //! Unit tests for individual methods are in src/runtime.rs
 
 mod common;
+#[path = "common/panic_hook.rs"]
+mod panic_hook;
 #[path = "common/trace_recorder.rs"]
 mod trace_recorder;
 
@@ -165,6 +167,14 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
         }
     }
 
+    // The default panic hook synchronously symbolicates a backtrace under
+    // `RUST_BACKTRACE=1` (set repo-wide in CI). On Windows that can be slow
+    // enough, on this `current_thread` runtime, to blow through the timeout
+    // below before the Timer subscription gets a chance to send Quit. Silence
+    // the hook for the panic this test triggers; see docs/testing.md.
+    let _hook_guard = panic_hook::PANIC_HOOK_GUARD.lock().await;
+    let _silent_hook = panic_hook::SilentPanicHook::install();
+
     let recorder = TraceRecorder::new()
         .with_target("tears::runtime")
         .with_level(tracing::Level::ERROR);
@@ -173,7 +183,7 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
     let mut terminal = common::test_terminal()?;
     let runtime = Runtime::<PanicCommandApp>::try_new((), 60).expect("frame rate must be valid");
 
-    timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await??;
+    timeout(Duration::from_secs(5), runtime.run(&mut terminal)).await??;
 
     assert!(
         recorder.event_count() >= 1,


### PR DESCRIPTION
## Summary
- `test_runtime_run_logs_command_task_panic` flaked on CI (windows-latest, beta run https://github.com/akiomik/tears/actions/runs/29112514556/job/86428001029) with `Error: deadline has elapsed`.
- Root cause: the default panic hook synchronously symbolicates a backtrace under `RUST_BACKTRACE=1` (set repo-wide in CI) before `catch_unwind` in `enqueue_command` regains control. On Windows that symbolication is slow and load-dependent; on this test's `current_thread` runtime, the same thread that's blocked doing symbolication also drives the `Timer` subscription the test relies on to reach `Quit`, so the hook cost ate into the 1s `timeout` budget.
- Added `tests/common/panic_hook.rs`: a `SilentPanicHook` RAII guard that installs a no-op hook for the duration of the test (removing the actual cost, not just papering over it with a longer timeout), serialized by a `tokio::sync::Mutex`-based `PANIC_HOOK_GUARD` per the existing "Process-Global Panic Hook Tests" guidance in `docs/testing.md`.
- Widened the test's timeout from 1s to 5s as defense in depth.
- Documented the hazard and fix pattern in `docs/testing.md` under a new "Panic Hook Cost In Timing-Bound Tests" section for future tests that intentionally panic inside a command/subscription under a bounded timeout.
- Audited the repo for other tests with the same shape (intentional panic + `catch_unwind` + bounded `timeout`, especially on `current_thread` runtimes) — this was the only one.

## Test plan
- [x] `cargo test --test runtime_run` passes
- [x] `RUST_BACKTRACE=1 cargo test --test runtime_run test_runtime_run_logs_command_task_panic -- --nocapture` confirms no panic backtrace is printed
- [x] `cargo test --all-targets --all-features` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes