### PR TITLE
feat!: close subscription::http::{mutation,query} to a single path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `use tears::prelude::*;` no longer brings `FrameRateError` into scope;
     import it explicitly with `use tears::FrameRateError;` if needed
   - `tears::FrameRateError` (the crate-root path) is unaffected
+- **Breaking:** `subscription::http::mutation` and `subscription::http::query`
+  are no longer public modules (requires `http` feature)
+  - `tears::subscription::http::mutation::Mutation` and
+    `tears::subscription::http::query::Query` (and their sibling types) are
+    gone; import them from `tears::subscription::http` instead, e.g.
+    `use tears::subscription::http::Mutation;`
+  - `config` / `key` / `result` already followed this single-path pattern;
+    `mutation` / `query` were the only `http` submodules with a second,
+    deeper public path to the same types
 
 ### Added
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -39,7 +39,7 @@
 //! ## Transaction-based (HTTP)
 //!
 //! ```rust,ignore
-//! use tears::subscription::http::query::Query;
+//! use tears::subscription::http::Query;
 //!
 //! // In update():
 //! Query::new(client).fetch(id, fetch_fn, Message::UserLoaded)

--- a/src/subscription/http.rs
+++ b/src/subscription/http.rs
@@ -64,9 +64,9 @@ mod config;
 #[cfg(feature = "http")]
 mod key;
 #[cfg(feature = "http")]
-pub mod mutation;
+mod mutation;
 #[cfg(feature = "http")]
-pub mod query;
+mod query;
 #[cfg(feature = "http")]
 mod reconcile;
 #[cfg(feature = "http")]


### PR DESCRIPTION
## Summary

- `subscription::http::mutation` and `subscription::http::query` (requires `http` feature) go from `pub mod` to private `mod`, so their types (`Mutation`, `Query`, `QueryClient`, etc.) are only reachable through the `tears::subscription::http::{Mutation, Query, ...}` re-exports, not the deeper `tears::subscription::http::mutation::Mutation` / `tears::subscription::http::query::Query` paths
- `config`, `key`, and `result` in the same `http` module already followed this private-mod + `pub use` pattern — `mutation`/`query` were the only two submodules with a second, deeper public path to the same types
- Updates the one rustdoc example that imported via the deeper path (`src/subscription.rs`, an ignored code block); `mutation.rs`/`query.rs`'s own doc examples already used the single-path form, and no README/tests/examples referenced the deep paths

No behavior change — this only removes an alternate, undocumented public path to types that stay fully accessible through `http::Mutation`, `http::Query`, etc.

## Test plan

- [x] `cargo build --all-features --all-targets`
- [x] `cargo test --all-features` (all passing)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features --all-targets` and `cargo clippy --all-targets` (default features) — no warnings
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (confirmed the `mutation`/`query` HTML directories rustdoc still emits are redirect stubs, same as the existing `config`/`key`/`result` modules — not an actual public Rust path)
- [x] `cargo +1.88.0 check --all-targets --all-features` (MSRV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)