### PR TITLE
test: check public API for dual paths and prelude subset in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,21 @@ jobs:
           RUSTFLAGS: --cfg loom
           LOOM_MAX_PREEMPTIONS: 3
 
+  api-surface:
+    name: Public API Surface
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      # `tests/api_surface.rs` shells out to `cargo +nightly rustdoc` itself
+      # (rustdoc JSON output is nightly-only); this just makes that toolchain
+      # available, it doesn't change what builds the test binary.
+      - name: Install nightly toolchain for rustdoc JSON
+        run: rustup toolchain install nightly
+      - uses: Swatinem/rust-cache@v2
+      - name: Check public API surface
+        run: cargo test --test api_surface -- --ignored
+
   doc:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "camino"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-manifest"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c6f1c3eb197d17dde4f1a1170fbe7ce3e5f23f1166ae480875a9f4a9c11c40"
+dependencies = [
+ "serde",
+ "thiserror 2.0.18",
+ "toml 0.8.23",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +381,18 @@ dependencies = [
  "ryu",
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -650,6 +706,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +1019,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1040,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1204,12 +1278,12 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1883,6 +1957,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "public-api"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d410e0b50432be9a8708e0bab4f5e0ddfde07236cc7f9481476aa9c5ef60ece3"
+dependencies = [
+ "hashbag",
+ "rustdoc-types",
+ "serde",
+ "serde_json",
+ "snapshot-testing",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2233,6 +2321,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustdoc-json"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2c5783825e93b4e3df439f1f98b8803f5912b2c2ce396a4c70eac909e558c"
+dependencies = [
+ "cargo-manifest",
+ "cargo_metadata",
+ "serde",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "rustdoc-types"
+version = "0.57.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be7e9f2ca82c1fcefb69332b82c289051edcd4a3245b1715f7756103918255"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2529,10 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2459,6 +2575,24 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2542,6 +2676,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "similar-asserts"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
+dependencies = [
+ "console",
+ "similar",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2708,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "snapshot-testing"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebf2194b9611339d00b28260cf6bd640073c60179ce7dd1e47badef1eb606e7"
+dependencies = [
+ "console",
+ "similar-asserts",
+]
 
 [[package]]
 name = "socket2"
@@ -2687,8 +2847,11 @@ dependencies = [
  "dashmap",
  "futures",
  "loom",
+ "public-api",
  "ratatui",
  "reqwest",
+ "rustdoc-json",
+ "rustdoc-types",
  "rustls",
  "serde",
  "serde_json",
@@ -2984,6 +3147,80 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -3746,6 +3983,21 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,11 @@ tracing = "0.1"
 
 [dev-dependencies]
 criterion = "0.8"
+# Used by the nightly-only `tests/api_surface.rs` structural check; see
+# docs/testing.md "Public API Surface Tests".
+public-api = "0.52"
+rustdoc-json = "0.9"
+rustdoc-types = "0.57"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # `test-util` (not part of `full`) provides paused virtual time for the idle

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -52,6 +52,9 @@ oversight — see "Prelude Membership" below. Every prelude item is reachable
 both at its canonical path and at `prelude::*` by design; that duplication
 is the entire point of a prelude.
 
+`tests/api_surface.rs` checks this rule (and that the prelude stays a subset
+of root-level items) mechanically in CI; see `docs/testing.md`.
+
 ## Root Promotion Criteria
 
 The crate root (`tears::*`) is for the vocabulary of a minimal

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -22,6 +22,35 @@ the contract:
 - Use integration tests for end-to-end runtime behavior, public API contracts,
   and interactions between runtime components.
 
+## Public API Surface Tests
+
+`tests/api_surface.rs` is a different category from the rest of `tests/`:
+it checks the *shape* of the crate's public API (which paths are reachable)
+per `docs/api-guidelines.md`, not runtime behavior. A downstream user never
+observes this directly — it only matters to whoever is deciding where a new
+item should live.
+
+This means it doesn't fit either bucket in "Test Placement" above (it needs
+no private access, but it isn't exercising behavior either), and it has
+different mechanics from every other test in this repository:
+
+- It parses rustdoc JSON via the `public-api` crate, which is only available
+  on the nightly toolchain — unlike everything else in this repo, which
+  builds under the pinned stable toolchain in `rust-toolchain.toml`.
+- Each test shells out to `cargo +nightly rustdoc`, so it needs a nightly
+  toolchain installed (`rustup toolchain install nightly`) and takes several
+  seconds per run.
+
+Both tests are `#[ignore]`d so `cargo test` stays fast and stable-only by
+default. Run them explicitly with:
+
+```sh
+cargo test --test api_surface -- --ignored
+```
+
+CI runs this as its own step with a nightly toolchain installed, separate
+from the main stable test job.
+
 ## Do Not Use Sleep For Synchronization
 
 Tests should not use `tokio::time::sleep(Duration::from_millis(...))` to wait

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -1,0 +1,136 @@
+//! Structural checks of the crate's public API shape, enforcing the "Single
+//! Canonical Path" and "Prelude Membership" rules from
+//! `docs/api-guidelines.md`. See `docs/testing.md` "Public API Surface Tests"
+//! for why these require nightly and are `#[ignore]`d by default.
+
+use std::collections::{HashMap, HashSet};
+
+use public_api::PublicItem;
+use public_api::tokens::Token;
+use rustdoc_types::Id;
+
+fn build_public_api() -> public_api::PublicApi {
+    let json_path = rustdoc_json::Builder::default()
+        .toolchain("nightly")
+        .manifest_path(env!("CARGO_MANIFEST_DIR").to_string() + "/Cargo.toml")
+        .all_features(true)
+        .build()
+        .expect(
+            "failed to build rustdoc JSON; install a nightly toolchain with \
+             `rustup toolchain install nightly`",
+        );
+
+    public_api::Builder::from_rustdoc_json(json_path)
+        // Blanket/auto-trait impls (`vzip`, `clone_into`, `Freeze`, ...) are
+        // rendered once per applicable type and are irrelevant to path
+        // reachability; they only add noise to the id-grouping below.
+        .omit_blanket_impls(true)
+        .omit_auto_trait_impls(true)
+        .build()
+        .expect("failed to parse rustdoc JSON into a PublicApi")
+}
+
+fn is_module(item: &PublicItem) -> bool {
+    item.tokens()
+        .any(|token| matches!(token, Token::Kind(kind) if kind == "mod"))
+}
+
+/// For every publicly reachable item defined directly in a module (i.e. not
+/// an associated method/type nested inside a struct or trait), the set of
+/// distinct module `Id`s it is reachable through.
+///
+/// Grouping by `PublicItem::id()` (the underlying rustdoc item id, stable
+/// across re-export paths) is what lets this distinguish "one item exposed
+/// through two paths" from "two different items that happen to share a
+/// name".
+fn top_level_reachability(api: &public_api::PublicApi) -> HashMap<Id, HashSet<Id>> {
+    let items: Vec<_> = api.items().collect();
+    let module_ids: HashSet<Id> = items
+        .iter()
+        .filter(|item| is_module(item))
+        .map(|item| item.id())
+        .collect();
+
+    let mut reachable_from: HashMap<Id, HashSet<Id>> = HashMap::new();
+    for item in &items {
+        if let Some(parent_id) = item.parent_id()
+            && module_ids.contains(&parent_id)
+        {
+            reachable_from
+                .entry(item.id())
+                .or_default()
+                .insert(parent_id);
+        }
+    }
+    reachable_from
+}
+
+fn root_module_id(api: &public_api::PublicApi) -> Id {
+    api.items()
+        .find(|item| is_module(item) && item.parent_id().is_none())
+        .map(PublicItem::id)
+        .expect("crate root module not found in rustdoc JSON")
+}
+
+fn prelude_module_id(api: &public_api::PublicApi, root_module_id: Id) -> Id {
+    api.items()
+        .find(|item| {
+            is_module(item)
+                && item.parent_id() == Some(root_module_id)
+                && item.to_string().ends_with("::prelude")
+        })
+        .map(PublicItem::id)
+        .expect("tears::prelude module not found in rustdoc JSON")
+}
+
+/// docs/api-guidelines.md "Single Canonical Path": an item's conceptual home
+/// (crate root, or a public submodule) must be its only reachable path. The
+/// prelude is a deliberate, documented exception (see "Prelude Membership"),
+/// so a prelude path never counts toward a violation here.
+#[test]
+#[ignore = "requires a nightly toolchain for rustdoc JSON; see docs/testing.md"]
+fn no_public_item_has_two_non_prelude_paths() {
+    let api = build_public_api();
+    let root_module_id = root_module_id(&api);
+    let prelude_module_id = prelude_module_id(&api, root_module_id);
+
+    let violations: Vec<Id> = top_level_reachability(&api)
+        .into_iter()
+        .filter(|(_id, parents)| parents.iter().filter(|p| **p != prelude_module_id).count() > 1)
+        .map(|(id, _)| id)
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "found public items reachable through more than one non-prelude path: {violations:?}\n\
+         Run `cargo +nightly public-api --all-features` to see the current surface and \
+         close the extra path per docs/api-guidelines.md \"Single Canonical Path\"."
+    );
+}
+
+/// docs/api-guidelines.md "Prelude Membership": the prelude is a subset of
+/// root-level vocabulary, not an alternate placement. Every item reachable
+/// through `tears::prelude::*` must also be reachable directly at the crate
+/// root (`tears::*`).
+#[test]
+#[ignore = "requires a nightly toolchain for rustdoc JSON; see docs/testing.md"]
+fn prelude_is_a_subset_of_root_level_items() {
+    let api = build_public_api();
+    let root_module_id = root_module_id(&api);
+    let prelude_module_id = prelude_module_id(&api, root_module_id);
+
+    let violations: Vec<Id> = top_level_reachability(&api)
+        .into_iter()
+        .filter(|(_id, parents)| {
+            parents.contains(&prelude_module_id) && !parents.contains(&root_module_id)
+        })
+        .map(|(id, _)| id)
+        .collect();
+
+    assert!(
+        violations.is_empty(),
+        "found prelude items not reachable at the crate root: {violations:?}\n\
+         Every prelude item must also resolve at `tears::*` per \
+         docs/api-guidelines.md \"Prelude Membership\"."
+    );
+}


### PR DESCRIPTION
## Summary

- Add `tests/api_surface.rs`, which mechanically checks two rules from `docs/api-guidelines.md` that were previously only verified by manual `cargo public-api diff` review (as in a9222fd):
  - **Single Canonical Path**: no public item is reachable through more than one non-prelude path.
  - **Prelude Membership**: every item reachable via `tears::prelude::*` is also reachable at the crate root.
- Both checks group `public-api`'s rustdoc-JSON items by their underlying rustdoc `Id` (stable across re-export paths, unlike rendered path strings), restricted to items whose parent is a module (excluding associated methods/types nested inside a struct or trait).
- Add a dedicated `api-surface` CI job that installs a nightly toolchain (rustdoc JSON output is nightly-only) and runs the `#[ignore]`d tests, without changing the stable-pinned toolchain used everywhere else.
- Document the new test category in `docs/testing.md` ("Public API Surface Tests"), since it doesn't fit the existing unit-test/integration-test split (it checks API shape, not runtime behavior).
- Add a one-line pointer from `docs/api-guidelines.md`'s "Single Canonical Path" section to the new test.

A full public-API snapshot test (`public_api::PublicApi::assert_eq_or_update`) was considered as well but deferred as future work — pre-1.0.0 the API still changes frequently, so a full-surface snapshot lock would add update friction without much payoff yet.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` / `cargo test --all-features` (unaffected; the new tests are `#[ignore]`d)
- [x] `cargo test --test api_surface -- --ignored` passes on `main`
- [x] Verified against the actual pre-a9222fd state (`HEAD^` at the time): both checks fail with exactly the 7 known-regressed items and no false positives
- [x] Verified the check fails when reintroducing a dual path locally (temporarily flipping `pub(crate) mod application` back to `pub mod application`), then reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)