### PR TITLE
refactor(subscription)!: remove obsolete source Hash impls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     type, and `SubscriptionId::of::<T>(u64)` is removed
   - `SubscriptionId` is `Clone` but no longer `Copy`; it remains `Send`,
     `Sync`, `UnwindSafe`, and `RefUnwindSafe`
+  - Built-in subscription source types no longer implement `Hash`: `Timer`,
+    `TerminalEvents`, Unix `Signal`, Windows `CtrlC` / `CtrlBreak`, and
+    feature-gated `WebSocket` / `Query`; hash or store their structural key
+    returned by `SubscriptionSource::key()` when lifecycle identity is needed
   - Duplicate desired subscriptions still keep the first declaration and now
     emit a warning under the `tears::subscription` tracing target
 

--- a/docs/rfcs/0005-structural-lifecycle-identity.md
+++ b/docs/rfcs/0005-structural-lifecycle-identity.md
@@ -984,7 +984,8 @@ Each built-in source must expose its actual lifecycle inputs as its associated
 
 - `Timer`: interval value;
 - terminal and signal sources: the semantic configuration or signal kind;
-- WebSocket: connection inputs that currently participate in its `Hash`;
+- WebSocket: connection inputs that define its lifecycle identity (currently
+  the URL);
 - HTTP `Query`: client identity, response type through `Self`, and structural
   `QueryKey` inputs;
 - `MockSource`: one clone-stable per-instance token stored by the source. The

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -479,16 +479,6 @@ where
     }
 }
 
-impl<V> Hash for Query<V> {
-    fn hash<H>(&self, hasher: &mut H)
-    where
-        H: Hasher,
-    {
-        self.client.client_id.hash(hasher);
-        self.key.hash(hasher);
-    }
-}
-
 #[derive(Clone, Copy)]
 struct QueryTrace {
     client_id: u64,

--- a/src/subscription/signal.rs
+++ b/src/subscription/signal.rs
@@ -6,7 +6,7 @@
 
 #[cfg(unix)]
 mod unix_signal {
-    use std::{hash::Hash, io};
+    use std::io;
 
     use futures::stream::BoxStream;
     use futures::{StreamExt as _, stream};
@@ -79,7 +79,7 @@ mod unix_signal {
     ///
     /// Multiple subscriptions for the same signal kind are allowed. Each subscription
     /// will independently receive the signal.
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct Signal {
         kind: SignalKind,
     }
@@ -256,7 +256,7 @@ mod windows_signal {
     ///
     /// This is a singleton subscription - all instances are considered identical
     /// and only one Ctrl+C handler will be active at a time.
-    #[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, Default)]
     pub struct CtrlC;
 
     impl CtrlC {
@@ -373,7 +373,7 @@ mod windows_signal {
     ///
     /// This is a singleton subscription - all instances are considered identical
     /// and only one Ctrl+Break handler will be active at a time.
-    #[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+    #[derive(Debug, Clone, PartialEq, Eq, Default)]
     pub struct CtrlBreak;
 
     impl CtrlBreak {

--- a/src/subscription/terminal.rs
+++ b/src/subscription/terminal.rs
@@ -3,7 +3,6 @@
 //! This module provides the [`TerminalEvents`] subscription source for handling
 //! terminal input events using crossterm.
 
-use std::hash::Hash;
 use std::io;
 
 use crossterm::event::{Event, EventStream};
@@ -85,7 +84,7 @@ use super::SubscriptionSource;
 ///
 /// This is a singleton subscription - all instances are considered identical
 /// and only one terminal event stream will be active at a time.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TerminalEvents;
 
 impl TerminalEvents {

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -3,7 +3,6 @@
 //! This module provides the [`Timer`] subscription source for creating
 //! time-based events in your application.
 
-use std::hash::{Hash, Hasher};
 use std::num::NonZeroU64;
 use std::time::Duration;
 
@@ -116,16 +115,9 @@ impl SubscriptionSource for Timer {
     }
 }
 
-impl Hash for Timer {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.interval_ms.hash(state);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::hash::DefaultHasher;
 
     use tokio::time::{Duration, Instant, timeout};
 
@@ -156,38 +148,6 @@ mod tests {
 
         // Different intervals should produce different IDs
         assert_ne!(timer1.key(), timer2.key());
-    }
-
-    #[test]
-    fn test_timer_hash_consistency() {
-        let timer1 = timer(1000);
-        let timer2 = timer(1000);
-
-        let mut hasher1 = DefaultHasher::new();
-        timer1.hash(&mut hasher1);
-        let hash1 = hasher1.finish();
-
-        let mut hasher2 = DefaultHasher::new();
-        timer2.hash(&mut hasher2);
-        let hash2 = hasher2.finish();
-
-        assert_eq!(hash1, hash2);
-    }
-
-    #[test]
-    fn test_timer_hash_different_intervals() {
-        let timer1 = timer(1000);
-        let timer2 = timer(2000);
-
-        let mut hasher1 = DefaultHasher::new();
-        timer1.hash(&mut hasher1);
-        let hash1 = hasher1.finish();
-
-        let mut hasher2 = DefaultHasher::new();
-        timer2.hash(&mut hasher2);
-        let hash2 = hasher2.finish();
-
-        assert_ne!(hash1, hash2);
     }
 
     #[tokio::test]

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -50,8 +50,6 @@
 //! tears = { version = "0.9", features = ["ws", "native-tls"] }
 //! ```
 
-use std::hash::Hash;
-
 use futures::stream::{BoxStream, SplitSink, SplitStream};
 use futures::{SinkExt as _, StreamExt as _, stream};
 use tokio::net::TcpStream;
@@ -189,7 +187,7 @@ pub enum WebSocketMessage {
 ///   a very high rate and the consumer is slower than the arrival rate, TCP receive-window
 ///   pressure will propagate back to the server.  Applications that need to decouple
 ///   consumption speed from network read speed should add their own buffering layer.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WebSocket {
     url: String,
 }


### PR DESCRIPTION
## Summary

Remove `Hash` implementations from built-in subscription source types now that
subscription lifecycle identity is derived from `SubscriptionSource::Key`.

This is an intentional breaking change for 0.10.0 and completes the cleanup
associated with RFC 0005 Phase A.

## Rationale

These `Hash` implementations existed to support the previous
`SubscriptionSource::id()` mechanism, which hashed each source into a `u64`
digest. That mechanism has been replaced by framework-owned structural identity,
so the source-level implementations no longer have an internal consumer.

Keeping them would accidentally commit the public source types to remaining
hashable even as their configuration evolves. Removing them as part of the
existing 0.10.0 subscription identity migration avoids carrying that constraint
forward or requiring another breaking release later.

## Changes

- Remove `Hash` from:
  - `Timer`
  - `TerminalEvents`
  - Unix `Signal`
  - Windows `CtrlC` and `CtrlBreak`
  - feature-gated `WebSocket` `Query`
- Remove the manual `Hash` implementation and two Hash-specific tests for
  `Timer`.
- Preserve `Debug`, `Clone`, `PartialEq`, `Eq`, and `Default` where previously
  implemented.
- Preserve `Hash` for lifecycle key types, `SubscriptionId`, and `CommandId`.
- Update the RFC 0005 implementation guidance and the 0.10.0 changelog.

## Migration

Code that needs a hashable lifecycle identity should store or hash the
structural key returned by `SubscriptionSource::key()` instead of the source
value itself:

```rust
use std::collections::HashSet;
use tears::SubscriptionSource;
use tears::subscription::time::Timer;

let keys: HashSet<_> = timers
    .iter()
    .map(|timer: &Timer| timer.key())
    .collect();
```

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`
- `cargo test --doc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo +1.88.0 check --all-targets --all-features`
- `cargo test --test api_surface -- --ignored`
- `cargo +nightly public-api --all-features`

The public API output confirms that `Hash` was removed only from the targeted
source types, while `CommandId`, `SubscriptionId`, `QueryKey`, and
`QueryKeyPart` remain hashable.
