### PR TITLE
refactor: share structural key erasure

### DIFF
--- a/src/command/cancellation.rs
+++ b/src/command/cancellation.rs
@@ -1,7 +1,7 @@
-use std::any::{Any, TypeId, type_name};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+
+use crate::structural_key::StructuralKey;
 
 /// Identifies one cancellable command-output lifecycle.
 ///
@@ -10,7 +10,7 @@ use std::sync::Arc;
 /// distinct command ids.
 #[derive(Clone)]
 pub struct CommandId {
-    inner: Arc<dyn ErasedCommandId>,
+    inner: StructuralKey,
 }
 
 impl CommandId {
@@ -20,7 +20,7 @@ impl CommandId {
         T: Eq + Hash + Send + Sync + 'static,
     {
         Self {
-            inner: Arc::new(TypedCommandId(value)),
+            inner: StructuralKey::new(value),
         }
     }
 }
@@ -36,8 +36,7 @@ impl fmt::Debug for CommandId {
 
 impl PartialEq for CommandId {
     fn eq(&self, other: &Self) -> bool {
-        self.inner.erased_type_id() == other.inner.erased_type_id()
-            && self.inner.eq_erased(other.inner.as_ref())
+        self.inner == other.inner
     }
 }
 
@@ -45,46 +44,7 @@ impl Eq for CommandId {}
 
 impl Hash for CommandId {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.erased_type_id().hash(state);
-        self.inner.hash_erased(state);
-    }
-}
-
-trait ErasedCommandId: Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-    fn erased_type_id(&self) -> TypeId;
-    fn type_name(&self) -> &'static str;
-    fn eq_erased(&self, other: &dyn ErasedCommandId) -> bool;
-    fn hash_erased(&self, state: &mut dyn Hasher);
-}
-
-struct TypedCommandId<T>(T);
-
-impl<T> ErasedCommandId for TypedCommandId<T>
-where
-    T: Eq + Hash + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn erased_type_id(&self) -> TypeId {
-        TypeId::of::<T>()
-    }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<T>()
-    }
-
-    fn eq_erased(&self, other: &dyn ErasedCommandId) -> bool {
-        other
-            .as_any()
-            .downcast_ref::<Self>()
-            .is_some_and(|other| self.0 == other.0)
-    }
-
-    fn hash_erased(&self, mut state: &mut dyn Hasher) {
-        self.0.hash(&mut state);
+        self.inner.hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod command;
 pub(crate) mod panic;
 pub mod prelude;
 pub(crate) mod runtime;
+mod structural_key;
 pub mod subscription;
 
 // Re-export commonly used types

--- a/src/structural_key.rs
+++ b/src/structural_key.rs
@@ -1,0 +1,177 @@
+//! Shared structural-key erasure for command and subscription lifecycle IDs.
+//!
+//! This implements the private helper described in RFC 0005 section 8.1 while
+//! letting each ID apply the namespace rules required by its lifecycle model.
+
+use std::any::{Any, TypeId, type_name};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+/// An owned, type-erased key with structural equality and hashing.
+///
+/// The default [`Eq`] and [`Hash`] implementations include the concrete key
+/// type. Owners that already provide a type namespace may use the value-only
+/// operations to avoid hashing the same type distinction twice.
+#[derive(Clone)]
+pub struct StructuralKey {
+    inner: Arc<dyn ErasedStructuralKey>,
+}
+
+impl StructuralKey {
+    pub fn new<T>(value: T) -> Self
+    where
+        T: Eq + Hash + Send + Sync + 'static,
+    {
+        Self {
+            inner: Arc::new(TypedStructuralKey(value)),
+        }
+    }
+
+    pub fn type_name(&self) -> &'static str {
+        self.inner.type_name()
+    }
+
+    /// Compares only the erased structural value.
+    ///
+    /// The erased implementation still downcasts safely before comparing. This
+    /// operation is intended for an owner whose own namespace guarantees the
+    /// concrete key type, such as a subscription source type and its associated
+    /// `Key`.
+    pub fn value_eq(&self, other: &Self) -> bool {
+        self.inner.eq_erased(other.inner.as_ref())
+    }
+
+    /// Hashes only the erased structural value.
+    ///
+    /// The caller must provide the namespace that fixes the concrete key type.
+    pub fn hash_value<H: Hasher>(&self, state: &mut H) {
+        self.inner.hash_erased(state);
+    }
+
+    fn type_id(&self) -> TypeId {
+        self.inner.erased_type_id()
+    }
+}
+
+impl PartialEq for StructuralKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.type_id() == other.type_id() && self.value_eq(other)
+    }
+}
+
+impl Eq for StructuralKey {}
+
+impl Hash for StructuralKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.type_id().hash(state);
+        self.hash_value(state);
+    }
+}
+
+trait ErasedStructuralKey: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+    fn erased_type_id(&self) -> TypeId;
+    fn type_name(&self) -> &'static str;
+    fn eq_erased(&self, other: &dyn ErasedStructuralKey) -> bool;
+    fn hash_erased(&self, state: &mut dyn Hasher);
+}
+
+struct TypedStructuralKey<T>(T);
+
+impl<T> ErasedStructuralKey for TypedStructuralKey<T>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+{
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn erased_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    fn type_name(&self) -> &'static str {
+        type_name::<T>()
+    }
+
+    fn eq_erased(&self, other: &dyn ErasedStructuralKey) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.0 == other.0)
+    }
+
+    fn hash_erased(&self, mut state: &mut dyn Hasher) {
+        self.0.hash(&mut state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn hash(key: &StructuralKey) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn hash_value(key: &StructuralKey) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        key.hash_value(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn equality_is_structural_and_type_sensitive() {
+        assert!(StructuralKey::new(7_u64) == StructuralKey::new(7_u64));
+        assert!(StructuralKey::new(7_u64) != StructuralKey::new(8_u64));
+        assert!(StructuralKey::new(7_u64) != StructuralKey::new(7_i64));
+        assert!(!StructuralKey::new(7_u64).value_eq(&StructuralKey::new(7_i64)));
+    }
+
+    #[test]
+    fn hash_collisions_do_not_make_distinct_values_equal() {
+        #[derive(Eq, PartialEq)]
+        struct Collision(u8);
+
+        impl Hash for Collision {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        let first = StructuralKey::new(Collision(1));
+        let second = StructuralKey::new(Collision(2));
+
+        assert_eq!(hash(&first), hash(&second));
+        assert!(first != second);
+    }
+
+    #[test]
+    fn value_only_hash_does_not_add_the_key_type_namespace() {
+        #[derive(Eq, PartialEq)]
+        struct First;
+
+        #[derive(Eq, PartialEq)]
+        struct Second;
+
+        impl Hash for First {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        impl Hash for Second {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        assert_eq!(
+            hash_value(&StructuralKey::new(First)),
+            hash_value(&StructuralKey::new(Second))
+        );
+    }
+}

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -5,13 +5,14 @@
 //! SubscriptionSource}` paths. See `runtime::frame_rate` for the same
 //! pattern applied to `Runtime`'s scheduling input.
 
-use std::any::{Any, TypeId, type_name};
+use std::any::{TypeId, type_name};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::panic::AssertUnwindSafe;
-use std::sync::Arc;
 
 use futures::{StreamExt, stream::BoxStream};
+
+use crate::structural_key::StructuralKey;
 
 /// A subscription represents an ongoing source of messages.
 ///
@@ -172,7 +173,7 @@ pub trait SubscriptionSource: Send {
 pub struct SubscriptionId {
     pub(super) source_type_id: TypeId,
     source_type_name: &'static str,
-    key: AssertUnwindSafe<Arc<dyn ErasedSubscriptionKey>>,
+    key: AssertUnwindSafe<StructuralKey>,
 }
 
 impl Clone for SubscriptionId {
@@ -193,7 +194,7 @@ impl SubscriptionId {
         Self {
             source_type_id: TypeId::of::<Source>(),
             source_type_name: type_name::<Source>(),
-            key: AssertUnwindSafe(Arc::new(TypedSubscriptionKey(key))),
+            key: AssertUnwindSafe(StructuralKey::new(key)),
         }
     }
 }
@@ -210,9 +211,9 @@ impl fmt::Debug for SubscriptionId {
 
 impl PartialEq for SubscriptionId {
     fn eq(&self, other: &Self) -> bool {
-        self.source_type_id == other.source_type_id
-            && self.key.0.erased_type_id() == other.key.0.erased_type_id()
-            && self.key.0.eq_erased(other.key.0.as_ref())
+        // One concrete source type has exactly one associated `Key` type, so
+        // the source namespace already fixes the erased key type.
+        self.source_type_id == other.source_type_id && self.key.0.value_eq(&other.key.0)
     }
 }
 
@@ -220,47 +221,10 @@ impl Eq for SubscriptionId {}
 
 impl Hash for SubscriptionId {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash the source namespace once; its associated `Key` type does not
+        // need a second type namespace in this identity.
         self.source_type_id.hash(state);
-        self.key.0.erased_type_id().hash(state);
-        self.key.0.hash_erased(state);
-    }
-}
-
-trait ErasedSubscriptionKey: Send + Sync {
-    fn as_any(&self) -> &dyn Any;
-    fn erased_type_id(&self) -> TypeId;
-    fn type_name(&self) -> &'static str;
-    fn eq_erased(&self, other: &dyn ErasedSubscriptionKey) -> bool;
-    fn hash_erased(&self, state: &mut dyn Hasher);
-}
-
-struct TypedSubscriptionKey<T>(T);
-
-impl<T> ErasedSubscriptionKey for TypedSubscriptionKey<T>
-where
-    T: Eq + Hash + Send + Sync + 'static,
-{
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn erased_type_id(&self) -> TypeId {
-        TypeId::of::<T>()
-    }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<T>()
-    }
-
-    fn eq_erased(&self, other: &dyn ErasedSubscriptionKey) -> bool {
-        other
-            .as_any()
-            .downcast_ref::<Self>()
-            .is_some_and(|other| self.0 == other.0)
-    }
-
-    fn hash_erased(&self, mut state: &mut dyn Hasher) {
-        self.0.hash(&mut state);
+        self.key.0.hash_value(state);
     }
 }
 


### PR DESCRIPTION
## Summary

Extract the duplicated type-erased structural key machinery from `CommandId`
and `SubscriptionId` into a private shared `StructuralKey` implementation.

This is an internal, behavior-preserving refactor with no public API changes.

## Key changes

- Add a private `StructuralKey` abstraction that owns the erased key value and
  centralizes cloning, type-aware equality, hashing, and diagnostic type names.
- Replace the separate `ErasedCommandId` and `ErasedSubscriptionKey`
  implementations with the shared helper.
- Keep `CommandId` type-sensitive by delegating to `StructuralKey`'s standard
  `Eq` and `Hash` implementations.
- Remove the redundant logical-key type namespace from `SubscriptionId`
  equality and hashing.
- Preserve collision-safe structural comparison, source-type namespacing,
  debug output, and `SubscriptionId`'s unwind-safety marker traits.
- Add focused tests for typed equality, collision safety, safe value-only
  comparison, and value-only hashing without an additional type namespace.

## Design rationale

`CommandId` has no outer type namespace, so its identity must include the
concrete logical-key type.

`SubscriptionId` already includes the concrete source type. Because each
`SubscriptionSource` has exactly one associated `Key` type, the source namespace
also fixes the erased key type. Its equality and hashing can therefore combine
the source type with the structural key value without adding the key type ID a
second time.

The value-only comparison still performs a safe downcast before comparing, so
the shared helper does not introduce unchecked type assumptions.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo test --doc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo +1.88.0 check --all-targets --all-features`
- `cargo test --test api_surface -- --ignored`
