### PR TITLE
feat(command): add keyed command cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Opt-in command cancellation keyed by `command::CommandId`, including
+  `Command::cancellable`, `Command::cancellable_with`, `Command::cancel`, and
+  the `command::CancelPolicy` same-id behavior
 - `Command::quit()` for requesting the application to quit, replacing the
   public use of `Command::effect(Action::Quit)`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -138,6 +147,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -761,7 +776,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
 ]
 
@@ -1957,6 +1972,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.10.0",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "public-api"
 version = "0.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2003,12 @@ dependencies = [
  "snapshot-testing",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quinn"
@@ -2083,6 +2123,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2451,6 +2500,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2847,6 +2908,7 @@ dependencies = [
  "dashmap",
  "futures",
  "loom",
+ "proptest",
  "public-api",
  "ratatui",
  "reqwest",
@@ -3376,6 +3438,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,6 +3540,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ criterion = "0.8"
 # Used by the nightly-only `tests/api_surface.rs` structural check; see
 # docs/testing.md "Public API Surface Tests".
 public-api = "0.52"
+# Exercises RFC 0003's pure keyed-command lifecycle state machine.
+proptest = "1"
 rustdoc-json = "0.9"
 rustdoc-types = "0.57"
 serde = { version = "1", features = ["derive"] }

--- a/docs/rfcs/0003-command-cancellation.md
+++ b/docs/rfcs/0003-command-cancellation.md
@@ -1,6 +1,6 @@
 # RFC 0003: Command Cancellation
 
-- Status: Accepted
+- Status: Implemented
 - Target: 0.10.0, additive public API with an internal runtime rework
 - Scope: opt-in cancellation for command output delivery, keyed by `CommandId`
 - Feature flag: none
@@ -320,7 +320,7 @@ returning `None`, then parks pending until the runtime removes it. This avoids a
 `StreamMap` footgun: inner streams that return `None` are silently removed
 without revealing which key closed.
 
-`CommandReceiver` also exposes after-pull facts:
+`CommandReceiver` also exposes after-pull facts to its owning `KeyedCommands`:
 
 ```rust
 struct ReceiverFacts {
@@ -329,8 +329,11 @@ struct ReceiverFacts {
 }
 ```
 
-These facts are sampled immediately after an `Output` item is pulled and before
-`update()` runs. They are not a cleanup event; they tell the lifecycle whether
+These facts stay inside the keyed-command module; they are not fields of
+`ReceiverEvent` or `AppInput`, and callers do not participate in lifecycle
+accounting. `KeyedCommands` samples them immediately after an `Output` item is
+pulled, applies the lifecycle transition, and only then returns the payload
+toward `update()`. They are not a cleanup event; they tell the lifecycle whether
 the just-delivered item was the last possible item from that sender. The
 implementation reads `sender_closed` from
 `mpsc::UnboundedReceiver::is_closed()` and `buffered` from `len()`:
@@ -373,7 +376,7 @@ Running   Cancel                             Absent     drop entry, abort task
 Running   Output(sender open)                Running    deliver output
 Running   Output(sender_closed, buf > 0)     Draining   deliver output
 Running   Output(sender_closed, buf == 0)    Absent     deliver output, remove entry
-Running   ReceiverClosed                     Absent     remove entry
+Running   ReceiverEvent::Closed              Absent     remove entry
 Running   TaskExit matching, buf > 0         Draining   task no longer abortable
 Running   TaskExit matching, buf == 0        Absent     remove entry
 Running   TaskExit stale                     Running    ignore
@@ -383,7 +386,7 @@ Draining  Spawn(KeepInFlight)                Draining   drop new stream
 Draining  Cancel                             Absent     drop entry
 Draining  Output(buf > 0)                    Draining   deliver output
 Draining  Output(buf == 0)                   Absent     deliver output, remove entry
-Draining  ReceiverClosed                     Absent     remove entry
+Draining  ReceiverEvent::Closed              Absent     remove entry
 Draining  TaskExit matching                  Draining   ignore; task end already known
 Draining  TaskExit stale                     Draining   ignore
 ```
@@ -393,13 +396,14 @@ are normal under cancellation. Delivery inputs are generated only while a
 receiver is owned; property tests should still include stale and late `TaskExit`
 sequences across all states.
 
-Before any `Spawn(policy)` decision, the manager runs `reconcile_id(id)`:
-
-- reap any completed keyed tasks currently available;
-- if the entry receiver for `id` is sender-closed and empty, remove the entry and
-  set `Absent`;
-- if a matching task has exited and the receiver still has output, set
-  `Draining`.
+Before any `Spawn(policy)` decision, the manager reaps every completed keyed task
+currently available, then samples receiver facts once for the target id. Each
+matching `TaskExit` and the target receiver snapshot apply the same pure
+lifecycle transition used by delivery accounting: a stale token is ignored, a
+closed-empty run becomes `Absent`, and a run with buffered output becomes
+`Draining`. The targeted snapshot closes the interval where a panicking task has
+dropped its sender but has not yet published its `TaskExit` because panic logging
+is still in progress.
 
 `KeepInFlight` consults this reconciled state. A same-id retry returned by the
 `update` that just handled keyed output is spawned only when the pre-spawn
@@ -407,8 +411,8 @@ reconciliation can prove the previous receiver is both sender-closed and empty.
 If the previous receiver is still open, as it may be for an arbitrary
 `Command::stream`, the id remains occupied and `KeepInFlight` drops the retry.
 The runtime does not infer that a delivered item was a stream's final result
-unless `ReceiverFacts` or reconciliation establish that `sender_closed` is true
-and `buffered` is `0`.
+unless internally sampled `ReceiverFacts` or a reaped task exit establish that
+the previous run no longer owns deliverable output.
 
 ### 4.3 Dispatching a Command
 
@@ -444,7 +448,9 @@ enqueue_command(parts):
 ```
 
 The stream-less early return happens after cancels are applied. A command with
-neither cancels nor a stream still takes today's no-op path.
+neither cancels nor a stream still takes today's no-op path. Enqueue-time
+reconciliation remains necessary for cancel-only commands; it only drains
+currently ready `JoinSet` exits and does not scan every live keyed receiver.
 
 ### 4.4 Event Loop and Drain Discipline
 
@@ -454,7 +460,7 @@ RFC 0003 extends that mux with keyed receiver events:
 ```rust
 enum AppInput<Msg> {
     Shared(Msg),
-    Keyed(CommandId, ReceiverEvent<Msg>),
+    Keyed(ReceiverEvent<Msg>),
 }
 
 struct AppInputs<Msg> {
@@ -491,7 +497,6 @@ tokio::select! {
     }
 
     () = self.scheduler.next_work_frame() => {
-        self.core.app_inputs.reconcile_keyed_available();
         self.process_frame_tick(terminal)?;
     }
 
@@ -528,11 +533,12 @@ process_input_batch(first_input):
   set subscriptions_dirty only if at least one item ran update()
 ```
 
-`process_app_input` is the only place that interprets `AppInput`:
+`process_app_input` is the only place that interprets `AppInput`; keyed lifecycle
+accounting has already happened inside `KeyedCommands` before an event reaches
+this layer:
 
-- `ReceiverClosed` updates keyed lifecycle state, runs
-  `reconcile_keyed_available()`, and does not call `update()`.
-- A keyed message records delivery before calling `update(msg)`.
+- `ReceiverEvent::Closed` does not call `update()`.
+- A keyed message calls `update(msg)`.
 - A shared message calls `update(msg)` directly.
 - Any command returned by `update()` is dispatched before another app input is
   pulled.
@@ -547,7 +553,7 @@ AppInputs::try_next_ready():
   if shared.try_recv() yields a shared message:
       return Shared(msg)
   if keyed.try_next_ready() yields a keyed receiver event:
-      return Keyed(id, event)
+      return Keyed(event)
   return None
 ```
 
@@ -564,7 +570,7 @@ messages, delivery is recorded before `update()` so a sender-closed empty
 receiver can release the id before same-id retry work is returned.
 
 `subscriptions_dirty` is set only when at least one item in the batch actually
-ran through `update()`. `ReceiverClosed` and keyed `Quit` do not dirty
+ran through `update()`. `ReceiverEvent::Closed` and keyed `Quit` do not dirty
 subscriptions by themselves.
 
 ## 5. Implementation Notes
@@ -726,9 +732,12 @@ still matches the current `Running` entry. Stale exits are ignored.
 `KeyedEntry<Msg>` implements `Stream<Item = ReceiverEvent<Msg>>` by delegating to
 `CommandReceiver`; `StreamMap` is only the polling merge. Policy decisions,
 delivery accounting, receiver removal, and task-exit reconciliation all go
-through `KeyedCommands` methods. If an implementation needs keyed mutable access
-that `StreamMap` does not expose, it may temporarily remove, update, and reinsert
-an entry, but that pattern must stay inside `KeyedCommands`.
+through `KeyedCommands` methods. After a receiver event is pulled, its facts are
+sampled and the transition is applied before the event leaves this module. If an
+implementation needs keyed mutable access that `StreamMap` does not expose, it
+may temporarily remove, update, and reinsert an entry, but that pattern must stay
+inside `KeyedCommands`; identity transitions return early without churning the
+`StreamMap`.
 
 ### 5.5 Spawning a Keyed Run
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -113,22 +113,33 @@ easy to compare across the two copies.
 
 ## Process-Global Panic Hook Tests
 
-Use `crate::test_support::PANIC_HOOK_GUARD` for crate-internal tests that call
-`std::panic::set_hook`, `std::panic::take_hook`, or deliberately trigger a panic
-while a recording hook is installed. The panic hook is process-global and tests
-run in parallel by default, so hook-swapping tests can otherwise clobber each
-other or observe an unrelated panic.
+Use `crate::test_support::PANIC_HOOK_GUARD` for crate-internal tests that directly
+call `std::panic::set_hook` or `std::panic::take_hook`. The panic hook is
+process-global and tests run in parallel by default, so hook-swapping tests can
+otherwise clobber each other or observe an unrelated panic.
 
 Hold the guard for the full critical section: install or take the hook, trigger
 and catch the panic if needed, restore the previous hook, and then inspect any
 recorded hook state. Ordinary tests that do not mutate the panic hook do not
 need the guard.
 
-If an integration test ever needs to mutate the panic hook, add a focused local
-guard under `tests/common/` rather than exposing the crate-internal test helper
-as public API. Because integration tests are async, that local guard should use
-`tokio::sync::Mutex` (not `std::sync::Mutex`) so it can be held across
-`.await` — see `tests/common/panic_hook.rs`.
+Crate-internal timing-bound tests that intentionally panic should run the
+relevant future through `crate::test_support::with_silent_panic_hook`. The helper
+owns the guard, catches an unexpected panic long enough to restore the previous
+hook, and only then resumes unwinding. Its guard uses `std::sync::Mutex`, so the
+helper is restricted to `current_thread` tests.
+
+Integration tests cannot use crate-private test support, so they use the focused
+local `with_silent_panic_hook` under `tests/common/panic_hook.rs`. Its guard uses
+`tokio::sync::Mutex` so it can be held across `.await` without blocking a runtime
+worker thread.
+
+Do not expose or directly hold the internal silent-hook RAII guard. Calling
+`std::panic::set_hook` from a panicking thread itself panics, so attempting to
+restore a hook from `Drop` during unwinding can abort the entire test process.
+The scoped helpers prevent that failure mode structurally. Keep ordinary
+timeout failures as `Result` values where practical, leave the silent scope,
+and perform assertions only after the previous hook has been restored.
 
 ### Panic Hook Cost In Timing-Bound Tests
 
@@ -148,10 +159,9 @@ otherwise finishes in single-digit milliseconds can intermittently blow
 through a one-second timeout on a loaded Windows runner.
 
 If a test intentionally triggers a command-task panic under a bounded
-`timeout`, install a no-op panic hook for the duration (see
-`tests/common/panic_hook.rs::SilentPanicHook`) rather than only widening the
-timeout. Widening the timeout alone hides the same unbounded cost behind a
-larger number instead of removing it.
+`timeout`, use the appropriate `with_silent_panic_hook` scope. Widening the
+timeout alone hides the same unbounded cost behind a larger number instead of
+removing it.
 
 ## Sleep Audit Notes
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -24,12 +24,15 @@
 //! let cmd = Command::perform(load_data(), Message::DataLoaded);
 //! ```
 
+mod cancellation;
 pub(crate) mod core;
 mod effect;
 mod retry;
 mod runtime_directives;
 mod runtime_parts;
 
+pub(crate) use cancellation::CancellableCommand;
+pub use cancellation::{CancelPolicy, CommandId};
 pub(crate) use core::Command;
 pub use retry::{RetryBackoff, RetryContext, RetryError, RetryPolicy, RetryStopReason};
 pub(crate) use runtime_parts::RuntimeCommandParts;

--- a/src/command/cancellation.rs
+++ b/src/command/cancellation.rs
@@ -1,0 +1,165 @@
+use std::any::{Any, TypeId, type_name};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+/// Identifies one cancellable command-output lifecycle.
+///
+/// Equality is structural and includes the concrete Rust type of the stored
+/// value. Consequently, values that compare equal but have different types are
+/// distinct command ids.
+#[derive(Clone)]
+pub struct CommandId {
+    inner: Arc<dyn ErasedCommandId>,
+}
+
+impl CommandId {
+    /// Creates an id from an owned, structurally comparable value.
+    pub fn new<T>(value: T) -> Self
+    where
+        T: Eq + Hash + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(TypedCommandId(value)),
+        }
+    }
+}
+
+impl fmt::Debug for CommandId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("CommandId")
+            .field("type", &self.inner.type_name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for CommandId {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner.erased_type_id() == other.inner.erased_type_id()
+            && self.inner.eq_erased(other.inner.as_ref())
+    }
+}
+
+impl Eq for CommandId {}
+
+impl Hash for CommandId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.inner.erased_type_id().hash(state);
+        self.inner.hash_erased(state);
+    }
+}
+
+trait ErasedCommandId: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn erased_type_id(&self) -> TypeId;
+    fn type_name(&self) -> &'static str;
+    fn eq_erased(&self, other: &dyn ErasedCommandId) -> bool;
+    fn hash_erased(&self, state: &mut dyn Hasher);
+}
+
+struct TypedCommandId<T>(T);
+
+impl<T> ErasedCommandId for TypedCommandId<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn erased_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
+
+    fn eq_erased(&self, other: &dyn ErasedCommandId) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.0 == other.0)
+    }
+
+    fn hash_erased(&self, mut state: &mut dyn Hasher) {
+        self.0.hash(&mut state);
+    }
+}
+
+/// Controls how a new command interacts with deliverable same-id work.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum CancelPolicy {
+    /// Drop the current receiver, abort its work, and start the new command.
+    #[default]
+    CancelInFlight,
+    /// Keep the current deliverable command and discard the new command stream.
+    KeepInFlight,
+}
+
+#[derive(Default)]
+pub(super) struct CommandCancellation {
+    pub(super) key: Option<CancellableCommand>,
+    pub(super) cancels: Vec<CommandId>,
+}
+
+#[derive(Clone, Debug)]
+pub struct CancellableCommand {
+    pub id: CommandId,
+    pub policy: CancelPolicy,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn hash(id: &CommandId) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        id.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn command_id_equality_is_structural_and_type_sensitive() {
+        assert_eq!(CommandId::new(7_u64), CommandId::new(7_u64));
+        assert_ne!(CommandId::new(7_u64), CommandId::new(8_u64));
+        assert_ne!(CommandId::new(7_u64), CommandId::new(7_i64));
+        assert_eq!(hash(&CommandId::new(7_u64)), hash(&CommandId::new(7_u64)));
+    }
+
+    #[test]
+    fn hash_collisions_do_not_make_distinct_values_equal() {
+        #[derive(Eq, PartialEq)]
+        struct Collision(u8);
+
+        impl Hash for Collision {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        let first = CommandId::new(Collision(1));
+        let second = CommandId::new(Collision(2));
+
+        assert_eq!(hash(&first), hash(&second));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn debug_identifies_only_the_erased_type() {
+        let first = format!("{:?}", CommandId::new(1_u64));
+        let second = format!("{:?}", CommandId::new(2_u64));
+
+        assert_eq!(first, second);
+        assert!(first.contains("u64"));
+        assert!(!first.contains('1'));
+    }
+
+    #[test]
+    fn default_policy_cancels_in_flight_work() {
+        assert_eq!(CancelPolicy::default(), CancelPolicy::CancelInFlight);
+    }
+}

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -10,6 +10,7 @@ use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt};
 
 use super::Action;
+use super::cancellation::{CancelPolicy, CancellableCommand, CommandCancellation, CommandId};
 use super::effect::Effect;
 use super::retry::{self, RetryContext, RetryError, RetryPolicy};
 use super::runtime_directives::RuntimeDirectives;
@@ -39,6 +40,7 @@ pub struct Command<Msg: Send + 'static> {
     // `Effect::leaf_count()` without a dedicated accessor.
     pub(super) effect: Effect<Msg>,
     directives: RuntimeDirectives,
+    cancellation: CommandCancellation,
 }
 
 impl<Msg: Send + 'static> Command<Msg> {
@@ -46,6 +48,10 @@ impl<Msg: Send + 'static> Command<Msg> {
         Self {
             effect,
             directives: RuntimeDirectives::DEFAULT,
+            cancellation: CommandCancellation {
+                key: None,
+                cancels: Vec::new(),
+            },
         }
     }
 
@@ -66,6 +72,10 @@ impl<Msg: Send + 'static> Command<Msg> {
         Self {
             effect: Effect::none(),
             directives: RuntimeDirectives::DEFAULT,
+            cancellation: CommandCancellation {
+                key: None,
+                cancels: Vec::new(),
+            },
         }
     }
 
@@ -125,7 +135,11 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// Decompose this command into the runtime-facing parts that must be
     /// observed together.
     pub(crate) fn into_runtime_parts(self) -> RuntimeCommandParts<Msg> {
-        RuntimeCommandParts::new(self.directives, self.effect.into_stream())
+        RuntimeCommandParts::new(
+            self.directives,
+            self.effect.into_stream(),
+            self.cancellation,
+        )
     }
 
     /// Declare that the update returning this command did not change the
@@ -139,6 +153,51 @@ impl<Msg: Send + 'static> Command<Msg> {
     pub const fn without_redraw(mut self) -> Self {
         self.directives = self.directives.without_redraw();
         self
+    }
+
+    /// Runs this command under `id`, replacing any deliverable same-id command.
+    ///
+    /// Cancellation is strict for output delivery: after replacement, buffered
+    /// messages and quit requests from the old command cannot affect the app.
+    /// This does not roll back external side effects that already occurred.
+    ///
+    /// A cancellation key applies to this top-level command only. If this
+    /// command is later passed as a child to [`Command::batch`], its key is
+    /// ignored; apply `cancellable` to the resulting batch instead.
+    #[must_use = "cancellable returns a modified command and does not mutate in place"]
+    pub fn cancellable(self, id: CommandId) -> Self {
+        self.cancellable_with(id, CancelPolicy::CancelInFlight)
+    }
+
+    /// Runs this command under `id` using the supplied same-id policy.
+    ///
+    /// [`CancelPolicy::CancelInFlight`] replaces current deliverable work;
+    /// [`CancelPolicy::KeepInFlight`] discards this command's stream while the
+    /// id is occupied. Runtime directives and explicit cancels still apply.
+    ///
+    /// A cancellation key applies to this top-level command only. Child keys
+    /// are ignored by [`Command::batch`]; key the resulting batch when the whole
+    /// batch should share one lifecycle.
+    #[must_use = "cancellable_with returns a modified command and does not mutate in place"]
+    pub fn cancellable_with(mut self, id: CommandId, policy: CancelPolicy) -> Self {
+        self.cancellation.key = Some(CancellableCommand { id, policy });
+        self
+    }
+
+    /// Cancels the current deliverable command for `id` without replacing it.
+    ///
+    /// Cancellation is idempotent and drops buffered messages and quit requests
+    /// in addition to aborting running work. Like other constructors, this
+    /// requests a redraw unless followed by [`Command::without_redraw`].
+    pub fn cancel(id: CommandId) -> Self {
+        Self {
+            effect: Effect::none(),
+            directives: RuntimeDirectives::DEFAULT,
+            cancellation: CommandCancellation {
+                key: None,
+                cancels: vec![id],
+            },
+        }
     }
 
     /// Add an overall deadline to every effect leaf in this command.
@@ -339,10 +398,19 @@ impl<Msg: Send + 'static> Command<Msg> {
         let mut directives = RuntimeDirectives::DEFAULT.without_redraw();
         let mut any_child = false;
         let mut effects = Vec::new();
+        let mut cancels = Vec::new();
 
         for cmd in commands {
             any_child = true;
             directives = directives.combine(cmd.directives);
+            if let Some(key) = cmd.cancellation.key {
+                tracing::warn!(
+                    target: "tears::command",
+                    id = ?key.id,
+                    "cancellable child key ignored by Command::batch"
+                );
+            }
+            cancels.extend(cmd.cancellation.cancels);
             effects.push(cmd.effect);
         }
 
@@ -350,6 +418,7 @@ impl<Msg: Send + 'static> Command<Msg> {
             Self {
                 effect: Effect::batch(effects),
                 directives,
+                cancellation: CommandCancellation { key: None, cancels },
             }
         } else {
             Self::none()
@@ -446,9 +515,14 @@ impl<Msg: Send + 'static> Command<Msg> {
         T: Send + 'static,
     {
         let directives = self.directives;
+        let cancellation = self.cancellation;
         let effect = self.effect.map(f);
 
-        Command { effect, directives }
+        Command {
+            effect,
+            directives,
+            cancellation,
+        }
     }
 }
 
@@ -460,6 +534,9 @@ mod tests {
 
     use futures::stream;
     use tokio::time::{advance, sleep};
+    use tracing::Level;
+
+    use crate::test_support::TraceRecorder;
 
     #[test]
     fn test_redraw_defaults_to_true_for_constructors() {
@@ -478,6 +555,90 @@ mod tests {
     fn test_without_redraw_flips_redraw() {
         let cmd = Command::<i32>::none().without_redraw();
         assert!(!cmd.requests_redraw());
+    }
+
+    #[test]
+    fn test_cancellation_metadata_defaults_empty() {
+        let command = Command::<i32>::none();
+
+        assert!(command.cancellation.key.is_none());
+        assert!(command.cancellation.cancels.is_empty());
+    }
+
+    #[test]
+    fn test_cancellable_is_last_call_wins() {
+        let command = Command::message(1)
+            .cancellable_with(CommandId::new("first"), CancelPolicy::KeepInFlight)
+            .cancellable(CommandId::new("second"));
+        let key = command.cancellation.key.expect("key should be present");
+
+        assert_eq!(key.id, CommandId::new("second"));
+        assert_eq!(key.policy, CancelPolicy::CancelInFlight);
+    }
+
+    #[test]
+    fn test_cancel_is_streamless_and_preserves_redraw_control() {
+        let id = CommandId::new("search");
+        let command = Command::<i32>::cancel(id.clone()).without_redraw();
+
+        assert!(command.is_none());
+        assert!(!command.requests_redraw());
+        assert_eq!(command.cancellation.cancels, vec![id]);
+        assert!(command.cancellation.key.is_none());
+    }
+
+    #[test]
+    fn test_map_preserves_cancellation_metadata() {
+        let cancel_id = CommandId::new("old");
+        let key_id = CommandId::new("current");
+        let command = Command::batch([Command::cancel(cancel_id.clone()), Command::message(1)])
+            .cancellable_with(key_id.clone(), CancelPolicy::KeepInFlight)
+            .map(|value| value.to_string());
+        let key = command.cancellation.key.expect("key should be present");
+
+        assert_eq!(command.cancellation.cancels, vec![cancel_id]);
+        assert_eq!(key.id, key_id);
+        assert_eq!(key.policy, CancelPolicy::KeepInFlight);
+    }
+
+    #[test]
+    fn test_batch_folds_cancels_and_discards_child_keys() {
+        let first = CommandId::new("first");
+        let second = CommandId::new("second");
+        let command = Command::batch([
+            Command::<i32>::cancel(first.clone()),
+            Command::cancel(second.clone()).cancellable(CommandId::new("ignored")),
+        ]);
+
+        assert_eq!(command.cancellation.cancels, vec![first, second]);
+        assert!(command.cancellation.key.is_none());
+    }
+
+    #[test]
+    fn test_batch_warns_when_discarding_a_child_key() {
+        let recorder = TraceRecorder::new()
+            .with_target("tears::command")
+            .with_level(Level::WARN);
+        let _guard = recorder.set_default();
+
+        let _command = Command::batch([
+            Command::message(1).cancellable(CommandId::new("ignored")),
+            Command::message(2),
+        ]);
+
+        assert_eq!(recorder.event_count(), 1);
+    }
+
+    #[test]
+    fn test_timeout_preserves_cancellation_metadata() {
+        let key_id = CommandId::new("timeout");
+        let command = Command::future(pending::<i32>())
+            .cancellable_with(key_id.clone(), CancelPolicy::KeepInFlight)
+            .timeout(Duration::from_secs(1), || 99);
+        let key = command.cancellation.key.expect("key should be present");
+
+        assert_eq!(key.id, key_id);
+        assert_eq!(key.policy, CancelPolicy::KeepInFlight);
     }
 
     #[test]

--- a/src/command/runtime_parts.rs
+++ b/src/command/runtime_parts.rs
@@ -1,7 +1,9 @@
 use futures::stream::BoxStream;
 
 use super::Action;
+use super::cancellation::CommandCancellation;
 use super::runtime_directives::RuntimeDirectives;
+use super::{CancellableCommand, CommandId};
 
 /// Internal command decomposition consumed by the runtime.
 ///
@@ -11,21 +13,40 @@ use super::runtime_directives::RuntimeDirectives;
 pub struct RuntimeCommandParts<Msg: Send + 'static> {
     directives: RuntimeDirectives,
     stream: Option<BoxStream<'static, Action<Msg>>>,
+    cancels: Vec<CommandId>,
+    key: Option<CancellableCommand>,
 }
 
 impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
-    pub(super) const fn new(
+    pub(super) fn new(
         directives: RuntimeDirectives,
         stream: Option<BoxStream<'static, Action<Msg>>>,
+        cancellation: CommandCancellation,
     ) -> Self {
-        Self { directives, stream }
+        Self {
+            directives,
+            stream,
+            cancels: cancellation.cancels,
+            key: cancellation.key,
+        }
     }
 
     pub(crate) const fn requests_redraw(&self) -> bool {
         self.directives.requests_redraw()
     }
 
+    #[cfg(test)]
     pub(crate) fn into_stream(self) -> Option<BoxStream<'static, Action<Msg>>> {
         self.stream
+    }
+
+    pub(crate) fn into_execution_parts(
+        self,
+    ) -> (
+        Vec<CommandId>,
+        Option<CancellableCommand>,
+        Option<BoxStream<'static, Action<Msg>>>,
+    ) {
+        (self.cancels, self.key, self.stream)
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -100,11 +100,13 @@ mod core;
 // `lib.rs`/`prelude` still need it nameable for their re-exports.
 pub mod frame_rate;
 mod frame_scheduler;
+mod keyed_commands;
 mod pending_work;
 
 use app_input::AppInput;
 use frame_rate::FrameRate;
 use frame_scheduler::FrameScheduler;
+use keyed_commands::{CommandOutput, ReceiverEvent};
 // `self::` disambiguates the submodule from the built-in `core` crate.
 use self::core::RuntimeCore;
 
@@ -136,6 +138,19 @@ pub struct Runtime<App: Application> {
     core: RuntimeCore<App>,
     /// Schedules frame work and gates idle wake-ups
     scheduler: FrameScheduler,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BatchOutcome {
+    Continue,
+    Quit,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputOutcome {
+    Updated,
+    NoUpdate,
+    Quit,
 }
 
 impl<App: Application> Runtime<App> {
@@ -190,7 +205,7 @@ impl<App: Application> Runtime<App> {
 
     #[cfg(test)]
     fn process_message_batch(&mut self, first_msg: App::Message) {
-        self.process_input_batch(AppInput::Shared(first_msg));
+        let _ = self.process_input_batch(AppInput::Shared(first_msg));
     }
 
     /// Processes a batch of application inputs that arrive in quick succession
@@ -200,20 +215,29 @@ impl<App: Application> Runtime<App> {
     /// inputs that arrived within 100μs. This reduces overhead by batching rapid
     /// input sequences while maintaining responsiveness.
     ///
-    /// Records a redraw request if any processed command wants one, and always
-    /// marks subscriptions dirty after processing.
-    fn process_input_batch(&mut self, first_input: AppInput<App::Message>) {
-        self.process_app_input(first_input);
-        let mut processed = 1usize;
+    /// Records a redraw request if any processed command wants one, and marks
+    /// subscriptions dirty when at least one input invokes `update`.
+    fn process_input_batch(&mut self, first_input: AppInput<App::Message>) -> BatchOutcome {
+        let mut processed = match self.process_app_input(first_input) {
+            InputOutcome::Updated => 1usize,
+            InputOutcome::NoUpdate => 0usize,
+            InputOutcome::Quit => return BatchOutcome::Quit,
+        };
 
         // Micro-batching: process additional messages that arrived during a short window
         let batch_deadline = Instant::now() + Duration::from_micros(100);
         while Instant::now() < batch_deadline {
             match self.core.app_inputs.try_next_ready() {
-                Some(input) => {
-                    self.process_app_input(input);
-                    processed += 1;
-                }
+                Some(input) => match self.process_app_input(input) {
+                    InputOutcome::Updated => processed += 1,
+                    InputOutcome::NoUpdate => {}
+                    InputOutcome::Quit => {
+                        if processed > 0 {
+                            self.scheduler.mark_subscriptions_dirty();
+                        }
+                        return BatchOutcome::Quit;
+                    }
+                },
                 None => break, // No more inputs available
             }
         }
@@ -221,15 +245,22 @@ impl<App: Application> Runtime<App> {
         tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
 
         // Mark that subscriptions may have changed even when redraw is suppressed.
-        self.scheduler.mark_subscriptions_dirty();
+        if processed > 0 {
+            self.scheduler.mark_subscriptions_dirty();
+        }
+        BatchOutcome::Continue
     }
 
-    fn process_app_input(&mut self, input: AppInput<App::Message>) {
+    fn process_app_input(&mut self, input: AppInput<App::Message>) -> InputOutcome {
         match input {
-            AppInput::Shared(msg) => {
+            AppInput::Shared(msg)
+            | AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Message(msg))) => {
                 let cmd = self.core.app.update(msg);
                 self.dispatch_update_command(cmd);
+                InputOutcome::Updated
             }
+            AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Quit)) => InputOutcome::Quit,
+            AppInput::Keyed(ReceiverEvent::Closed) => InputOutcome::NoUpdate,
         }
     }
 
@@ -376,7 +407,10 @@ impl<App: Application> Runtime<App> {
             tokio::select! {
                 // Message received: batch process messages that arrive in quick succession
                 Some(input) = self.core.app_inputs.next() => {
-                    self.process_input_batch(input);
+                    if self.process_input_batch(input) == BatchOutcome::Quit {
+                        tracing::debug!(target: "tears::runtime", "keyed quit signal received");
+                        break;
+                    }
                 }
 
                 // Frame tick: render if needed and update subscriptions. The
@@ -408,17 +442,19 @@ impl<App: Application> Runtime<App> {
 mod tests {
     use super::*;
 
+    use std::future::pending;
     use std::num::NonZeroU32;
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-    use futures::stream::{self, BoxStream};
+    use futures::stream::{self, BoxStream, iter};
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
+    use tokio::sync::oneshot;
     use tokio::time::{Duration, sleep, timeout};
 
     use crate::application::Application;
-    use crate::command::Command;
+    use crate::command::{CancelPolicy, Command, CommandId};
     use crate::subscription::{Subscription, SubscriptionId, SubscriptionSource};
     use crate::test_support::{TestApp, TestMessage, TraceRecorder, wait_until};
 
@@ -693,6 +729,186 @@ mod tests {
             .await
             .expect("run() should quit before the timeout")?;
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn shared_cancel_drops_ready_keyed_output_before_batch_delivery() {
+        enum Message {
+            Leave,
+            Result(i32),
+        }
+
+        struct CancellationApp {
+            results: Vec<i32>,
+        }
+
+        impl Application for CancellationApp {
+            type Message = Message;
+            type Flags = ();
+
+            fn new((): ()) -> (Self, Command<Self::Message>) {
+                (
+                    Self {
+                        results: Vec::new(),
+                    },
+                    Command::none(),
+                )
+            }
+
+            fn update(&mut self, message: Self::Message) -> Command<Self::Message> {
+                match message {
+                    Message::Leave => Command::cancel(CommandId::new("search")),
+                    Message::Result(value) => {
+                        self.results.push(value);
+                        Command::none()
+                    }
+                }
+            }
+
+            fn view(&self, _frame: &mut Frame<'_>) {}
+
+            fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+                Vec::new()
+            }
+        }
+
+        let id = CommandId::new("search");
+        let mut runtime = Runtime::<CancellationApp>::new((), frame_rate(60));
+        runtime.core.enqueue_command(
+            Command::stream(iter([Message::Result(1), Message::Result(2)]))
+                .cancellable(id.clone())
+                .into_runtime_parts(),
+        );
+        wait_until(
+            || runtime.core.app_inputs.has_closed_buffered(&id),
+            "keyed results should be buffered before cancellation",
+        )
+        .await;
+        runtime
+            .core
+            .msg_tx
+            .send(Message::Leave)
+            .expect("message receiver should be open");
+
+        let first = runtime
+            .core
+            .app_inputs
+            .next()
+            .await
+            .expect("shared input should be ready");
+        assert!(matches!(first, AppInput::Shared(Message::Leave)));
+        assert_eq!(runtime.process_input_batch(first), BatchOutcome::Continue);
+
+        assert!(runtime.core.app.results.is_empty());
+        assert!(runtime.core.app_inputs.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn keep_in_flight_applies_redraw_and_cancels_before_dropping_new_stream() {
+        struct DropGuard(Arc<AtomicBool>);
+
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let keep_id = CommandId::new("kept");
+        let cancel_id = CommandId::new("cancelled");
+        let kept_dropped = Arc::new(AtomicBool::new(false));
+        let cancelled_dropped = Arc::new(AtomicBool::new(false));
+        let arrival_dropped = Arc::new(AtomicBool::new(false));
+        let (kept_started_tx, kept_started_rx) = oneshot::channel();
+        let (cancelled_started_tx, cancelled_started_rx) = oneshot::channel();
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        let kept_guard = DropGuard(Arc::clone(&kept_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = kept_guard;
+                let _ = kept_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable(keep_id.clone())
+            .into_runtime_parts(),
+        );
+        let cancelled_guard = DropGuard(Arc::clone(&cancelled_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = cancelled_guard;
+                let _ = cancelled_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable(cancel_id.clone())
+            .into_runtime_parts(),
+        );
+        timeout(Duration::from_secs(1), kept_started_rx)
+            .await
+            .expect("kept command should start before the timeout")
+            .expect("kept command should signal that it started");
+        timeout(Duration::from_secs(1), cancelled_started_rx)
+            .await
+            .expect("cancelled command should start before the timeout")
+            .expect("cancelled command should signal that it started");
+
+        runtime.scheduler.pending.needs_redraw = false;
+        let arrival_guard = DropGuard(Arc::clone(&arrival_dropped));
+        let dropped_arrival = Command::future(async move {
+            let _guard = arrival_guard;
+            pending::<TestMessage>().await
+        });
+        let command = Command::batch([Command::cancel(cancel_id), dropped_arrival])
+            .cancellable_with(keep_id, CancelPolicy::KeepInFlight);
+
+        runtime.dispatch_update_command(command);
+
+        assert!(runtime.scheduler.pending.needs_redraw);
+        assert!(arrival_dropped.load(Ordering::SeqCst));
+        assert!(!kept_dropped.load(Ordering::SeqCst));
+        wait_until(
+            || cancelled_dropped.load(Ordering::SeqCst),
+            "explicit cancels should be applied before KeepInFlight drops the arrival",
+        )
+        .await;
+
+        runtime.core.shutdown();
+        wait_until(
+            || kept_dropped.load(Ordering::SeqCst),
+            "shutdown should clean up the kept command",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn live_keyed_quit_exits_the_runtime() -> Result<()> {
+        struct KeyedQuitApp;
+
+        impl Application for KeyedQuitApp {
+            type Message = ();
+            type Flags = ();
+
+            fn new((): ()) -> (Self, Command<Self::Message>) {
+                (Self, Command::quit().cancellable(CommandId::new("quit")))
+            }
+
+            fn update(&mut self, (): ()) -> Command<Self::Message> {
+                Command::none()
+            }
+
+            fn view(&self, _frame: &mut Frame<'_>) {}
+
+            fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+                Vec::new()
+            }
+        }
+
+        let runtime = Runtime::<KeyedQuitApp>::new((), frame_rate(60));
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        timeout(Duration::from_secs(1), runtime.run(&mut terminal))
+            .await
+            .expect("live keyed quit should stop the runtime")?;
         Ok(())
     }
 

--- a/src/runtime/app_input.rs
+++ b/src/runtime/app_input.rs
@@ -1,46 +1,102 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures::stream::BoxStream;
 use tokio::sync::mpsc;
+
+use crate::command::{Action, CancelPolicy, CommandId};
+
+use super::keyed_commands::{KeyedCommands, ReceiverEvent};
 
 /// Input events consumed by the runtime's application loop.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub(super) enum AppInput<Msg> {
     /// A message sent through the application's shared message channel.
     Shared(Msg),
+    /// Output sent through a cancellable command's private receiver.
+    Keyed(ReceiverEvent<Msg>),
 }
 
 /// Stream of application inputs backed by runtime message channels.
-pub(super) struct AppInputs<Msg> {
+pub(super) struct AppInputs<Msg: Send + 'static> {
     shared: mpsc::UnboundedReceiver<Msg>,
+    keyed: KeyedCommands<Msg>,
 }
 
-impl<Msg> AppInputs<Msg> {
+impl<Msg: Send + 'static> AppInputs<Msg> {
     /// Creates an input stream from the shared message receiver.
-    pub(super) const fn new(shared: mpsc::UnboundedReceiver<Msg>) -> Self {
-        Self { shared }
+    pub(super) fn new(shared: mpsc::UnboundedReceiver<Msg>) -> Self {
+        Self {
+            shared,
+            keyed: KeyedCommands::new(),
+        }
     }
 
     /// Returns the next queued input without waiting for new messages.
     pub(super) fn try_next_ready(&mut self) -> Option<AppInput<Msg>> {
-        self.shared.try_recv().ok().map(AppInput::Shared)
+        if let Ok(message) = self.shared.try_recv() {
+            return Some(AppInput::Shared(message));
+        }
+        self.keyed
+            .try_next_ready()
+            .map(|(_, event)| AppInput::Keyed(event))
+    }
+
+    pub(super) fn reconcile_keyed_available(&mut self) {
+        self.keyed.reconcile_available();
+    }
+
+    pub(super) fn cancel_keyed(&mut self, id: &CommandId) {
+        self.keyed.cancel(id);
+    }
+
+    pub(super) fn spawn_keyed(
+        &mut self,
+        id: CommandId,
+        policy: CancelPolicy,
+        stream: BoxStream<'static, Action<Msg>>,
+    ) {
+        self.keyed.spawn(id, policy, stream);
+    }
+
+    pub(super) fn shutdown_keyed(&mut self) {
+        self.keyed.shutdown();
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_closed_buffered(&self, id: &CommandId) -> bool {
+        self.keyed.has_closed_buffered(id)
     }
 }
 
-impl<Msg> futures::Stream for AppInputs<Msg> {
+impl<Msg: Send + 'static> futures::Stream for AppInputs<Msg> {
     type Item = AppInput<Msg>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.shared
-            .poll_recv(cx)
-            .map(|input| input.map(AppInput::Shared))
+        let shared_closed = match self.shared.poll_recv(cx) {
+            Poll::Ready(Some(message)) => return Poll::Ready(Some(AppInput::Shared(message))),
+            Poll::Ready(None) => true,
+            Poll::Pending => false,
+        };
+
+        match Pin::new(&mut self.keyed).poll_next(cx) {
+            Poll::Ready(Some((_, event))) => Poll::Ready(Some(AppInput::Keyed(event))),
+            Poll::Ready(None) | Poll::Pending if shared_closed && self.keyed.is_empty() => {
+                Poll::Ready(None)
+            }
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::stream::StreamExt;
+    use futures::stream::{self, StreamExt, pending};
+    use tokio::task::yield_now;
+    use tokio::time::{Duration, timeout};
+
+    use super::super::keyed_commands::{CommandOutput, ReceiverEvent};
 
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_shared_after_send() {
@@ -95,5 +151,72 @@ mod tests {
         drop(tx);
 
         assert_eq!(inputs.next().await, None);
+    }
+
+    #[tokio::test]
+    async fn shared_input_wins_when_keyed_output_is_also_ready() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut inputs = AppInputs::new(rx);
+        let id = CommandId::new("search");
+        inputs.spawn_keyed(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            stream::iter([Action::Message(2)]).boxed(),
+        );
+        yield_now().await;
+        tx.send(1).expect("receiver should be open");
+
+        assert_eq!(inputs.next().await, Some(AppInput::Shared(1)));
+        inputs
+            .next()
+            .await
+            .and_then(|input| match input {
+                AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Message(2))) => Some(()),
+                AppInput::Shared(_)
+                | AppInput::Keyed(ReceiverEvent::Output(_) | ReceiverEvent::Closed) => None,
+            })
+            .expect("keyed output should follow the shared input");
+    }
+
+    #[tokio::test]
+    async fn closed_shared_channel_and_drained_keyed_entries_terminate_the_stream() {
+        let (tx, rx) = mpsc::unbounded_channel::<i32>();
+        let mut inputs = AppInputs::new(rx);
+        inputs.spawn_keyed(
+            CommandId::new("empty"),
+            CancelPolicy::CancelInFlight,
+            stream::empty().boxed(),
+        );
+        drop(tx);
+        yield_now().await;
+
+        let end = timeout(Duration::from_secs(1), async {
+            loop {
+                match inputs.next().await {
+                    Some(AppInput::Keyed(ReceiverEvent::Closed)) => {}
+                    Some(AppInput::Shared(_) | AppInput::Keyed(ReceiverEvent::Output(_))) => {
+                        return false;
+                    }
+                    None => return true,
+                }
+            }
+        })
+        .await
+        .expect("AppInputs should not hang after every sender closes");
+
+        assert!(end);
+    }
+
+    #[tokio::test]
+    async fn try_next_ready_does_not_wait_for_pending_keyed_streams() {
+        let (_tx, rx) = mpsc::unbounded_channel::<i32>();
+        let mut inputs = AppInputs::new(rx);
+        inputs.spawn_keyed(
+            CommandId::new("pending"),
+            CancelPolicy::CancelInFlight,
+            pending().boxed(),
+        );
+
+        assert_eq!(inputs.try_next_ready(), None);
     }
 }

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -111,7 +111,19 @@ impl<App: Application> RuntimeCore<App> {
     ///
     /// Send failures are silently ignored as they only occur during application shutdown.
     pub(super) fn enqueue_command(&mut self, parts: RuntimeCommandParts<App::Message>) {
-        if let Some(stream) = parts.into_stream() {
+        let (cancels, key, stream) = parts.into_execution_parts();
+
+        self.app_inputs.reconcile_keyed_available();
+        for id in cancels {
+            self.app_inputs.cancel_keyed(&id);
+        }
+
+        if let Some(stream) = stream {
+            if let Some(key) = key {
+                self.app_inputs.spawn_keyed(key.id, key.policy, stream);
+                return;
+            }
+
             let msg_tx = self.msg_tx.clone();
             let quit_tx = self.quit_tx.clone();
 
@@ -187,6 +199,7 @@ impl<App: Application> RuntimeCore<App> {
     pub(super) fn shutdown(&mut self) {
         self.subscription_manager.shutdown();
         self.command_tasks.abort_all();
+        self.app_inputs.shutdown_keyed();
     }
 }
 
@@ -204,7 +217,7 @@ mod tests {
     use tokio::sync::oneshot;
     use tokio::time::{Duration, advance, timeout};
 
-    use crate::command::{Command, RetryPolicy};
+    use crate::command::{Command, CommandId, RetryPolicy};
     use crate::runtime::AppInput;
     use crate::subscription::Subscription;
     use crate::subscription::time::Timer;
@@ -562,6 +575,46 @@ mod tests {
         wait_until(
             || aborted.load(Ordering::SeqCst),
             "dropping the core should abort running command tasks",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn test_dropping_core_aborts_keyed_command_tasks() {
+        struct AbortGuard(Arc<AtomicBool>);
+
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let aborted = Arc::new(AtomicBool::new(false));
+
+        {
+            let mut core = RuntimeCore::<TestApp>::new(0);
+            let guard = AbortGuard(Arc::clone(&aborted));
+            let (started_tx, started_rx) = oneshot::channel();
+            core.enqueue_command(
+                Command::future(async move {
+                    let _guard = guard;
+                    let _ = started_tx.send(());
+                    pending::<TestMessage>().await
+                })
+                .cancellable(CommandId::new("running"))
+                .into_runtime_parts(),
+            );
+
+            timeout(Duration::from_secs(1), started_rx)
+                .await
+                .expect("keyed command task should start before the timeout")
+                .expect("keyed command task should signal that it started");
+            assert!(!aborted.load(Ordering::SeqCst));
+        }
+
+        wait_until(
+            || aborted.load(Ordering::SeqCst),
+            "dropping the core should abort running keyed command tasks",
         )
         .await;
     }

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -1,0 +1,1120 @@
+use std::panic::AssertUnwindSafe;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::FutureExt;
+use futures::stream::{BoxStream, Stream, StreamExt};
+use futures::task::noop_waker_ref;
+use tokio::sync::mpsc;
+use tokio::task::{AbortHandle, JoinSet};
+use tokio_stream::StreamMap;
+
+use crate::command::{Action, CancelPolicy, CommandId};
+
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub(super) enum CommandOutput<Msg> {
+    Message(Msg),
+    Quit,
+}
+
+#[cfg_attr(test, derive(Debug, PartialEq, Eq))]
+pub(super) enum ReceiverEvent<Msg> {
+    Output(CommandOutput<Msg>),
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ReceiverFacts {
+    sender_closed: bool,
+    buffered: usize,
+}
+
+struct CommandReceiver<Msg> {
+    receiver: mpsc::UnboundedReceiver<CommandOutput<Msg>>,
+    reported_closed: bool,
+}
+
+impl<Msg> CommandReceiver<Msg> {
+    const fn new(receiver: mpsc::UnboundedReceiver<CommandOutput<Msg>>) -> Self {
+        Self {
+            receiver,
+            reported_closed: false,
+        }
+    }
+
+    fn facts(&self) -> ReceiverFacts {
+        ReceiverFacts {
+            sender_closed: self.receiver.is_closed(),
+            buffered: self.receiver.len(),
+        }
+    }
+}
+
+impl<Msg> Stream for CommandReceiver<Msg> {
+    type Item = ReceiverEvent<Msg>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.receiver.poll_recv(cx) {
+            Poll::Ready(Some(output)) => Poll::Ready(Some(ReceiverEvent::Output(output))),
+            Poll::Ready(None) if !self.reported_closed => {
+                self.reported_closed = true;
+                Poll::Ready(Some(ReceiverEvent::Closed))
+            }
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+struct KeyedEntry<Msg> {
+    receiver: CommandReceiver<Msg>,
+    run: KeyRun,
+}
+
+impl<Msg> Stream for KeyedEntry<Msg> {
+    type Item = ReceiverEvent<Msg>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.receiver).poll_next(cx)
+    }
+}
+
+enum KeyRun {
+    Running { token: RunToken, abort: AbortHandle },
+    Draining { token: RunToken },
+}
+
+impl KeyRun {
+    const fn token(&self) -> RunToken {
+        match self {
+            Self::Running { token, .. } | Self::Draining { token } => *token,
+        }
+    }
+
+    const fn lifecycle_state(&self) -> LifecycleState {
+        match self {
+            Self::Running { token, .. } => LifecycleState::Running { token: *token },
+            Self::Draining { token } => LifecycleState::Draining { token: *token },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RunToken(u64);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum LifecycleState {
+    Running { token: RunToken },
+    Draining { token: RunToken },
+}
+
+impl LifecycleState {
+    const fn token(self) -> RunToken {
+        match self {
+            Self::Running { token } | Self::Draining { token } => token,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum LifecycleEvent {
+    Spawn {
+        token: RunToken,
+        policy: CancelPolicy,
+    },
+    Cancel,
+    Reconcile(ReceiverFacts),
+    Output(ReceiverFacts),
+    TaskExit {
+        token: RunToken,
+        facts: ReceiverFacts,
+    },
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct LifecycleEffects {
+    spawn: bool,
+    abort: bool,
+    drop_receiver: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct LifecycleTransition {
+    state: Option<LifecycleState>,
+    effects: LifecycleEffects,
+}
+
+fn lifecycle_transition(
+    state: Option<LifecycleState>,
+    event: LifecycleEvent,
+) -> LifecycleTransition {
+    let occupied = state.is_some();
+    let running = matches!(state, Some(LifecycleState::Running { .. }));
+
+    match event {
+        LifecycleEvent::Spawn { token, policy } => {
+            if occupied && policy == CancelPolicy::KeepInFlight {
+                return LifecycleTransition {
+                    state,
+                    effects: LifecycleEffects::default(),
+                };
+            }
+
+            LifecycleTransition {
+                state: Some(LifecycleState::Running { token }),
+                effects: LifecycleEffects {
+                    spawn: true,
+                    abort: running,
+                    drop_receiver: occupied,
+                },
+            }
+        }
+        LifecycleEvent::Cancel => LifecycleTransition {
+            state: None,
+            effects: LifecycleEffects {
+                spawn: false,
+                abort: running,
+                drop_receiver: occupied,
+            },
+        },
+        LifecycleEvent::Reconcile(facts) | LifecycleEvent::Output(facts) => {
+            let state = match state {
+                Some(_) if facts.sender_closed && facts.buffered == 0 => None,
+                Some(state) if facts.sender_closed => Some(LifecycleState::Draining {
+                    token: state.token(),
+                }),
+                state => state,
+            };
+            LifecycleTransition {
+                effects: LifecycleEffects {
+                    drop_receiver: occupied && state.is_none(),
+                    ..LifecycleEffects::default()
+                },
+                state,
+            }
+        }
+        LifecycleEvent::TaskExit { token, facts } => {
+            let matching = matches!(
+                state,
+                Some(LifecycleState::Running { token: current }) if current == token
+            );
+            let state = if matching {
+                if facts.buffered == 0 {
+                    None
+                } else {
+                    Some(LifecycleState::Draining { token })
+                }
+            } else {
+                state
+            };
+            LifecycleTransition {
+                effects: LifecycleEffects {
+                    drop_receiver: matching && state.is_none(),
+                    ..LifecycleEffects::default()
+                },
+                state,
+            }
+        }
+        LifecycleEvent::Closed => LifecycleTransition {
+            state: None,
+            effects: LifecycleEffects {
+                drop_receiver: occupied,
+                ..LifecycleEffects::default()
+            },
+        },
+    }
+}
+
+struct TaskExit {
+    id: CommandId,
+    token: RunToken,
+}
+
+pub(super) struct KeyedCommands<Msg: Send + 'static> {
+    entries: StreamMap<CommandId, KeyedEntry<Msg>>,
+    tasks: JoinSet<TaskExit>,
+    next_token: u64,
+}
+
+impl<Msg: Send + 'static> KeyedCommands<Msg> {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: StreamMap::new(),
+            tasks: JoinSet::new(),
+            next_token: 0,
+        }
+    }
+
+    pub(super) fn spawn(
+        &mut self,
+        id: CommandId,
+        policy: CancelPolicy,
+        stream: BoxStream<'static, Action<Msg>>,
+    ) {
+        self.reconcile_available();
+        let token = RunToken(self.next_token);
+        let state = self.reconcile_receiver(&id);
+        let transition = lifecycle_transition(state, LifecycleEvent::Spawn { token, policy });
+        if !transition.effects.spawn {
+            tracing::trace!(
+                target: "tears::runtime",
+                id = ?id,
+                "keyed command kept in-flight; new stream dropped"
+            );
+            return;
+        }
+
+        self.apply_transition(&id, state, transition);
+        self.next_token = self.next_token.wrapping_add(1);
+        let (output_tx, output_rx) = mpsc::unbounded_channel();
+        let task_id = id.clone();
+
+        let abort = self.tasks.spawn(async move {
+            let result = AssertUnwindSafe(async move {
+                futures::pin_mut!(stream);
+                while let Some(action) = stream.next().await {
+                    match action {
+                        Action::Message(message) => {
+                            if output_tx.send(CommandOutput::Message(message)).is_err() {
+                                break;
+                            }
+                        }
+                        Action::Quit => {
+                            let _ = output_tx.send(CommandOutput::Quit);
+                            break;
+                        }
+                    }
+                }
+            })
+            .catch_unwind()
+            .await;
+
+            if let Err(error) = result {
+                tracing::error!(
+                    target: "tears::runtime",
+                    panic = ?error,
+                    "keyed command task panicked"
+                );
+            }
+
+            TaskExit { id: task_id, token }
+        });
+
+        tracing::trace!(target: "tears::runtime", id = ?id, "keyed command spawned");
+        self.entries.insert(
+            id,
+            KeyedEntry {
+                receiver: CommandReceiver::new(output_rx),
+                run: KeyRun::Running { token, abort },
+            },
+        );
+    }
+
+    pub(super) fn cancel(&mut self, id: &CommandId) {
+        let state = self.lifecycle_state(id);
+        let transition = lifecycle_transition(state, LifecycleEvent::Cancel);
+        if transition.effects.drop_receiver {
+            self.apply_transition(id, state, transition);
+            tracing::trace!(target: "tears::runtime", id = ?id, "keyed command cancelled");
+        }
+    }
+
+    pub(super) fn reconcile_available(&mut self) {
+        while let Some(result) = self.tasks.try_join_next() {
+            if let Ok(exit) = result {
+                self.record_task_exit(&exit);
+            }
+        }
+    }
+
+    fn record_task_exit(&mut self, exit: &TaskExit) {
+        let Some((state, facts)) = self.entries.iter().find_map(|(id, entry)| {
+            (id == &exit.id).then(|| (entry.run.lifecycle_state(), entry.receiver.facts()))
+        }) else {
+            return;
+        };
+        let transition = lifecycle_transition(
+            Some(state),
+            LifecycleEvent::TaskExit {
+                token: exit.token,
+                facts,
+            },
+        );
+        self.apply_transition(&exit.id, Some(state), transition);
+    }
+
+    fn record_receiver_event(&mut self, id: &CommandId, event: &ReceiverEvent<Msg>) {
+        let Some((state, facts)) = self.entries.iter().find_map(|(entry_id, entry)| {
+            (entry_id == id).then(|| (entry.run.lifecycle_state(), entry.receiver.facts()))
+        }) else {
+            return;
+        };
+        let lifecycle_event = match event {
+            ReceiverEvent::Output(_) => LifecycleEvent::Output(facts),
+            ReceiverEvent::Closed => LifecycleEvent::Closed,
+        };
+        let transition = lifecycle_transition(Some(state), lifecycle_event);
+        self.apply_transition(id, Some(state), transition);
+    }
+
+    fn reconcile_receiver(&mut self, id: &CommandId) -> Option<LifecycleState> {
+        let (state, facts) = self.entries.iter().find_map(|(entry_id, entry)| {
+            (entry_id == id).then(|| (entry.run.lifecycle_state(), entry.receiver.facts()))
+        })?;
+        let transition = lifecycle_transition(Some(state), LifecycleEvent::Reconcile(facts));
+        self.apply_transition(id, Some(state), transition);
+        transition.state
+    }
+
+    fn lifecycle_state(&self, id: &CommandId) -> Option<LifecycleState> {
+        self.entries
+            .iter()
+            .find_map(|(entry_id, entry)| (entry_id == id).then(|| entry.run.lifecycle_state()))
+    }
+
+    fn apply_transition(
+        &mut self,
+        id: &CommandId,
+        current: Option<LifecycleState>,
+        transition: LifecycleTransition,
+    ) {
+        if current == transition.state && transition.effects == LifecycleEffects::default() {
+            return;
+        }
+        let Some(mut entry) = self.entries.remove(id) else {
+            return;
+        };
+
+        if transition.effects.abort
+            && let KeyRun::Running { abort, .. } = &entry.run
+        {
+            abort.abort();
+        }
+
+        if transition.effects.drop_receiver {
+            return;
+        }
+
+        match transition.state {
+            None => {
+                debug_assert!(transition.effects.drop_receiver);
+            }
+            Some(LifecycleState::Running { token }) => {
+                debug_assert_eq!(entry.run.token(), token);
+                self.entries.insert(id.clone(), entry);
+            }
+            Some(LifecycleState::Draining { token }) => {
+                entry.run = KeyRun::Draining { token };
+                self.entries.insert(id.clone(), entry);
+            }
+        }
+    }
+
+    pub(super) fn try_next_ready(&mut self) -> Option<(CommandId, ReceiverEvent<Msg>)> {
+        self.reconcile_available();
+        let mut context = Context::from_waker(noop_waker_ref());
+        match Pin::new(&mut self.entries).poll_next(&mut context) {
+            Poll::Ready(Some((id, event))) => {
+                self.record_receiver_event(&id, &event);
+                Some((id, event))
+            }
+            Poll::Ready(None) | Poll::Pending => None,
+        }
+    }
+
+    pub(super) fn shutdown(&mut self) {
+        self.tasks.abort_all();
+        self.entries.clear();
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn contains(&self, id: &CommandId) -> bool {
+        self.entries.contains_key(id)
+    }
+
+    #[cfg(test)]
+    pub(super) fn has_closed_buffered(&self, id: &CommandId) -> bool {
+        self.entries.iter().any(|(entry_id, entry)| {
+            entry_id == id && {
+                let facts = entry.receiver.facts();
+                facts.sender_closed && facts.buffered > 0
+            }
+        })
+    }
+}
+
+impl<Msg: Send + 'static> Stream for KeyedCommands<Msg> {
+    type Item = (CommandId, ReceiverEvent<Msg>);
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let manager = &mut *self;
+        manager.reconcile_available();
+        match Pin::new(&mut manager.entries).poll_next(cx) {
+            Poll::Ready(Some((id, event))) => {
+                manager.record_receiver_event(&id, &event);
+                Poll::Ready(Some((id, event)))
+            }
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::future::pending;
+    use std::num::NonZeroUsize;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use futures::stream;
+    use tokio::sync::oneshot;
+    use tokio::task::yield_now;
+    use tokio::time::{advance, timeout};
+    use tracing::Level;
+
+    use crate::Command;
+    use crate::command::RetryPolicy;
+    use crate::test_support::{TraceRecorder, wait_until, with_silent_panic_hook};
+
+    fn actions<I>(items: I) -> BoxStream<'static, Action<i32>>
+    where
+        I: IntoIterator<Item = Action<i32>>,
+        I::IntoIter: Send + 'static,
+    {
+        stream::iter(items).boxed()
+    }
+
+    fn command_stream(command: Command<i32>) -> BoxStream<'static, Action<i32>> {
+        let (_, _, stream) = command.into_runtime_parts().into_execution_parts();
+        stream.expect("command should have a stream")
+    }
+
+    async fn wait_for_closed_buffered(manager: &mut KeyedCommands<i32>, id: &CommandId) {
+        wait_until(
+            || {
+                manager.entries.iter().any(|(entry_id, entry)| {
+                    entry_id == id && {
+                        let facts = entry.receiver.facts();
+                        facts.sender_closed && facts.buffered > 0
+                    }
+                })
+            },
+            "keyed output should become buffered after its task finishes",
+        )
+        .await;
+        manager.reconcile_available();
+    }
+
+    fn take_message(manager: &mut KeyedCommands<i32>, expected_id: &CommandId) -> i32 {
+        let (id, event) = manager
+            .try_next_ready()
+            .expect("keyed output should be ready");
+        assert_eq!(&id, expected_id);
+        match event {
+            ReceiverEvent::Output(CommandOutput::Message(message)) => Some(message),
+            ReceiverEvent::Output(CommandOutput::Quit) | ReceiverEvent::Closed => None,
+        }
+        .expect("expected a keyed message")
+    }
+
+    #[tokio::test]
+    async fn cancel_in_flight_drops_finished_buffered_output() {
+        let id = CommandId::new("search");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(2)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        assert_eq!(take_message(&mut manager, &id), 2);
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn explicit_cancel_is_strict_and_idempotent() {
+        let id = CommandId::new("search");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1), Action::Message(2)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        manager.cancel(&id);
+        manager.cancel(&id);
+
+        assert!(!manager.contains(&id));
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn explicit_cancel_aborts_running_work() {
+        struct AbortGuard(Arc<AtomicBool>);
+
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let id = CommandId::new("search");
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard = AbortGuard(Arc::clone(&dropped));
+        let (started_tx, started_rx) = oneshot::channel();
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(async move {
+                let _guard = guard;
+                let _ = started_tx.send(());
+                pending().await
+            })),
+        );
+
+        timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("keyed command should start before the timeout")
+            .expect("keyed command should signal that it started");
+        manager.cancel(&id);
+
+        wait_until(
+            || dropped.load(Ordering::SeqCst),
+            "explicit cancellation should drop running keyed work",
+        )
+        .await;
+        assert!(!manager.contains(&id));
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn transition_applier_honors_abort_without_dropping_the_receiver() {
+        struct AbortGuard(Arc<AtomicBool>);
+
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let id = CommandId::new("abort-only");
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard = AbortGuard(Arc::clone(&dropped));
+        let (started_tx, started_rx) = oneshot::channel();
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(async move {
+                let _guard = guard;
+                let _ = started_tx.send(());
+                pending().await
+            })),
+        );
+        timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("keyed command should start before the timeout")
+            .expect("keyed command should signal that it started");
+
+        let state = manager.lifecycle_state(&id);
+        manager.apply_transition(
+            &id,
+            state,
+            LifecycleTransition {
+                state,
+                effects: LifecycleEffects {
+                    abort: true,
+                    ..LifecycleEffects::default()
+                },
+            },
+        );
+
+        wait_until(
+            || dropped.load(Ordering::SeqCst),
+            "abort-only transition should stop the task",
+        )
+        .await;
+        assert!(manager.contains(&id));
+        manager.cancel(&id);
+    }
+
+    #[tokio::test]
+    async fn keep_in_flight_preserves_finished_buffered_output() {
+        let id = CommandId::new("submit");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::KeepInFlight,
+            actions([Action::Message(2)]),
+        );
+
+        assert_eq!(take_message(&mut manager, &id), 1);
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn keep_in_flight_rechecks_a_closed_empty_receiver_before_task_exit() {
+        let id = CommandId::new("submit");
+        let token = RunToken(0);
+        let mut manager = KeyedCommands::new();
+        // Model the panic-reporting window: the task still has no published
+        // TaskExit, but unwinding has already dropped its output sender.
+        let (output_tx, output_rx) = mpsc::unbounded_channel();
+        drop(output_tx);
+        let abort = manager.tasks.spawn(pending::<TaskExit>());
+        manager.entries.insert(
+            id.clone(),
+            KeyedEntry {
+                receiver: CommandReceiver::new(output_rx),
+                run: KeyRun::Running { token, abort },
+            },
+        );
+        manager.next_token = 1;
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::KeepInFlight,
+            actions([Action::Message(2)]),
+        );
+
+        assert_eq!(
+            manager.lifecycle_state(&id),
+            Some(LifecycleState::Running { token: RunToken(1) })
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+        assert_eq!(take_message(&mut manager, &id), 2);
+        manager.shutdown();
+    }
+
+    #[tokio::test]
+    async fn delivering_the_closed_senders_last_item_releases_the_id_for_retry() {
+        let id = CommandId::new("submit");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        assert_eq!(take_message(&mut manager, &id), 1);
+        assert!(!manager.contains(&id));
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::KeepInFlight,
+            actions([Action::Message(2)]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+        assert_eq!(take_message(&mut manager, &id), 2);
+    }
+
+    #[tokio::test]
+    async fn keep_in_flight_does_not_spawn_while_sender_is_open() {
+        let id = CommandId::new("submit");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(pending())),
+        );
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::KeepInFlight,
+            actions([Action::Message(2)]),
+        );
+
+        assert!(manager.contains(&id));
+        assert!(manager.try_next_ready().is_none());
+        manager.cancel(&id);
+    }
+
+    #[tokio::test]
+    async fn cancelling_buffered_quit_suppresses_it() {
+        let id = CommandId::new("quit");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Quit]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        manager.cancel(&id);
+
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancelling_suppresses_a_pending_timeout_message() {
+        let id = CommandId::new("timeout");
+        let mut manager = KeyedCommands::new();
+        let command = Command::future(pending())
+            .timeout(Duration::from_secs(5), || 99)
+            .cancellable(id.clone());
+        let (_, key, stream) = command.into_runtime_parts().into_execution_parts();
+        let key = key.expect("key should be present");
+        manager.spawn(key.id, key.policy, stream.expect("stream should exist"));
+
+        assert!(manager.try_next_ready().is_none());
+        manager.cancel(&id);
+        advance(Duration::from_secs(5)).await;
+
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn superseding_during_retry_backoff_suppresses_the_old_final_message() {
+        let id = CommandId::new("retry");
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let operation_attempts = Arc::clone(&attempts);
+        let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"))
+            .with_fixed_backoff(Duration::from_secs(5));
+        let retry = Command::retry(
+            policy,
+            move |_| {
+                operation_attempts.fetch_add(1, Ordering::SeqCst);
+                async { Err::<i32, &'static str>("temporary") }
+            },
+            |_| 1,
+        );
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(retry),
+        );
+        wait_until(
+            || attempts.load(Ordering::SeqCst) == 1,
+            "retry should enter its first backoff",
+        )
+        .await;
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(2)]),
+        );
+        advance(Duration::from_secs(10)).await;
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        assert_eq!(take_message(&mut manager, &id), 2);
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    #[tokio::test]
+    async fn keep_in_flight_prevents_a_second_retry_from_starting() {
+        let id = CommandId::new("retry");
+        let second_attempts = Arc::new(AtomicUsize::new(0));
+        let observed_second_attempts = Arc::clone(&second_attempts);
+        let policy = RetryPolicy::new(NonZeroUsize::new(2).expect("non-zero"));
+        let first = Command::future(pending());
+        let second = Command::retry(
+            policy,
+            move |_| {
+                observed_second_attempts.fetch_add(1, Ordering::SeqCst);
+                async { Ok::<i32, &'static str>(2) }
+            },
+            |result| result.expect("second retry would succeed"),
+        );
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(first),
+        );
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::KeepInFlight,
+            command_stream(second),
+        );
+        yield_now().await;
+
+        assert_eq!(second_attempts.load(Ordering::SeqCst), 0);
+        manager.cancel(&id);
+    }
+
+    #[tokio::test]
+    async fn stale_completion_cannot_remove_or_mutate_a_successor() {
+        let id = CommandId::new("search");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(pending())),
+        );
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(pending())),
+        );
+
+        // Inject the old run's normal completion directly. The real aborted
+        // task reaps as JoinError::cancelled and cannot exercise this branch.
+        manager.record_task_exit(&TaskExit {
+            id: id.clone(),
+            token: RunToken(0),
+        });
+
+        assert!(manager.contains(&id));
+        assert_eq!(
+            manager.lifecycle_state(&id),
+            Some(LifecycleState::Running { token: RunToken(1) })
+        );
+        manager.cancel(&id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(clippy::panic, reason = "the command intentionally panics")]
+    async fn keyed_task_panic_is_logged() {
+        let recorder = TraceRecorder::new()
+            .with_target("tears::runtime")
+            .with_level(Level::ERROR);
+        let _guard = recorder.set_default();
+        let id = CommandId::new("panic");
+        let mut manager = KeyedCommands::new();
+        let (event_count, contains_id) = with_silent_panic_hook(async {
+            manager.spawn(
+                id.clone(),
+                CancelPolicy::CancelInFlight,
+                command_stream(Command::future(async {
+                    panic!("boom");
+                    #[allow(unreachable_code)]
+                    1
+                })),
+            );
+
+            wait_until(
+                || recorder.event_count() == 1,
+                "keyed task panic should emit an error event",
+            )
+            .await;
+            manager.reconcile_available();
+            (recorder.event_count(), manager.contains(&id))
+        })
+        .await;
+
+        assert_eq!(event_count, 1);
+        assert!(!contains_id);
+    }
+
+    #[tokio::test]
+    async fn shutdown_aborts_keyed_tasks() {
+        struct AbortGuard(Arc<AtomicBool>);
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard = AbortGuard(Arc::clone(&dropped));
+        let id = CommandId::new("running");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id,
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(async move {
+                let _guard = guard;
+                pending().await
+            })),
+        );
+        yield_now().await;
+
+        manager.shutdown();
+        wait_until(
+            || dropped.load(Ordering::SeqCst),
+            "shutdown should drop the running keyed future",
+        )
+        .await;
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_model_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[derive(Clone, Copy, Debug)]
+    enum Input {
+        SpawnCancel,
+        SpawnKeep,
+        Cancel,
+        Reconcile(ReceiverFacts),
+        Output(ReceiverFacts),
+        TaskExit {
+            token: RunToken,
+            facts: ReceiverFacts,
+        },
+        Closed,
+    }
+
+    #[derive(Debug)]
+    struct Model {
+        state: Option<LifecycleState>,
+        next_token: u64,
+    }
+
+    impl Model {
+        const fn new() -> Self {
+            Self {
+                state: None,
+                next_token: 0,
+            }
+        }
+
+        fn apply(&mut self, input: Input) -> LifecycleEffects {
+            let event = match input {
+                Input::SpawnCancel => LifecycleEvent::Spawn {
+                    token: RunToken(self.next_token),
+                    policy: CancelPolicy::CancelInFlight,
+                },
+                Input::SpawnKeep => LifecycleEvent::Spawn {
+                    token: RunToken(self.next_token),
+                    policy: CancelPolicy::KeepInFlight,
+                },
+                Input::Cancel => LifecycleEvent::Cancel,
+                Input::Reconcile(facts) => LifecycleEvent::Reconcile(facts),
+                Input::Output(facts) => LifecycleEvent::Output(facts),
+                Input::TaskExit { token, facts } => LifecycleEvent::TaskExit { token, facts },
+                Input::Closed => LifecycleEvent::Closed,
+            };
+            let transition = lifecycle_transition(self.state, event);
+            if transition.effects.spawn {
+                self.next_token = self.next_token.wrapping_add(1);
+            }
+            self.state = transition.state;
+            transition.effects
+        }
+    }
+
+    fn facts() -> impl Strategy<Value = ReceiverFacts> {
+        (any::<bool>(), 0_usize..4).prop_map(|(sender_closed, buffered)| ReceiverFacts {
+            sender_closed,
+            buffered,
+        })
+    }
+
+    fn inputs() -> impl Strategy<Value = Vec<Input>> {
+        prop::collection::vec(
+            prop_oneof![
+                Just(Input::SpawnCancel),
+                Just(Input::SpawnKeep),
+                Just(Input::Cancel),
+                facts().prop_map(Input::Reconcile),
+                facts().prop_map(Input::Output),
+                (any::<u64>(), facts()).prop_map(|(token, facts)| Input::TaskExit {
+                    token: RunToken(token),
+                    facts,
+                }),
+                Just(Input::Closed),
+            ],
+            0..128,
+        )
+    }
+
+    #[test]
+    fn closed_empty_reconciliation_drops_the_owned_receiver() {
+        let transition = lifecycle_transition(
+            Some(LifecycleState::Running { token: RunToken(7) }),
+            LifecycleEvent::Reconcile(ReceiverFacts {
+                sender_closed: true,
+                buffered: 0,
+            }),
+        );
+
+        assert_eq!(
+            transition,
+            LifecycleTransition {
+                state: None,
+                effects: LifecycleEffects {
+                    drop_receiver: true,
+                    ..LifecycleEffects::default()
+                },
+            }
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn lifecycle_invariants_hold_for_arbitrary_sequences(sequence in inputs()) {
+            let mut model = Model::new();
+
+            for input in sequence {
+                let before = model.state;
+                let effects = model.apply(input);
+
+                match input {
+                    Input::Cancel => {
+                        prop_assert_eq!(effects.drop_receiver, before.is_some());
+                        prop_assert_eq!(model.state, None);
+                    }
+                    Input::SpawnKeep if before.is_some() => {
+                        prop_assert!(!effects.spawn);
+                        prop_assert_eq!(model.state, before);
+                    }
+                    Input::SpawnCancel => {
+                        prop_assert!(effects.spawn);
+                        prop_assert_eq!(effects.drop_receiver, before.is_some());
+                    }
+                    Input::TaskExit { token, .. } => {
+                        let matches_current = matches!(
+                            before,
+                            Some(LifecycleState::Running { token: current }) if current == token
+                        );
+                        if !matches_current {
+                            prop_assert_eq!(model.state, before);
+                        }
+                    }
+                    Input::Reconcile(ReceiverFacts { sender_closed: true, buffered: 0 })
+                    | Input::Output(ReceiverFacts { sender_closed: true, buffered: 0 }) => {
+                        prop_assert_eq!(model.state, None);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        #[test]
+        fn cancel_is_idempotent(sequence in inputs()) {
+            let mut model = Model::new();
+            for input in sequence {
+                model.apply(input);
+            }
+
+            model.apply(Input::Cancel);
+            let after_first = model.state;
+            let second_effects = model.apply(Input::Cancel);
+
+            prop_assert_eq!(after_first, None);
+            prop_assert_eq!(model.state, None);
+            prop_assert_eq!(second_effects, LifecycleEffects::default());
+        }
+    }
+}

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,8 +5,12 @@
 //! intentionally be duplicated in integration-test `common` modules; that is
 //! clearer than a workspace-only helper crate until reuse grows.
 
-use std::sync::Mutex;
+use std::future::Future;
+use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
+use std::sync::{Mutex, PoisonError};
+use std::thread;
 
+use futures::FutureExt;
 use ratatui::Frame;
 
 use crate::application::Application;
@@ -26,6 +30,74 @@ mod trace_recorder;
 /// records hook activity and a test that panics must not run concurrently, or
 /// the panicking test's hook invocation would pollute the recording one.
 pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
+
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+struct SilentPanicHook {
+    previous: Option<PanicHook>,
+}
+
+impl SilentPanicHook {
+    fn install() -> Self {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(|_info| {}));
+        Self {
+            previous: Some(previous),
+        }
+    }
+
+    fn restore(mut self) {
+        self.restore_inner();
+    }
+
+    fn restore_inner(&mut self) {
+        if let Some(hook) = self.previous.take() {
+            panic::set_hook(hook);
+        }
+    }
+}
+
+impl Drop for SilentPanicHook {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            self.restore_inner();
+        }
+    }
+}
+
+/// Runs a future with a no-op process-global panic hook installed.
+///
+/// Panics from the future are caught long enough to restore the previous hook,
+/// then resumed. Cancellation also restores the hook through the internal drop
+/// guard. This helper is for `current_thread` tests because it holds
+/// [`PANIC_HOOK_GUARD`] across `.await`.
+#[allow(
+    clippy::await_holding_lock,
+    clippy::future_not_send,
+    reason = "the helper intentionally serializes a process-global hook across a current-thread future"
+)]
+pub async fn with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let _hook_guard = PANIC_HOOK_GUARD
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    run_with_silent_panic_hook(future).await
+}
+
+async fn run_with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let hook = SilentPanicHook::install();
+    let result = AssertUnwindSafe(future).catch_unwind().await;
+    hook.restore();
+    match result {
+        Ok(output) => output,
+        Err(payload) => panic::resume_unwind(payload),
+    }
+}
 
 /// A minimal counter [`Application`] shared by the runtime and runtime-core
 /// tests. Increments on [`TestMessage::Increment`] and quits on
@@ -76,5 +148,47 @@ impl Application for TestApp {
 
     fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
         vec![]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(
+        clippy::await_holding_lock,
+        clippy::panic,
+        reason = "the test verifies hook restoration across an intentional panic on one thread"
+    )]
+    async fn silent_scope_restores_the_previous_hook_before_resuming_a_panic() {
+        let hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let original = panic::take_hook();
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let recorded_calls = Arc::clone(&hook_calls);
+        panic::set_hook(Box::new(move |_info| {
+            recorded_calls.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        let outcome = AssertUnwindSafe(run_with_silent_panic_hook(async {
+            panic!("silenced panic");
+        }))
+        .catch_unwind()
+        .await;
+        let probe = panic::catch_unwind(|| panic!("restored hook probe"));
+
+        let restored_hook = panic::take_hook();
+        panic::set_hook(original);
+        drop(restored_hook);
+        drop(hook_guard);
+
+        assert!(outcome.is_err());
+        assert!(probe.is_err());
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/tests/common/panic_hook.rs
+++ b/tests/common/panic_hook.rs
@@ -1,11 +1,14 @@
 // Focused local guard for integration tests that mutate the process-global
 // panic hook, per docs/testing.md "Process-Global Panic Hook Tests". Kept
-// separate from `crate::test_support::PANIC_HOOK_GUARD` (crate-internal,
-// synchronous-only) because integration tests need to hold the guard across
-// `.await` while a spawned command panics.
+// separate because crate test support is not public API, and uses an async
+// mutex because integration tests may hold the guard across `.await` while a
+// spawned command panics.
 
-use std::panic::{self, PanicHookInfo};
+use std::future::Future;
+use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
+use std::thread;
 
+use futures::FutureExt;
 use tokio::sync::Mutex;
 
 /// Serializes integration tests that install a process-global panic hook.
@@ -18,33 +21,62 @@ pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::const_new(());
 
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
 
-/// Installs a no-op panic hook for as long as the guard is held, restoring
-/// the previous hook on drop.
-///
-/// The default hook synchronously captures and symbolicates a backtrace when
-/// `RUST_BACKTRACE=1` (set repo-wide in CI), on the panicking thread, before
-/// `catch_unwind` regains control. On Windows this symbolication can be slow
-/// enough to blow through a bounded `timeout`, especially when the panic
-/// happens on a `current_thread` runtime where the same thread also drives
-/// the timers/subscriptions the test is waiting on. See docs/testing.md.
-pub struct SilentPanicHook {
+struct SilentPanicHook {
     previous: Option<PanicHook>,
 }
 
 impl SilentPanicHook {
-    pub fn install() -> Self {
+    fn install() -> Self {
         let previous = panic::take_hook();
         panic::set_hook(Box::new(|_info| {}));
         Self {
             previous: Some(previous),
         }
     }
+
+    fn restore(mut self) {
+        self.restore_inner();
+    }
+
+    fn restore_inner(&mut self) {
+        if let Some(hook) = self.previous.take() {
+            panic::set_hook(hook);
+        }
+    }
 }
 
 impl Drop for SilentPanicHook {
     fn drop(&mut self) {
-        if let Some(hook) = self.previous.take() {
-            panic::set_hook(hook);
+        if !thread::panicking() {
+            self.restore_inner();
         }
+    }
+}
+
+/// Runs a future with the default panic reporter silenced.
+///
+/// The previous process-global hook is restored before a panic from `future`
+/// is resumed. Cancellation restores it through the internal drop guard. The
+/// default hook can synchronously symbolize a backtrace under
+/// `RUST_BACKTRACE=1`, so timing-bound panic tests should use this scope rather
+/// than installing hooks directly. See `docs/testing.md`.
+pub async fn with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let _hook_guard = PANIC_HOOK_GUARD.lock().await;
+    run_with_silent_panic_hook(future).await
+}
+
+async fn run_with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let hook = SilentPanicHook::install();
+    let result = AssertUnwindSafe(future).catch_unwind().await;
+    hook.restore();
+    match result {
+        Ok(output) => output,
+        Err(payload) => panic::resume_unwind(payload),
     }
 }

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -175,9 +175,6 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
     // enough, on this `current_thread` runtime, to blow through the timeout
     // below before the Timer subscription gets a chance to send Quit. Silence
     // the hook for the panic this test triggers; see docs/testing.md.
-    let _hook_guard = panic_hook::PANIC_HOOK_GUARD.lock().await;
-    let _silent_hook = panic_hook::SilentPanicHook::install();
-
     let recorder = TraceRecorder::new()
         .with_target("tears::runtime")
         .with_level(tracing::Level::ERROR);
@@ -186,7 +183,12 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
     let mut terminal = common::test_terminal()?;
     let runtime = Runtime::<PanicCommandApp>::new((), frame_rate(60));
 
-    timeout(Duration::from_secs(5), runtime.run(&mut terminal)).await??;
+    let run_result = panic_hook::with_silent_panic_hook(timeout(
+        Duration::from_secs(5),
+        runtime.run(&mut terminal),
+    ))
+    .await;
+    run_result??;
 
     assert!(
         recorder.event_count() >= 1,


### PR DESCRIPTION
## Summary

Implements [RFC 0003: Command Cancellation](docs/rfcs/0003-command-cancellation.md).

This PR adds opt-in keyed cancellation for command lifecycles while preserving the existing behavior of unkeyed commands. It also defines deterministic lifecycle semantics for cancellation, replacement, buffered output, task completion, and runtime shutdown.

## Public API

- Add `command::CommandId` for structurally typed command identities
- Add `command::CancelPolicy`
  - `CancelInFlight`
  - `KeepInFlight`
- Add:
  - `Command::cancellable`
  - `Command::cancellable_with`
  - `Command::cancel`

Cancellation types remain available only through the canonical `tears::command::*` path and are not re-exported from the crate root or prelude.

## Runtime behavior

- Route keyed command output through private per-command receivers
- Track keyed tasks separately with `JoinSet`
- Model keyed command lifecycles as `Running`, `Draining`, or absent
- Use run tokens so stale `TaskExit` events cannot remove or mutate a successor
- Abort keyed tasks during:
  - explicit cancellation
  - `CancelInFlight` replacement
  - runtime shutdown
  - `RuntimeCore` drop
- Suppress stale buffered messages and `Quit` actions after cancellation or replacement
- Preserve buffered output for `KeepInFlight`
- Log keyed task panics without allowing them to escape the runtime task wrapper
- Preserve shared-input-first ordering so an update can cancel ready keyed output before it is delivered

## Lifecycle correctness

- Keep receiver lifecycle facts internal to `KeyedCommands`
- Apply receiver transitions before an event leaves the keyed-command module
- Use one pure lifecycle transition function for production behavior and property tests
- Use a single transition applier for receiver removal, task abortion, and state updates
- Avoid `StreamMap` remove/reinsert churn for identity transitions
- Reap only completed `JoinSet` entries instead of scanning every live keyed receiver on each runtime wake-up
- Recheck the target receiver immediately before a spawn policy decision
  - A closed and empty receiver releases its ID even if `TaskExit` has not yet been published
  - This covers the panic-reporting interval after the output sender is dropped but before panic logging completes
- Ensure `AppInputs` terminates with `None` when the shared channel is closed and keyed reconciliation removes the final entry, rather than returning an unwakeable `Pending`

## Command composition

- Preserve cancellation metadata through `Command::map` and `Command::timeout`
- Fold explicit cancels and runtime directives through `Command::batch`
- Ignore child cancellation keys at the batch boundary and emit a warning-level event
- Apply explicit cancellations and redraw directives before discarding a `KeepInFlight` arrival
- Preserve timeout and retry cancellation behavior defined by RFC 0004

## Testing

- Add property tests over the production lifecycle transition function
- Inject stale `TaskExit` events directly to exercise token matching
- Add deterministic contract tests for:
  - cancellation of running and completed commands
  - buffered message and `Quit` suppression
  - `CancelInFlight` and `KeepInFlight` behavior
  - the closed-receiver/pre-`TaskExit` panic-reporting window
  - keyed task panic logging
  - runtime shutdown and `RuntimeCore` drop
  - batch child-key warning events
  - shared-first drain ordering
  - `AppInputs` closed-stream termination
  - timeout and retry integration
- Add scoped silent-panic-hook helpers for crate-internal and integration tests
  - catch unexpected test panics
  - restore the previous process-global hook
  - resume unwinding only after restoration
  - restore the hook when the scoped future is cancelled
- Add a regression test proving that the previous hook is restored before a captured panic resumes
- Update `docs/testing.md` with the safe panic-hook testing contract
- Update RFC 0003 to match the final event types, ownership boundaries, and reconciliation timing

## Verification

- `cargo test --all-targets --all-features`
  - 291 unit tests passed
  - all integration tests and enabled targets passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- Rust 1.88: `cargo check --all-targets --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`