### PR TITLE
feat!: drop FrameRateError from the prelude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     crate-internal tests
   - No behavior change for applications; the runtime continues to manage
     subscriptions the same way
+- **Breaking:** `FrameRateError` is no longer re-exported from
+  `tears::prelude`
+  - `use tears::prelude::*;` no longer brings `FrameRateError` into scope;
+    import it explicitly with `use tears::FrameRateError;` if needed
+  - `tears::FrameRateError` (the crate-root path) is unaffected
 
 ### Added
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,5 +15,5 @@
 pub use crate::application::Application;
 pub use crate::command::Command;
 pub use crate::runtime::Runtime;
-pub use crate::runtime::frame_rate::{FrameRate, FrameRateError};
+pub use crate::runtime::frame_rate::FrameRate;
 pub use crate::subscription::Subscription;


### PR DESCRIPTION
## Summary

- `FrameRateError` is removed from `tears::prelude`'s re-exports; `FrameRate` stays
- `tears::FrameRateError` (the crate-root path) is unaffected
- The prelude module doc's "What's included" list already didn't mention `FrameRateError` (it listed 5 items against 6 actual exports), so no further doc changes were needed once the export itself was dropped

Rationale: the prelude's own bar is "vocabulary a minimal app skeleton names directly." Skeleton code reaches `FrameRate` via `FrameRate::new(...).expect(...)` or `?` without ever writing the error type's name, so `FrameRateError` was the one prelude member that didn't meet that bar. Leaving it in the prelude's public doc list would have made it harder to remove later, so this is done now while 0.10.0 is already bundling other breaking prelude/API changes.

## Test plan

- [x] `cargo build --all-features --all-targets`
- [x] `cargo test --all-features` (all passing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` (no warnings)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo +1.88.0 check --all-targets --all-features` (MSRV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)