### PR TITLE
ci: split benches into a dedicated job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,22 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo test --all-targets --all-features
+        # Benches are excluded from this matrix (and run once, on Linux
+        # only, in the `bench` job below) since `runtime_load`'s custom
+        # harness ignores `cargo test`'s `--test` flag and always runs its
+        # full scenarios; matrixing that across every OS/toolchain makes
+        # Windows CI disproportionately slow for no additional coverage.
+        run: cargo test --lib --bins --tests --examples --all-features
+
+  bench:
+    name: Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run benchmarks
+        run: cargo test --benches --all-features
 
   loom:
     name: Loom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run benchmarks
-        run: cargo test --benches --all-features
+        # `--bench <name>` (singular, per-target) rather than `--benches`
+        # (plural): the plural form implicitly also runs the lib's unit
+        # tests, duplicating what the `test` job's matrix already covers.
+        run: cargo test --bench subscription --bench runtime_load --all-features
 
   loom:
     name: Loom


### PR DESCRIPTION
## Summary

- The `test` job's matrix (3 OSes x 2 rust toolchains) previously ran `cargo test --all-targets --all-features`, which also builds and runs the bench targets on every matrix cell.
- `benches/runtime_load.rs` uses a custom `main()` (not `criterion_main!`), so it ignores cargo test's `--test` flag and always runs its full load scenarios regardless of context. Running that across all 6 matrix cells made Windows CI disproportionately slow.
- Benches are now excluded from the `test` matrix (`--lib --bins --tests --examples`) and moved to a new dedicated `bench` job that runs once, on `ubuntu-latest` only.

## Test plan

- [x] `cargo test --lib --bins --tests --examples --all-features` locally — passes, no bench targets run
- [x] `cargo test --benches --all-features` locally — both `subscription` (criterion test-mode) and `runtime_load` (full scenarios) run successfully
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)