### PR TITLE
docs(rfc): mark RFC 0006 as Accepted

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -1,7 +1,7 @@
 # RFC 0006: Runtime Load Control
 
-- Status: Draft (moves to Accepted when 0.10.0 ships on the section 3 verdict;
-  to Implemented when the sections 4–6 implementation lands)
+- Status: Accepted (0.10.0 shipped on the section 3 verdict on 2026-07-17;
+  moves to Implemented when the sections 4–6 implementation lands)
 - Target: release-gate decision for 0.10.0 (section 3); implementation after
   0.10.0 (additive)
 - Scope: bounded memory, backpressure, and latency behavior of the runtime


### PR DESCRIPTION
## Summary

v0.10.0 was released on 2026-07-17, shipping on RFC 0006's section 3 release-gate verdict (no breaking change from this RFC; load control lands post-0.10.0 as opt-in `RuntimeConfig`). Per the status lifecycle defined in #208, that moves the RFC from Draft to Accepted. It moves to Implemented when the sections 4–6 implementation lands.

One-line status change; no contract edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)