### PR TITLE
docs(testing): point duplication comments at testing.md instead of restating it

### DIFF
--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -1,7 +1,6 @@
-// Intentionally duplicated with `tests/common/panic_hook.rs`. A shared
-// workspace-only crate made publish/tarball behavior less intuitive for this
-// small helper, and a feature-gated public test API would add test invocation
-// constraints. Unit and integration tests keep local copies for now.
+// Intentionally duplicated with `tests/common/panic_hook.rs`. See
+// docs/testing.md "Why Test Helpers Are Duplicated Instead of Shared" and
+// "Process-Global Panic Hook Tests" for why, and how the two copies differ.
 
 use std::future::Future;
 use std::panic::{self, AssertUnwindSafe, PanicHookInfo};

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -10,10 +10,8 @@ use tracing::span::{Attributes, Id, Record};
 use tracing::subscriber::{DefaultGuard, Interest, set_default};
 use tracing::{Dispatch, Event, Level, Metadata, Subscriber};
 
-// Intentionally duplicated with `tests/common/trace_recorder.rs`. A shared
-// workspace-only crate made publish/tarball behavior less intuitive for this
-// small helper, and a feature-gated public test API would add test invocation
-// constraints. Unit and integration tests keep local copies for now.
+// Intentionally duplicated with `tests/common/trace_recorder.rs`. See
+// docs/testing.md "Why Test Helpers Are Duplicated Instead of Shared" for why.
 
 // `tracing`'s dispatcher registry and callsite interest cache are process-wide.
 // Serialize recorder install/drop cache rebuilds, and keep a no-op dispatcher

--- a/tests/common/panic_hook.rs
+++ b/tests/common/panic_hook.rs
@@ -1,8 +1,6 @@
-// Focused local guard for integration tests that mutate the process-global
-// panic hook, per docs/testing.md "Process-Global Panic Hook Tests". Kept
-// separate because crate test support is not public API, and uses an async
-// mutex because integration tests may hold the guard across `.await` while a
-// spawned command panics.
+// Intentionally duplicated with `src/test_support/panic_hook.rs`. See
+// docs/testing.md "Why Test Helpers Are Duplicated Instead of Shared" and
+// "Process-Global Panic Hook Tests" for why, and how the two copies differ.
 
 use std::future::Future;
 use std::panic::{self, AssertUnwindSafe, PanicHookInfo};

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -10,10 +10,8 @@ use tracing::span::{Attributes, Id, Record};
 use tracing::subscriber::{DefaultGuard, Interest, set_default};
 use tracing::{Dispatch, Event, Level, Metadata, Subscriber};
 
-// Intentionally overlaps with `src/test_support/trace_recorder.rs`. A shared
-// workspace-only crate made publish/tarball behavior less intuitive for this
-// small helper, and a feature-gated public test API would add test invocation
-// constraints. Integration tests keep a local copy for now.
+// Intentionally duplicated with `src/test_support/trace_recorder.rs`. See
+// docs/testing.md "Why Test Helpers Are Duplicated Instead of Shared" for why.
 
 // `tracing`'s dispatcher registry and callsite interest cache are process-wide.
 // Serialize recorder install/drop cache rebuilds, and keep a no-op dispatcher


### PR DESCRIPTION
## Summary

Follow-up to #189, which merged before this second commit landed.

- Replace the rationale restated in the `src/test_support/{panic_hook,trace_recorder}.rs` and `tests/common/{panic_hook,trace_recorder}.rs` header comments with a pointer to `docs/testing.md` "Why Test Helpers Are Duplicated Instead of Shared" (and "Process-Global Panic Hook Tests" for the panic-hook pair), so the reasoning has a single source of truth instead of risking drift between the code comments and the doc.

## Test plan
- [x] `cargo build --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`