### PR TITLE
bench(runtime): full-loop load harness and RFC 0006 draft (S4 release gate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3081,6 +3081,7 @@ dependencies = [
  "crossterm 0.29.0",
  "dashmap",
  "futures",
+ "libc",
  "loom",
  "proptest",
  "public-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,18 @@ tracing = "0.1"
 [target.'cfg(not(loom))'.dev-dependencies]
 reqwest = { version = "0.13", features = ["json", "query"] }
 
+[target.'cfg(unix)'.dev-dependencies]
+# Peak-RSS measurement (`getrusage`) in `benches/runtime_load.rs`.
+libc = "0.2"
+
 [[bench]]
 name = "subscription"
 harness = false
 required-features = ["bench-internals"]
+
+[[bench]]
+name = "runtime_load"
+harness = false
 
 [[example]]
 name = "websocket"

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -37,10 +37,10 @@
     clippy::cast_sign_loss
 )]
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Mutex;
 use std::num::NonZeroU32;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use std::{env, hint, mem};
 
@@ -290,7 +290,9 @@ impl Application for LoadApp {
                 }
                 self.last_processed = Some((seq, sent_at));
                 self.processed += 1;
-                self.metrics.processed.store(self.processed, Ordering::Relaxed);
+                self.metrics
+                    .processed
+                    .store(self.processed, Ordering::Relaxed);
                 if self.processed == self.cfg.total {
                     return Command::quit();
                 }
@@ -310,7 +312,9 @@ impl Application for LoadApp {
             let marker = seq + 1;
             // Only the runtime task calls `view`, so load-then-store is safe.
             if self.metrics.rendered_marker.load(Ordering::Relaxed) < marker {
-                self.metrics.rendered_marker.store(marker, Ordering::Relaxed);
+                self.metrics
+                    .rendered_marker
+                    .store(marker, Ordering::Relaxed);
                 Metrics::push_latency(&self.metrics.render_lat_ns, sent_at);
             }
         }
@@ -387,8 +391,7 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
     let samples = sampler.await.expect("sampler task");
 
     let producer_done_ns = metrics.producer_done_ns.load(Ordering::Relaxed);
-    let producer_done =
-        (producer_done_ns > 0).then(|| Duration::from_nanos(producer_done_ns));
+    let producer_done = (producer_done_ns > 0).then(|| Duration::from_nanos(producer_done_ns));
     let depth_at_producer_done = producer_done.and_then(|done| {
         samples
             .iter()

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -1,0 +1,554 @@
+//! Full-loop runtime load harness for the S4 runtime load control RFC.
+//!
+//! Unlike `benches/subscription.rs`, which isolates the reconciliation hot
+//! path, this harness drives the real [`Runtime`] end-to-end through the
+//! public API: a subscription floods the shared message channel at a
+//! configured rate while the application simulates per-message update work
+//! and per-frame render work. It observes the load characteristics that
+//! throughput numbers alone hide:
+//!
+//! - **Queue depth**: pending messages (produced - processed), sampled while
+//!   the scenario runs; all runtime channels are unbounded today, so this is
+//!   the direct driver of memory growth under overload.
+//! - **Update latency**: message emission to `Application::update`.
+//! - **Render latency**: message emission to the first `Application::view`
+//!   call that observes it (input-to-screen staleness).
+//! - **Keyed delivery latency**: emission to update for outputs of a
+//!   cancellable (keyed) command while the shared channel is loaded, to
+//!   expose ordering bias between the shared and keyed input paths.
+//! - **Memory**: peak RSS delta per scenario plus an estimate of the backlog
+//!   footprint from the maximum observed queue depth.
+//!
+//! Run all scenarios, or name a subset:
+//!
+//! ```bash
+//! cargo bench --bench runtime_load
+//! cargo bench --bench runtime_load -- overload keyed_overload
+//! ```
+//!
+//! Peak RSS is process-wide and monotone, so for clean memory numbers run a
+//! single scenario per invocation.
+
+// Metric reporting converts counters and nanosecond values to floating point
+// for human-readable output; precision loss there is irrelevant.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::num::NonZeroU32;
+use std::time::{Duration, Instant};
+use std::{env, hint, mem};
+
+use futures::stream::{self, StreamExt};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use tears::command::CommandId;
+use tears::prelude::*;
+use tears::{BoxStream, SubscriptionSource};
+use tokio::runtime::Builder;
+use tokio::time::{MissedTickBehavior, interval, timeout};
+use tokio_stream::wrappers::IntervalStream;
+
+/// Message rate for scenarios that emit their whole load in one burst.
+const BURST: u64 = 0;
+
+#[derive(Clone)]
+struct ScenarioCfg {
+    name: &'static str,
+    /// Messages per second, or [`BURST`] to emit everything at once.
+    rate: u64,
+    /// Total number of flood messages to emit.
+    total: u64,
+    /// Simulated CPU cost per `update` call.
+    update_cost: Duration,
+    /// Simulated CPU cost per `view` call.
+    render_cost: Duration,
+    /// Whether to run a keyed command emitting probe messages every 25ms.
+    keyed_probe: bool,
+    /// Wall-clock guard; the scenario is aborted and reported as timed out.
+    max_wall: Duration,
+}
+
+fn scenarios() -> Vec<ScenarioCfg> {
+    vec![
+        // Paced load well below consumer capacity: the baseline contract.
+        ScenarioCfg {
+            name: "steady_20k",
+            rate: 20_000,
+            total: 100_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            max_wall: Duration::from_secs(30),
+        },
+        // Paced load near consumer capacity.
+        ScenarioCfg {
+            name: "steady_200k",
+            rate: 200_000,
+            total: 1_000_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            max_wall: Duration::from_secs(30),
+        },
+        // One burst dumped into the unbounded channel at t=0; measures drain
+        // behavior and worst-case backlog for a spike.
+        ScenarioCfg {
+            name: "burst_200k",
+            rate: BURST,
+            total: 200_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            max_wall: Duration::from_secs(30),
+        },
+        // Sustained producer faster than the consumer: queue depth and
+        // latency must grow without bound while the producer runs.
+        ScenarioCfg {
+            name: "overload",
+            rate: 100_000,
+            total: 500_000,
+            update_cost: Duration::from_micros(25),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            max_wall: Duration::from_secs(60),
+        },
+        // Control: keyed command outputs while the shared channel is lightly
+        // loaded.
+        ScenarioCfg {
+            name: "keyed_steady",
+            rate: 20_000,
+            total: 100_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: true,
+            max_wall: Duration::from_secs(30),
+        },
+        // Keyed command outputs while the shared channel is overloaded; the
+        // input mux polls the shared channel first, so this measures how much
+        // a shared-channel backlog delays keyed delivery.
+        ScenarioCfg {
+            name: "keyed_overload",
+            rate: 100_000,
+            total: 500_000,
+            update_cost: Duration::from_micros(25),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: true,
+            max_wall: Duration::from_secs(60),
+        },
+    ]
+}
+
+struct Metrics {
+    start: Instant,
+    produced: AtomicU64,
+    processed: AtomicU64,
+    /// Nanoseconds from `start` at which the producer emitted its last
+    /// message; 0 while still producing.
+    producer_done_ns: AtomicU64,
+    frames: AtomicU64,
+    /// `seq + 1` of the newest flood message observed by `view`; 0 if none.
+    rendered_marker: AtomicU64,
+    update_lat_ns: Mutex<Vec<u64>>,
+    render_lat_ns: Mutex<Vec<u64>>,
+    keyed_lat_ns: Mutex<Vec<u64>>,
+}
+
+impl Metrics {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            produced: AtomicU64::new(0),
+            processed: AtomicU64::new(0),
+            producer_done_ns: AtomicU64::new(0),
+            frames: AtomicU64::new(0),
+            rendered_marker: AtomicU64::new(0),
+            update_lat_ns: Mutex::new(Vec::new()),
+            render_lat_ns: Mutex::new(Vec::new()),
+            keyed_lat_ns: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn queue_depth(&self) -> u64 {
+        let produced = self.produced.load(Ordering::Relaxed);
+        let processed = self.processed.load(Ordering::Relaxed);
+        produced.saturating_sub(processed)
+    }
+
+    fn push_latency(bucket: &Mutex<Vec<u64>>, sent_at: Instant) {
+        let nanos = u64::try_from(sent_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        bucket.lock().expect("latency bucket poisoned").push(nanos);
+    }
+}
+
+enum Msg {
+    Load { seq: u64, sent_at: Instant },
+    KeyedProbe { sent_at: Instant },
+}
+
+/// Emits `total` flood messages, paced by `rate`, then stays pending forever
+/// so the subscription task is never reaped and restarted by reconciliation.
+struct FloodSource {
+    cfg: ScenarioCfg,
+    metrics: Arc<Metrics>,
+}
+
+impl SubscriptionSource for FloodSource {
+    type Output = Msg;
+    type Key = &'static str;
+
+    fn stream(&self) -> BoxStream<'static, Msg> {
+        let metrics = Arc::clone(&self.metrics);
+        let total = self.cfg.total;
+        let per_tick = if self.cfg.rate == BURST {
+            usize::try_from(total).expect("total fits in usize")
+        } else {
+            // 1ms ticks; keep at least one message per tick.
+            usize::try_from((self.cfg.rate / 1_000).max(1)).expect("per-tick fits in usize")
+        };
+
+        let mut ticker = interval(Duration::from_millis(1));
+        // Catch up after missed ticks so the configured rate holds on average.
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Burst);
+
+        IntervalStream::new(ticker)
+            .flat_map(move |_| {
+                let metrics = Arc::clone(&metrics);
+                stream::iter((0..per_tick).map(move |_| {
+                    let seq = metrics.produced.fetch_add(1, Ordering::Relaxed);
+                    if seq + 1 == total {
+                        let elapsed =
+                            u64::try_from(metrics.start.elapsed().as_nanos()).unwrap_or(u64::MAX);
+                        metrics.producer_done_ns.store(elapsed, Ordering::Relaxed);
+                    }
+                    Msg::Load {
+                        seq,
+                        sent_at: Instant::now(),
+                    }
+                }))
+            })
+            .take(usize::try_from(total).expect("total fits in usize"))
+            .chain(stream::pending())
+            .boxed()
+    }
+
+    fn key(&self) -> Self::Key {
+        "flood"
+    }
+}
+
+struct LoadApp {
+    cfg: ScenarioCfg,
+    metrics: Arc<Metrics>,
+    /// Newest flood message applied to state, for render staleness.
+    last_processed: Option<(u64, Instant)>,
+    processed: u64,
+    /// Record every Nth update latency to bound sample memory.
+    sample_every: u64,
+}
+
+impl Application for LoadApp {
+    type Message = Msg;
+    type Flags = (ScenarioCfg, Arc<Metrics>);
+
+    fn new((cfg, metrics): Self::Flags) -> (Self, Command<Msg>) {
+        let cmd = if cfg.keyed_probe {
+            let mut ticker = interval(Duration::from_millis(25));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let probes = IntervalStream::new(ticker).map(|_| Msg::KeyedProbe {
+                sent_at: Instant::now(),
+            });
+            Command::stream(probes).cancellable(CommandId::new("keyed-probe"))
+        } else {
+            Command::none()
+        };
+
+        let sample_every = (cfg.total / 100_000).max(1);
+        (
+            Self {
+                cfg,
+                metrics,
+                last_processed: None,
+                processed: 0,
+                sample_every,
+            },
+            cmd,
+        )
+    }
+
+    fn update(&mut self, msg: Msg) -> Command<Msg> {
+        match msg {
+            Msg::Load { seq, sent_at } => {
+                spin(self.cfg.update_cost);
+                if seq % self.sample_every == 0 {
+                    Metrics::push_latency(&self.metrics.update_lat_ns, sent_at);
+                }
+                self.last_processed = Some((seq, sent_at));
+                self.processed += 1;
+                self.metrics.processed.store(self.processed, Ordering::Relaxed);
+                if self.processed == self.cfg.total {
+                    return Command::quit();
+                }
+                Command::none()
+            }
+            Msg::KeyedProbe { sent_at } => {
+                Metrics::push_latency(&self.metrics.keyed_lat_ns, sent_at);
+                Command::none()
+            }
+        }
+    }
+
+    fn view(&self, _frame: &mut ratatui::Frame<'_>) {
+        spin(self.cfg.render_cost);
+        self.metrics.frames.fetch_add(1, Ordering::Relaxed);
+        if let Some((seq, sent_at)) = self.last_processed {
+            let marker = seq + 1;
+            // Only the runtime task calls `view`, so load-then-store is safe.
+            if self.metrics.rendered_marker.load(Ordering::Relaxed) < marker {
+                self.metrics.rendered_marker.store(marker, Ordering::Relaxed);
+                Metrics::push_latency(&self.metrics.render_lat_ns, sent_at);
+            }
+        }
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Msg>> {
+        vec![Subscription::new(FloodSource {
+            cfg: self.cfg.clone(),
+            metrics: Arc::clone(&self.metrics),
+        })]
+    }
+}
+
+/// Busy-waits for `duration` to simulate CPU-bound work on the runtime task.
+fn spin(duration: Duration) {
+    if duration.is_zero() {
+        return;
+    }
+    let deadline = Instant::now() + duration;
+    while Instant::now() < deadline {
+        hint::spin_loop();
+    }
+}
+
+struct Report {
+    cfg: ScenarioCfg,
+    wall: Duration,
+    timed_out: bool,
+    produced: u64,
+    processed: u64,
+    frames: u64,
+    max_depth: u64,
+    depth_at_producer_done: Option<u64>,
+    producer_done: Option<Duration>,
+    update_lat_ns: Vec<u64>,
+    render_lat_ns: Vec<u64>,
+    keyed_lat_ns: Vec<u64>,
+    peak_rss_delta: Option<u64>,
+}
+
+async fn run_scenario(cfg: ScenarioCfg) -> Report {
+    let rss_before = peak_rss_bytes();
+    let metrics = Arc::new(Metrics::new());
+
+    // Queue depth sampler; runs until the scenario finishes.
+    let stop = Arc::new(AtomicBool::new(false));
+    let sampler = {
+        let metrics = Arc::clone(&metrics);
+        let stop = Arc::clone(&stop);
+        tokio::spawn(async move {
+            let mut samples: Vec<(Duration, u64)> = Vec::new();
+            let mut ticker = interval(Duration::from_millis(5));
+            while !stop.load(Ordering::Relaxed) {
+                ticker.tick().await;
+                samples.push((metrics.start.elapsed(), metrics.queue_depth()));
+            }
+            samples
+        })
+    };
+
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
+        .expect("60 FPS is a valid frame rate");
+    let runtime = Runtime::<LoadApp>::new((cfg.clone(), Arc::clone(&metrics)), frame_rate);
+    let mut terminal =
+        Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
+
+    let started = Instant::now();
+    let timed_out = timeout(cfg.max_wall, runtime.run(&mut terminal))
+        .await
+        .is_err();
+    let wall = started.elapsed();
+
+    stop.store(true, Ordering::Relaxed);
+    let samples = sampler.await.expect("sampler task");
+
+    let producer_done_ns = metrics.producer_done_ns.load(Ordering::Relaxed);
+    let producer_done =
+        (producer_done_ns > 0).then(|| Duration::from_nanos(producer_done_ns));
+    let depth_at_producer_done = producer_done.and_then(|done| {
+        samples
+            .iter()
+            .find(|(at, _)| *at >= done)
+            .map(|(_, depth)| *depth)
+    });
+
+    let take_sorted = |bucket: &Mutex<Vec<u64>>| {
+        let mut values = bucket.lock().expect("latency bucket poisoned").clone();
+        values.sort_unstable();
+        values
+    };
+
+    Report {
+        wall,
+        timed_out,
+        produced: metrics.produced.load(Ordering::Relaxed),
+        processed: metrics.processed.load(Ordering::Relaxed),
+        frames: metrics.frames.load(Ordering::Relaxed),
+        max_depth: samples.iter().map(|(_, depth)| *depth).max().unwrap_or(0),
+        depth_at_producer_done,
+        producer_done,
+        update_lat_ns: take_sorted(&metrics.update_lat_ns),
+        render_lat_ns: take_sorted(&metrics.render_lat_ns),
+        keyed_lat_ns: take_sorted(&metrics.keyed_lat_ns),
+        peak_rss_delta: match (rss_before, peak_rss_bytes()) {
+            (Some(before), Some(after)) => Some(after.saturating_sub(before)),
+            _ => None,
+        },
+        cfg,
+    }
+}
+
+fn percentile(sorted: &[u64], p: f64) -> u64 {
+    if sorted.is_empty() {
+        return 0;
+    }
+    let rank = ((sorted.len() as f64) * p).ceil() as usize;
+    sorted[rank.clamp(1, sorted.len()) - 1]
+}
+
+fn format_lat(sorted: &[u64]) -> String {
+    if sorted.is_empty() {
+        return "n/a".to_owned();
+    }
+    let ms = |ns: u64| ns as f64 / 1_000_000.0;
+    format!(
+        "p50={:.3}ms p95={:.3}ms p99={:.3}ms max={:.3}ms (n={})",
+        ms(percentile(sorted, 0.50)),
+        ms(percentile(sorted, 0.95)),
+        ms(percentile(sorted, 0.99)),
+        ms(*sorted.last().expect("non-empty")),
+        sorted.len(),
+    )
+}
+
+fn print_report(report: &Report) {
+    let cfg = &report.cfg;
+    println!("## {}", cfg.name);
+    let rate = if cfg.rate == BURST {
+        "burst".to_owned()
+    } else {
+        format!("{}/s", cfg.rate)
+    };
+    println!(
+        "   load: rate={rate} total={} update_cost={:?} render_cost={:?} keyed_probe={}",
+        cfg.total, cfg.update_cost, cfg.render_cost, cfg.keyed_probe
+    );
+    let status = if report.timed_out { "TIMED OUT" } else { "ok" };
+    println!(
+        "   run: {status} wall={:.2}s produced={} processed={} throughput={:.0}/s",
+        report.wall.as_secs_f64(),
+        report.produced,
+        report.processed,
+        report.processed as f64 / report.wall.as_secs_f64(),
+    );
+    println!(
+        "   frames: {} ({:.1} fps effective)",
+        report.frames,
+        report.frames as f64 / report.wall.as_secs_f64(),
+    );
+    let backlog_bytes = report.max_depth * mem::size_of::<Msg>() as u64;
+    println!(
+        "   queue: max_depth={} (~{:.1} MiB backlog)",
+        report.max_depth,
+        backlog_bytes as f64 / (1024.0 * 1024.0),
+    );
+    if let (Some(done), Some(depth)) = (report.producer_done, report.depth_at_producer_done) {
+        let drain = report.wall.saturating_sub(done);
+        println!(
+            "   producer done at {:.2}s: depth={depth} drain={:.2}s",
+            done.as_secs_f64(),
+            drain.as_secs_f64(),
+        );
+    }
+    println!("   update latency: {}", format_lat(&report.update_lat_ns));
+    println!("   render latency: {}", format_lat(&report.render_lat_ns));
+    if cfg.keyed_probe {
+        println!("   keyed latency:  {}", format_lat(&report.keyed_lat_ns));
+    }
+    if let Some(delta) = report.peak_rss_delta {
+        println!(
+            "   peak RSS delta: {:.1} MiB (process-wide, monotone across scenarios)",
+            delta as f64 / (1024.0 * 1024.0),
+        );
+    }
+    println!();
+}
+
+#[cfg(unix)]
+fn peak_rss_bytes() -> Option<u64> {
+    let mut usage = mem::MaybeUninit::<libc::rusage>::zeroed();
+    // SAFETY: `usage` points to writable memory of the correct type, and
+    // `getrusage` only writes into it.
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+    if rc != 0 {
+        return None;
+    }
+    // SAFETY: `getrusage` returned 0, so the struct is initialized.
+    let usage = unsafe { usage.assume_init() };
+    let raw = u64::try_from(usage.ru_maxrss).ok()?;
+    // macOS reports bytes; Linux reports kilobytes.
+    if cfg!(target_os = "macos") {
+        Some(raw)
+    } else {
+        Some(raw * 1024)
+    }
+}
+
+#[cfg(not(unix))]
+fn peak_rss_bytes() -> Option<u64> {
+    None
+}
+
+fn main() {
+    // Positional arguments select scenarios by name; flags (e.g. the
+    // `--bench` cargo passes) are ignored.
+    let selected: Vec<String> = env::args()
+        .skip(1)
+        .filter(|arg| !arg.starts_with('-'))
+        .collect();
+
+    let to_run: Vec<ScenarioCfg> = scenarios()
+        .into_iter()
+        .filter(|cfg| selected.is_empty() || selected.iter().any(|name| name == cfg.name))
+        .collect();
+    if to_run.is_empty() {
+        let names: Vec<&str> = scenarios().iter().map(|cfg| cfg.name).collect();
+        println!("no matching scenario; available: {}", names.join(", "));
+        return;
+    }
+
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    println!("# tears runtime load harness\n");
+    for cfg in to_run {
+        let report = runtime.block_on(run_scenario(cfg));
+        print_report(&report);
+    }
+}

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -14,7 +14,10 @@
 > sections 4–6 turns out to be unimplementable without breaking the public
 > API. Sections 4–6 fix the direction of the load-control contract but their
 > details (capacities, batching caps, per-source classes) remain open until
-> implementation.
+> implementation. In particular, cross-channel fairness (section 4.3), the
+> quit delivery path (section 4.2), and the exact scope of the memory bound
+> (INV-L1) are contracts to settle before the post-0.10.0 implementation;
+> none of them gates the 0.10.0 release.
 
 ## Summary
 
@@ -76,8 +79,12 @@ Scheduling facts that interact with load:
 - **R3**: Input-to-screen latency under load must be observable and, with a
   bounded configuration, bounded by queue capacity rather than by overload
   duration.
-- **R4**: Quit must stay responsive under load (it has a dedicated channel and
-  select branch; this must remain true).
+- **R4**: A quit signal already in the dedicated quit channel must be
+  delivered with latency independent of app backlog (the dedicated channel
+  and its always-armed select branch must remain). Quit requests still
+  traveling inside command streams — a keyed `Action::Quit` in its private
+  channel, or a quit behind earlier sends of the same unkeyed stream —
+  follow their stream's delivery semantics (section 4.2).
 - **R5**: RFC 0003's cancellation and FIFO invariants (per-command FIFO,
   cancel-before-delivery, INV-14) must be preserved or explicitly amended.
 - **R6**: The default (unconfigured) behavior of existing applications must
@@ -122,14 +129,20 @@ Findings:
   shared overload, keyed probe delivery is deferred until the shared backlog
   fully drains (p50 9.2s, max ≈ the run's full wall time), versus p50 0.1ms
   in the steady control. This is the INV-14 shared-first bias taken to its
-  limit. It is a consequence of *unbounded* shared readiness: with a bounded
-  shared queue, the starvation window is bounded by the time to drain one
-  queue capacity, so load control addresses it without amending INV-14.
-- **F5 — The frame and quit branches survive overload.** The unbiased select
-  plus the 100µs batch cap kept the frame branch at 60 FPS through every
-  overload scenario, and quit (delivered after the last processed message)
-  terminated each run promptly. No structural event-loop change is required
-  for frame or quit scheduling.
+  limit, and RFC 0003 already states that bounded fairness is not
+  guaranteed. A bounded shared queue does *not* bound this delay: every
+  message the loop pulls lets a waiting producer refill the queue, so the
+  shared channel can stay continuously ready for as long as overload lasts,
+  even with a capacity of 1. Capacity controls backlog and memory (F3);
+  bounded keyed-delivery latency needs a scheduling policy of its own
+  (section 4.3, open question 6).
+- **F5 — The frame branch survives overload.** The unbiased select plus the
+  100µs batch cap kept the frame branch at 60 FPS through every overload
+  scenario; no structural event-loop change is required for frame
+  scheduling. The harness does **not** measure quit responsiveness under
+  backlog: its quit is generated only after the last load message is
+  processed. A quit-under-backlog scenario is required before implementation
+  to validate INV-L4 and the quit-path contract (open question 8).
 
 ## 3. Release-gate decision for 0.10.0
 
@@ -189,8 +202,8 @@ proceeds with the breaking changes already on `main`; the S4 implementation
 - `batch_max_messages: Option<NonZeroUsize>` — count cap for one micro-batch
   window, complementing the 100µs time cap.
 
-The quit channel is never bounded (R4); quit signals are rare and must not
-participate in backpressure.
+The dedicated quit channel is never bounded (R4); signals in it are rare and
+must not participate in backpressure.
 
 ### 4.2 Backpressure semantics per source class
 
@@ -208,7 +221,15 @@ mode's send contract, by source class:
   memory).
 - **Commands (keyed and unkeyed)**: the command task awaits capacity before
   its next send. Command streams are already async pull; no API change.
-- **Quit**: never blocked, never dropped (R4).
+- **Quit**: the dedicated quit channel is never blocked and never dropped,
+  but that guarantee covers only signals already in that channel (R4). A
+  keyed `Action::Quit` is delivered through its command's private channel,
+  and a quit later in an unkeyed stream sits behind that stream's earlier
+  sends; in bounded mode both can therefore wait like any other output
+  (keyed quit is already subject to shared-first pull ordering today).
+  Whether quit requests should be re-routed to the dedicated channel at the
+  producer side — letting quit bypass stream order, a deliberate semantic
+  change relative to RFC 0003's FIFO — is open question 7.
 
 Delivery in bounded mode remains lossless up to shutdown: the runtime never
 drops a message to relieve pressure (R2). Lossy strategies (coalescing,
@@ -219,10 +240,16 @@ of "which messages may be merged" are known.
 
 - **Per-command and per-subscription FIFO** (RFC 0003): unchanged; awaiting a
   send preserves order.
-- **INV-14 shared-first pull**: unchanged. F4's starvation is unbounded only
-  because shared readiness is unbounded; with `app_channel_capacity = n`, the
-  keyed delivery delay is bounded by the drain time of at most `n` shared
-  messages plus producer refills, which the capacity also paces.
+- **INV-14 shared-first pull**: unchanged, and bounded mode adds no fairness
+  guarantee on top of it. A full shared channel is refilled by a waiting
+  producer each time the loop pulls one message, so shared readiness — and
+  with it F4's keyed starvation — can persist for as long as overload
+  lasts, independent of the configured capacity. Bounded capacity controls
+  backlog and memory only. If bounded keyed-delivery latency becomes a
+  requirement, it needs an explicit scheduling policy (for example a
+  shared-pull quota per batch window) defined as a deliberate relaxation of
+  INV-14 that preserves cancel-before-delivery; that policy is open
+  question 6 and is not part of the initial bounded mode.
 - **Cancellation**: cancel-before-delivery and buffered-output suppression
   (RFC 0003) are unaffected; a keyed producer blocked on a full private
   channel is aborted exactly like a running one.
@@ -243,21 +270,35 @@ what to measure.
 
 To be finalized as contract tests before implementation:
 
-- **INV-L1**: With `app_channel_capacity = n`, at most `n` shared messages
-  are pending at any time; total pending runtime work is bounded by the sum
-  of configured capacities.
+- **INV-L1**: With `app_channel_capacity = n`, the shared channel buffers at
+  most `n` messages, and each configured keyed channel buffers at most its
+  capacity. This bounds runtime-owned channel buffers, not all pending work:
+  each producer task blocked on a full channel additionally holds one
+  in-flight message, and keyed channels exist per active `CommandId`, so the
+  conceptual total is `shared capacity + number of blocked producers +
+  Σ(per-command keyed capacity)`. A single global memory bound would require
+  a global permit pool or a cap on active producers (open question 3).
 - **INV-L2**: Bounded mode never drops a message before shutdown.
-- **INV-L3**: With bounded capacity, emission-to-update latency of the oldest
-  pending message is bounded by the time to drain one full queue, independent
-  of overload duration.
-- **INV-L4**: Quit delivery latency is independent of app-channel backlog.
+- **INV-L3**: With bounded capacity, a message accepted into the shared
+  channel is preceded by at most `n - 1` earlier shared messages (FIFO), so
+  its emission-to-update latency is bounded by the drain time of one full
+  queue plus the producer's own wait for acceptance, independent of overload
+  duration. No such bound exists for keyed delivery unless the fairness
+  policy (open question 6) defines one.
+- **INV-L4**: A quit signal already in the dedicated quit channel is
+  delivered with latency independent of app-channel backlog. Quit requests
+  still inside command streams are outside this invariant and follow their
+  stream's delivery semantics (section 4.2).
 - **INV-L5**: All RFC 0003 invariants hold unchanged in bounded mode.
 - **INV-L6**: Default configuration reproduces current behavior exactly.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
-integration test; the harness's overload and keyed-probe scenarios are the
-acceptance measurements for INV-L1/L3 (bounded queue depth and keyed latency
-must flatten where the unbounded baseline grows linearly).
+integration test. The overload scenario is the acceptance measurement for
+INV-L1/L3: bounded queue depth and shared update latency must flatten where
+the unbounded baseline grows linearly. The keyed-probe scenario becomes an
+acceptance measurement only once the fairness policy (open question 6) fixes
+what keyed latency bound, if any, to expect; INV-L4 needs the new
+quit-under-backlog scenario (open question 8).
 
 ## 6. Open questions (to resolve before implementation)
 
@@ -273,6 +314,17 @@ must flatten where the unbounded baseline grows linearly).
 5. S8a interaction: whether restart rate control consumes the same
    `RuntimeConfig` surface or stays a subscription-level policy (current
    position: subscription-level, per RFC backlog).
+6. Cross-channel fairness: whether bounded keyed-delivery latency is a goal
+   at all and, if so, which scheduling policy (for example a shared-pull
+   quota per batch window) relaxes INV-14 while preserving
+   cancel-before-delivery (F4, section 4.3).
+7. Quit routing: whether keyed / in-stream `Action::Quit` should be
+   re-routed to the dedicated quit channel at the producer side — letting
+   quit bypass stream order, a deliberate semantic change relative to RFC
+   0003's FIFO — or stay in stream order under INV-L4's narrower scope
+   (section 4.2).
+8. Harness follow-up: add a quit-under-backlog scenario (F5) and a bounded
+   vs. unbounded comparison matrix before implementation.
 
 ## 7. References
 

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -1,0 +1,287 @@
+# RFC 0006: Runtime Load Control
+
+- Status: Draft
+- Target: release-gate decision for 0.10.0 (section 3); implementation after
+  0.10.0 (additive)
+- Scope: bounded memory, backpressure, and latency behavior of the runtime
+  under load; the delivery contract of every runtime-owned channel
+- Feature flag: none
+- CHANGELOG: `Added` (opt-in `RuntimeConfig`); no `Changed` entry is required
+  for 0.10.0 (see section 3)
+
+> **Decision scope.** Section 3 (the release-gate verdict) is the part of this
+> draft that 0.10.0 depends on, and it is final unless the contract design in
+> sections 4–6 turns out to be unimplementable without breaking the public
+> API. Sections 4–6 fix the direction of the load-control contract but their
+> details (capacities, batching caps, per-source classes) remain open until
+> implementation.
+
+## Summary
+
+Every runtime-owned channel is unbounded and every sender completes
+immediately. Under sustained overload — producers faster than the update loop
+— pending messages, memory, and input-to-screen latency all grow without
+bound, and outputs of keyed (cancellable) commands are starved for as long as
+the shared queue stays non-empty. Full-loop measurements
+(`benches/runtime_load.rs`) confirm each of these failure modes and also
+confirm that the runtime behaves well within capacity: bounded queues, sub-ms
+latencies, and a stable frame rate, with bursts absorbed and drained.
+
+This RFC defines the load-control contract in two steps:
+
+1. **0.10.0 release gate (decided here).** Load control can be delivered as an
+   opt-in, additive `RuntimeConfig`; the default delivery semantics and the
+   existing constructors do not change. S4 therefore adds **no breaking
+   change** to 0.10.0, and 0.10.0 does not wait for the S4 implementation.
+2. **Post-0.10.0 implementation (direction fixed, details open).** A bounded
+   delivery mode with per-source-class capacity and backpressure contracts,
+   configured through `RuntimeConfig`, plus load observability via `tracing`.
+
+## 1. Context and constraints
+
+### 1.1 Channel and scheduling inventory
+
+The runtime owns these channels and scheduling mechanisms today:
+
+| Input | Channel | Capacity | Sender behavior |
+| --- | --- | --- | --- |
+| Shared app messages | one `mpsc::unbounded_channel` | unbounded | `send` never waits; errors only after shutdown |
+| Subscription output | forwarded into the shared channel by one task per subscription | unbounded | forwarding task polls the source stream as fast as `send` allows, i.e. unpaced |
+| Unkeyed command output | sent into the shared channel by the command task | unbounded | same |
+| Keyed command output | one private `mpsc::unbounded_channel` per `CommandId` | unbounded | same |
+| Quit | dedicated `mpsc::unbounded_channel` | unbounded | same |
+
+Scheduling facts that interact with load:
+
+- The event loop is an unbiased `tokio::select!` over app inputs, the frame
+  tick, and quit. The frame branch is gated on pending work and paced by the
+  frame interval (`MissedTickBehavior::Skip`); the quit branch is always
+  armed.
+- Message micro-batching drains additional ready inputs for up to 100µs after
+  the first one. The window is time-capped but not count-capped.
+- `AppInputs` polls the shared receiver before keyed receivers at every pull
+  point. This is RFC 0003's INV-14: a ready shared cancel message must be able
+  to suppress a ready keyed output before delivery. RFC 0003 already notes
+  that a continuous stream of ready shared inputs can delay keyed delivery;
+  section 2 quantifies how far that goes under overload.
+- Subscription forwarding applies no pacing of its own: a source stream that
+  is always ready is polled in a tight send loop on a worker task.
+
+### 1.2 Requirements carried into the contract
+
+- **R1**: Memory used by pending runtime work must be boundable by
+  configuration.
+- **R2**: A configured bound must not silently drop messages by default;
+  backpressure (slowing the producer) is the default overload response.
+- **R3**: Input-to-screen latency under load must be observable and, with a
+  bounded configuration, bounded by queue capacity rather than by overload
+  duration.
+- **R4**: Quit must stay responsive under load (it has a dedicated channel and
+  select branch; this must remain true).
+- **R5**: RFC 0003's cancellation and FIFO invariants (per-command FIFO,
+  cancel-before-delivery, INV-14) must be preserved or explicitly amended.
+- **R6**: The default (unconfigured) behavior of existing applications must
+  not change in 0.10.0.
+
+## 2. Measurements
+
+Full-loop load characteristics were measured with `benches/runtime_load.rs`,
+which drives the real `Runtime` through the public API: a subscription floods
+the shared channel at a configured rate; `update` and `view` simulate CPU cost
+(2–25µs and 500µs respectively); a keyed command emits probe messages every
+25ms in the `keyed_*` scenarios. Reference run: Apple M1 Max (10 cores),
+rustc 1.97.0, `cargo bench --bench runtime_load`, 60 FPS target.
+
+| Scenario | Load | Max queue depth | Update latency p50 / p99 | Render latency p50 / p99 | Keyed latency p50 / max | FPS |
+| --- | --- | --- | --- | --- | --- | --- |
+| `steady_20k` | 20k/s for 5s, 2µs update | 140 | 0.04ms / 0.77ms | 0.60ms / 2.3ms | — | 60 |
+| `steady_200k` | 200k/s for 5s, 2µs update | 400 | 0.26ms / 1.2ms | 0.92ms / 1.7ms | — | 60 |
+| `burst_200k` | 200k at t=0, 2µs update | 193,221 | 212ms / 421ms | 210ms / 422ms | — | 61 |
+| `overload` | 100k/s for 5s vs ~38k/s capacity, 25µs update | 307,869 | 4.0s / 7.9s | 4.0s / 7.9s | — | 60 |
+| `keyed_steady` | as `steady_20k` + keyed probe | 680 | 0.05ms / 2.2ms | 0.63ms / 8.9ms | 0.10ms / 5.2ms | 60 |
+| `keyed_overload` | as `overload` + keyed probe | 308,733 | 4.0s / 7.9s | 4.0s / 7.9s | **9.2s / 13.0s** | 60 |
+
+Findings:
+
+- **F1 — In-capacity behavior is healthy.** At up to 200k msg/s within
+  consumer capacity, queue depth stays bounded (≤400), latency stays around a
+  frame period, and the frame rate holds. No contract change is needed for
+  the in-capacity regime.
+- **F2 — Bursts are absorbed, then drained.** A 200k-message burst peaks at
+  ~4.4MiB of backlog and drains in 0.43s. The unbounded queue is what makes
+  this absorption free of coordination; a bounded contract must state what
+  replaces it (capacity sized for expected bursts, or backpressure into the
+  source).
+- **F3 — Sustained overload grows without bound.** With the producer ~2.6×
+  consumer capacity, queue depth grows linearly (~62k messages per overload
+  second, ~7MiB in 5s) and input-to-screen latency reaches 8s, bounded only
+  by how long the overload lasts. Rendering continues at 60 FPS, so the UI
+  looks alive while showing state that is seconds old. This is the failure
+  mode R1–R3 target.
+- **F4 — Keyed outputs starve while the shared queue is non-empty.** Under
+  shared overload, keyed probe delivery is deferred until the shared backlog
+  fully drains (p50 9.2s, max ≈ the run's full wall time), versus p50 0.1ms
+  in the steady control. This is the INV-14 shared-first bias taken to its
+  limit. It is a consequence of *unbounded* shared readiness: with a bounded
+  shared queue, the starvation window is bounded by the time to drain one
+  queue capacity, so load control addresses it without amending INV-14.
+- **F5 — The frame and quit branches survive overload.** The unbiased select
+  plus the 100µs batch cap kept the frame branch at 60 FPS through every
+  overload scenario, and quit (delivered after the last processed message)
+  terminated each run promptly. No structural event-loop change is required
+  for frame or quit scheduling.
+
+## 3. Release-gate decision for 0.10.0
+
+Two questions decide whether S4 forces breaking changes into 0.10.0.
+
+### 3.1 Does the default send contract change?
+
+**No.** The measured failure modes (F3, F4) appear only under sustained
+overload; the in-capacity and burst regimes (F1, F2) — which are what typical
+TUI applications inhabit — behave well with the current unbounded,
+never-waiting senders. Changing the default to bounded delivery would impose
+new deadlock and tuning considerations on every existing application to fix a
+regime most of them never enter. The default therefore stays: unbounded
+channels, senders never wait, no message loss before shutdown.
+
+Bounded delivery ships as an explicit opt-in. If field experience (e.g.
+long-running dashboards with hot subscriptions) later argues for a bounded
+default, that is a deliberate pre-1.0 breaking change for a later minor
+release, made with migration notes — not a 0.10.0 gate.
+
+### 3.2 Does the opt-in fit the existing public API additively?
+
+**Yes.** The opt-in surface is a new `RuntimeConfig` (task P7) consumed by a
+new constructor (for example `Runtime::with_config(flags, frame_rate,
+config)`), with `Runtime::new` unchanged and equivalent to the default
+configuration. Bounded behavior activates only through that surface:
+
+- Capacity limits replace the unbounded channels inside the runtime; no
+  public channel type is exposed today, so this is internal.
+- Backpressure applies inside the runtime-owned forwarding and command tasks:
+  an awaiting `send` stops the task from polling its source stream or command
+  stream until the consumer catches up. `SubscriptionSource::stream` and
+  `Command` contracts already permit arbitrary poll pacing, so no trait or
+  type changes.
+- A micro-batch count cap is internal scheduling policy, observable only as
+  performance.
+
+Nothing in the current public API documents unbounded buffering as a
+guarantee, so offering a bounded mode contradicts no published contract.
+
+### 3.3 Verdict
+
+**S4 requires no additional breaking change in 0.10.0.** The 0.10.0 release
+proceeds with the breaking changes already on `main`; the S4 implementation
+(sections 4–6) lands after 0.10.0 behind `RuntimeConfig`.
+
+## 4. Contract design (post-0.10.0, direction fixed)
+
+### 4.1 Configuration surface
+
+`RuntimeConfig` (owned by P7, consumed by this RFC) with at least:
+
+- `app_channel_capacity: Option<NonZeroUsize>` — `None` (default) keeps the
+  unbounded shared channel; `Some(n)` bounds it.
+- `keyed_channel_capacity: Option<NonZeroUsize>` — same for each keyed
+  command's private channel.
+- `batch_max_messages: Option<NonZeroUsize>` — count cap for one micro-batch
+  window, complementing the 100µs time cap.
+
+The quit channel is never bounded (R4); quit signals are rare and must not
+participate in backpressure.
+
+### 4.2 Backpressure semantics per source class
+
+One channel policy is not applied mechanically to all inputs. The bounded
+mode's send contract, by source class:
+
+- **Subscriptions (Timer, TerminalEvents, signals, WebSocket, Query,
+  user sources)**: the forwarding task awaits channel capacity. Backpressure
+  propagates by not polling the source stream. Sources whose upstream cannot
+  pause (e.g. a WebSocket peer) buffer or shed in source-specific policy —
+  that is P5 (debounce/throttle wrappers) and source-level concerns, not the
+  runtime's. Terminal input is a subscription like any other; awaiting simply
+  defers reading further input events, which is the desired behavior (typing
+  ahead of an overloaded app queues in the terminal, not in unbounded
+  memory).
+- **Commands (keyed and unkeyed)**: the command task awaits capacity before
+  its next send. Command streams are already async pull; no API change.
+- **Quit**: never blocked, never dropped (R4).
+
+Delivery in bounded mode remains lossless up to shutdown: the runtime never
+drops a message to relieve pressure (R2). Lossy strategies (coalescing,
+sampling) are source-level policies layered on top (P5), where the semantics
+of "which messages may be merged" are known.
+
+### 4.3 Interaction with existing invariants
+
+- **Per-command and per-subscription FIFO** (RFC 0003): unchanged; awaiting a
+  send preserves order.
+- **INV-14 shared-first pull**: unchanged. F4's starvation is unbounded only
+  because shared readiness is unbounded; with `app_channel_capacity = n`, the
+  keyed delivery delay is bounded by the drain time of at most `n` shared
+  messages plus producer refills, which the capacity also paces.
+- **Cancellation**: cancel-before-delivery and buffered-output suppression
+  (RFC 0003) are unaffected; a keyed producer blocked on a full private
+  channel is aborted exactly like a running one.
+- **Redraw suppression** (RFC 0002) and subscription re-evaluation gating:
+  unchanged; they operate downstream of input delivery.
+- **Shutdown**: bounded channels close exactly like unbounded ones; senders
+  blocked in `send` observe the closed channel and terminate their tasks.
+
+### 4.4 Observability
+
+Bounded or not, the runtime should expose load signals under `tracing`
+targets (`tears::runtime::load` or similar): queue depth high-water marks,
+batch sizes, and time spent awaiting capacity. P12 (profiling hooks) decides
+whether more than `tracing` is needed; the load harness already demonstrates
+what to measure.
+
+## 5. Invariants (draft)
+
+To be finalized as contract tests before implementation:
+
+- **INV-L1**: With `app_channel_capacity = n`, at most `n` shared messages
+  are pending at any time; total pending runtime work is bounded by the sum
+  of configured capacities.
+- **INV-L2**: Bounded mode never drops a message before shutdown.
+- **INV-L3**: With bounded capacity, emission-to-update latency of the oldest
+  pending message is bounded by the time to drain one full queue, independent
+  of overload duration.
+- **INV-L4**: Quit delivery latency is independent of app-channel backlog.
+- **INV-L5**: All RFC 0003 invariants hold unchanged in bounded mode.
+- **INV-L6**: Default configuration reproduces current behavior exactly.
+
+Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
+integration test; the harness's overload and keyed-probe scenarios are the
+acceptance measurements for INV-L1/L3 (bounded queue depth and keyed latency
+must flatten where the unbounded baseline grows linearly).
+
+## 6. Open questions (to resolve before implementation)
+
+1. Default capacity values to recommend in documentation (measurement-driven;
+   the harness's burst scenario sizes the absorption/latency trade-off).
+2. Whether `batch_max_messages` needs a default even in unbounded mode (F5
+   suggests the 100µs cap already protects the frame branch).
+3. Whether keyed channels share one capacity pool or are bounded per command
+   (per-command is simpler and matches per-command FIFO; a pool bounds total
+   memory more tightly).
+4. Where backpressure-wait telemetry lives (`tracing` only, or counters that
+   P12 exposes).
+5. S8a interaction: whether restart rate control consumes the same
+   `RuntimeConfig` surface or stays a subscription-level policy (current
+   position: subscription-level, per RFC backlog).
+
+## 7. References
+
+- `benches/runtime_load.rs` — full-loop load harness and reference numbers
+  (section 2).
+- RFC 0002 — redraw suppression (frame-branch behavior under load).
+- RFC 0003 — command cancellation (INV-14 shared-first pull, FIFO,
+  cancel-before-delivery).
+- RFC 0005 — structural lifecycle identity (subscription reconciliation the
+  load path feeds).
+- Backlog tasks: S4 (this RFC), P5 (debounce/throttle), P7 (`RuntimeConfig`),
+  P12 (profiling hooks), S8a (restart rate control).


### PR DESCRIPTION
## Summary

Resolves the remaining 0.10.0 release gate: whether S4 (runtime load control) forces additional breaking changes into 0.10.0.

- **`benches/runtime_load.rs`**: a public-API-only harness that drives the real `Runtime` end-to-end and measures queue depth, emission-to-update / emission-to-render latency percentiles, keyed-command delivery latency under shared-channel load, effective FPS, drain time, and peak RSS. Run with `cargo bench --bench runtime_load [-- <scenario>...]`.
- **`docs/rfcs/0006-runtime-load-control.md`** (Draft): defines the load-control contract. Section 3 is the release-gate verdict; sections 4–6 fix the post-0.10.0 implementation direction with the open contract questions listed explicitly.

## Release-gate verdict

**S4 adds no breaking change to 0.10.0.** The default send contract (unbounded channels, never-waiting senders) and existing constructors stay unchanged; bounded delivery ships post-0.10.0 as an opt-in `RuntimeConfig` (P7) via an additive constructor.

## Measurements (Apple M1 Max, 60 FPS target)

| Regime | Result |
| --- | --- |
| Steady 20k–200k msg/s within capacity | queue ≤400, sub-ms update latency, 60 FPS |
| 200k-message burst | absorbed (~4.4 MiB backlog), drained in 0.43s |
| Sustained overload (2.6× capacity, 5s) | queue grows linearly (~308k msgs, ~7 MiB), input-to-screen latency reaches 8s while FPS stays 60 |
| Keyed probe under shared overload | keyed delivery starved until the shared backlog drains: p50 9.2s vs 0.1ms in the steady control (RFC 0003 INV-14 shared-first pull) |

## Review scoping (second docs commit)

Per review, three post-0.10.0 guarantees the draft overstated are narrowed; the verdict is unchanged:

1. Bounded capacity controls backlog/memory only — it does **not** bound keyed starvation (waiting producers refill the queue on every pull), so keyed fairness needs its own scheduling policy (open question 6) and INV-L3 is restricted to shared-channel FIFO.
2. R4/INV-L4 cover only signals already in the dedicated quit channel; keyed `Action::Quit` rides the command's private channel and in-stream quits follow stream order (open questions 7–8, including a quit-under-backlog harness scenario).
3. INV-L1 bounds runtime-owned channel buffers, not total pending work; a global memory bound needs a permit pool (open question 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)