### PR TITLE
feat!: unify Timer/RetryPolicy/FrameRate/Runtime constructors on new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (already the preferred form)
   - `Action` remains as a private runtime-internal stream item, so no runtime
     behavior changes
+- **Breaking:** Removed the fallible `try_new` constructors in favor of a
+  single `new` per type
+  - `Timer::try_new(u64) -> Option<Timer>` is gone; use
+    `Timer::new(NonZeroU64::new(ms).expect(...))`
+  - `RetryPolicy::try_new(usize) -> Option<RetryPolicy>` is gone; use
+    `RetryPolicy::new(NonZeroUsize::new(n).expect(...))`
+  - `FrameRate::try_new(u32) -> Result<FrameRate, FrameRateError>` is gone;
+    use `FrameRate::new(NonZeroU32::new(fps).expect(...))`
+  - `Runtime::try_new(flags, u32) -> Result<Runtime<_>, FrameRateError>` is
+    gone; build a `FrameRate` first and pass it to `Runtime::new(flags,
+    frame_rate)`
+  - `FrameRateError::Zero` is removed: the non-zero invariant is now enforced
+    by `NonZeroU32` at the call site instead of at runtime
+  - `FrameRateError` is now `#[non_exhaustive]`
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,12 @@ impl Application for App {
 To run your application, create an `Runtime` and call `run()`:
 
 ```rust
+use std::num::NonZeroU32;
+
 #[tokio::main]
 async fn main() -> Result<()> {
-    let runtime = Runtime::<App>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
 
     // Setup terminal (see complete example below)
     // ...
@@ -94,6 +97,8 @@ async fn main() -> Result<()> {
 Here's a simple counter application that increments every second:
 
 ```rust
+use std::num::{NonZeroU32, NonZeroU64};
+
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode};
 use ratatui::{Frame, text::Text};
@@ -143,7 +148,7 @@ impl Application for Counter {
 
     fn subscriptions(&self) -> Vec<Subscription<Message>> {
         vec![
-            Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero")).map(|timer_msg| {
+            Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero"))).map(|timer_msg| {
                 match timer_msg {
                     TimerEvent::Tick => Message::Tick,
                 }
@@ -168,7 +173,8 @@ async fn main() -> Result<()> {
     tears::install_panic_hook();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<Counter>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<Counter>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal (normal exit path)
@@ -200,6 +206,7 @@ Retry support types are imported explicitly from `tears::command` rather than
 from the crate root or prelude:
 
 ```rust
+use std::num::NonZeroUsize;
 use std::time::Duration;
 use tears::Command;
 use tears::command::{RetryError, RetryPolicy};
@@ -208,8 +215,7 @@ enum Message {
     Loaded(Result<String, RetryError<&'static str>>),
 }
 
-let policy = RetryPolicy::try_new(3)
-    .expect("attempt count must be non-zero")
+let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"))
     .with_fixed_backoff(Duration::from_millis(200));
 
 let command = Command::retry(

--- a/docs/rfcs/0004-command-timeout-retry.md
+++ b/docs/rfcs/0004-command-timeout-retry.md
@@ -301,8 +301,7 @@ async fn fetch_todo(
     Ok(Todo)
 }
 
-let policy = RetryPolicy::try_new(3)
-    .expect("max attempts must be non-zero")
+let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"))
     .with_fixed_backoff(Duration::from_millis(200));
 
 let todo_id = 42;
@@ -329,10 +328,10 @@ error.
 | `RetryError<E>` | Attempt count, last error, and stop reason |
 | `RetryStopReason` | `Exhausted` or `StoppedByPredicate` |
 
-`RetryPolicy::new` accepts `NonZeroUsize`. The convenience
-`RetryPolicy::try_new(usize)` returns `None` for zero instead of panicking.
-The default backoff is `RetryBackoff::None`. Appendix A contains the complete
-support API and compatibility attributes.
+`RetryPolicy::new` accepts `NonZeroUsize`; the non-zero invariant is enforced
+by the type, so there is no fallible convenience constructor. The default
+backoff is `RetryBackoff::None`. Appendix A contains the complete support API
+and compatibility attributes.
 
 ### 3.4 Core semantics
 
@@ -511,8 +510,6 @@ impl RetryPolicy {
     #[must_use]
     pub const fn new(max_attempts: NonZeroUsize) -> Self;
     #[must_use]
-    pub const fn try_new(max_attempts: usize) -> Option<Self>;
-    #[must_use]
     pub const fn max_attempts(&self) -> NonZeroUsize;
     #[must_use]
     pub const fn backoff(&self) -> &RetryBackoff;
@@ -552,10 +549,13 @@ impl<E: std::error::Error + 'static> std::error::Error for RetryError<E>;
 
 ### A.3 Compatibility consequences
 
-- `RetryPolicy::new(NonZeroUsize)` is infallible, while
-  `try_new(usize) -> Option<Self>` represents the single invalid case. This
-  follows the `Timer::try_new` precedent; `FrameRate::try_new` uses `Result`
-  because it distinguishes multiple invalid cases.
+- `RetryPolicy::new(NonZeroUsize)` is infallible: the non-zero invariant is
+  expressed by the `NonZeroUsize` parameter type itself, so there is no
+  fallible `try_new(usize) -> Option<Self>` convenience constructor. This
+  matches `Timer::new(NonZeroU64)`, which is likewise the sole constructor.
+  `FrameRate::new(NonZeroU32) -> Result<Self, FrameRateError>` stays fallible
+  because it additionally validates an upper bound that `NonZero*` cannot
+  express.
 - `RetryBackoff` and its field-bearing variants are `#[non_exhaustive]`.
   Enum variant fields share the enum's visibility, so variant-level
   `#[non_exhaustive]` permits downstream matching with patterns such as
@@ -604,7 +604,7 @@ exact test locations and representative cases are verification guidance.
 | R3 | `StoppedByPredicate` occurs only while attempts remain. |
 | R4 | `None` adds no delay; `Fixed` waits the same delay before every next attempt. |
 | R5 | `RetryError` retains `last_error` and exposes it through `Display` and `Error::source()`. |
-| R6 | `try_new(0)` is `None`; `new` defaults to no backoff; fixed-backoff builders preserve `max_attempts`. |
+| R6 | `new` defaults to no backoff; fixed-backoff builders preserve `max_attempts`. Zero attempts is unrepresentable: `new` takes `NonZeroUsize`, not a runtime-checked count. |
 | R7 | A retry command behaves under `map`, `without_redraw`, and `batch` like a single-leaf future command. |
 | R8 | `should_retry` may retain local state through its `FnMut` bound. |
 

--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -9,6 +9,7 @@
 //! Run with: cargo run --example counter
 
 use std::io;
+use std::num::{NonZeroU32, NonZeroU64};
 
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode};
@@ -83,7 +84,7 @@ impl Application for Counter {
     fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
         vec![
             // Timer that ticks every 1000ms (1 second)
-            Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+            Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
                 .map(Message::Timer),
             // Terminal events (keyboard, mouse, resize)
             // Note: Returns Result to handle potential I/O errors
@@ -103,7 +104,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<Counter>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<Counter>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -9,6 +9,8 @@
 //!
 //! Run with: cargo run --example dashboard
 
+use std::num::NonZeroU32;
+
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use ratatui::prelude::*;
@@ -609,7 +611,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<App>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/http_todo.rs
+++ b/examples/http_todo.rs
@@ -11,6 +11,7 @@
 //! Run with: `cargo run --example http_todo --features http`
 
 use std::io;
+use std::num::NonZeroU32;
 use std::sync::Arc;
 
 use color_eyre::eyre::Result;
@@ -284,7 +285,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<App>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -20,6 +20,7 @@
 //! Run with: `cargo run --example panic_hook`
 
 use std::io;
+use std::num::NonZeroU32;
 
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode};
@@ -94,7 +95,8 @@ async fn main() -> Result<()> {
     tears::install_panic_hook();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<PanicDemo>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<PanicDemo>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal (normal exit path)

--- a/examples/signals.rs
+++ b/examples/signals.rs
@@ -16,6 +16,7 @@
 //! - Press 'q' to quit normally
 
 use std::io;
+use std::num::NonZeroU32;
 use std::process;
 
 use color_eyre::eyre::Result;
@@ -303,7 +304,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<App>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/views.rs
+++ b/examples/views.rs
@@ -17,6 +17,8 @@
 //!
 //! Run with: cargo run --example views
 
+use std::num::{NonZeroU32, NonZeroU64};
+
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent};
 use ratatui::prelude::*;
@@ -132,10 +134,11 @@ impl Application for App {
         // Add timer subscription only in Counter view
         if matches!(self.view, View::Counter { .. }) {
             subs.push(
-                Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
-                    .map(|timer_msg| match timer_msg {
+                Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero"))).map(
+                    |timer_msg| match timer_msg {
                         TimerEvent::Tick => Message::Tick,
-                    }),
+                    },
+                ),
             );
         }
 
@@ -375,7 +378,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<App>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -11,6 +11,7 @@
 //! Run with: cargo run --example websocket --features ws,rustls
 
 use std::io;
+use std::num::NonZeroU32;
 
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyEventKind};
@@ -252,7 +253,8 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run the application at 60 FPS
-    let runtime = Runtime::<EchoChat>::try_new((), 60)?;
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<EchoChat>::new((), frame_rate);
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal

--- a/src/application.rs
+++ b/src/application.rs
@@ -169,9 +169,10 @@ pub trait Application: Sized {
     /// #     fn view(&self, frame: &mut Frame<'_>) {}
     /// fn subscriptions(&self) -> Vec<Subscription<Message>> {
     ///     if self.enabled {
+    ///         use std::num::NonZeroU64;
     ///         use tears::subscription::time::Timer;
     ///         vec![
-    ///             Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+    ///             Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
     ///                 .map(|_| Message::Tick),
     ///         ]
     ///     } else {

--- a/src/command.rs
+++ b/src/command.rs
@@ -223,6 +223,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// # Examples
     ///
     /// ```
+    /// use std::num::NonZeroUsize;
     /// use tears::Command;
     /// use tears::command::{RetryError, RetryPolicy};
     ///
@@ -230,7 +231,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///     Loaded(Result<String, RetryError<&'static str>>),
     /// }
     ///
-    /// let policy = RetryPolicy::try_new(3).expect("attempt count is non-zero");
+    /// let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"));
     /// let command = Command::retry(
     ///     policy,
     ///     |_| async { Ok::<_, &'static str>("data".to_string()) },

--- a/src/command/retry.rs
+++ b/src/command/retry.rs
@@ -27,17 +27,6 @@ impl RetryPolicy {
         }
     }
 
-    /// Create a retry policy from a raw attempt count.
-    ///
-    /// Returns `None` when `max_attempts` is zero.
-    #[must_use]
-    pub const fn try_new(max_attempts: usize) -> Option<Self> {
-        match NonZeroUsize::new(max_attempts) {
-            Some(max_attempts) => Some(Self::new(max_attempts)),
-            None => None,
-        }
-    }
-
     /// Return the maximum number of executions, including the first attempt.
     #[must_use]
     pub const fn max_attempts(&self) -> NonZeroUsize {
@@ -242,6 +231,10 @@ mod tests {
 
     use crate::command::{Action, Command};
 
+    fn policy(max_attempts: usize) -> RetryPolicy {
+        RetryPolicy::new(NonZeroUsize::new(max_attempts).expect("max_attempts must be non-zero"))
+    }
+
     async fn final_result<A, E>(
         command: Command<Result<A, RetryError<E>>>,
     ) -> Result<A, RetryError<E>>
@@ -264,7 +257,7 @@ mod tests {
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_by_operation = Arc::clone(&attempts);
         let command = Command::retry(
-            RetryPolicy::try_new(3).expect("valid policy"),
+            policy(3),
             move |context| {
                 let attempts = Arc::clone(&attempts_by_operation);
                 async move {
@@ -285,7 +278,7 @@ mod tests {
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_by_operation = Arc::clone(&attempts);
         let command = Command::retry(
-            RetryPolicy::try_new(3).expect("valid policy"),
+            policy(3),
             move |context| {
                 let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
                 async move {
@@ -309,7 +302,7 @@ mod tests {
         let predicate_calls = Arc::new(AtomicUsize::new(0));
         let calls_by_predicate = Arc::clone(&predicate_calls);
         let command = Command::retry_if(
-            RetryPolicy::try_new(1).expect("valid policy"),
+            policy(1),
             |_| async { Err::<i32, _>("failed") },
             move |_, _| {
                 calls_by_predicate.fetch_add(1, Ordering::SeqCst);
@@ -329,7 +322,7 @@ mod tests {
     #[tokio::test]
     async fn predicate_stop_occurs_only_while_attempts_remain() {
         let command = Command::retry_if(
-            RetryPolicy::try_new(3).expect("valid policy"),
+            policy(3),
             |_| async { Err::<i32, _>("permanent") },
             |_, context| {
                 assert_eq!(context.attempt().get(), 1);
@@ -350,7 +343,7 @@ mod tests {
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_by_operation = Arc::clone(&attempts);
         let command = Command::retry(
-            RetryPolicy::try_new(2).expect("valid policy"),
+            policy(2),
             move |_| {
                 let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
                 async move {
@@ -373,9 +366,7 @@ mod tests {
         let attempts = Arc::new(AtomicUsize::new(0));
         let attempts_by_operation = Arc::clone(&attempts);
         let command = Command::retry(
-            RetryPolicy::try_new(3)
-                .expect("valid policy")
-                .with_fixed_backoff(Duration::from_secs(2)),
+            policy(3).with_fixed_backoff(Duration::from_secs(2)),
             move |_| {
                 let attempt = attempts_by_operation.fetch_add(1, Ordering::SeqCst) + 1;
                 async move {
@@ -404,9 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn retry_policy_validates_attempts_and_preserves_them_in_builders() {
-        assert_eq!(RetryPolicy::try_new(0), None);
-
+    fn retry_policy_preserves_max_attempts_in_builders() {
         let max_attempts = NonZeroUsize::new(3).expect("non-zero");
         let policy = RetryPolicy::new(max_attempts);
         assert_eq!(policy.max_attempts(), max_attempts);
@@ -462,7 +451,7 @@ mod tests {
     #[tokio::test]
     async fn retry_composes_as_a_single_leaf_command() {
         let retry = Command::retry(
-            RetryPolicy::try_new(1).expect("valid policy"),
+            policy(1),
             |_| async { Ok::<_, &'static str>(20) },
             |result| result.expect("operation should succeed"),
         )
@@ -494,7 +483,7 @@ mod tests {
     async fn retry_predicate_may_retain_mutable_local_state() {
         let mut predicate_calls = 0;
         let command = Command::retry_if(
-            RetryPolicy::try_new(4).expect("valid policy"),
+            policy(4),
             |_| async { Err::<i32, _>("failed") },
             move |_, _| {
                 predicate_calls += 1;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -29,6 +29,8 @@
 //! # Example
 //!
 //! ```rust,no_run
+//! use std::num::NonZeroU32;
+//!
 //! use color_eyre::eyre::Result;
 //! use ratatui::Frame;
 //! use tears::prelude::*;
@@ -71,7 +73,8 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!     let runtime = Runtime::<CounterApp>::try_new((), 60)?;
+//!     let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+//!     let runtime = Runtime::<CounterApp>::new((), frame_rate);
 //!     let mut terminal = ratatui::init();
 //!     // Restore the terminal if the application panics.
 //!     tears::install_panic_hook();
@@ -81,7 +84,6 @@
 //! }
 //! ```
 
-use std::result::Result as StdResult;
 use std::time::{Duration, Instant};
 
 use color_eyre::eyre::Result;
@@ -99,7 +101,7 @@ mod frame_scheduler;
 mod pending_work;
 
 use app_input::AppInput;
-use frame_rate::{FrameRate, FrameRateError};
+use frame_rate::FrameRate;
 use frame_scheduler::FrameScheduler;
 // `self::` disambiguates the submodule from the built-in `core` crate.
 use self::core::RuntimeCore;
@@ -154,6 +156,7 @@ impl<App: Application> Runtime<App> {
     /// # Examples
     ///
     /// ```rust,no_run
+    /// # use std::num::NonZeroU32;
     /// # use tears::prelude::*;
     /// # use ratatui::Frame;
     /// #
@@ -169,7 +172,8 @@ impl<App: Application> Runtime<App> {
     /// # }
     ///
     /// // Create runtime with 60 FPS target
-    /// let frame_rate = FrameRate::try_new(60).expect("frame rate must be valid");
+    /// let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))
+    ///     .expect("frame rate must be valid");
     /// let runtime = Runtime::<MyApp>::new((), frame_rate);
     /// ```
     #[must_use]
@@ -180,38 +184,6 @@ impl<App: Application> Runtime<App> {
             core,
             scheduler: FrameScheduler::new(frame_rate),
         }
-    }
-
-    /// Tries to create a new runtime with the given initialization flags and FPS value.
-    ///
-    /// This is a convenience wrapper around [`FrameRate::try_new`] and
-    /// [`Runtime::new`].
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FrameRateError`] when `frame_rate` is zero or too high to
-    /// produce a non-zero frame duration.
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// # use tears::prelude::*;
-    /// # use ratatui::Frame;
-    /// #
-    /// # struct MyApp;
-    /// # enum Message {}
-    /// # impl Application for MyApp {
-    /// #     type Message = Message;
-    /// #     type Flags = ();
-    /// #     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
-    /// #     fn update(&mut self, _: Message) -> Command<Message> { Command::none() }
-    /// #     fn view(&self, _: &mut Frame<'_>) {}
-    /// #     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
-    /// # }
-    /// let runtime = Runtime::<MyApp>::try_new((), 60).expect("frame rate must be valid");
-    /// ```
-    pub fn try_new(flags: App::Flags, frame_rate: u32) -> StdResult<Self, FrameRateError> {
-        Ok(Self::new(flags, FrameRate::try_new(frame_rate)?))
     }
 
     #[cfg(test)]
@@ -356,6 +328,8 @@ impl<App: Application> Runtime<App> {
     /// # Examples
     ///
     /// ```rust,no_run
+    /// # use std::num::NonZeroU32;
+    /// #
     /// # use color_eyre::eyre::Result;
     /// # use ratatui::Frame;
     /// # use tears::prelude::*;
@@ -381,7 +355,8 @@ impl<App: Application> Runtime<App> {
     ///     // Restore the terminal if the application panics.
     ///     tears::install_panic_hook();
     ///
-    ///     let runtime = Runtime::<MyApp>::try_new((), 60)?;
+    ///     let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    ///     let runtime = Runtime::<MyApp>::new((), frame_rate);
     ///     runtime.run(&mut terminal).await?;
     ///
     ///     ratatui::restore();
@@ -431,6 +406,7 @@ impl<App: Application> Runtime<App> {
 mod tests {
     use super::*;
 
+    use std::num::NonZeroU32;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -445,7 +421,8 @@ mod tests {
     use crate::test_support::{TestApp, TestMessage, TraceRecorder, wait_until};
 
     fn frame_rate(value: u32) -> FrameRate {
-        FrameRate::try_new(value).expect("frame rate must be valid")
+        FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+            .expect("frame rate must be valid")
     }
 
     struct RedrawControlApp;

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -195,6 +195,7 @@ mod tests {
     use super::*;
 
     use std::future::pending;
+    use std::num::{NonZeroU64, NonZeroUsize};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -325,7 +326,7 @@ mod tests {
         let mut core = RuntimeCore::<TestApp>::new(0);
         let mut attempts = 0;
         let command = Command::retry(
-            RetryPolicy::try_new(2).expect("valid policy"),
+            RetryPolicy::new(NonZeroUsize::new(2).expect("non-zero")),
             move |_| {
                 attempts += 1;
                 let attempt = attempts;
@@ -431,10 +432,8 @@ mod tests {
 
             fn subscriptions(&self) -> Vec<Subscription<()>> {
                 vec![
-                    Subscription::new(
-                        Timer::try_new(100).expect("timer interval must be non-zero"),
-                    )
-                    .map(|_| ()),
+                    Subscription::new(Timer::new(NonZeroU64::new(100).expect("non-zero")))
+                        .map(|_| ()),
                 ]
             }
         }
@@ -507,10 +506,8 @@ mod tests {
 
             fn subscriptions(&self) -> Vec<Subscription<()>> {
                 vec![
-                    Subscription::new(
-                        Timer::try_new(100).expect("timer interval must be non-zero"),
-                    )
-                    .map(|_| ()),
+                    Subscription::new(Timer::new(NonZeroU64::new(100).expect("non-zero")))
+                        .map(|_| ()),
                 ]
             }
         }

--- a/src/runtime/frame_rate.rs
+++ b/src/runtime/frame_rate.rs
@@ -41,19 +41,6 @@ impl FrameRate {
         }
     }
 
-    /// Tries to create a frame rate from an FPS value.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FrameRateError::Zero`] when `frames_per_second` is zero, or
-    /// [`FrameRateError::TooHigh`] when it is greater than [`FrameRate::MAX`].
-    pub const fn try_new(frames_per_second: u32) -> StdResult<Self, FrameRateError> {
-        match NonZeroU32::new(frames_per_second) {
-            Some(frames_per_second) => Self::new(frames_per_second),
-            None => Err(FrameRateError::Zero),
-        }
-    }
-
     /// Returns the frame rate in frames per second.
     #[must_use]
     pub const fn get(self) -> u32 {
@@ -67,9 +54,8 @@ impl FrameRate {
 
 /// Error returned when constructing an invalid [`FrameRate`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum FrameRateError {
-    /// Frame rate must be non-zero.
-    Zero,
     /// Frame rate is too high to produce a non-zero frame duration.
     TooHigh {
         /// Provided frame rate.
@@ -82,7 +68,6 @@ pub enum FrameRateError {
 impl Display for FrameRateError {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::Zero => f.write_str("frame rate must be non-zero"),
             Self::TooHigh { value, max } => {
                 write!(f, "frame rate must be at most {max}, got {value}")
             }
@@ -97,15 +82,15 @@ mod tests {
     use super::*;
 
     fn frame_rate(value: u32) -> FrameRate {
-        FrameRate::try_new(value).expect("frame rate must be valid")
+        FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+            .expect("frame rate must be valid")
     }
 
     #[test]
-    fn test_frame_rate_try_new() {
-        assert_eq!(FrameRate::try_new(0), Err(FrameRateError::Zero));
-        assert_eq!(FrameRate::try_new(60).map(FrameRate::get), Ok(60));
+    fn test_frame_rate_new() {
+        assert_eq!(frame_rate(60).get(), 60);
         assert_eq!(
-            FrameRate::try_new(FrameRate::MAX + 1),
+            FrameRate::new(NonZeroU32::new(FrameRate::MAX + 1).expect("non-zero")),
             Err(FrameRateError::TooHigh {
                 value: FrameRate::MAX + 1,
                 max: FrameRate::MAX,

--- a/src/runtime/frame_scheduler.rs
+++ b/src/runtime/frame_scheduler.rs
@@ -95,12 +95,15 @@ impl FrameScheduler {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU32;
+
     use tokio::time::{Duration, Instant, timeout};
 
     use super::*;
 
     fn frame_rate(value: u32) -> FrameRate {
-        FrameRate::try_new(value).expect("frame rate must be valid")
+        FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+            .expect("frame rate must be valid")
     }
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -15,10 +15,11 @@
 //! ## Unidirectional (Timer)
 //!
 //! ```rust
+//! use std::num::NonZeroU64;
 //! use tears::subscription::{Subscription, time::Timer};
 //!
 //! # enum Message { Tick }
-//! let timer = Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+//! let timer = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
 //!     .map(|_| Message::Tick);
 //! ```
 //!
@@ -164,6 +165,7 @@ use tokio::{
 /// # Example
 ///
 /// ```
+/// use std::num::NonZeroU64;
 /// use tears::subscription::{Subscription, time::Timer};
 ///
 /// enum Message {
@@ -171,7 +173,7 @@ use tokio::{
 /// }
 ///
 /// // Create a subscription that sends a message every second
-/// let sub = Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+/// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
 ///     .map(|_| Message::Tick);
 /// ```
 pub struct Subscription<Msg: 'static> {
@@ -185,9 +187,10 @@ impl<Msg: 'static> Subscription<Msg> {
     /// # Examples
     ///
     /// ```
+    /// use std::num::NonZeroU64;
     /// use tears::subscription::{Subscription, time::Timer};
     ///
-    /// let sub = Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"));
+    /// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")));
     /// ```
     #[must_use]
     pub fn new(source: impl SubscriptionSource<Output = Msg> + 'static) -> Self {
@@ -204,11 +207,12 @@ impl<Msg: 'static> Subscription<Msg> {
     /// # Examples
     ///
     /// ```
+    /// use std::num::NonZeroU64;
     /// use tears::subscription::{Subscription, time::Timer};
     ///
     /// enum AppMessage { TimerTick }
     ///
-    /// let sub = Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+    /// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
     ///     .map(|_| AppMessage::TimerTick);
     /// ```
     #[must_use]

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -42,6 +42,7 @@ pub enum TimerEvent {
 /// # Example
 ///
 /// ```rust
+/// use std::num::NonZeroU64;
 /// use tears::subscription::{Subscription, time::Timer};
 ///
 /// enum AppMessage {
@@ -49,11 +50,11 @@ pub enum TimerEvent {
 /// }
 ///
 /// // Create a timer that ticks every second (1000ms)
-/// let sub = Subscription::new(Timer::try_new(1000).expect("timer interval must be non-zero"))
+/// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
 ///     .map(|_| AppMessage::Tick);
 ///
 /// // For 60 FPS animations (approximately 16.67ms per frame)
-/// let animation_timer = Subscription::new(Timer::try_new(16).expect("timer interval must be non-zero"))
+/// let animation_timer = Subscription::new(Timer::new(NonZeroU64::new(16).expect("non-zero")))
 ///     .map(|_| AppMessage::Tick);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,26 +84,6 @@ impl Timer {
     #[must_use]
     pub const fn new(interval_ms: NonZeroU64) -> Self {
         Self { interval_ms }
-    }
-
-    /// Try to create a new timer with the specified interval in milliseconds.
-    ///
-    /// Returns [`None`] when `interval_ms` is zero.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use tears::subscription::time::Timer;
-    ///
-    /// let timer = Timer::try_new(1000).expect("timer interval must be non-zero");
-    /// assert!(Timer::try_new(0).is_none());
-    /// ```
-    #[must_use]
-    pub const fn try_new(interval_ms: u64) -> Option<Self> {
-        match NonZeroU64::new(interval_ms) {
-            Some(interval_ms) => Some(Self::new(interval_ms)),
-            None => None,
-        }
     }
 }
 
@@ -148,7 +129,7 @@ mod tests {
     use tokio::time::{Duration, Instant, timeout};
 
     fn timer(interval_ms: u64) -> Timer {
-        Timer::try_new(interval_ms).expect("timer interval must be non-zero")
+        Timer::new(NonZeroU64::new(interval_ms).expect("timer interval must be non-zero"))
     }
 
     #[test]
@@ -156,12 +137,6 @@ mod tests {
         let interval_ms = NonZeroU64::new(1000).expect("timer interval must be non-zero");
         let timer = Timer::new(interval_ms);
         assert_eq!(timer.interval_ms, interval_ms);
-    }
-
-    #[test]
-    fn test_timer_try_new() {
-        assert_eq!(Timer::try_new(1000), Some(timer(1000)));
-        assert_eq!(Timer::try_new(0), None);
     }
 
     #[test]

--- a/tests/idle_wakeup.rs
+++ b/tests/idle_wakeup.rs
@@ -7,6 +7,7 @@ mod common;
 #[path = "common/trace_recorder.rs"]
 mod trace_recorder;
 
+use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex};
 
 use color_eyre::eyre::Result;
@@ -14,6 +15,11 @@ use ratatui::Frame;
 use tears::prelude::*;
 use tokio::time::{Duration, Instant, sleep};
 use trace_recorder::TraceRecorder;
+
+fn frame_rate(value: u32) -> FrameRate {
+    FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+        .expect("frame rate must be valid")
+}
 
 // Idle window: one second is ~60 frame periods at 60 FPS, so an ungated loop
 // would wake ~60 times before the message arrives.
@@ -71,7 +77,7 @@ async fn idle_loop_does_not_wake_at_frame_rate() -> Result<()> {
 
     let renders = Arc::new(Mutex::new(Vec::new()));
     let mut terminal = common::test_terminal()?;
-    let runtime = Runtime::<IdleThenQuitApp>::try_new(renders, 60)?;
+    let runtime = Runtime::<IdleThenQuitApp>::new(renders, frame_rate(60));
     runtime.run(&mut terminal).await?;
 
     // Only the initial render and the single post-message render wake the frame
@@ -103,7 +109,7 @@ async fn message_after_idle_renders_without_extra_frame_delay() -> Result<()> {
 
     let renders = Arc::new(Mutex::new(Vec::new()));
     let mut terminal = common::test_terminal()?;
-    let runtime = Runtime::<IdleThenQuitApp>::try_new(renders.clone(), 60)?;
+    let runtime = Runtime::<IdleThenQuitApp>::new(renders.clone(), frame_rate(60));
     runtime.run(&mut terminal).await?;
 
     let times: Vec<Duration> = renders

--- a/tests/quit_handling.rs
+++ b/tests/quit_handling.rs
@@ -2,11 +2,18 @@
 
 mod common;
 
+use std::num::NonZeroU32;
+
 use color_eyre::eyre::Result;
 use ratatui::Frame;
 use tears::prelude::*;
 
 use tokio::time::{Duration, Instant, sleep, timeout};
+
+fn frame_rate(value: u32) -> FrameRate {
+    FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+        .expect("frame rate must be valid")
+}
 
 // Test application that sends quit from init command
 
@@ -16,7 +23,7 @@ async fn test_quit_responsiveness_low_framerate() -> Result<()> {
     // This test uses InitQuitApp which sends quit from init command
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<InitQuitApp>::try_new((), 16).expect("frame rate must be valid");
+    let runtime = Runtime::<InitQuitApp>::new((), frame_rate(16));
 
     let start = Instant::now();
     // Use low frame rate (16 FPS = 62.5ms per frame)
@@ -62,7 +69,7 @@ async fn test_quit_from_init_command() -> Result<()> {
     // Test that quit from init command is processed quickly
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<InitQuitApp>::try_new((), 60).expect("frame rate must be valid");
+    let runtime = Runtime::<InitQuitApp>::new((), frame_rate(60));
 
     let start = Instant::now();
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
@@ -111,7 +118,7 @@ async fn test_quit_during_frame_wait() -> Result<()> {
     // Test that quit signal during frame wait is processed immediately
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<DelayedQuitApp>::try_new((), 10).expect("frame rate must be valid");
+    let runtime = Runtime::<DelayedQuitApp>::new((), frame_rate(10));
 
     let start = Instant::now();
     // Use very low frame rate (10 FPS = 100ms per frame)
@@ -179,8 +186,7 @@ async fn test_quit_after_multiple_messages() -> Result<()> {
     // Test that quit is processed quickly even after multiple messages
     let mut terminal = common::test_terminal()?;
 
-    let runtime =
-        Runtime::<MultiMessageQuitApp>::try_new((), 60).expect("frame rate must be valid");
+    let runtime = Runtime::<MultiMessageQuitApp>::new((), frame_rate(60));
 
     let start = Instant::now();
     let result = timeout(Duration::from_millis(500), runtime.run(&mut terminal)).await?;

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -10,6 +10,7 @@ mod trace_recorder;
 
 use std::{
     future::pending,
+    num::{NonZeroU32, NonZeroU64, NonZeroUsize},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -22,6 +23,11 @@ use tears::command::RetryPolicy;
 use tears::prelude::*;
 use tokio::time::{Duration, timeout};
 use trace_recorder::TraceRecorder;
+
+fn frame_rate(value: u32) -> FrameRate {
+    FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+        .expect("frame rate must be valid")
+}
 
 // Helper: Simple counter app
 #[derive(Debug)]
@@ -103,10 +109,7 @@ impl Application for SubApp {
 
     fn subscriptions(&self) -> Vec<Subscription<()>> {
         use tears::subscription::time::Timer;
-        vec![
-            Subscription::new(Timer::try_new(10).expect("timer interval must be non-zero"))
-                .map(|_| ()),
-        ]
+        vec![Subscription::new(Timer::new(NonZeroU64::new(10).expect("non-zero"))).map(|_| ())]
     }
 }
 
@@ -115,7 +118,7 @@ async fn test_runtime_run_end_to_end_basic() -> Result<()> {
     // End-to-end: Basic application lifecycle
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<CounterApp>::try_new(0, 60).expect("frame rate must be valid"); // Quit immediately
+    let runtime = Runtime::<CounterApp>::new(0, frame_rate(60)); // Quit immediately
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
@@ -161,7 +164,7 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
             use tears::subscription::time::Timer;
 
             vec![
-                Subscription::new(Timer::try_new(10).expect("timer interval must be non-zero"))
+                Subscription::new(Timer::new(NonZeroU64::new(10).expect("non-zero")))
                     .map(|_| Message::Quit),
             ]
         }
@@ -181,7 +184,7 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
     let _guard = recorder.set_default();
 
     let mut terminal = common::test_terminal()?;
-    let runtime = Runtime::<PanicCommandApp>::try_new((), 60).expect("frame rate must be valid");
+    let runtime = Runtime::<PanicCommandApp>::new((), frame_rate(60));
 
     timeout(Duration::from_secs(5), runtime.run(&mut terminal)).await??;
 
@@ -231,7 +234,7 @@ async fn test_runtime_run_end_to_end_with_commands() -> Result<()> {
 
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<MessageApp>::try_new((), 60).expect("frame rate must be valid");
+    let runtime = Runtime::<MessageApp>::new((), frame_rate(60));
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 
@@ -265,7 +268,7 @@ async fn test_runtime_run_delivers_timeout_and_retry_messages_to_update() -> Res
 
             let mut attempts = 0;
             let retry_command = Command::retry(
-                RetryPolicy::try_new(2).expect("valid retry policy"),
+                RetryPolicy::new(NonZeroUsize::new(2).expect("non-zero")),
                 move |_| {
                     attempts += 1;
                     let attempt = attempts;
@@ -312,8 +315,7 @@ async fn test_runtime_run_delivers_timeout_and_retry_messages_to_update() -> Res
 
     let observed = Arc::new(AtomicUsize::new(0));
     let mut terminal = common::test_terminal()?;
-    let runtime = Runtime::<LifecycleApp>::try_new(Arc::clone(&observed), 60)
-        .expect("frame rate must be valid");
+    let runtime = Runtime::<LifecycleApp>::new(Arc::clone(&observed), frame_rate(60));
 
     timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await??;
 
@@ -327,7 +329,7 @@ async fn test_runtime_run_end_to_end_with_subscriptions() -> Result<()> {
     // End-to-end: Subscription message processing
     let mut terminal = common::test_terminal()?;
 
-    let runtime = Runtime::<SubApp>::try_new((), 60).expect("frame rate must be valid");
+    let runtime = Runtime::<SubApp>::new((), frame_rate(60));
 
     let result = timeout(Duration::from_secs(1), runtime.run(&mut terminal)).await?;
 


### PR DESCRIPTION
## Summary

Drops the fallible `try_new` convenience constructors in favor of a single `new` per type:

- `Timer::try_new(u64) -> Option<Self>` is gone; use `Timer::new(NonZeroU64::new(ms).expect(...))`
- `RetryPolicy::try_new(usize) -> Option<Self>` is gone; use `RetryPolicy::new(NonZeroUsize::new(n).expect(...))`
- `FrameRate::try_new(u32) -> Result<Self, FrameRateError>` is gone; use `FrameRate::new(NonZeroU32::new(fps).expect(...))`
- `Runtime::try_new(flags, u32)` is gone; build a `FrameRate` first and pass it to `Runtime::new(flags, frame_rate)`

`Timer` and `RetryPolicy` already expressed their non-zero invariant through a `NonZero*` parameter, so `try_new` was a same-operation duplicate constructor rather than a distinct fallible path — the `try_`/`new` split only made sense while `FrameRate` needed both, and now that it's the only type validating past `NonZero*`, the split is no longer a pattern worth keeping elsewhere. `FrameRateError::Zero` is removed for the same reason (`NonZeroU32` now excludes it statically), and `FrameRateError` gains `#[non_exhaustive]` so future variants (e.g. additional `FrameRate` validation) stay non-breaking.

Updates every call site: rustdoc examples, `examples/`, `tests/`, `README.md`, and the retry RFC's now-stale `try_new` references (usage examples, the constructor list in Appendix A.2, the design-comparison note in A.3, and contract R6 in Appendix B.2).

## Test plan

- [x] `cargo build --all-features --all-targets`
- [x] `cargo test --all-features` (all passing, including doctests)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` (no warnings)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (no broken intra-doc links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)