### PR TITLE
docs(rfc): fix contract gaps found in second review pass on RFC 0006

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -52,9 +52,16 @@ The runtime owns these channels and scheduling mechanisms today:
 | --- | --- | --- | --- |
 | Shared app messages | one `mpsc::unbounded_channel` | unbounded | `send` never waits; errors only after shutdown |
 | Subscription output | forwarded into the shared channel by one task per subscription | unbounded | forwarding task polls the source stream as fast as `send` allows, i.e. unpaced |
-| Unkeyed command output | sent into the shared channel by the command task | unbounded | same |
+| Unkeyed command output (`Action::Message`) | sent into the shared channel by the command task | unbounded | same |
 | Keyed command output | one private `mpsc::unbounded_channel` per `CommandId` | unbounded | same |
-| Quit | dedicated `mpsc::unbounded_channel` | unbounded | same |
+| Quit (`Action::Quit`) | dedicated `mpsc::unbounded_channel` | unbounded | same |
+
+`Action::Quit` never enters the "Unkeyed command output" row above: for an
+unkeyed command, the task sends `Action::Quit` straight to the dedicated
+quit channel, never to the shared channel, regardless of source (including
+a user-initiated quit returned from `update`). A keyed command's
+`Action::Quit`, by contrast, is sent into that command's own private
+channel like any other keyed output (section 4.2).
 
 Scheduling facts that interact with load:
 
@@ -74,23 +81,38 @@ Scheduling facts that interact with load:
 
 ### 1.2 Requirements carried into the contract
 
-- **R1**: Memory used by pending runtime work must be boundable by
-  configuration.
+- **R1**: Memory used by pending runtime-owned channel buffers must be
+  boundable by configuration. This is a bound on buffered messages waiting
+  in a channel, not on all pending-work memory: each producer blocked
+  awaiting channel capacity additionally holds one in-flight message
+  outside the channel, and the number of concurrent producers (active
+  subscriptions, running commands) is controlled by the application, not by
+  `RuntimeConfig`. A full memory bound also requires bounding producer
+  count, which this RFC's channel-capacity controls do not deliver on their
+  own (INV-L1, open question 3).
 - **R2**: A configured bound must not silently drop messages by default;
   backpressure (slowing the producer) is the default overload response.
 - **R3**: Input-to-screen latency under load must be observable and, with a
   bounded configuration, bounded by queue capacity rather than by overload
-  duration.
+  duration — given a bounded number of concurrent producers, the same
+  premise INV-L3 and open question 3 depend on.
 - **R4**: A quit signal already in the dedicated quit channel must be
   delivered with latency independent of app backlog (the dedicated channel
-  and its always-armed select branch must remain). Quit requests still
-  traveling inside command streams — a keyed `Action::Quit` in its private
-  channel, or a quit behind earlier sends of the same unkeyed stream —
-  follow their stream's delivery semantics (section 4.2). User-initiated
-  quit (a key press arriving as a shared input, turned into a quit command
-  by `update`) travels the shared path end-to-end, so it is not a gap in
-  this requirement — it improves under bounded mode along with INV-L3 like
-  any other shared input (section 4.2).
+  and its always-armed select branch must remain — see INV-L4 for the
+  current implementation's fairness caveat on "always-armed"). Every
+  unkeyed `Action::Quit` — including a user-initiated quit that `update`
+  returns as `Command::quit()` — is sent directly to this dedicated
+  channel, never through the shared channel, so its *delivery* is already
+  covered by R4 today, unaffected by `app_channel_capacity` in both the
+  unbounded default and the future bounded mode. What R4 does not cover is
+  the time for an unkeyed command's task to *reach* a quit that follows
+  earlier `Action::Message` items in the same stream: the task processes
+  its stream strictly in order, so it cannot dispatch the quit until each
+  earlier item's send has completed, and in bounded mode those earlier
+  sends can wait on shared channel capacity. A keyed `Action::Quit` is
+  different again — it travels through its command's private channel like
+  any other keyed output — and follows that channel's delivery semantics
+  (section 4.2).
 - **R5**: RFC 0003's cancellation and FIFO invariants (per-command FIFO,
   cancel-before-delivery, INV-14) must be preserved or explicitly amended.
 - **R6**: The default (unconfigured) behavior of existing applications must
@@ -148,7 +170,9 @@ Findings:
   scheduling. The harness does **not** measure quit responsiveness under
   backlog: its quit is generated only after the last load message is
   processed. A quit-under-backlog scenario is required before implementation
-  to validate INV-L4 and the quit-path contract (open question 8).
+  to validate INV-L4 and the quit-path contract (open question 8); because
+  the select is unbiased, that scenario needs tail latency across many
+  trials, not a single run, to say anything about INV-L4.
 
 ## 3. Release-gate decision for 0.10.0
 
@@ -231,20 +255,29 @@ mode's send contract, by source class:
 - **Commands (keyed and unkeyed)**: the command task awaits capacity before
   its next send. Command streams are already async pull; no API change.
 - **Quit**: the dedicated quit channel is never blocked and never dropped,
-  but that guarantee covers only signals already in that channel (R4). A
-  keyed `Action::Quit` is delivered through its command's private channel,
-  and a quit later in an unkeyed stream sits behind that stream's earlier
-  sends; in bounded mode both can therefore wait like any other output
-  (keyed quit is already subject to shared-first pull ordering today).
-  Whether quit requests should be re-routed to the dedicated channel at the
-  producer side — letting quit bypass stream order, a deliberate semantic
-  change relative to RFC 0003's FIFO — is open question 7. User-initiated
-  quit is a different, already-favorable case: a key press arrives as a
-  shared input, `update` turns it into a quit command, and that command's
-  output is itself unkeyed (shared-channel) delivery per section 1.1 — so
-  the whole path is shared-channel traffic and improves under bounded mode
-  along with INV-L3 (R4), rather than being subject to the deferral
-  described above for keyed or in-stream quits.
+  and every unkeyed `Action::Quit` — including a user-initiated quit that
+  `update` returns as `Command::quit()` — is sent directly into it (section
+  1.1), so its *delivery* is already independent of `app_channel_capacity`
+  today, before any bounded-mode change (R4). What bounded mode changes is
+  only how long an unkeyed command's task takes to *reach* a quit that
+  follows earlier `Action::Message` items in the same stream: the task
+  consumes the stream strictly in order and cannot dispatch the quit until
+  each earlier item's send completes, so a quit behind a backlog of earlier
+  sends in the same stream waits on that backlog, not on the quit channel
+  itself. A keyed `Action::Quit` is delivered through its command's private
+  channel instead, so in bounded mode it can wait on
+  `keyed_channel_capacity` like any other keyed output, and is additionally
+  subject to INV-14 shared-first pull once delivered (keyed quit is already
+  subject to that ordering today). Whether keyed / in-stream quit should
+  instead be re-routed to the dedicated channel — matching what unkeyed
+  `Action::Quit` already does — is open question 7, which also covers why
+  that reroute is not a trivial channel swap for a quit that follows
+  not-yet-sent earlier items in the same stream. User-initiated quit itself
+  is not part of that open question: as an unkeyed command with no earlier
+  actions ahead of it, it already gets R4's independence from
+  `app_channel_capacity`; only the input leg (the key press traveling
+  through the shared channel to `update`) is shared-channel traffic and
+  benefits from INV-L3 in bounded mode.
 
 This source-class split relies on a structural precondition: no send
 described above ever originates from the event loop task itself (INV-L7);
@@ -312,7 +345,15 @@ To be finalized as contract tests before implementation:
   conceptual total is `shared capacity + number of blocked producers +
   Σ(per-command keyed capacity)`. A single global memory bound would require
   a global permit pool or a cap on active producers (open question 3).
-- **INV-L2**: Bounded mode never drops a message before shutdown.
+- **INV-L2**: Bounded mode never drops a message to relieve backpressure —
+  capacity pressure is resolved only by the producer waiting, never by the
+  runtime discarding queued or in-flight output. This does not override RFC
+  0003's cancellation contract: explicit cancel, `CancelInFlight` supersede,
+  and subscription reconciliation still drop buffered or in-flight output
+  exactly as in unbounded mode (RFC 0003 INV-4, INV-5), and shutdown still
+  discards anything undelivered. A bare "never drops before shutdown" would
+  contradict INV-L5, since RFC 0003 already mandates drops that are not
+  shutdown.
 - **INV-L3**: With bounded capacity `n`, a message accepted into the shared
   channel is preceded by at most `n - 1` earlier shared messages (FIFO), so
   its drain-side wait — once accepted — is bounded by the drain time of one
@@ -327,9 +368,23 @@ To be finalized as contract tests before implementation:
   exists for keyed delivery unless the fairness policy (open question 6)
   defines one.
 - **INV-L4**: A quit signal already in the dedicated quit channel is
-  delivered with latency independent of app-channel backlog. Quit requests
-  still inside command streams are outside this invariant and follow their
-  stream's delivery semantics (section 4.2).
+  delivered with latency independent of app-channel backlog. This is not
+  automatically a hard worst-case bound under the current implementation:
+  the event loop's `tokio::select!` (`run()`) is unbiased, so when the quit
+  branch and the app-input branch are both ready in the same poll, which
+  one is chosen is a pseudo-random tie-break, not quit-first, and the
+  app-input branch's up-to-100µs micro-batch extends how much work a single
+  lost tie-break can cost. Resolving INV-L4 needs either (a) a deterministic
+  priority for the quit branch — `biased` select, or checking `quit_rx`
+  before entering the app-input branch — reconciled with F5's frame-branch
+  fairness, or (b) a statistical formulation with defined measurement
+  conditions (trial count, load profile, and the percentile/threshold that
+  counts as passing), since a single harness run cannot validate a claim of
+  the form "always independent of backlog." Quit requests still inside
+  command streams are outside this invariant and follow their stream's
+  delivery semantics (section 4.2). The new quit-under-backlog scenario
+  (open question 8) needs to settle which of the two this invariant is
+  before it becomes an acceptance measurement.
 - **INV-L5**: All RFC 0003 invariants hold unchanged in bounded mode.
 - **INV-L6**: Default configuration (`app_channel_capacity: None`,
   `keyed_channel_capacity: None`, `batch_max_messages: None`) reproduces
@@ -366,9 +421,15 @@ send site, not by a bench scenario.
    the harness's burst scenario sizes the absorption/latency trade-off).
 2. Whether `batch_max_messages` needs a default even in unbounded mode (F5
    suggests the 100µs cap already protects the frame branch).
-3. Whether keyed channels share one capacity pool or are bounded per command
-   (per-command is simpler and matches per-command FIFO; a pool bounds total
-   memory more tightly).
+3. Producer-count bounding: whether and how to bound the number of
+   concurrent producers (active subscriptions, running commands) that
+   INV-L1's and INV-L3's per-producer accounting assumes is bounded — for
+   example an admission limit on active subscriptions or `CommandId`s — and,
+   within that, whether keyed channels share one capacity pool or are
+   bounded per command (per-command is simpler and matches per-command
+   FIFO; a pool bounds total memory more tightly). Without an answer, R1's
+   and R3's boundable-memory and bounded-latency claims hold only for
+   channel buffers, not total pending-work memory or latency.
 4. Where backpressure-wait telemetry lives (`tracing` only, or counters
    exposed by future profiling-hook work).
 5. Restart-rate-control interaction: whether a future restart-rate-control
@@ -378,11 +439,25 @@ send site, not by a bench scenario.
    at all and, if so, which scheduling policy (for example a shared-pull
    quota per batch window) relaxes INV-14 while preserving
    cancel-before-delivery (F4, section 4.3).
-7. Quit routing: whether keyed / in-stream `Action::Quit` should be
-   re-routed to the dedicated quit channel at the producer side — letting
-   quit bypass stream order, a deliberate semantic change relative to RFC
-   0003's FIFO — or stay in stream order under INV-L4's narrower scope
-   (section 4.2).
+7. Quit routing: whether a keyed `Action::Quit` should be re-routed to the
+   dedicated quit channel at the producer side — matching what unkeyed
+   `Action::Quit` already does — or stay in its private channel under
+   INV-L4's narrower scope (section 4.2). This question has two different
+   shapes with different feasibility. Re-routing a quit only once it
+   reaches the front of its own stream — i.e. changing which channel it is
+   sent to, with no change to when the task discovers it — is a small,
+   deliverable change (unkeyed commands already do exactly this, section
+   1.1). Re-routing a quit that is *behind* not-yet-sent earlier items in
+   the same stream is a different and harder proposal: both keyed and
+   unkeyed command tasks consume their stream strictly one item at a time
+   and cannot discover a later action before every earlier one has been
+   sent (or, for unkeyed quit, dispatched to the dedicated channel).
+   Bypassing stream order in that sense would require either look-ahead
+   buffering of unsent items — reintroducing unbounded memory and
+   contradicting R1/R2 — or an out-of-band quit signal that does not depend
+   on stream position at all, which is a deliberate semantic change
+   relative to RFC 0003's FIFO. Any resolution of this question should say
+   which of the two shapes it delivers.
 8. Harness follow-up: add a quit-under-backlog scenario (F5) and a bounded
    vs. unbounded comparison matrix before implementation.
 


### PR DESCRIPTION
## Summary

Second round of review findings on RFC 0006 (Runtime Load Control), all confirmed by reading the actual runtime code (`src/runtime/core.rs`, `src/runtime/keyed_commands.rs`, `src/subscription.rs`, `src/runtime.rs`):

- **R1/R3 overclaim boundable memory/latency**: neither requirement previously acknowledged that the number of concurrent producers (active subscriptions, running commands) is application-controlled, not bounded by `RuntimeConfig`. INV-L1 already admitted this gap for memory; R1/R3 now say so explicitly and open question 3 is broadened from "keyed channel pooling" to "producer-count bounding" in general.
- **INV-L2 contradicted RFC 0003's cancellation contract**: an unqualified "never drops a message before shutdown" conflicts with RFC 0003 INV-4/INV-5, which mandate dropping buffered/in-flight output on explicit cancel and `CancelInFlight` supersede. INV-L2 is now scoped to backpressure-driven drops only.
- **Quit-routing description was factually wrong**: `src/runtime/core.rs` sends an unkeyed `Action::Quit` (including a user-initiated quit returned from `update`) directly to the dedicated quit channel, never through the shared channel — contradicting the previous "shared-channel delivery" claim in R4 and 4.2. Only a *keyed* `Action::Quit` goes through its command's private channel. Fixed in the section 1.1 table, R4, and 4.2.
- **Open question 7's "bypass stream order" reroute is not free**: both keyed and unkeyed command tasks consume their stream strictly one item at a time, so a task blocked on an earlier item's send cannot know about a later quit. Split the question into a cheap shape (swap destination channel once the task naturally reaches quit — unkeyed already does this) and a hard shape (skip ahead of unsent earlier items, which needs look-ahead buffering or an out-of-band signal).
- **INV-L4 asserted a bound the current unbiased `tokio::select!` can't guarantee**: added the fairness caveat and two ways to resolve it (deterministic quit priority, or a statistically defined acceptance test), and noted the harness needs multi-trial tail latency, not a single run.

No code changes — RFC draft only. Builds on #206 (merged).

## Test plan

- [x] Re-read the full document for internal consistency after edits
- N/A — documentation-only change