### PR TITLE
feat(subscription): add structural lifecycle identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Sync`, `UnwindSafe`, and `RefUnwindSafe`
   - Duplicate desired subscriptions still keep the first declaration and now
     emit a warning under the `tears::subscription` tracing target
+
+  Before:
+
+  ```rust
+  impl SubscriptionSource for WatchSource {
+      type Output = WatchEvent;
+
+      fn id(&self) -> SubscriptionId {
+          let mut hasher = DefaultHasher::new();
+          self.path.hash(&mut hasher);
+          SubscriptionId::of::<Self>(hasher.finish())
+      }
+
+      // ...
+  }
+  ```
+
+  After, return the original logical key and let `Subscription::new` construct
+  the ID:
+
+  ```rust
+  impl SubscriptionSource for WatchSource {
+      type Output = WatchEvent;
+      type Key = PathBuf;
+
+      fn key(&self) -> Self::Key {
+          self.path.clone()
+      }
+
+      // ...
+  }
+  ```
 - **Breaking:** Raised MSRV to Rust 1.88.0 (from 1.86.0)
   - Required to pull in `time >=0.3.47`, which resolves RUSTSEC-2026-0009
     (denial of service via stack exhaustion) in the `time` crate pulled in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Subscription identity is now structural and collision-safe
+  - `SubscriptionSource::id() -> SubscriptionId` is replaced by an associated
+    `type Key` and `key() -> Self::Key`; return the owned logical key instead
+    of a precomputed hash digest
+  - `Subscription::new(source)` now combines that key with the concrete source
+    type, and `SubscriptionId::of::<T>(u64)` is removed
+  - `SubscriptionId` is `Clone` but no longer `Copy`; it remains `Send`,
+    `Sync`, `UnwindSafe`, and `RefUnwindSafe`
+  - Duplicate desired subscriptions still keep the first declaration and now
+    emit a warning under the `tears::subscription` tracing target
 - **Breaking:** Raised MSRV to Rust 1.88.0 (from 1.86.0)
   - Required to pull in `time >=0.3.47`, which resolves RUSTSEC-2026-0009
     (denial of service via stack exhaustion) in the `time` crate pulled in

--- a/benches/subscription.rs
+++ b/benches/subscription.rs
@@ -17,7 +17,7 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use futures::stream::{self, StreamExt};
 use tears::subscription::BenchSubscriptionManager;
-use tears::{BoxStream, Subscription, SubscriptionId, SubscriptionSource};
+use tears::{BoxStream, Subscription, SubscriptionSource};
 use tokio::runtime::Builder;
 use tokio::sync::mpsc;
 
@@ -29,13 +29,14 @@ struct BenchSource {
 
 impl SubscriptionSource for BenchSource {
     type Output = ();
+    type Key = u64;
 
     fn stream(&self) -> BoxStream<'static, ()> {
         stream::pending().boxed()
     }
 
-    fn id(&self) -> SubscriptionId {
-        SubscriptionId::of::<Self>(self.id)
+    fn key(&self) -> Self::Key {
+        self.id
     }
 }
 

--- a/docs/api-guidelines.md
+++ b/docs/api-guidelines.md
@@ -65,13 +65,13 @@ directly.
 
 A second, narrower test covers the extension contract behind a skeleton
 item. Every `Subscription` is built (via `From`) from an implementation of
-`SubscriptionSource`, whose `id()` method returns a `SubscriptionId` —
-together they are the single general mechanism the subscription system is
-built on, not one feature among several. The dividing question: is the
-item the one contract all implementations satisfy (root-eligible), or one
-implementation among several? `Timer`, `WebSocket`, and `http::Query` are
-implementations — each one is still just one option, however common, so
-none of them get promoted.
+`SubscriptionSource`, whose associated `Key` and `key()` method let the
+framework construct a `SubscriptionId` — together they are the single general
+mechanism the subscription system is built on, not one feature among several.
+The dividing question: is the item the one contract all implementations satisfy
+(root-eligible), or one implementation among several? `Timer`, `WebSocket`, and
+`http::Query` are implementations — each one is still just one option, however
+common, so none of them get promoted.
 
 An item that fails both tests does **not** need root promotion just
 because it is public: it stays at its domain path

--- a/docs/rfcs/0005-structural-lifecycle-identity.md
+++ b/docs/rfcs/0005-structural-lifecycle-identity.md
@@ -1,6 +1,6 @@
 # RFC 0005: Structural Lifecycle Identity and Composition Scopes
 
-- Status: Accepted
+- Status: Partially Implemented (Phase A); Phase B pending
 - Target: Phase A in 0.10.0 (breaking); Phase B after 0.10.0 (additive)
 - Scope: collision-safe subscription identity and hierarchical identity
   namespacing for composed command and subscription lifecycles

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -456,7 +456,7 @@ mod tests {
 
     use crate::application::Application;
     use crate::command::{CancelPolicy, Command, CommandId};
-    use crate::subscription::{Subscription, SubscriptionId, SubscriptionSource};
+    use crate::subscription::{Subscription, SubscriptionSource};
     use crate::test_support::{TestApp, TestMessage, TraceRecorder, wait_until};
 
     fn frame_rate(value: u32) -> FrameRate {
@@ -1005,15 +1005,14 @@ mod tests {
 
         impl SubscriptionSource for ParkedSource {
             type Output = ();
+            type Key = ();
 
             fn stream(&self) -> BoxStream<'static, ()> {
                 self.spawns.fetch_add(1, Ordering::SeqCst);
                 stream::pending().boxed()
             }
 
-            fn id(&self) -> SubscriptionId {
-                SubscriptionId::of::<Self>(0)
-            }
+            fn key(&self) -> Self::Key {}
         }
 
         struct App {
@@ -1175,6 +1174,7 @@ mod tests {
 
         impl SubscriptionSource for OneshotSource {
             type Output = ();
+            type Key = ();
 
             fn stream(&self) -> BoxStream<'static, ()> {
                 self.counters.spawns.fetch_add(1, Ordering::SeqCst);
@@ -1193,10 +1193,9 @@ mod tests {
                 .boxed()
             }
 
-            fn id(&self) -> SubscriptionId {
+            fn key(&self) -> Self::Key {
                 // A constant ID: the set of IDs never changes across frames,
                 // which is exactly the case the removed hash cache skipped.
-                SubscriptionId::of::<Self>(0)
             }
         }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -70,10 +70,9 @@
 //! create your own subscription types:
 //!
 //! ```
-//! use tears::{Subscription, SubscriptionId, SubscriptionSource};
+//! use tears::{Subscription, SubscriptionSource};
 //! use tears::BoxStream;
 //! use futures::{StreamExt, stream};
-//! use std::hash::{Hash, Hasher};
 //!
 //! struct MySubscription {
 //!     id: u64,
@@ -81,13 +80,14 @@
 //!
 //! impl SubscriptionSource for MySubscription {
 //!     type Output = String;
+//!     type Key = u64;
 //!
 //!     fn stream(&self) -> BoxStream<'static, Self::Output> {
 //!         stream::once(async { "Hello".to_string() }).boxed()
 //!     }
 //!
-//!     fn id(&self) -> SubscriptionId {
-//!         SubscriptionId::of::<Self>(self.id)
+//!     fn key(&self) -> Self::Key {
+//!         self.id
 //!     }
 //! }
 //!
@@ -197,12 +197,14 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
         let mut new_subs = Vec::new();
         let mut new_ids = HashSet::new();
 
-        for sub in subscriptions {
+        for Subscription { id, spawn } in subscriptions {
             // Keep the first subscription for a given ID. Subscriptions with
             // the same ID are considered identical, and preserving the first
             // one avoids making duplicate IDs silently "last one wins".
-            if new_ids.insert(sub.id) {
-                new_subs.push((sub.id, sub.spawn));
+            if new_ids.insert(id.clone()) {
+                new_subs.push((id, spawn));
+            } else {
+                tracing::warn!(target: "tears::subscription", subscription_id = ?id, "duplicate subscription ignored");
             }
         }
 
@@ -212,7 +214,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
         self.running.retain(|id, rs| {
             let finished = rs.handle.is_finished();
             if finished {
-                finished_ids.insert(*id);
+                finished_ids.insert(id.clone());
             }
             !finished
         });
@@ -330,6 +332,7 @@ impl<Msg: Send + 'static> BenchSubscriptionManager<Msg> {
 mod tests {
     use super::*;
 
+    use std::hash::{Hash, Hasher};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
     use std::task::Poll;
@@ -347,15 +350,14 @@ mod tests {
 
     impl SubscriptionSource for OneshotSource {
         type Output = i32;
+        type Key = ();
 
         fn stream(&self) -> BoxStream<'static, i32> {
             let v = self.value;
             stream::once(async move { v }).boxed()
         }
 
-        fn id(&self) -> SubscriptionId {
-            SubscriptionId::of::<Self>(0)
-        }
+        fn key(&self) -> Self::Key {}
     }
 
     async fn assert_completed_oneshot_subscription_restarts() -> Result<()> {
@@ -401,7 +403,7 @@ mod tests {
         let sub = Subscription::new(mock);
 
         // Should have correct ID type
-        assert_eq!(sub.id.type_id, TypeId::of::<MockSource<i32>>());
+        assert_eq!(sub.id.source_type_id, TypeId::of::<MockSource<i32>>());
     }
 
     #[tokio::test]
@@ -461,21 +463,53 @@ mod tests {
     }
 
     #[test]
-    fn test_subscription_id_of() {
-        let id1 = SubscriptionId::of::<i32>(12345);
-        let id2 = SubscriptionId::of::<i32>(12345);
-        let id3 = SubscriptionId::of::<i32>(67890);
+    fn test_subscription_id_is_structural() {
+        struct Source(u64);
+        impl SubscriptionSource for Source {
+            type Output = ();
+            type Key = u64;
+            fn stream(&self) -> BoxStream<'static, ()> {
+                stream::empty().boxed()
+            }
+            fn key(&self) -> Self::Key {
+                self.0
+            }
+        }
+        let id1 = Subscription::new(Source(12345)).id;
+        let id2 = Subscription::new(Source(12345)).id;
+        let id3 = Subscription::new(Source(67890)).id;
 
         assert_eq!(id1, id2);
         assert_ne!(id1, id3);
     }
 
     #[test]
-    fn test_subscription_id_different_types() {
-        // Same hash value but different types should produce different IDs
-        let id_i32 = SubscriptionId::of::<i32>(12345);
-        let id_u64 = SubscriptionId::of::<u64>(12345);
-        let id_string = SubscriptionId::of::<String>(12345);
+    fn test_subscription_id_different_source_types() {
+        struct I32Source;
+        struct U64Source;
+        impl SubscriptionSource for I32Source {
+            type Output = ();
+            type Key = u64;
+            fn stream(&self) -> BoxStream<'static, ()> {
+                stream::empty().boxed()
+            }
+            fn key(&self) -> Self::Key {
+                12345
+            }
+        }
+        impl SubscriptionSource for U64Source {
+            type Output = ();
+            type Key = u64;
+            fn stream(&self) -> BoxStream<'static, ()> {
+                stream::empty().boxed()
+            }
+            fn key(&self) -> Self::Key {
+                12345
+            }
+        }
+        let id_i32 = Subscription::new(I32Source).id;
+        let id_u64 = Subscription::new(U64Source).id;
+        let id_string = Subscription::new(MockSource::<String>::new()).id;
 
         assert_ne!(id_i32, id_u64);
         assert_ne!(id_i32, id_string);
@@ -514,6 +548,7 @@ mod tests {
         struct InfiniteSub;
         impl SubscriptionSource for InfiniteSub {
             type Output = i32;
+            type Key = ();
 
             fn stream(&self) -> BoxStream<'static, Self::Output> {
                 stream::unfold(0, |state| async move {
@@ -523,9 +558,7 @@ mod tests {
                 .boxed()
             }
 
-            fn id(&self) -> SubscriptionId {
-                SubscriptionId::of::<Self>(999)
-            }
+            fn key(&self) -> Self::Key {}
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -563,6 +596,7 @@ mod tests {
         }
         impl SubscriptionSource for ParkedSource {
             type Output = i32;
+            type Key = ();
 
             fn stream(&self) -> BoxStream<'static, i32> {
                 let started = self.started.clone();
@@ -575,9 +609,7 @@ mod tests {
                 .boxed()
             }
 
-            fn id(&self) -> SubscriptionId {
-                SubscriptionId::of::<Self>(0)
-            }
+            fn key(&self) -> Self::Key {}
         }
 
         let started = Arc::new(AtomicBool::new(false));
@@ -643,20 +675,129 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_subscription_manager_starts_new_subscriptions_in_input_order() {
-        struct OrderedStart;
+    async fn duplicate_subscriptions_keep_the_first_and_warn() {
+        let recorder = TraceRecorder::new()
+            .with_target("tears::subscription")
+            .with_level(tracing::Level::WARN);
+        let _guard = recorder.set_default();
 
-        fn recording_subscription(id_hash: u64, started: Arc<Mutex<Vec<u64>>>) -> Subscription<()> {
-            Subscription {
-                id: SubscriptionId::of::<OrderedStart>(id_hash),
-                spawn: Box::new(move || {
-                    started
-                        .lock()
-                        .expect("started order mutex should not be poisoned")
-                        .push(id_hash);
-                    stream::empty().boxed()
-                }),
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+        let first = MockSource::<i32>::new();
+        let duplicate = first.clone();
+
+        manager.update(vec![
+            Subscription::new(first.clone()),
+            Subscription::new(duplicate.clone()),
+        ]);
+
+        wait_for_mock_receivers(&first, 1).await;
+        assert_eq!(
+            duplicate.receiver_count(),
+            1,
+            "only the first spawner should run"
+        );
+        assert_eq!(
+            recorder.event_count(),
+            1,
+            "the ignored duplicate should warn"
+        );
+    }
+
+    #[tokio::test]
+    async fn hash_colliding_subscriptions_start_and_map_independently() -> Result<()> {
+        #[derive(Eq, PartialEq)]
+        struct CollisionKey(u8);
+
+        impl Hash for CollisionKey {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
             }
+        }
+
+        struct CollidingSource {
+            key: CollisionKey,
+            value: u8,
+        }
+
+        impl SubscriptionSource for CollidingSource {
+            type Output = u8;
+            type Key = CollisionKey;
+
+            fn stream(&self) -> BoxStream<'static, Self::Output> {
+                let value = self.value;
+                stream::once(async move { value }).boxed()
+            }
+
+            fn key(&self) -> Self::Key {
+                CollisionKey(self.key.0)
+            }
+        }
+
+        #[derive(Debug, Eq, PartialEq)]
+        enum Message {
+            First(u8),
+            Second(u8),
+        }
+
+        let recorder = TraceRecorder::new()
+            .with_target("tears::subscription")
+            .with_level(tracing::Level::WARN);
+        let _guard = recorder.set_default();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+
+        manager.update(vec![
+            Subscription::new(CollidingSource {
+                key: CollisionKey(1),
+                value: 10,
+            })
+            .map(Message::First),
+            Subscription::new(CollidingSource {
+                key: CollisionKey(2),
+                value: 20,
+            })
+            .map(Message::Second),
+        ]);
+
+        let first = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let second = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let messages = [first, second];
+
+        assert!(messages.contains(&Some(Message::First(10))));
+        assert!(messages.contains(&Some(Message::Second(20))));
+        assert_eq!(
+            recorder.event_count(),
+            0,
+            "hash collisions are not duplicates"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_subscription_manager_starts_new_subscriptions_in_input_order() {
+        struct OrderedStart {
+            id: u64,
+            started: Arc<Mutex<Vec<u64>>>,
+        }
+        impl SubscriptionSource for OrderedStart {
+            type Output = ();
+            type Key = u64;
+            fn stream(&self) -> BoxStream<'static, ()> {
+                self.started
+                    .lock()
+                    .expect("started order mutex should not be poisoned")
+                    .push(self.id);
+                stream::empty().boxed()
+            }
+            fn key(&self) -> Self::Key {
+                self.id
+            }
+        }
+
+        fn recording_subscription(id: u64, started: Arc<Mutex<Vec<u64>>>) -> Subscription<()> {
+            Subscription::new(OrderedStart { id, started })
         }
 
         let (tx, _rx) = mpsc::unbounded_channel();
@@ -792,14 +933,13 @@ mod tests {
 
         impl SubscriptionSource for OneshotSource {
             type Output = i32;
+            type Key = ();
 
             fn stream(&self) -> BoxStream<'static, i32> {
                 stream::once(async move { 42 }).boxed()
             }
 
-            fn id(&self) -> SubscriptionId {
-                SubscriptionId::of::<Self>(0)
-            }
+            fn key(&self) -> Self::Key {}
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -333,7 +333,7 @@ mod tests {
     use super::*;
 
     use std::hash::{Hash, Hasher};
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::task::Poll;
 
@@ -358,6 +358,96 @@ mod tests {
         }
 
         fn key(&self) -> Self::Key {}
+    }
+
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    struct ManagerCollisionKey(u8);
+
+    impl Hash for ManagerCollisionKey {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            0_u8.hash(state);
+        }
+    }
+
+    #[derive(Default)]
+    struct LifecycleProbe {
+        starts: AtomicUsize,
+        drops: AtomicUsize,
+    }
+
+    struct StreamDropProbe(Arc<LifecycleProbe>);
+
+    impl Drop for StreamDropProbe {
+        fn drop(&mut self) {
+            self.0.drops.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    enum ProbedStream {
+        Pending,
+        Once(i32),
+    }
+
+    #[derive(Clone)]
+    struct ProbedCollidingSource {
+        key: ManagerCollisionKey,
+        stream: ProbedStream,
+        probe: Arc<LifecycleProbe>,
+    }
+
+    impl ProbedCollidingSource {
+        fn pending(key: u8) -> Self {
+            Self {
+                key: ManagerCollisionKey(key),
+                stream: ProbedStream::Pending,
+                probe: Arc::new(LifecycleProbe::default()),
+            }
+        }
+
+        fn once(key: u8, value: i32) -> Self {
+            Self {
+                key: ManagerCollisionKey(key),
+                stream: ProbedStream::Once(value),
+                probe: Arc::new(LifecycleProbe::default()),
+            }
+        }
+
+        fn restarted_with(&self, value: i32) -> Self {
+            Self {
+                key: self.key,
+                stream: ProbedStream::Once(value),
+                probe: self.probe.clone(),
+            }
+        }
+    }
+
+    impl SubscriptionSource for ProbedCollidingSource {
+        type Output = i32;
+        type Key = ManagerCollisionKey;
+
+        fn stream(&self) -> BoxStream<'static, Self::Output> {
+            self.probe.starts.fetch_add(1, Ordering::SeqCst);
+            let drop_probe = StreamDropProbe(self.probe.clone());
+
+            match self.stream {
+                ProbedStream::Pending => stream::pending()
+                    .map(move |value| {
+                        let _ = &drop_probe;
+                        value
+                    })
+                    .boxed(),
+                ProbedStream::Once(value) => stream::once(async move {
+                    let _drop_probe = drop_probe;
+                    value
+                })
+                .boxed(),
+            }
+        }
+
+        fn key(&self) -> Self::Key {
+            self.key
+        }
     }
 
     async fn assert_completed_oneshot_subscription_restarts() -> Result<()> {
@@ -770,6 +860,76 @@ mod tests {
             recorder.event_count(),
             0,
             "hash collisions are not duplicates"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn removing_one_hash_colliding_subscription_aborts_only_its_stream() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+        let first = ProbedCollidingSource::pending(1);
+        let second = ProbedCollidingSource::pending(2);
+
+        manager.update(vec![
+            Subscription::new(first.clone()),
+            Subscription::new(second.clone()),
+        ]);
+        assert_eq!(first.probe.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(second.probe.starts.load(Ordering::SeqCst), 1);
+
+        manager.update(vec![Subscription::new(second.clone())]);
+
+        wait_until(
+            || first.probe.drops.load(Ordering::SeqCst) == 1,
+            "removed colliding stream should be dropped after abort",
+        )
+        .await;
+        assert_eq!(second.probe.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(second.probe.drops.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn completed_hash_colliding_subscription_restarts_without_replacing_the_other()
+    -> Result<()> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+        let completed = ProbedCollidingSource::once(1, 10);
+        let continuing = ProbedCollidingSource::pending(2);
+        let completed_subscription = Subscription::new(completed.clone());
+        let completed_id = completed_subscription.id.clone();
+
+        manager.update(vec![
+            completed_subscription,
+            Subscription::new(continuing.clone()),
+        ]);
+        assert_eq!(
+            timeout(Duration::from_millis(100), rx.recv()).await?,
+            Some(10)
+        );
+        wait_until(
+            || {
+                manager
+                    .running
+                    .get(&completed_id)
+                    .is_some_and(|running| running.handle.is_finished())
+            },
+            "colliding one-shot subscription should finish before restart",
+        )
+        .await;
+
+        manager.update(vec![
+            Subscription::new(completed.restarted_with(11)),
+            Subscription::new(continuing.clone()),
+        ]);
+
+        assert_eq!(completed.probe.starts.load(Ordering::SeqCst), 2);
+        assert_eq!(continuing.probe.starts.load(Ordering::SeqCst), 1);
+        assert_eq!(continuing.probe.drops.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            timeout(Duration::from_millis(100), rx.recv()).await?,
+            Some(11)
         );
 
         Ok(())

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -5,7 +5,11 @@
 //! SubscriptionSource}` paths. See `runtime::frame_rate` for the same
 //! pattern applied to `Runtime`'s scheduling input.
 
-use std::any::TypeId;
+use std::any::{Any, TypeId, type_name};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 
 use futures::{StreamExt, stream::BoxStream};
 
@@ -54,8 +58,11 @@ impl<Msg: 'static> Subscription<Msg> {
     /// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")));
     /// ```
     #[must_use]
-    pub fn new(source: impl SubscriptionSource<Output = Msg> + 'static) -> Self {
-        let id = source.id();
+    pub fn new<Source>(source: Source) -> Self
+    where
+        Source: SubscriptionSource<Output = Msg> + 'static,
+    {
+        let id = SubscriptionId::from_source::<Source>(source.key());
 
         Self {
             id,
@@ -106,10 +113,9 @@ impl<A: SubscriptionSource<Output = Msg> + 'static, Msg> From<A> for Subscriptio
 /// # Example
 ///
 /// ```
-/// use tears::{SubscriptionSource, SubscriptionId};
+/// use tears::SubscriptionSource;
 /// use tears::BoxStream;
 /// use futures::{StreamExt, stream};
-/// use std::hash::{Hash, Hasher};
 ///
 /// struct MySubscription {
 ///     interval_ms: u64,
@@ -117,15 +123,14 @@ impl<A: SubscriptionSource<Output = Msg> + 'static, Msg> From<A> for Subscriptio
 ///
 /// impl SubscriptionSource for MySubscription {
 ///     type Output = ();
+///     type Key = u64;
 ///
 ///     fn stream(&self) -> BoxStream<'static, Self::Output> {
 ///         stream::empty().boxed()
 ///     }
 ///
-///     fn id(&self) -> SubscriptionId {
-///         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-///         self.interval_ms.hash(&mut hasher);
-///         SubscriptionId::of::<Self>(hasher.finish())
+///     fn key(&self) -> Self::Key {
+///         self.interval_ms
 ///     }
 /// }
 /// ```
@@ -133,52 +138,227 @@ pub trait SubscriptionSource: Send {
     /// The type of messages this subscription produces.
     type Output;
 
+    /// The owned structural key for one subscription lifecycle.
+    ///
+    /// This key must be stable across equivalent evaluations of a source. A
+    /// changing key expresses a new lifecycle, causing the old subscription to
+    /// stop and a new one to start during reconciliation.
+    type Key: Eq + Hash + Send + Sync + 'static;
+
     /// Create the stream of messages for this subscription.
     fn stream(&self) -> BoxStream<'static, Self::Output>;
 
-    /// Get a unique identifier for this subscription.
+    /// Get the structural key for this subscription.
     ///
-    /// Subscriptions with the same ID are considered identical.
-    fn id(&self) -> SubscriptionId;
+    /// The framework combines this value with the concrete source type when it
+    /// constructs the opaque subscription identity.
+    fn key(&self) -> Self::Key;
 }
 
 /// A unique identifier for a subscription.
 ///
 /// Two subscriptions with the same ID are considered identical.
-/// The ID includes type information and a hash value to prevent collisions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// IDs compare their concrete source type and original structural key. Hashing
+/// is used only for indexing and never makes unequal keys equal.
 pub struct SubscriptionId {
-    pub(super) type_id: TypeId,
-    hash: u64,
+    pub(super) source_type_id: TypeId,
+    source_type_name: &'static str,
+    key: AssertUnwindSafe<Arc<dyn ErasedSubscriptionKey>>,
+}
+
+impl Clone for SubscriptionId {
+    fn clone(&self) -> Self {
+        Self {
+            source_type_id: self.source_type_id,
+            source_type_name: self.source_type_name,
+            key: AssertUnwindSafe(self.key.0.clone()),
+        }
+    }
 }
 
 impl SubscriptionId {
-    /// Create a subscription ID from a type and a hash value.
-    ///
-    /// Typically used when implementing [`SubscriptionSource::id`].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tears::SubscriptionId;
-    /// use std::hash::{Hash, Hasher};
-    /// use std::collections::hash_map::DefaultHasher;
-    ///
-    /// struct MySubscription { interval_ms: u64 }
-    ///
-    /// impl MySubscription {
-    ///     fn compute_id(&self) -> SubscriptionId {
-    ///         let mut hasher = DefaultHasher::new();
-    ///         self.interval_ms.hash(&mut hasher);
-    ///         SubscriptionId::of::<Self>(hasher.finish())
-    ///     }
-    /// }
-    /// ```
-    #[must_use]
-    pub fn of<T: 'static>(hash: u64) -> Self {
+    fn from_source<Source>(key: Source::Key) -> Self
+    where
+        Source: SubscriptionSource + 'static,
+    {
         Self {
-            type_id: TypeId::of::<T>(),
-            hash,
+            source_type_id: TypeId::of::<Source>(),
+            source_type_name: type_name::<Source>(),
+            key: AssertUnwindSafe(Arc::new(TypedSubscriptionKey(key))),
         }
+    }
+}
+
+impl fmt::Debug for SubscriptionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SubscriptionId")
+            .field("source", &self.source_type_name)
+            .field("key", &self.key.0.type_name())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for SubscriptionId {
+    fn eq(&self, other: &Self) -> bool {
+        self.source_type_id == other.source_type_id
+            && self.key.0.erased_type_id() == other.key.0.erased_type_id()
+            && self.key.0.eq_erased(other.key.0.as_ref())
+    }
+}
+
+impl Eq for SubscriptionId {}
+
+impl Hash for SubscriptionId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.source_type_id.hash(state);
+        self.key.0.erased_type_id().hash(state);
+        self.key.0.hash_erased(state);
+    }
+}
+
+trait ErasedSubscriptionKey: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn erased_type_id(&self) -> TypeId;
+    fn type_name(&self) -> &'static str;
+    fn eq_erased(&self, other: &dyn ErasedSubscriptionKey) -> bool;
+    fn hash_erased(&self, state: &mut dyn Hasher);
+}
+
+struct TypedSubscriptionKey<T>(T);
+
+impl<T> ErasedSubscriptionKey for TypedSubscriptionKey<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn erased_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
+
+    fn eq_erased(&self, other: &dyn ErasedSubscriptionKey) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.0 == other.0)
+    }
+
+    fn hash_erased(&self, mut state: &mut dyn Hasher) {
+        self.0.hash(&mut state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+    use std::panic::{RefUnwindSafe, UnwindSafe};
+
+    use futures::{StreamExt, stream};
+
+    struct SourceA(u8);
+    struct SourceB(u8);
+
+    impl SubscriptionSource for SourceA {
+        type Output = ();
+        type Key = u8;
+
+        fn stream(&self) -> BoxStream<'static, Self::Output> {
+            stream::empty().boxed()
+        }
+
+        fn key(&self) -> Self::Key {
+            self.0
+        }
+    }
+
+    impl SubscriptionSource for SourceB {
+        type Output = ();
+        type Key = u8;
+
+        fn stream(&self) -> BoxStream<'static, Self::Output> {
+            stream::empty().boxed()
+        }
+
+        fn key(&self) -> Self::Key {
+            self.0
+        }
+    }
+
+    #[derive(Eq, PartialEq)]
+    struct Collision(u8);
+
+    impl Hash for Collision {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            0_u8.hash(state);
+        }
+    }
+
+    struct CollisionSource(Collision);
+
+    impl SubscriptionSource for CollisionSource {
+        type Output = ();
+        type Key = Collision;
+
+        fn stream(&self) -> BoxStream<'static, Self::Output> {
+            stream::empty().boxed()
+        }
+
+        fn key(&self) -> Self::Key {
+            Collision(self.0.0)
+        }
+    }
+
+    fn hash(id: &SubscriptionId) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        id.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn subscription_ids_are_structural_and_source_namespaced() {
+        let first = Subscription::new(SourceA(1)).id;
+        let equal = Subscription::new(SourceA(1)).id;
+        let different_key = Subscription::new(SourceA(2)).id;
+        let different_source = Subscription::new(SourceB(1)).id;
+
+        assert_eq!(first, equal);
+        assert_ne!(first, different_key);
+        assert_ne!(first, different_source);
+        assert_eq!(hash(&first), hash(&equal));
+        assert_eq!(first, first.clone());
+    }
+
+    #[test]
+    fn hash_collisions_do_not_make_subscription_ids_equal() {
+        let first = Subscription::new(CollisionSource(Collision(1))).id;
+        let second = Subscription::new(CollisionSource(Collision(2))).id;
+
+        assert_eq!(hash(&first), hash(&second));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn debug_only_reports_type_names() {
+        let first = format!("{:?}", Subscription::new(SourceA(1)).id);
+        let second = format!("{:?}", Subscription::new(SourceA(2)).id);
+
+        assert_eq!(first, second);
+        assert!(first.contains("SourceA"));
+        assert!(!first.contains('1'));
+    }
+
+    #[test]
+    fn subscription_id_preserves_marker_traits() {
+        fn assert_traits<T: Send + Sync + UnwindSafe + RefUnwindSafe>() {}
+        assert_traits::<SubscriptionId>();
     }
 }

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -148,10 +148,18 @@ pub trait SubscriptionSource: Send {
     /// Create the stream of messages for this subscription.
     fn stream(&self) -> BoxStream<'static, Self::Output>;
 
-    /// Get the structural key for this subscription.
+    /// Get the owned structural key for this subscription.
     ///
     /// The framework combines this value with the concrete source type when it
     /// constructs the opaque subscription identity.
+    ///
+    /// This method must return equal keys for the same logical source identity
+    /// across calls, including when fresh source values are constructed by
+    /// successive [`Application::subscriptions`](crate::Application::subscriptions)
+    /// evaluations. A per-instance source must generate its instance token
+    /// once, store it, and return the stored token here. Generating a fresh key
+    /// on each evaluation aborts and respawns the subscription during
+    /// reconciliation.
     fn key(&self) -> Self::Key;
 }
 

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -74,7 +74,7 @@ use futures::future::BoxFuture;
 use futures::stream::{self, BoxStream};
 use thiserror::Error;
 
-use crate::subscription::{SubscriptionId, SubscriptionSource};
+use crate::subscription::SubscriptionSource;
 
 use super::cell::{AnyCell, Cell, CellSubscription};
 use super::config::QueryConfig;
@@ -398,6 +398,7 @@ where
     V: Clone + Send + Sync + 'static,
 {
     type Output = QueryResult<V>;
+    type Key = (u64, QueryKey);
 
     fn stream(&self) -> BoxStream<'static, Self::Output> {
         let key = self.key.clone();
@@ -473,10 +474,8 @@ where
         .boxed()
     }
 
-    fn id(&self) -> SubscriptionId {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        SubscriptionId::of::<Self>(hasher.finish())
+    fn key(&self) -> Self::Key {
+        (self.client.client_id, self.key.clone())
     }
 }
 
@@ -1136,7 +1135,7 @@ mod tests {
         );
 
         // Same key should produce the same ID
-        assert_eq!(query1.id(), query2.id());
+        assert_eq!(query1.key(), query2.key());
     }
 
     #[test]
@@ -1156,7 +1155,7 @@ mod tests {
         );
 
         // Different keys should produce different IDs
-        assert_ne!(query1.id(), query2.id());
+        assert_ne!(query1.key(), query2.key());
     }
 
     #[test]
@@ -1176,8 +1175,8 @@ mod tests {
         );
 
         assert_ne!(
-            query1.id(),
-            query2.id(),
+            query1.key(),
+            query2.key(),
             "same-key queries on different QueryClient instances should be distinct subscriptions"
         );
     }
@@ -1199,8 +1198,8 @@ mod tests {
         );
 
         assert_eq!(
-            query1.id(),
-            query2.id(),
+            query1.key(),
+            query2.key(),
             "QueryClient::clone should preserve the client identity"
         );
     }
@@ -1222,8 +1221,12 @@ mod tests {
         );
 
         // Same key but different types should produce different IDs
-        // because SubscriptionId::of::<Self> includes the type information
-        assert_ne!(query1.id(), query2.id());
+        // The source type includes the response type, so full IDs differ even
+        // though these logical keys are equal.
+        assert_ne!(
+            crate::Subscription::new(query1).id,
+            crate::Subscription::new(query2).id
+        );
     }
 
     /// Same-key queries with different output types must use independent cells.

--- a/src/subscription/mock.rs
+++ b/src/subscription/mock.rs
@@ -139,6 +139,8 @@ impl<T: Clone + 'static> MockSource<T> {
     ///
     /// # Panics
     ///
+    /// Panics if `capacity` is zero.
+    ///
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         let (tx, _rx) = broadcast::channel(capacity);

--- a/src/subscription/mock.rs
+++ b/src/subscription/mock.rs
@@ -106,17 +106,16 @@
 //! assert_eq!(app.subscriptions().len(), 0);
 //! ```
 
-use std::any::type_name;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use futures::StreamExt;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 use crate::BoxStream;
-use crate::subscription::{SubscriptionId, SubscriptionSource};
+use crate::subscription::SubscriptionSource;
+
+static NEXT_MOCK_SOURCE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// A mock subscription source that emits values on demand.
 ///
@@ -128,7 +127,7 @@ use crate::subscription::{SubscriptionId, SubscriptionSource};
 #[derive(Debug, Clone)]
 pub struct MockSource<T: Clone> {
     sender: broadcast::Sender<T>,
-    id: SubscriptionId,
+    key: u64,
 }
 
 impl<T: Clone + 'static> MockSource<T> {
@@ -140,23 +139,12 @@ impl<T: Clone + 'static> MockSource<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the system time is before [`std::time::UNIX_EPOCH`] (should never happen on modern systems).
     #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
-        // Use a random ID for each instance
-        let mut hasher = DefaultHasher::new();
-        // Use current timestamp + type name for uniqueness
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("System time before UNIX_EPOCH")
-            .as_nanos()
-            .hash(&mut hasher);
-        type_name::<T>().hash(&mut hasher);
-
         let (tx, _rx) = broadcast::channel(capacity);
         Self {
             sender: tx,
-            id: SubscriptionId::of::<Self>(hasher.finish()),
+            key: NEXT_MOCK_SOURCE_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
 
@@ -190,14 +178,15 @@ impl<T: Clone + 'static> Default for MockSource<T> {
 
 impl<T: Clone + Send + 'static> SubscriptionSource for MockSource<T> {
     type Output = T;
+    type Key = u64;
 
     fn stream(&self) -> BoxStream<'static, Self::Output> {
         let rx = self.sender.subscribe();
         Box::pin(BroadcastStream::new(rx).filter_map(|result| async move { result.ok() }))
     }
 
-    fn id(&self) -> SubscriptionId {
-        self.id
+    fn key(&self) -> Self::Key {
+        self.key
     }
 }
 

--- a/src/subscription/signal.rs
+++ b/src/subscription/signal.rs
@@ -6,16 +6,13 @@
 
 #[cfg(unix)]
 mod unix_signal {
-    use std::{
-        hash::{DefaultHasher, Hash, Hasher},
-        io,
-    };
+    use std::{hash::Hash, io};
 
     use futures::stream::BoxStream;
     use futures::{StreamExt as _, stream};
     use tokio::signal::unix::{Signal as TokioSignal, SignalKind, signal};
 
-    use crate::subscription::{SubscriptionId, SubscriptionSource};
+    use crate::subscription::SubscriptionSource;
 
     /// A subscription source for Unix signals.
     ///
@@ -114,6 +111,7 @@ mod unix_signal {
 
     impl SubscriptionSource for Signal {
         type Output = Result<(), io::Error>;
+        type Key = SignalKind;
 
         fn stream(&self) -> BoxStream<'static, Self::Output> {
             let kind = self.kind;
@@ -169,10 +167,8 @@ mod unix_signal {
             .boxed()
         }
 
-        fn id(&self) -> SubscriptionId {
-            let mut hasher = DefaultHasher::new();
-            self.hash(&mut hasher);
-            SubscriptionId::of::<Self>(hasher.finish())
+        fn key(&self) -> Self::Key {
+            self.kind
         }
     }
 
@@ -192,7 +188,7 @@ mod unix_signal {
             let sig2 = Signal::new(SignalKind::interrupt());
 
             // Same signal kind should produce the same ID
-            assert_eq!(sig1.id(), sig2.id());
+            assert_eq!(sig1.key(), sig2.key());
         }
 
         #[test]
@@ -201,7 +197,7 @@ mod unix_signal {
             let sig2 = Signal::new(SignalKind::terminate());
 
             // Different signal kinds should produce different IDs
-            assert_ne!(sig1.id(), sig2.id());
+            assert_ne!(sig1.key(), sig2.key());
         }
     }
 }
@@ -222,7 +218,7 @@ mod windows_signal {
         CtrlBreak as TokioCtrlBreak, CtrlC as TokioCtrlC, ctrl_break, ctrl_c,
     };
 
-    use crate::subscription::{SubscriptionId, SubscriptionSource};
+    use crate::subscription::SubscriptionSource;
 
     /// A subscription source for Windows Ctrl+C events.
     ///
@@ -284,6 +280,7 @@ mod windows_signal {
 
     impl SubscriptionSource for CtrlC {
         type Output = Result<(), io::Error>;
+        type Key = ();
 
         fn stream(&self) -> BoxStream<'static, Self::Output> {
             // Create a stream that yields () each time Ctrl+C is pressed
@@ -337,11 +334,7 @@ mod windows_signal {
             .boxed()
         }
 
-        fn id(&self) -> SubscriptionId {
-            let mut hasher = DefaultHasher::new();
-            self.hash(&mut hasher);
-            SubscriptionId::of::<Self>(hasher.finish())
-        }
+        fn key(&self) -> Self::Key {}
     }
 
     /// A subscription source for Windows Ctrl+Break events.
@@ -404,6 +397,7 @@ mod windows_signal {
 
     impl SubscriptionSource for CtrlBreak {
         type Output = Result<(), io::Error>;
+        type Key = ();
 
         fn stream(&self) -> BoxStream<'static, Self::Output> {
             // Create a stream that yields () each time Ctrl+Break is pressed
@@ -457,11 +451,7 @@ mod windows_signal {
             .boxed()
         }
 
-        fn id(&self) -> SubscriptionId {
-            let mut hasher = DefaultHasher::new();
-            self.hash(&mut hasher);
-            SubscriptionId::of::<Self>(hasher.finish())
-        }
+        fn key(&self) -> Self::Key {}
     }
 
     #[cfg(test)]
@@ -474,7 +464,7 @@ mod windows_signal {
             let ctrl_c2 = CtrlC::new();
 
             // Same subscription should have the same ID
-            assert_eq!(ctrl_c1.id(), ctrl_c2.id());
+            assert_eq!(ctrl_c1.key(), ctrl_c2.key());
         }
 
         #[test]
@@ -483,7 +473,7 @@ mod windows_signal {
             let ctrl_break2 = CtrlBreak::new();
 
             // Same subscription should have the same ID
-            assert_eq!(ctrl_break1.id(), ctrl_break2.id());
+            assert_eq!(ctrl_break1.key(), ctrl_break2.key());
         }
 
         #[test]
@@ -492,7 +482,7 @@ mod windows_signal {
             let ctrl_break = CtrlBreak::new();
 
             // Different signal types should have different IDs
-            assert_ne!(ctrl_c.id(), ctrl_break.id());
+            assert_eq!(ctrl_c.key(), ctrl_break.key());
         }
     }
 }

--- a/src/subscription/signal.rs
+++ b/src/subscription/signal.rs
@@ -207,10 +207,7 @@ pub use unix_signal::Signal;
 
 #[cfg(windows)]
 mod windows_signal {
-    use std::{
-        hash::{DefaultHasher, Hash, Hasher},
-        io,
-    };
+    use std::io;
 
     use futures::StreamExt as _;
     use futures::stream::{self, BoxStream};
@@ -457,6 +454,7 @@ mod windows_signal {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use crate::subscription::Subscription;
 
         #[test]
         fn test_ctrl_c_id_consistency() {
@@ -464,7 +462,7 @@ mod windows_signal {
             let ctrl_c2 = CtrlC::new();
 
             // Same subscription should have the same ID
-            assert_eq!(ctrl_c1.key(), ctrl_c2.key());
+            assert_eq!(Subscription::new(ctrl_c1).id, Subscription::new(ctrl_c2).id);
         }
 
         #[test]
@@ -473,7 +471,10 @@ mod windows_signal {
             let ctrl_break2 = CtrlBreak::new();
 
             // Same subscription should have the same ID
-            assert_eq!(ctrl_break1.key(), ctrl_break2.key());
+            assert_eq!(
+                Subscription::new(ctrl_break1).id,
+                Subscription::new(ctrl_break2).id
+            );
         }
 
         #[test]
@@ -482,7 +483,10 @@ mod windows_signal {
             let ctrl_break = CtrlBreak::new();
 
             // Different signal types should have different IDs
-            assert_eq!(ctrl_c.key(), ctrl_break.key());
+            assert_ne!(
+                Subscription::new(ctrl_c).id,
+                Subscription::new(ctrl_break).id
+            );
         }
     }
 }

--- a/src/subscription/terminal.rs
+++ b/src/subscription/terminal.rs
@@ -3,13 +3,13 @@
 //! This module provides the [`TerminalEvents`] subscription source for handling
 //! terminal input events using crossterm.
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::Hash;
 use std::io;
 
 use crossterm::event::{Event, EventStream};
 use futures::{StreamExt, stream, stream::BoxStream};
 
-use super::{SubscriptionId, SubscriptionSource};
+use super::SubscriptionSource;
 
 /// A subscription source for terminal events.
 ///
@@ -106,6 +106,7 @@ impl TerminalEvents {
 
 impl SubscriptionSource for TerminalEvents {
     type Output = Result<Event, io::Error>;
+    type Key = ();
 
     fn stream(&self) -> BoxStream<'static, Self::Output> {
         let stream = EventStream::new();
@@ -138,12 +139,7 @@ impl SubscriptionSource for TerminalEvents {
         .boxed()
     }
 
-    fn id(&self) -> SubscriptionId {
-        // Since TerminalEvents is a singleton (no parameters), use a constant ID
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        SubscriptionId::of::<Self>(hasher.finish())
-    }
+    fn key(&self) -> Self::Key {}
 }
 
 const fn trace_event_type(event: &Event) -> &'static str {
@@ -160,6 +156,7 @@ const fn trace_event_type(event: &Event) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Subscription;
 
     #[test]
     fn test_terminal_events_new() {
@@ -173,6 +170,6 @@ mod tests {
         let events2 = TerminalEvents::new();
 
         // Same subscription should have the same ID
-        assert_eq!(events1.id(), events2.id());
+        assert_eq!(Subscription::new(events1).id, Subscription::new(events2).id);
     }
 }

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -3,7 +3,7 @@
 //! This module provides the [`Timer`] subscription source for creating
 //! time-based events in your application.
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::{Hash, Hasher};
 use std::num::NonZeroU64;
 use std::time::Duration;
 
@@ -13,7 +13,7 @@ use tokio::time::MissedTickBehavior;
 use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 
-use super::{SubscriptionId, SubscriptionSource};
+use super::SubscriptionSource;
 
 /// Events produced by the [`Timer`] subscription.
 #[derive(Debug, Clone)]
@@ -90,6 +90,7 @@ impl Timer {
 
 impl SubscriptionSource for Timer {
     type Output = TimerEvent;
+    type Key = NonZeroU64;
 
     fn stream(&self) -> BoxStream<'static, TimerEvent> {
         // NOTE: Using Skip behavior to drop missed ticks rather than trying to catch up.
@@ -110,10 +111,8 @@ impl SubscriptionSource for Timer {
             .boxed()
     }
 
-    fn id(&self) -> SubscriptionId {
-        let mut hasher = DefaultHasher::new();
-        self.interval_ms.hash(&mut hasher);
-        SubscriptionId::of::<Self>(hasher.finish())
+    fn key(&self) -> Self::Key {
+        self.interval_ms
     }
 }
 
@@ -126,6 +125,7 @@ impl Hash for Timer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::hash::DefaultHasher;
 
     use tokio::time::{Duration, Instant, timeout};
 
@@ -146,7 +146,7 @@ mod tests {
         let timer2 = timer(1000);
 
         // Same configuration should produce the same ID
-        assert_eq!(timer1.id(), timer2.id());
+        assert_eq!(timer1.key(), timer2.key());
     }
 
     #[test]
@@ -155,7 +155,7 @@ mod tests {
         let timer2 = timer(2000);
 
         // Different intervals should produce different IDs
-        assert_ne!(timer1.id(), timer2.id());
+        assert_ne!(timer1.key(), timer2.key());
     }
 
     #[test]

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -50,7 +50,7 @@
 //! tears = { version = "0.9", features = ["ws", "native-tls"] }
 //! ```
 
-use std::hash::{DefaultHasher, Hash, Hasher};
+use std::hash::Hash;
 
 use futures::stream::{BoxStream, SplitSink, SplitStream};
 use futures::{SinkExt as _, StreamExt as _, stream};
@@ -60,7 +60,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
 
-use super::{SubscriptionId, SubscriptionSource};
+use super::SubscriptionSource;
 
 /// Commands that can be sent to the WebSocket connection.
 #[derive(Debug, Clone)]
@@ -233,6 +233,7 @@ enum WsStreamState {
 
 impl SubscriptionSource for WebSocket {
     type Output = WebSocketMessage;
+    type Key = String;
 
     #[allow(clippy::too_many_lines)]
     fn stream(&self) -> BoxStream<'static, WebSocketMessage> {
@@ -420,10 +421,8 @@ impl SubscriptionSource for WebSocket {
         .boxed()
     }
 
-    fn id(&self) -> SubscriptionId {
-        let mut hasher = DefaultHasher::new();
-        self.hash(&mut hasher);
-        SubscriptionId::of::<Self>(hasher.finish())
+    fn key(&self) -> Self::Key {
+        self.url.clone()
     }
 }
 
@@ -486,7 +485,7 @@ mod tests {
         let ws2 = WebSocket::new("wss://example.com");
 
         // Same configuration should produce the same ID
-        assert_eq!(ws1.id(), ws2.id());
+        assert_eq!(ws1.key(), ws2.key());
     }
 
     #[test]
@@ -495,7 +494,7 @@ mod tests {
         let ws2 = WebSocket::new("wss://different.com");
 
         // Different urls should produce different IDs
-        assert_ne!(ws1.id(), ws2.id());
+        assert_ne!(ws1.key(), ws2.key());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements Phase A of RFC 0005 by replacing pre-hashed subscription IDs with framework-owned structural lifecycle identity.

This is a breaking change for custom `SubscriptionSource` implementations: `id()` is replaced by an associated `Key` type and `key()` method, and `SubscriptionId` is no longer `Copy`.

## Key changes

- Replace `SubscriptionId { TypeId, u64 }` with collision-safe structural identity.
- Make `Subscription::new` combine the concrete source type with its original logical key.
- Migrate all built-in sources, tests, examples, and benchmarks to `SubscriptionSource::Key`.
- Preserve `SubscriptionId` marker traits including `Send`, `Sync`, `UnwindSafe`, and `RefUnwindSafe`.
- Update `SubscriptionManager` for non-`Copy` IDs while preserving lazy spawning, restart behavior, and first-wins duplicate handling.
- Emit a warning when an equal duplicate subscription is ignored.
- Add collision regression coverage for independent startup, message mapping, removal, and restart behavior.
- Document the `key()` stability contract and add a before/after migration example to the changelog.
- Fix the Windows Ctrl+C/Ctrl+Break identity tests and remove obsolete Windows imports.
- Update stale API documentation and document the zero-capacity panic condition for `MockSource`.

## Deferred follow-ups

The following cleanup items are intentionally excluded from this PR and will be handled separately:

- Extract a private structural-key helper shared by `CommandId` and `SubscriptionId`.
- Revisit the redundant erased key type ID stored alongside the source type namespace.
- Review source-level `Hash` implementations and derives that are no longer required internally, including their public API compatibility implications.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo test --doc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo +1.88.0 check --all-targets --all-features`
- `cargo test --test api_surface -- --ignored`

The Windows-specific identity regression is covered by a `cfg(windows)` unit test and will run in the Windows CI jobs.