### PR TITLE
feat!: raise MSRV to Rust 1.88.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,13 @@ jobs:
           RUSTDOCFLAGS: -D warnings
 
   msrv:
-    name: MSRV (1.86.0)
+    name: MSRV (1.88.0)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.86.0
+          toolchain: 1.88.0
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV
         run: cargo check --all-targets --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** Raised MSRV to Rust 1.88.0 (from 1.86.0)
+  - Required to pull in `time >=0.3.47`, which resolves RUSTSEC-2026-0009
+    (denial of service via stack exhaustion) in the `time` crate pulled in
+    transitively via `ratatui-widgets`
+
 ## [0.9.3] - 2026-07-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,9 +1545,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2839,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "libc",
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 readme = "README.md"
 keywords = ["tui", "tea", "elm-architecture", "ratatui", "framework"]
 categories = ["command-line-interface", "asynchronous"]
-rust-version = "1.86.0"
+rust-version = "1.88.0"
 include = [
     "src/**/*",
     "examples/**/*",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/tears/badge.svg)](https://docs.rs/tears)
 [![CI](https://github.com/akiomik/tears/workflows/CI/badge.svg)](https://github.com/akiomik/tears/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/tears.svg)](LICENSE)
-[![Rust Version](https://img.shields.io/badge/rust-1.86.0%2B-blue.svg)](https://www.rust-lang.org)
+[![Rust Version](https://img.shields.io/badge/rust-1.88.0%2B-blue.svg)](https://www.rust-lang.org)
 [![codecov](https://codecov.io/gh/akiomik/tears/graph/badge.svg?token=QF9SO8I0AM)](https://codecov.io/gh/akiomik/tears)
 
 A simple and elegant framework for building TUI applications using **The Elm Architecture (TEA)**.
@@ -334,7 +334,7 @@ The framework is designed with these principles:
 
 ## Minimum Supported Rust Version (MSRV)
 
-Tears requires Rust 1.86.0 or later (uses edition 2024).
+Tears requires Rust 1.88.0 or later (uses edition 2024).
 
 ## License
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -56,11 +56,11 @@ impl Application for Counter {
             }
             Message::Terminal(event) => {
                 // Handle keyboard events
-                if let Event::Key(key) = event {
-                    if key.code == KeyCode::Char('q') {
-                        // Quit on 'q' key press
-                        return Command::effect(Action::Quit);
-                    }
+                if let Event::Key(key) = event
+                    && key.code == KeyCode::Char('q')
+                {
+                    // Quit on 'q' key press
+                    return Command::effect(Action::Quit);
                 }
                 Command::none()
             }

--- a/src/application.rs
+++ b/src/application.rs
@@ -330,10 +330,10 @@ mod tests {
         assert!(cmd.is_some());
 
         // Verify the command produces the expected message
-        if let Some(mut stream) = cmd.into_stream() {
-            if let Some(action) = stream.next().await {
-                assert!(matches!(action, Action::Message(msg) if msg == "initialized"));
-            }
+        if let Some(mut stream) = cmd.into_stream()
+            && let Some(action) = stream.next().await
+        {
+            assert!(matches!(action, Action::Message(msg) if msg == "initialized"));
         }
     }
 

--- a/src/command/effect.rs
+++ b/src/command/effect.rs
@@ -148,38 +148,21 @@ where
 // preserves each leaf's identity through `Command` composition, which is what a
 // future per-leaf cancellation id would attach to.
 //
-// The empty case is a distinct `None` variant rather than an empty `Vec` so
-// that `is_none()`/`is_some()` stay `const fn` (these back the public
-// `Command::is_none`/`is_some`); `Vec::is_empty` only became usable in `const`
-// in Rust 1.87, past this crate's MSRV. The invariant is therefore that
-// `Leaves` is always non-empty.
-//
-// TODO(msrv >= 1.87): collapse this back to a plain
-// `Vec<BoxStream<'static, Action<Msg>>>` and implement the `const`
-// `is_none()`/`is_some()` with `Vec::is_empty`, dropping the `None` variant and
-// its non-empty invariant.
-//
-// Future room: to carry per-leaf metadata, `Leaves` could hold
+// Future room: to carry per-leaf metadata, `leaves` could hold
 // `Vec<(LeafMeta, BoxStream<'static, Action<Msg>>)>` without reworking the fold
 // at the `into_stream()` boundary.
-pub(super) enum Effect<Msg: Send + 'static> {
-    None,
-    Leaves(Vec<BoxStream<'static, Action<Msg>>>),
+pub(super) struct Effect<Msg: Send + 'static> {
+    leaves: Vec<BoxStream<'static, Action<Msg>>>,
 }
 
 impl<Msg: Send + 'static> Effect<Msg> {
     pub(super) const fn none() -> Self {
-        Self::None
+        Self { leaves: Vec::new() }
     }
 
     fn from_stream(stream: BoxStream<'static, Action<Msg>>) -> Self {
-        Self::Leaves(vec![stream])
-    }
-
-    fn into_leaves(self) -> Vec<BoxStream<'static, Action<Msg>>> {
-        match self {
-            Self::None => Vec::new(),
-            Self::Leaves(leaves) => leaves,
+        Self {
+            leaves: vec![stream],
         }
     }
 
@@ -198,32 +181,26 @@ impl<Msg: Send + 'static> Effect<Msg> {
     pub(super) fn batch(effects: impl IntoIterator<Item = Self>) -> Self {
         // Concatenate the children's leaves. Because every effect already holds
         // a flat leaf sequence, nested batches flatten automatically and
-        // stream-less children contribute nothing. Collapse to `None` when no
-        // child had a leaf so the non-empty `Leaves` invariant holds.
-        let leaves: Vec<_> = effects.into_iter().flat_map(Self::into_leaves).collect();
+        // stream-less children contribute nothing.
+        let leaves: Vec<_> = effects
+            .into_iter()
+            .flat_map(|effect| effect.leaves)
+            .collect();
 
-        if leaves.is_empty() {
-            Self::None
-        } else {
-            Self::Leaves(leaves)
-        }
+        Self { leaves }
     }
 
     pub(super) fn timeout<F>(self, duration: Duration, on_timeout: F) -> Self
     where
         F: FnOnce() -> Msg + Send + 'static,
     {
-        match self {
-            Self::None => Self::None,
-            Self::Leaves(leaves) => {
-                let on_timeout = Arc::new(Mutex::new(Some(on_timeout)));
-                let leaves = leaves
-                    .into_iter()
-                    .map(|leaf| TimeoutLeaf::new(leaf, duration, Arc::clone(&on_timeout)).boxed())
-                    .collect();
-                Self::Leaves(leaves)
-            }
-        }
+        let on_timeout = Arc::new(Mutex::new(Some(on_timeout)));
+        let leaves = self
+            .leaves
+            .into_iter()
+            .map(|leaf| TimeoutLeaf::new(leaf, duration, Arc::clone(&on_timeout)).boxed())
+            .collect();
+        Self { leaves }
     }
 
     pub(super) fn map<T>(self, f: impl Fn(Msg) -> T + Send + 'static) -> Effect<T>
@@ -250,62 +227,59 @@ impl<Msg: Send + 'static> Effect<Msg> {
         // cost (the pre-refactor path). Several leaves must share `f`: `Arc<F>`
         // alone would require `F: Sync`, but the public `map` bound is only
         // `Fn + Send`, so a `Mutex` supplies the needed `Sync`.
-        match self {
-            Self::None => Effect::None,
-            Self::Leaves(mut leaves) if leaves.len() == 1 => {
-                let leaf = leaves.pop().expect("length checked to be 1");
-                Effect::Leaves(vec![map_leaf(leaf, f)])
-            }
-            Self::Leaves(leaves) => {
-                let f = Arc::new(Mutex::new(f));
-                let mapped = leaves
-                    .into_iter()
-                    .map(|leaf| {
-                        let f = Arc::clone(&f);
-                        map_leaf(leaf, move |msg| {
-                            // The mutex only lends `Sync` to the shared `Fn`; it
-                            // guards no mutable state, so a poisoned lock carries
-                            // no corrupted invariant. Recover the guard rather
-                            // than panicking, which would otherwise turn one
-                            // leaf's panic into a misleading "mutex poisoned"
-                            // cascade across its sibling leaves.
-                            let guard = f.lock().unwrap_or_else(PoisonError::into_inner);
-                            (*guard)(msg)
-                        })
-                    })
-                    .collect();
-                Effect::Leaves(mapped)
-            }
+        let mut leaves = self.leaves;
+        if leaves.len() == 1 {
+            let leaf = leaves.pop().expect("length checked to be 1");
+            return Effect {
+                leaves: vec![map_leaf(leaf, f)],
+            };
         }
+
+        let f = Arc::new(Mutex::new(f));
+        let mapped = leaves
+            .into_iter()
+            .map(|leaf| {
+                let f = Arc::clone(&f);
+                map_leaf(leaf, move |msg| {
+                    // The mutex only lends `Sync` to the shared `Fn`; it
+                    // guards no mutable state, so a poisoned lock carries
+                    // no corrupted invariant. Recover the guard rather
+                    // than panicking, which would otherwise turn one
+                    // leaf's panic into a misleading "mutex poisoned"
+                    // cascade across its sibling leaves.
+                    let guard = f.lock().unwrap_or_else(PoisonError::into_inner);
+                    (*guard)(msg)
+                })
+            })
+            .collect();
+        Effect { leaves: mapped }
     }
 
     pub(super) const fn is_none(&self) -> bool {
-        matches!(self, Self::None)
+        self.leaves.is_empty()
     }
 
     pub(super) const fn is_some(&self) -> bool {
-        matches!(self, Self::Leaves(_))
+        !self.leaves.is_empty()
     }
 
     // Observe the leaf count so tests in `command.rs` can pin down nested-batch
     // flattening. Not needed by non-test builds.
     #[cfg(test)]
     pub(super) fn leaf_count(&self) -> usize {
-        match self {
-            Self::None => 0,
-            Self::Leaves(leaves) => leaves.len(),
-        }
+        self.leaves.len()
     }
 
     pub(super) fn into_stream(self) -> Option<BoxStream<'static, Action<Msg>>> {
         // Fold the leaves back into one stream here, at the boundary. A single
         // leaf is returned as-is (a `select_all` over one stream is observably
-        // identical); `None` yields no stream, which the runtime treats as no
-        // work to spawn. `Leaves` is always non-empty by invariant.
-        match self {
-            Self::None => None,
-            Self::Leaves(mut leaves) if leaves.len() == 1 => leaves.pop(),
-            Self::Leaves(leaves) => Some(select_all(leaves).boxed()),
+        // identical); no leaves yields no stream, which the runtime treats as
+        // no work to spawn.
+        let mut leaves = self.leaves;
+        match leaves.len() {
+            0 => None,
+            1 => leaves.pop(),
+            _ => Some(select_all(leaves).boxed()),
         }
     }
 }

--- a/tests/websocket_leak.rs
+++ b/tests/websocket_leak.rs
@@ -133,10 +133,10 @@ async fn websocket_closes_connection_when_outer_task_is_aborted() {
     let mut stream = ws.stream();
     let task = tokio::spawn(async move {
         while let Some(msg) = stream.next().await {
-            if matches!(msg, WebSocketMessage::Connected { .. }) {
-                if let Some(tx) = connected_tx.take() {
-                    let _ = tx.send(());
-                }
+            if matches!(msg, WebSocketMessage::Connected { .. })
+                && let Some(tx) = connected_tx.take()
+            {
+                let _ = tx.send(());
             }
         }
     });


### PR DESCRIPTION
## Summary

- Raise MSRV from 1.86.0 to 1.88.0 (`Cargo.toml`, README, CI MSRV job)
- Update `time` to `>=0.3.47` (via `cargo update -p time --precise 0.3.47`) to resolve [RUSTSEC-2026-0009](https://rustsec.org/advisories/RUSTSEC-2026-0009) (stack exhaustion DoS), which is pulled in transitively via `ratatui-widgets` and requires Rust 1.88.0+
- Collapse `Effect::None | Leaves(Vec<...>)` back to a plain `Vec<BoxStream<'static, Action<Msg>>>` now that `Vec::is_empty` is `const`-usable (stabilized in 1.87), resolving the `TODO(msrv >= 1.87)` in `src/command/effect.rs`

Part of the 0.10.0 breaking-change train.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (all passing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` (no new warnings)
- [x] `cargo +1.88.0 check --all-targets --all-features` (confirms the new MSRV floor actually builds)
- [x] `cargo audit` (0 vulnerabilities, RUSTSEC-2026-0009 resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)