### PR TITLE
docs: move command timeout/retry into examples, add cancellation demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,47 +184,6 @@ async fn main() -> Result<()> {
 }
 ```
 
-### Command timeouts and retries
-
-Commands can enforce an overall deadline without changing their message type:
-
-```rust
-use std::time::Duration;
-use tears::prelude::*;
-
-enum Message {
-    Loaded(String),
-    TimedOut,
-}
-
-let command = Command::perform(async { "data".to_string() }, Message::Loaded)
-    .timeout(Duration::from_secs(5), || Message::TimedOut);
-```
-
-Retrying commands take a factory so every attempt receives a fresh future.
-Retry support types are imported explicitly from `tears::command` rather than
-from the crate root or prelude:
-
-```rust
-use std::num::NonZeroUsize;
-use std::time::Duration;
-use tears::Command;
-use tears::command::{RetryError, RetryPolicy};
-
-enum Message {
-    Loaded(Result<String, RetryError<&'static str>>),
-}
-
-let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"))
-    .with_fixed_backoff(Duration::from_millis(200));
-
-let command = Command::retry(
-    policy,
-    |_| async { Ok::<_, &'static str>("data".to_string()) },
-    Message::Loaded,
-);
-```
-
 ## Architecture
 
 Tears follows **The Elm Architecture (TEA)** pattern:
@@ -279,8 +238,13 @@ Check out the [`examples/`](examples/) directory for more examples:
 - [`views.rs`](examples/views.rs) - Multiple view states with navigation and conditional subscriptions
 - [`dashboard.rs`](examples/dashboard.rs) - Structured state management with nested state and child messages
 - [`signals.rs`](examples/signals.rs) - OS signal handling with graceful shutdown (SIGINT, SIGTERM, etc.)
+- [`command_timeout_retry.rs`](examples/command_timeout_retry.rs) - Enforcing a `Command` deadline with `timeout` and recovering from failures with `retry`
+- [`command_cancellation.rs`](examples/command_cancellation.rs) - Cancelling superseded in-flight commands with `cancellable`/`cancellable_with` and `CancelPolicy`
 - [`websocket.rs`](examples/websocket.rs) - WebSocket echo chat demonstrating real-time communication (requires `ws` feature)
 - [`http_todo.rs`](examples/http_todo.rs) - HTTP Todo list with Query subscription, Mutation, and cache management (requires `http` feature)
+
+`RetryError`/`RetryPolicy` and `CommandId`/`CancelPolicy` are imported explicitly
+from `tears::command` rather than from the crate root or prelude.
 
 Run an example:
 
@@ -290,6 +254,8 @@ cargo run --example panic_hook
 cargo run --example views
 cargo run --example dashboard
 cargo run --example signals
+cargo run --example command_timeout_retry
+cargo run --example command_cancellation
 cargo run --example websocket --features ws,rustls
 cargo run --example http_todo --features http
 ```

--- a/examples/command_cancellation.rs
+++ b/examples/command_cancellation.rs
@@ -1,0 +1,253 @@
+//! Example demonstrating keyed command cancellation.
+//!
+//! Every keystroke starts a new "search" command tied to the same
+//! [`CommandId`], so the runtime can decide what to do with the previous
+//! in-flight search:
+//! - [`CancelPolicy::CancelInFlight`] (the default) aborts it and starts the
+//!   new one, so only the most recently typed query ever produces a result
+//! - [`CancelPolicy::KeepInFlight`] lets the current search finish and drops
+//!   the new command instead, so the results can lag behind what's typed
+//!
+//! # Running the example
+//!
+//! ```bash
+//! cargo run --example command_cancellation
+//! ```
+//!
+//! Then try:
+//! - Type letters to search (results arrive after a simulated 400ms delay)
+//! - Type quickly and compare how results settle under each policy
+//! - Press Tab to switch between `CancelInFlight` and `KeepInFlight`
+//! - Press Esc to clear the query and explicitly cancel any in-flight search
+//! - Press Backspace to edit the query
+//! - Press Ctrl+C to quit
+
+use std::io;
+use std::num::NonZeroU32;
+use std::time::Duration;
+
+use color_eyre::eyre::Result;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+use tears::command::{CancelPolicy, CommandId};
+use tears::prelude::*;
+use tears::subscription::terminal::TerminalEvents;
+use tokio::time::sleep;
+
+const WORDS: &[&str] = &[
+    "rust",
+    "ratatui",
+    "tokio",
+    "elm",
+    "tears",
+    "cancel",
+    "command",
+    "runtime",
+    "subscription",
+    "message",
+];
+
+#[derive(Debug)]
+enum Message {
+    Input(Event),
+    InputError(io::Error),
+    SearchFinished {
+        query: String,
+        results: Vec<&'static str>,
+    },
+}
+
+struct App {
+    should_quit: bool,
+    query: String,
+    policy: CancelPolicy,
+    log: Vec<String>,
+}
+
+impl Application for App {
+    type Message = Message;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (
+            Self {
+                should_quit: false,
+                query: String::new(),
+                policy: CancelPolicy::CancelInFlight,
+                log: vec!["Ready".to_string()],
+            },
+            Command::none(),
+        )
+    }
+
+    fn update(&mut self, msg: Message) -> Command<Message> {
+        match msg {
+            Message::Input(Event::Key(KeyEvent {
+                code, modifiers, ..
+            })) => match code {
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.should_quit = true;
+                    return Command::quit();
+                }
+                KeyCode::Tab => {
+                    self.policy = match self.policy {
+                        CancelPolicy::CancelInFlight => CancelPolicy::KeepInFlight,
+                        _ => CancelPolicy::CancelInFlight,
+                    };
+                    self.log
+                        .push(format!("Policy switched to {:?}", self.policy));
+                }
+                KeyCode::Esc => {
+                    self.query.clear();
+                    self.log
+                        .push("Query cleared, cancelling in-flight search".to_string());
+                    return Command::cancel(search_id());
+                }
+                KeyCode::Backspace => {
+                    self.query.pop();
+                    if self.query.is_empty() {
+                        self.log
+                            .push("Query empty, cancelling in-flight search".to_string());
+                        return Command::cancel(search_id());
+                    }
+                    return self.search_command();
+                }
+                KeyCode::Char(c) if !modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.query.push(c);
+                    return self.search_command();
+                }
+                _ => {}
+            },
+            Message::Input(_) => {}
+            Message::InputError(e) => {
+                self.log.push(format!("Terminal error: {e}"));
+                self.should_quit = true;
+            }
+            Message::SearchFinished { query, results } => {
+                self.log.push(format!("Results for '{query}': {results:?}"));
+            }
+        }
+
+        if self.should_quit {
+            Command::quit()
+        } else {
+            Command::none()
+        }
+    }
+
+    fn view(&self, frame: &mut Frame) {
+        let chunks = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+        let title = Paragraph::new("Command Cancellation Example")
+            .style(Style::default().fg(Color::Cyan))
+            .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(title, chunks[0]);
+
+        let status = Paragraph::new(format!(
+            "Query: {}  |  Policy: {:?}",
+            self.query, self.policy
+        ))
+        .style(Style::default().fg(Color::White))
+        .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(status, chunks[1]);
+
+        self.render_log(frame, chunks[2]);
+
+        let instructions = Paragraph::new(
+            "Type to search | Tab: toggle policy | Esc: clear & cancel | Backspace: edit | Ctrl+C: quit",
+        )
+        .style(Style::default().fg(Color::Gray))
+        .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(instructions, chunks[3]);
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Message>> {
+        vec![
+            Subscription::new(TerminalEvents::new()).map(|result| match result {
+                Ok(event) => Message::Input(event),
+                Err(e) => Message::InputError(e),
+            }),
+        ]
+    }
+}
+
+impl App {
+    fn search_command(&mut self) -> Command<Message> {
+        let query = self.query.clone();
+        self.log
+            .push(format!("Searching '{query}' (policy: {:?})", self.policy));
+
+        let message_query = query.clone();
+        Command::perform(search(query), move |results| Message::SearchFinished {
+            query: message_query,
+            results,
+        })
+        .cancellable_with(search_id(), self.policy)
+    }
+
+    fn render_log(&self, frame: &mut Frame, area: Rect) {
+        let items: Vec<ListItem> = self
+            .log
+            .iter()
+            .rev()
+            .take(20)
+            .map(|msg| {
+                ListItem::new(Line::from(vec![
+                    Span::raw("• "),
+                    Span::styled(msg, Style::default().fg(Color::Yellow)),
+                ]))
+            })
+            .collect();
+
+        let list = List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Log (most recent first)"),
+        );
+
+        frame.render_widget(list, area);
+    }
+}
+
+fn search_id() -> CommandId {
+    CommandId::new("search")
+}
+
+async fn search(query: String) -> Vec<&'static str> {
+    sleep(Duration::from_millis(400)).await;
+    let needle = query.to_lowercase();
+    WORDS
+        .iter()
+        .copied()
+        .filter(|word| word.contains(&needle))
+        .collect()
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut terminal = ratatui::init();
+
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
+    let result = runtime.run(&mut terminal).await;
+
+    ratatui::restore();
+
+    result?;
+
+    Ok(())
+}

--- a/examples/command_timeout_retry.rs
+++ b/examples/command_timeout_retry.rs
@@ -1,0 +1,233 @@
+//! Example demonstrating `Command::timeout` and `Command::retry`.
+//!
+//! This example shows four kinds of asynchronous outcomes:
+//! - A fetch that completes well within its deadline
+//! - A fetch that is slower than its deadline and times out
+//! - A flaky operation that fails twice and recovers on retry
+//! - A flaky operation that keeps failing until the retry policy is exhausted
+//!
+//! # Running the example
+//!
+//! ```bash
+//! cargo run --example command_timeout_retry
+//! ```
+//!
+//! Then try:
+//! - Press 'f' for a fast fetch (completes before the deadline)
+//! - Press 's' for a slow fetch (exceeds the deadline and times out)
+//! - Press 'r' for a flaky fetch that recovers after two failed attempts
+//! - Press 'x' for a flaky fetch that exhausts its retry attempts
+//! - Press Ctrl+C to quit
+
+use std::io;
+use std::num::{NonZeroU32, NonZeroUsize};
+use std::time::Duration;
+
+use color_eyre::eyre::Result;
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+};
+use tears::command::{RetryContext, RetryError, RetryPolicy};
+use tears::prelude::*;
+use tears::subscription::terminal::TerminalEvents;
+use tokio::time::sleep;
+
+#[derive(Debug)]
+enum Message {
+    Input(Event),
+    InputError(io::Error),
+    Loaded(String),
+    TimedOut,
+    RetryFinished(Result<String, RetryError<String>>),
+}
+
+struct App {
+    should_quit: bool,
+    log: Vec<String>,
+}
+
+impl Application for App {
+    type Message = Message;
+    type Flags = ();
+
+    fn new(_flags: ()) -> (Self, Command<Message>) {
+        (
+            Self {
+                should_quit: false,
+                log: vec!["Ready".to_string()],
+            },
+            Command::none(),
+        )
+    }
+
+    fn update(&mut self, msg: Message) -> Command<Message> {
+        match msg {
+            Message::Input(Event::Key(KeyEvent {
+                code, modifiers, ..
+            })) => match code {
+                KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.should_quit = true;
+                    return Command::quit();
+                }
+                KeyCode::Char('f') => {
+                    self.log
+                        .push("Fast fetch: started (1s deadline)".to_string());
+                    return Command::perform(
+                        fetch(Duration::from_millis(200), "fast data"),
+                        Message::Loaded,
+                    )
+                    .timeout(Duration::from_secs(1), || Message::TimedOut);
+                }
+                KeyCode::Char('s') => {
+                    self.log
+                        .push("Slow fetch: started (800ms deadline)".to_string());
+                    return Command::perform(
+                        fetch(Duration::from_secs(3), "slow data"),
+                        Message::Loaded,
+                    )
+                    .timeout(Duration::from_millis(800), || Message::TimedOut);
+                }
+                KeyCode::Char('r') => {
+                    self.log
+                        .push("Recovering fetch: started (3 attempts)".to_string());
+                    let policy = RetryPolicy::new(NonZeroUsize::new(3).expect("non-zero"))
+                        .with_fixed_backoff(Duration::from_millis(300));
+                    return Command::retry(policy, recovering_fetch, Message::RetryFinished);
+                }
+                KeyCode::Char('x') => {
+                    self.log
+                        .push("Exhausting fetch: started (2 attempts)".to_string());
+                    let policy = RetryPolicy::new(NonZeroUsize::new(2).expect("non-zero"))
+                        .with_fixed_backoff(Duration::from_millis(300));
+                    return Command::retry(policy, always_failing_fetch, Message::RetryFinished);
+                }
+                _ => {}
+            },
+            Message::Input(_) => {}
+            Message::InputError(e) => {
+                self.log.push(format!("Terminal error: {e}"));
+                self.should_quit = true;
+            }
+            Message::Loaded(data) => {
+                self.log.push(format!("Loaded: {data}"));
+            }
+            Message::TimedOut => {
+                self.log.push("Timed out before the deadline".to_string());
+            }
+            Message::RetryFinished(Ok(data)) => {
+                self.log.push(format!("Retry succeeded: {data}"));
+            }
+            Message::RetryFinished(Err(e)) => {
+                self.log.push(format!(
+                    "Retry gave up after {} attempt(s): {}",
+                    e.attempts(),
+                    e.into_last_error()
+                ));
+            }
+        }
+
+        if self.should_quit {
+            Command::quit()
+        } else {
+            Command::none()
+        }
+    }
+
+    fn view(&self, frame: &mut Frame) {
+        let chunks = Layout::vertical([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+        let title = Paragraph::new("Command Timeout & Retry Example")
+            .style(Style::default().fg(Color::Cyan))
+            .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(title, chunks[0]);
+
+        self.render_log(frame, chunks[1]);
+
+        let instructions = Paragraph::new(
+            "f: fast fetch | s: slow fetch (times out) | r: retry (recovers) | x: retry (exhausts) | Ctrl+C: quit",
+        )
+        .style(Style::default().fg(Color::Gray))
+        .block(Block::default().borders(Borders::ALL));
+        frame.render_widget(instructions, chunks[2]);
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Message>> {
+        vec![
+            Subscription::new(TerminalEvents::new()).map(|result| match result {
+                Ok(event) => Message::Input(event),
+                Err(e) => Message::InputError(e),
+            }),
+        ]
+    }
+}
+
+impl App {
+    fn render_log(&self, frame: &mut Frame, area: Rect) {
+        let items: Vec<ListItem> = self
+            .log
+            .iter()
+            .rev()
+            .take(20)
+            .map(|msg| {
+                ListItem::new(Line::from(vec![
+                    Span::raw("• "),
+                    Span::styled(msg, Style::default().fg(Color::Yellow)),
+                ]))
+            })
+            .collect();
+
+        let list = List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Log (most recent first)"),
+        );
+
+        frame.render_widget(list, area);
+    }
+}
+
+async fn fetch(delay: Duration, data: &'static str) -> String {
+    sleep(delay).await;
+    data.to_string()
+}
+
+async fn recovering_fetch(ctx: RetryContext) -> Result<String, String> {
+    sleep(Duration::from_millis(200)).await;
+    if ctx.attempt().get() < 3 {
+        Err(format!("attempt {} failed", ctx.attempt()))
+    } else {
+        Ok(format!("recovered on attempt {}", ctx.attempt()))
+    }
+}
+
+async fn always_failing_fetch(ctx: RetryContext) -> Result<String, String> {
+    sleep(Duration::from_millis(200)).await;
+    Err(format!("attempt {} failed", ctx.attempt()))
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let mut terminal = ratatui::init();
+
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+    let runtime = Runtime::<App>::new((), frame_rate);
+    let result = runtime.run(&mut terminal).await;
+
+    ratatui::restore();
+
+    result?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Remove the README's "Command timeouts and retries" section, which was a feature deep-dive out of step with the rest of the README's granularity and whose code blocks were never compiled anywhere
- Add `examples/command_timeout_retry.rs`, a small TUI demo covering `Command::timeout` (both under- and over-deadline cases) and `Command::retry` (both recovering and exhausted-attempts cases)
- Add `examples/command_cancellation.rs`, a small TUI demo covering `Command::cancellable`/`cancellable_with`, `Command::cancel`, `CommandId`, and both `CancelPolicy` variants (search-as-you-type, where each keystroke starts a new keyed search command) — this API landed on main via RFC 0003 but previously had no user-facing docs at all
- Update the README's Examples list, run-command list, and add a one-line note on where `RetryError`/`RetryPolicy`/`CommandId`/`CancelPolicy` are imported from

## Test plan
- [x] `cargo build --example command_timeout_retry --example command_cancellation`
- [x] `cargo clippy --example command_timeout_retry --example command_cancellation --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Manually drove both examples in a tmux pty (fast/slow fetch, retry recover/exhaust, CancelInFlight vs KeepInFlight typing behavior, Esc/Tab/Ctrl+C) and confirmed the on-screen log matches the intended behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)