### PR TITLE
refactor(test-support): split panic hook helpers into their own module

### DIFF
--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -5,12 +5,6 @@
 //! intentionally be duplicated in integration-test `common` modules; that is
 //! clearer than a workspace-only helper crate until reuse grows.
 
-use std::future::Future;
-use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
-use std::sync::{Mutex, PoisonError};
-use std::thread;
-
-use futures::FutureExt;
 use ratatui::Frame;
 
 use crate::application::Application;
@@ -18,86 +12,12 @@ use crate::command::Command;
 use crate::subscription::Subscription;
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
+pub use panic_hook::{PANIC_HOOK_GUARD, with_silent_panic_hook};
 pub use trace_recorder::TraceRecorder;
 
 mod async_utils;
+mod panic_hook;
 mod trace_recorder;
-
-/// Serializes tests that install a process-global panic hook or deliberately
-/// trigger panics.
-///
-/// The panic hook is process-global and shared across threads, so a test that
-/// records hook activity and a test that panics must not run concurrently, or
-/// the panicking test's hook invocation would pollute the recording one.
-pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
-
-type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
-
-struct SilentPanicHook {
-    previous: Option<PanicHook>,
-}
-
-impl SilentPanicHook {
-    fn install() -> Self {
-        let previous = panic::take_hook();
-        panic::set_hook(Box::new(|_info| {}));
-        Self {
-            previous: Some(previous),
-        }
-    }
-
-    fn restore(mut self) {
-        self.restore_inner();
-    }
-
-    fn restore_inner(&mut self) {
-        if let Some(hook) = self.previous.take() {
-            panic::set_hook(hook);
-        }
-    }
-}
-
-impl Drop for SilentPanicHook {
-    fn drop(&mut self) {
-        if !thread::panicking() {
-            self.restore_inner();
-        }
-    }
-}
-
-/// Runs a future with a no-op process-global panic hook installed.
-///
-/// Panics from the future are caught long enough to restore the previous hook,
-/// then resumed. Cancellation also restores the hook through the internal drop
-/// guard. This helper is for `current_thread` tests because it holds
-/// [`PANIC_HOOK_GUARD`] across `.await`.
-#[allow(
-    clippy::await_holding_lock,
-    clippy::future_not_send,
-    reason = "the helper intentionally serializes a process-global hook across a current-thread future"
-)]
-pub async fn with_silent_panic_hook<F, T>(future: F) -> T
-where
-    F: Future<Output = T>,
-{
-    let _hook_guard = PANIC_HOOK_GUARD
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner);
-    run_with_silent_panic_hook(future).await
-}
-
-async fn run_with_silent_panic_hook<F, T>(future: F) -> T
-where
-    F: Future<Output = T>,
-{
-    let hook = SilentPanicHook::install();
-    let result = AssertUnwindSafe(future).catch_unwind().await;
-    hook.restore();
-    match result {
-        Ok(output) => output,
-        Err(payload) => panic::resume_unwind(payload),
-    }
-}
 
 /// A minimal counter [`Application`] shared by the runtime and runtime-core
 /// tests. Increments on [`TestMessage::Increment`] and quits on
@@ -148,47 +68,5 @@ impl Application for TestApp {
 
     fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
         vec![]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
-    use super::*;
-
-    #[tokio::test(flavor = "current_thread")]
-    #[allow(
-        clippy::await_holding_lock,
-        clippy::panic,
-        reason = "the test verifies hook restoration across an intentional panic on one thread"
-    )]
-    async fn silent_scope_restores_the_previous_hook_before_resuming_a_panic() {
-        let hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
-        let original = panic::take_hook();
-        let hook_calls = Arc::new(AtomicUsize::new(0));
-        let recorded_calls = Arc::clone(&hook_calls);
-        panic::set_hook(Box::new(move |_info| {
-            recorded_calls.fetch_add(1, Ordering::SeqCst);
-        }));
-
-        let outcome = AssertUnwindSafe(run_with_silent_panic_hook(async {
-            panic!("silenced panic");
-        }))
-        .catch_unwind()
-        .await;
-        let probe = panic::catch_unwind(|| panic!("restored hook probe"));
-
-        let restored_hook = panic::take_hook();
-        panic::set_hook(original);
-        drop(restored_hook);
-        drop(hook_guard);
-
-        assert!(outcome.is_err());
-        assert!(probe.is_err());
-        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -1,0 +1,129 @@
+// Intentionally duplicated with `tests/common/panic_hook.rs`. A shared
+// workspace-only crate made publish/tarball behavior less intuitive for this
+// small helper, and a feature-gated public test API would add test invocation
+// constraints. Unit and integration tests keep local copies for now.
+
+use std::future::Future;
+use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
+use std::sync::{Mutex, PoisonError};
+use std::thread;
+
+use futures::FutureExt;
+
+/// Serializes tests that install a process-global panic hook or deliberately
+/// trigger panics.
+///
+/// The panic hook is process-global and shared across threads, so a test that
+/// records hook activity and a test that panics must not run concurrently, or
+/// the panicking test's hook invocation would pollute the recording one.
+pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
+
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+struct SilentPanicHook {
+    previous: Option<PanicHook>,
+}
+
+impl SilentPanicHook {
+    fn install() -> Self {
+        let previous = panic::take_hook();
+        panic::set_hook(Box::new(|_info| {}));
+        Self {
+            previous: Some(previous),
+        }
+    }
+
+    fn restore(mut self) {
+        self.restore_inner();
+    }
+
+    fn restore_inner(&mut self) {
+        if let Some(hook) = self.previous.take() {
+            panic::set_hook(hook);
+        }
+    }
+}
+
+impl Drop for SilentPanicHook {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            self.restore_inner();
+        }
+    }
+}
+
+/// Runs a future with a no-op process-global panic hook installed.
+///
+/// Panics from the future are caught long enough to restore the previous hook,
+/// then resumed. Cancellation also restores the hook through the internal drop
+/// guard. This helper is for `current_thread` tests because it holds
+/// [`PANIC_HOOK_GUARD`] across `.await`.
+#[allow(
+    clippy::await_holding_lock,
+    clippy::future_not_send,
+    reason = "the helper intentionally serializes a process-global hook across a current-thread future"
+)]
+pub async fn with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let _hook_guard = PANIC_HOOK_GUARD
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    run_with_silent_panic_hook(future).await
+}
+
+async fn run_with_silent_panic_hook<F, T>(future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    let hook = SilentPanicHook::install();
+    let result = AssertUnwindSafe(future).catch_unwind().await;
+    hook.restore();
+    match result {
+        Ok(output) => output,
+        Err(payload) => panic::resume_unwind(payload),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread")]
+    #[allow(
+        clippy::await_holding_lock,
+        clippy::panic,
+        reason = "the test verifies hook restoration across an intentional panic on one thread"
+    )]
+    async fn silent_scope_restores_the_previous_hook_before_resuming_a_panic() {
+        let hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let original = panic::take_hook();
+        let hook_calls = Arc::new(AtomicUsize::new(0));
+        let recorded_calls = Arc::clone(&hook_calls);
+        panic::set_hook(Box::new(move |_info| {
+            recorded_calls.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        let outcome = AssertUnwindSafe(run_with_silent_panic_hook(async {
+            panic!("silenced panic");
+        }))
+        .catch_unwind()
+        .await;
+        let probe = panic::catch_unwind(|| panic!("restored hook probe"));
+
+        let restored_hook = panic::take_hook();
+        panic::set_hook(original);
+        drop(restored_hook);
+        drop(hook_guard);
+
+        assert!(outcome.is_err());
+        assert!(probe.is_err());
+        assert_eq!(hook_calls.load(Ordering::SeqCst), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- Move `PANIC_HOOK_GUARD`, `SilentPanicHook`, and `with_silent_panic_hook` out of `src/test_support.rs` into a new `src/test_support/panic_hook.rs` submodule, matching the existing `async_utils`/`trace_recorder` split.
- Re-export via `pub use panic_hook::{PANIC_HOOK_GUARD, with_silent_panic_hook};` so every existing `crate::test_support::...` call site is unaffected.
- Gives `src/test_support/panic_hook.rs` the same duplication-rationale comment style as `async_utils.rs`/`trace_recorder.rs`, mirroring `tests/common/panic_hook.rs`.
- Checked `docs/testing.md`: all references use the public `crate::test_support::...` path, which is unchanged, so no doc updates were needed.

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --workspace`