### PR TITLE
feat!: hide SubscriptionManager from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `FrameRateError::Zero` is removed: the non-zero invariant is now enforced
     by `NonZeroU32` at the call site instead of at runtime
   - `FrameRateError` is now `#[non_exhaustive]`
+- **Breaking:** `SubscriptionManager` is no longer part of the public API
+  - `tears::subscription::SubscriptionManager` is gone; it was already
+    documented as runtime-internal and used only by `Runtime` and
+    crate-internal tests
+  - No behavior change for applications; the runtime continues to manage
+    subscriptions the same way
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ include = [
 default = []
 
 http = ["dashmap", "thiserror"]
+# Bench-only feature exposing internal-only subscription reconciliation hooks
+# to `benches/subscription.rs`; do not enable for normal builds. Not part of
+# the public API and not covered by semver.
+bench-internals = []
 # Test-only feature for the isolated loom cell core; do not enable for normal builds.
 loom-core = ["dep:loom"]
 ws = ["tokio-tungstenite/connect", "tokio-tungstenite/handshake"]
@@ -66,6 +70,7 @@ reqwest = { version = "0.13", features = ["json", "query"] }
 [[bench]]
 name = "subscription"
 harness = false
+required-features = ["bench-internals"]
 
 [[example]]
 name = "websocket"

--- a/benches/subscription.rs
+++ b/benches/subscription.rs
@@ -2,18 +2,24 @@
 //!
 //! These establish a regression baseline for the runtime's subscription work:
 //!
-//! - **reconcile (steady)**: [`SubscriptionManager::update`] when the requested
+//! - **reconcile (steady)**: [`BenchSubscriptionManager::update`] when the requested
 //!   set is unchanged — the common per-message case, which must diff cheaply and
 //!   keep the existing tasks running.
 //! - **reconcile (churn)**: `update` when the whole set is replaced — measures
 //!   the abort + spawn bookkeeping.
 //!
-//! Run with `cargo bench --bench subscription`.
+//! `SubscriptionManager` is crate-private, so this benchmark goes through
+//! [`BenchSubscriptionManager`], a thin bench-only wrapper gated behind the
+//! `bench-internals` feature.
+//!
+//! Run with `cargo bench --bench subscription --features bench-internals`.
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::stream::{self, StreamExt};
 use tears::BoxStream;
-use tears::subscription::{Subscription, SubscriptionId, SubscriptionManager, SubscriptionSource};
+use tears::subscription::{
+    BenchSubscriptionManager, Subscription, SubscriptionId, SubscriptionSource,
+};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
@@ -42,7 +48,7 @@ fn subscriptions(ids: impl IntoIterator<Item = u64>) -> Vec<Subscription<()>> {
 }
 
 fn bench_reconcile_steady(c: &mut Criterion) {
-    // `SubscriptionManager::update` spawns tasks, so it must run inside a Tokio
+    // `BenchSubscriptionManager::update` spawns tasks, so it must run inside a Tokio
     // runtime context. The tasks park immediately on the pending stream.
     let rt = Builder::new_multi_thread()
         .worker_threads(1)
@@ -54,7 +60,7 @@ fn bench_reconcile_steady(c: &mut Criterion) {
     for count in [1u64, 8, 64, 256] {
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
             let (tx, _rx) = mpsc::unbounded_channel();
-            let mut manager = SubscriptionManager::new(tx);
+            let mut manager = BenchSubscriptionManager::new(tx);
             // Prime the manager so subsequent updates hit the steady-state path
             // (same IDs, tasks already running -> no spawns, just the diff).
             manager.update(subscriptions(0..count));
@@ -80,7 +86,7 @@ fn bench_reconcile_churn(c: &mut Criterion) {
     for count in [1u64, 8, 64, 256] {
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
             let (tx, _rx) = mpsc::unbounded_channel();
-            let mut manager = SubscriptionManager::new(tx);
+            let mut manager = BenchSubscriptionManager::new(tx);
 
             // Alternate between two disjoint ID sets so every update aborts the
             // previous set and spawns a whole new one.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -327,8 +327,8 @@ struct RunningSubscription {
 
 /// Manages the lifecycle of active subscriptions.
 ///
-/// Used internally by the runtime. You typically don't interact with this directly.
-pub struct SubscriptionManager<Msg> {
+/// Internal to the runtime; not part of the public API.
+pub(crate) struct SubscriptionManager<Msg> {
     running: HashMap<SubscriptionId, RunningSubscription>,
     msg_sender: mpsc::UnboundedSender<Msg>,
 }
@@ -336,7 +336,7 @@ pub struct SubscriptionManager<Msg> {
 impl<Msg: Send + 'static> SubscriptionManager<Msg> {
     /// Create a new subscription manager.
     #[must_use]
-    pub fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
+    pub(crate) fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
         Self {
             running: HashMap::new(),
             msg_sender,
@@ -354,7 +354,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
     /// # Arguments
     ///
     /// * `subscriptions` - The new set of subscriptions to run
-    pub fn update<I>(&mut self, subscriptions: I)
+    pub(crate) fn update<I>(&mut self, subscriptions: I)
     where
         I: IntoIterator<Item = Subscription<Msg>>,
     {
@@ -431,7 +431,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
     ///
     /// This cancels all running subscription tasks. Called automatically
     /// when the runtime shuts down.
-    pub fn shutdown(&mut self) {
+    pub(crate) fn shutdown(&mut self) {
         self.abort_running();
         self.running.clear();
     }
@@ -456,6 +456,40 @@ impl<Msg> Drop for SubscriptionManager<Msg> {
         // is dropped without `shutdown()` — for instance while unwinding from a
         // panic — would otherwise leak its subscription tasks.
         self.abort_running();
+    }
+}
+
+/// Bench-only wrapper exposing [`SubscriptionManager`]'s reconciliation hot
+/// path to `benches/subscription.rs`.
+///
+/// `benches/subscription.rs` compiles as a separate crate that only sees the
+/// public API, so it cannot name `SubscriptionManager` directly once that
+/// type is crate-private. This wrapper delegates to the real implementation
+/// and exists solely to keep that benchmark isolating
+/// `SubscriptionManager::update`'s cost from the rest of the runtime. Gated
+/// behind the `bench-internals` feature, which is not part of the public API
+/// and carries no semver guarantees; do not enable it for normal builds.
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub struct BenchSubscriptionManager<Msg>(SubscriptionManager<Msg>);
+
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+impl<Msg: Send + 'static> BenchSubscriptionManager<Msg> {
+    #[must_use]
+    pub fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
+        Self(SubscriptionManager::new(msg_sender))
+    }
+
+    pub fn update<I>(&mut self, subscriptions: I)
+    where
+        I: IntoIterator<Item = Subscription<Msg>>,
+    {
+        self.0.update(subscriptions);
+    }
+
+    pub fn shutdown(&mut self) {
+        self.0.shutdown();
     }
 }
 


### PR DESCRIPTION
## Summary

- `SubscriptionManager` moves from `pub` to `pub(crate)` (`new`/`update`/`shutdown` narrowed to match) — it's no longer reachable as `tears::subscription::SubscriptionManager`
- Its rustdoc already said "used internally by the runtime, you typically don't interact with this directly," but nothing in a user-facing signature ever names it; only `Runtime` and crate-internal tests use it
- `benches/subscription.rs` compiles as a separate crate and measures `SubscriptionManager::update` in isolation, so it still needs a way to reach it. Added a bench-only `bench-internals` Cargo feature (mirroring the existing `loom-core` pattern: not in default features, not covered by semver) gating a `#[doc(hidden)]` `BenchSubscriptionManager` wrapper that just delegates to the real type
- The bench target now declares `required-features = ["bench-internals"]`, so it's skipped entirely in ordinary builds (`cargo bench --bench subscription --features bench-internals` to run it)

## Test plan

- [x] `cargo build --all-features --all-targets`
- [x] `cargo build --all-targets` (default features, confirms the bench target is skipped cleanly)
- [x] `cargo test --all-features` (all passing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` and `cargo clippy --features bench-internals --all-targets` (no warnings)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo +1.88.0 check --all-targets --all-features` (MSRV)
- [x] `cargo bench --bench subscription --features bench-internals --no-run` (bench target compiles and links)

🤖 Generated with [Claude Code](https://claude.com/claude-code)