### PR TITLE
feat!: hide Action from the public API, add Command::quit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (denial of service via stack exhaustion) in the `time` crate pulled in
     transitively via `ratatui-widgets`
 
+### Removed
+
+- **Breaking:** `Action` is no longer part of the public API
+  - `tears::Action` and `tears::prelude::Action` are gone; `Command::effect`
+    (which took an `Action`) is removed
+  - Replace `Command::effect(Action::Quit)` with the new `Command::quit()`
+  - Replace `Command::effect(Action::Message(msg))` with `Command::message(msg)`
+    (already the preferred form)
+  - `Action` remains as a private runtime-internal stream item, so no runtime
+    behavior changes
+
+### Added
+
+- `Command::quit()` for requesting the application to quit, replacing the
+  public use of `Command::effect(Action::Quit)`
+
 ## [0.9.3] - 2026-07-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ impl Application for Counter {
                 Command::none()
             }
             Message::Input(Event::Key(key)) if key.code == KeyCode::Char('q') => {
-                Command::effect(Action::Quit)
+                Command::quit()
             }
             Message::InputError(e) => {
                 eprintln!("Input error: {e}");
-                Command::effect(Action::Quit)
+                Command::quit()
             }
             _ => Command::none(),
         }

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -60,7 +60,7 @@ impl Application for Counter {
                     && key.code == KeyCode::Char('q')
                 {
                     // Quit on 'q' key press
-                    return Command::effect(Action::Quit);
+                    return Command::quit();
                 }
                 Command::none()
             }
@@ -68,7 +68,7 @@ impl Application for Counter {
                 // Handle terminal event stream errors
                 // In this example, we log the error and quit
                 eprintln!("Terminal error: {e}");
-                Command::effect(Action::Quit)
+                Command::quit()
             }
         }
     }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -132,9 +132,9 @@ impl Application for App {
             Message::Terminal(_) => {}
             Message::TerminalError(e) => {
                 eprintln!("Terminal error: {e}");
-                return Command::effect(Action::Quit);
+                return Command::quit();
             }
-            Message::Quit => return Command::effect(Action::Quit),
+            Message::Quit => return Command::quit(),
         }
 
         Command::none()

--- a/examples/http_todo.rs
+++ b/examples/http_todo.rs
@@ -159,7 +159,7 @@ impl Application for App {
                 self.status = format!("Failed to create todo: {e}");
                 Command::none()
             }
-            Message::Quit => Command::effect(Action::Quit),
+            Message::Quit => Command::quit(),
         }
     }
 

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -56,13 +56,13 @@ impl Application for PanicDemo {
                 #[allow(clippy::panic, reason = "demonstrating panic recovery")]
                 KeyCode::Char('p') => panic!("intentional panic triggered by 'p'"),
                 // Quit normally.
-                KeyCode::Char('q') => Command::effect(Action::Quit),
+                KeyCode::Char('q') => Command::quit(),
                 _ => Command::none(),
             },
             Message::Terminal(_) => Command::none(),
             Message::TerminalError(e) => {
                 eprintln!("Terminal error: {e}");
-                Command::effect(Action::Quit)
+                Command::quit()
             }
         }
     }

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -138,7 +138,7 @@ impl Application for App {
         }
 
         if self.should_quit {
-            Command::effect(Action::Quit)
+            Command::quit()
         } else {
             Command::none()
         }

--- a/examples/views.rs
+++ b/examples/views.rs
@@ -166,7 +166,7 @@ impl App {
                     selected: 0,
                 };
             }
-            Message::Quit => return Command::effect(Action::Quit),
+            Message::Quit => return Command::quit(),
             _ => {}
         }
 
@@ -281,7 +281,7 @@ fn handle_key_event(view: &View, key: KeyEvent) -> Command<Message> {
 
 fn handle_terminal_error(error: &str) -> Command<Message> {
     eprintln!("Terminal error: {error}");
-    Command::effect(Action::Quit)
+    Command::quit()
 }
 
 /// Render the menu view

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -169,7 +169,7 @@ impl Application for EchoChat {
                 }
                 Command::none()
             }
-            Msg::Quit => Command::effect(Action::Quit),
+            Msg::Quit => Command::quit(),
         }
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -101,7 +101,7 @@ pub trait Application: Sized {
     /// fn update(&mut self, msg: Message) -> Command<Message> {
     ///     match msg {
     ///         Message::Save => Command::perform(async { /* save */ }, |_| Message::Quit),
-    ///         Message::Quit => Command::effect(Action::Quit),
+    ///         Message::Quit => Command::quit(),
     ///     }
     /// }
     /// #     fn view(&self, frame: &mut Frame<'_>) {}

--- a/src/command.rs
+++ b/src/command.rs
@@ -39,8 +39,11 @@ pub use retry::{RetryBackoff, RetryContext, RetryError, RetryPolicy, RetryStopRe
 use runtime_directives::RuntimeDirectives;
 pub(crate) use runtime_parts::RuntimeCommandParts;
 
-/// An action that can be performed by a command.
-pub enum Action<Msg> {
+/// An internal runtime directive produced by a command's effect stream.
+///
+/// This type is not part of the public API. Use [`Command::message`] and
+/// [`Command::quit`] to construct the corresponding commands.
+pub(crate) enum Action<Msg> {
     /// Send a message to the application's update function.
     Message(Msg),
 
@@ -326,20 +329,20 @@ impl<Msg: Send + 'static> Command<Msg> {
         Self::effect(Action::Message(msg))
     }
 
-    /// Create a command that performs a single action immediately.
+    /// Create a command that requests the application to quit immediately.
     ///
     /// # Examples
     ///
     /// ```
     /// use tears::prelude::*;
     ///
-    /// // Quit the application
-    /// let cmd: Command<i32> = Command::effect(Action::Quit);
-    ///
-    /// // Send a message (prefer Command::message for this)
-    /// let cmd = Command::effect(Action::Message(42));
+    /// let cmd: Command<i32> = Command::quit();
     /// ```
-    pub fn effect(action: Action<Msg>) -> Self {
+    pub fn quit() -> Self {
+        Self::effect(Action::Quit)
+    }
+
+    fn effect(action: Action<Msg>) -> Self {
         Self::with_effect(Effect::action(action))
     }
 
@@ -495,7 +498,7 @@ mod tests {
         assert!(Command::message(1).requests_redraw());
         assert!(Command::future(async { 1 }).requests_redraw());
         assert!(Command::perform(async { 1 }, |value| value).requests_redraw());
-        assert!(Command::<i32>::effect(Action::Quit).requests_redraw());
+        assert!(Command::<i32>::quit().requests_redraw());
         assert!(Command::stream(stream::iter(vec![1])).requests_redraw());
         assert!(Command::run(stream::iter(vec![1]), |value| value).requests_redraw());
         assert!(Command::batch(vec![Command::<i32>::none()]).requests_redraw());
@@ -621,8 +624,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_into_runtime_parts_effect_quit_yields_quit() {
-        let parts = Command::<i32>::effect(Action::Quit).into_runtime_parts();
+    async fn test_into_runtime_parts_quit_yields_quit() {
+        let parts = Command::<i32>::quit().into_runtime_parts();
 
         assert!(parts.requests_redraw());
 
@@ -748,7 +751,7 @@ mod tests {
     #[tokio::test]
     async fn test_batch_with_quit_action() {
         let cmd1 = Command::future(async { 1 });
-        let cmd2 = Command::effect(Action::Quit);
+        let cmd2 = Command::quit();
         let cmd3 = Command::future(async { 3 });
 
         let cmd = Command::batch(vec![cmd1, cmd2, cmd3]);
@@ -1113,7 +1116,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_map_preserves_quit() {
-        let cmd: Command<i32> = Command::effect(Action::Quit);
+        let cmd: Command<i32> = Command::quit();
         let mapped = cmd.map(|x| x * 2);
 
         let mut stream = mapped.into_stream().expect("stream should exist");
@@ -1151,8 +1154,8 @@ mod tests {
     }
 
     #[test]
-    fn test_is_some_with_effect() {
-        let cmd: Command<i32> = Command::effect(Action::Quit);
+    fn test_is_some_with_quit() {
+        let cmd: Command<i32> = Command::quit();
         assert!(cmd.is_some());
         assert!(!cmd.is_none());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub mod subscription;
 
 // Re-export commonly used types
 pub use application::Application;
-pub use command::{Action, Command};
+pub use command::Command;
 // Re-exported because implementing `SubscriptionSource::stream` requires
 // writing this type out in the return position; see docs/api-guidelines.md
 // "External Crate Re-exports".

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,13 +8,12 @@
 //!
 //! - [`Application`] - The main application trait
 //! - [`Command`] - For side effects and runtime directives
-//! - [`Action`] - Actions that commands can perform
 //! - [`Subscription`] - For handling event sources
 //! - [`Runtime`] - The runtime for running applications
 //! - [`FrameRate`] - Validated runtime frame rate
 
 pub use crate::application::Application;
-pub use crate::command::{Action, Command};
+pub use crate::command::Command;
 pub use crate::runtime::Runtime;
 pub use crate::runtime::frame_rate::{FrameRate, FrameRateError};
 pub use crate::subscription::Subscription;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -56,7 +56,7 @@
 //!                 self.count += 1;
 //!                 Command::none()
 //!             }
-//!             Message::Quit => Command::effect(Action::Quit),
+//!             Message::Quit => Command::quit(),
 //!         }
 //!     }
 //!
@@ -327,7 +327,7 @@ impl<App: Application> Runtime<App> {
     ///
     /// This is the main entry point for executing the application. It starts the event loop
     /// that processes messages, renders the UI, and manages subscriptions. The loop continues
-    /// until the application sends a quit signal via [`Action::Quit`](crate::command::Action::Quit).
+    /// until the application sends a quit signal via [`Command::quit`](crate::command::Command::quit).
     ///
     /// # Event Loop
     ///
@@ -368,7 +368,7 @@ impl<App: Application> Runtime<App> {
     /// #     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
     /// #     fn update(&mut self, msg: Message) -> Command<Message> {
     /// #         match msg {
-    /// #             Message::Quit => Command::effect(Action::Quit),
+    /// #             Message::Quit => Command::quit(),
     /// #         }
     /// #     }
     /// #     fn view(&self, frame: &mut Frame<'_>) {}

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -356,7 +356,7 @@ mod tests {
         let mut core = RuntimeCore::<TestApp>::new(0);
 
         // Enqueue a quit command
-        let cmd = Command::effect(Action::Quit);
+        let cmd = Command::quit();
         core.enqueue_command(cmd.into_runtime_parts());
 
         timeout(Duration::from_secs(1), core.quit_rx.recv())

--- a/src/subscription/terminal.rs
+++ b/src/subscription/terminal.rs
@@ -73,7 +73,7 @@ use super::{SubscriptionId, SubscriptionSource};
 ///         Message::InputError(e) => {
 ///             // Handle the error (log, show UI, exit, etc.)
 ///             eprintln!("Terminal error: {}", e);
-///             Command::effect(Action::Quit)
+///             Command::quit()
 ///         }
 ///     }
 /// }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -10,7 +10,7 @@ use std::sync::Mutex;
 use ratatui::Frame;
 
 use crate::application::Application;
-use crate::command::{Action, Command};
+use crate::command::Command;
 use crate::subscription::Subscription;
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
@@ -65,7 +65,7 @@ impl Application for TestApp {
             }
             TestMessage::Quit => {
                 self.should_quit = true;
-                Command::effect(Action::Quit)
+                Command::quit()
             }
         }
     }

--- a/tests/idle_wakeup.rs
+++ b/tests/idle_wakeup.rs
@@ -46,7 +46,7 @@ impl Application for IdleThenQuitApp {
     }
 
     fn update(&mut self, _msg: Wake) -> Command<Self::Message> {
-        Command::effect(Action::Quit)
+        Command::quit()
     }
 
     fn view(&self, _frame: &mut Frame<'_>) {

--- a/tests/quit_handling.rs
+++ b/tests/quit_handling.rs
@@ -43,7 +43,7 @@ impl Application for InitQuitApp {
 
     fn new(_flags: ()) -> (Self, Command<Self::Message>) {
         // Quit immediately after initialization
-        (Self, Command::effect(Action::Quit))
+        (Self, Command::quit())
     }
 
     fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
@@ -96,7 +96,7 @@ impl Application for DelayedQuitApp {
     }
 
     fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
-        Command::effect(Action::Quit)
+        Command::quit()
     }
 
     fn view(&self, _frame: &mut Frame<'_>) {}
@@ -163,7 +163,7 @@ impl Application for MultiMessageQuitApp {
                 self.counter += 1;
                 Command::none()
             }
-            MultiMessage::Quit => Command::effect(Action::Quit),
+            MultiMessage::Quit => Command::quit(),
         }
     }
 

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -43,7 +43,7 @@ impl Application for CounterApp {
     fn new(max_count: u32) -> (Self, Command<Self::Message>) {
         let cmd = if max_count == 0 {
             // Quit immediately if max_count is 0
-            Command::effect(Action::Quit)
+            Command::quit()
         } else {
             Command::none()
         };
@@ -62,7 +62,7 @@ impl Application for CounterApp {
             CounterMessage::Increment => {
                 self.count += 1;
                 if self.count >= self.max_count {
-                    Command::effect(Action::Quit)
+                    Command::quit()
                 } else {
                     Command::none()
                 }
@@ -93,7 +93,7 @@ impl Application for SubApp {
     fn update(&mut self, (): ()) -> Command<()> {
         self.tick_count += 1;
         if self.tick_count >= 3 {
-            Command::effect(Action::Quit)
+            Command::quit()
         } else {
             Command::none()
         }
@@ -152,7 +152,7 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
         }
 
         fn update(&mut self, _msg: Message) -> Command<Message> {
-            Command::effect(Action::Quit)
+            Command::quit()
         }
 
         fn view(&self, _frame: &mut Frame<'_>) {}
@@ -216,7 +216,7 @@ async fn test_runtime_run_end_to_end_with_commands() -> Result<()> {
         fn update(&mut self, msg: String) -> Command<String> {
             self.received.push(msg);
             if self.received.len() >= 3 {
-                Command::effect(Action::Quit)
+                Command::quit()
             } else {
                 Command::none()
             }
@@ -297,7 +297,7 @@ async fn test_runtime_run_delivers_timeout_and_retry_messages_to_update() -> Res
             let observed = self.observed.fetch_or(bit, Ordering::SeqCst) | bit;
 
             if observed == (TIMED_OUT | RETRIED) {
-                Command::effect(Action::Quit)
+                Command::quit()
             } else {
                 Command::none()
             }


### PR DESCRIPTION
## Summary

- `Action<Msg>` moves from `pub` to `pub(crate)` — it is no longer reachable as `tears::Action` or via `tears::prelude::*`
- `Command::effect(...)` is removed from the public API; use the new `Command::quit()` instead of `Command::effect(Action::Quit)` (`Command::message()` already covered the `Action::Message` case)
- Updates all rustdoc examples, README, `examples/`, and `tests/` to the new `Command::quit()` form
- `Action::Message` / `Action::Quit` remain as private runtime-internal stream items — no runtime behavior change

Rationale (from `docs/rfcs/0002-redraw-suppression.md` §9): while `Action` stayed public, every new internal runtime directive was a breaking change. Closing the public surface over `Command` constructors alone means the directive set can grow later (e.g. a future `cancellable` modifier) without further breaks.

Part of the 0.10.0 breaking-change train.

## Test plan

- [x] `cargo build --all-features --all-targets`
- [x] `cargo test --all-features` (all passing, including doctests)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` (no warnings)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (no broken intra-doc links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)