### PR TITLE
fix: drop direct rustdoc-types dev-dependency in favor of public-api's re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,7 +3087,6 @@ dependencies = [
  "ratatui",
  "reqwest",
  "rustdoc-json",
- "rustdoc-types",
  "rustls",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,12 +56,13 @@ tracing = "0.1"
 [dev-dependencies]
 criterion = "0.8"
 # Used by the nightly-only `tests/api_surface.rs` structural check; see
-# docs/testing.md "Public API Surface Tests".
-public-api = "0.52"
+# docs/testing.md "Public API Surface Tests". The re-export feature avoids a
+# direct `rustdoc-types` dependency, so its version stays locked to whatever
+# `public-api` itself requires instead of drifting independently.
+public-api = { version = "0.52", features = ["experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types"] }
 # Exercises RFC 0003's pure keyed-command lifecycle state machine.
 proptest = "1"
 rustdoc-json = "0.9"
-rustdoc-types = "0.57"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # `test-util` (not part of `full`) provides paused virtual time for the idle

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -6,8 +6,8 @@
 use std::collections::{HashMap, HashSet};
 
 use public_api::PublicItem;
+use public_api::rustdoc_types::Id;
 use public_api::tokens::Token;
-use rustdoc_types::Id;
 
 fn build_public_api() -> public_api::PublicApi {
     let mut manifest_path = env!("CARGO_MANIFEST_DIR").to_owned();


### PR DESCRIPTION
## Summary
- `rustdoc-types` was a direct dev-dependency used only in `tests/api_surface.rs`, while `public-api` (also a dev-dependency) pins its own `rustdoc-types` version internally
- Since 0.x releases aren't semver-compatible across minor bumps, a Dependabot bump of tears' own `rustdoc-types` requirement independently (as in #197, 0.57.4 -> 0.60.0) puts two incompatible versions of the crate in the dependency graph, breaking `rustdoc_types::Id` equality checks in `tests/api_surface.rs`
- Enables `public-api`'s `experimental-feature-that-can-be-removed-in-a-patch-release_re-export-rustdoc-types` feature and imports `Id` through `public_api::rustdoc_types` instead, removing the direct dependency entirely, so its version can no longer drift out of sync with what `public-api` requires

## Test plan
- [x] `cargo build --tests`
- [x] `cargo clippy --tests --all-features`
- [x] `cargo fmt --check`
- [x] `cargo test --test api_surface -- --ignored --nocapture` (nightly toolchain, both tests pass)
- [x] `cargo tree -i rustdoc-types` confirms a single resolved version

🤖 Generated with [Claude Code](https://claude.com/claude-code)