### PR TITLE
fix(docs): make MockSource doctests actually run and type-check

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -104,26 +104,26 @@
 //!
 //! Use [`mock::MockSource`] for deterministic testing without real I/O:
 //!
-//! ```no_run
+//! ```
 //! use tears::SubscriptionSource;
 //! use tears::subscription::mock::MockSource;
 //! use futures::StreamExt;
 //!
-//! #[tokio::test]
-//! async fn test_example() {
-//!     // Create a controllable mock
-//!     let mock = MockSource::<i32>::new();
+//! # #[tokio::main(flavor = "current_thread")]
+//! # async fn main() {
+//! // Create a controllable mock
+//! let mock = MockSource::<i32>::new();
 //!
-//!     // Call the SubscriptionSource trait method directly to get a stream
-//!     let mut stream = mock.stream();
+//! // Call the SubscriptionSource trait method directly to get a stream
+//! let mut stream = mock.stream();
 //!
-//!     // Control events from your test
-//!     mock.emit(42).expect("should emit");
+//! // Control events from your test
+//! mock.emit(42).expect("should emit");
 //!
-//!     // Receive the value
-//!     let value = stream.next().await;
-//!     assert_eq!(value, Some(42));
-//! }
+//! // Receive the value
+//! let value = stream.next().await;
+//! assert_eq!(value, Some(42));
+//! # }
 //! ```
 //!
 //! See the [`mock`] module documentation for complete testing examples.

--- a/src/subscription/mock.rs
+++ b/src/subscription/mock.rs
@@ -13,9 +13,7 @@
 //! let subscription = Subscription::new(mock.clone());
 //!
 //! // Emit values from the mock (requires at least one receiver)
-//! # #[cfg(not(test))] // Skip in doctest
 //! let _ = mock.emit(42);
-//! # #[cfg(not(test))]
 //! let _ = mock.emit(100);
 //! ```
 //!
@@ -23,8 +21,9 @@
 //!
 //! `MockSource` is designed to be shared between your application and test code:
 //!
-//! ```no_run
+//! ```
 //! use tears::prelude::*;
+//! use tears::SubscriptionSource;
 //! use tears::subscription::mock::MockSource;
 //! # use ratatui::Frame;
 //!
@@ -54,22 +53,26 @@
 //!     }
 //! }
 //!
-//! #[tokio::test]
-//! async fn test_my_app() -> color_eyre::Result<()> {
-//!     let mock = MockSource::new();
+//! # #[tokio::main(flavor = "current_thread")]
+//! # async fn main() -> color_eyre::Result<()> {
+//! let mock = MockSource::new();
 //!
-//!     // Pass mock to app
-//!     let (mut app, _) = MyApp::new(mock.clone());
+//! // Pass mock to app
+//! let (mut app, _) = MyApp::new(mock.clone());
 //!
-//!     // Emit events from test
-//!     mock.emit(())?;
+//! // Emit requires at least one receiver; normally the runtime subscribes
+//! // via `app.subscriptions()`, but here we hold a stream directly.
+//! let _stream = mock.stream();
 //!
-//!     // Manually call update for unit testing
-//!     app.update(());
+//! // Emit events from test
+//! mock.emit(())?;
 //!
-//!     assert_eq!(app.count, 1);
-//!     Ok(())
-//! }
+//! // Manually call update for unit testing
+//! app.update(());
+//!
+//! assert_eq!(app.count, 1);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Dynamic Subscriptions


### PR DESCRIPTION
## Summary

- Two doctests (`src/subscription.rs` and `src/subscription/mock.rs`) were fenced with `no_run` and wrapped their bodies in `#[tokio::test] async fn ...`. Since rustdoc strips `#[test]`-attributed functions when compiling outside `--test` mode, these function bodies were never even type-checked, let alone executed.
- Rewrote both as directly-executed async examples using a hidden `#[tokio::main]` wrapper (`no_run` removed), so `cargo test --doc` now actually compiles and runs them.
- Running the previously-untested body in `mock.rs` surfaced a real bug in the example: `mock.emit(())?` had no live receiver (nothing had called `.stream()`), so it failed with a channel-closed error. Fixed by holding a `mock.stream()` receiver before emitting.
- Removed the `# #[cfg(not(test))]` hidden lines in the basic-usage example in `mock.rs`: doctests compile without `cfg(test)`, so this cfg never applied and did nothing.

## Test plan

- [x] `cargo test --doc` — all 43 doctests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean