### PR TITLE
fix(runtime): pause the clock for the message-batching test

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -84,11 +84,10 @@
 //! }
 //! ```
 
-use std::time::{Duration, Instant};
-
 use color_eyre::eyre::Result;
 use futures::stream::StreamExt;
 use ratatui::prelude::Backend;
+use tokio::time::{Duration, Instant};
 
 use crate::{application::Application, command::Command};
 
@@ -224,7 +223,9 @@ impl<App: Application> Runtime<App> {
             InputOutcome::Quit => return BatchOutcome::Quit,
         };
 
-        // Micro-batching: process additional messages that arrived during a short window
+        // Micro-batching: process additional messages that arrived during a short window.
+        // Uses tokio::time::Instant (not std) so tests can pause the clock and avoid
+        // flaking under CI scheduling jitter around this tight deadline.
         let batch_deadline = Instant::now() + Duration::from_micros(100);
         while Instant::now() < batch_deadline {
             match self.core.app_inputs.try_next_ready() {
@@ -604,7 +605,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_event_loop_process_message_batch_with_batching() {
         let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 


### PR DESCRIPTION
## Summary
- CI failure: https://github.com/akiomik/tears/actions/runs/29227179588/job/86743623429 (`Test (ubuntu-latest, beta)`) — `runtime::tests::test_event_loop_process_message_batch_with_batching` failed with `left: 1, right: 4`, passed on rerun.
- Root cause: `process_input_batch`'s 100μs micro-batching window is a real-time busy-wait on `std::time::Instant`. Under CI scheduling jitter, the window can elapse after only the first message is processed, so the test's strict count assertion fails nondeterministically.
- Fix: switch the deadline to `tokio::time::Instant` (behaves identically to `std::time::Instant` in production) and mark the flaky test `#[tokio::test(start_paused = true)]`. Since the batching loop never `.await`s, the paused virtual clock can't advance mid-loop, so the test deterministically drains all queued messages regardless of runner speed.
- Audited the rest of the crate for other real-time-dependent tests built on `std::time::Instant`: the only other production usages (`subscription/http/cell.rs`, `subscription/http/query.rs`) are cache-timestamp bookkeeping whose tests use `Duration::ZERO`, so they don't depend on elapsed wall-clock time. No other issues found.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (293 tests passed)
- [x] `cargo clippy --all-features --all-targets` (clean)
- [x] `cargo fmt --check` (clean)
- [x] Ran `test_event_loop_process_message_batch_with_batching` 20x in a row to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWWmEs6wR2pFsNLzNR9Kki