### PR TITLE
Resolve RFC 0006 open question 8: quit-under-backlog harness and acceptance matrix

### DIFF
--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -9,11 +9,13 @@
 //!
 //! - **Queue depth**: pending messages (produced - processed), sampled while
 //!   the scenario runs; all runtime channels are unbounded today, so this is
-//!   the direct driver of memory growth under overload. `produced` counts
-//!   source emissions, not channel admissions, so under a future bounded
-//!   configuration the observable bound is `capacity + producers` — each
-//!   producer blocked in `send` holds one in-flight message outside the
-//!   channel (RFC 0006 section 5.1).
+//!   the direct driver of memory growth under overload. `produced` counts a
+//!   message when the source stream yields it and `processed` counts it when
+//!   `update` begins (once it has left the channel), so under a future
+//!   bounded configuration the observable bound is `capacity + producers`:
+//!   each producer blocked in `send` holds one in-flight message outside the
+//!   channel, while the message currently inside `update` is already
+//!   excluded (RFC 0006 section 5.1).
 //! - **Update latency**: message emission to `Application::update`.
 //! - **Render latency**: message emission to the first `Application::view`
 //!   call that observes it (input-to-screen staleness).
@@ -68,6 +70,7 @@
 
 use std::fmt::Debug;
 use std::num::NonZeroU32;
+use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -402,11 +405,13 @@ impl Metrics {
         }
     }
 
-    /// Pending messages as `produced - processed`. `produced` counts source
-    /// emissions, not channel admissions, so under a future bounded
-    /// configuration a producer blocked in `send` contributes the one
-    /// in-flight message it holds outside the channel: the observable bound
-    /// is `capacity + producers`, not raw channel occupancy (RFC 0006
+    /// Pending messages as `produced - processed`. `produced` counts a
+    /// message at source emission, not channel admission; `processed` counts
+    /// it when `update` begins, once it has left the channel. Under a future
+    /// bounded configuration a producer blocked in `send` therefore
+    /// contributes the one in-flight message it holds outside the channel,
+    /// while the message being processed contributes nothing: the observable
+    /// bound is `capacity + producers`, not raw channel occupancy (RFC 0006
     /// section 5.1).
     fn queue_depth(&self) -> u64 {
         let produced = self.produced.load(Ordering::Relaxed);
@@ -522,15 +527,20 @@ impl Application for LoadApp {
     fn update(&mut self, msg: Msg) -> Command<Msg> {
         match msg {
             Msg::Load { seq, sent_at } => {
+                // Counted when `update` begins, i.e. once the message has
+                // left the runtime's channel: queue depth then excludes the
+                // message being processed, keeping the bounded-mode
+                // acceptance bound at `capacity + producers` instead of
+                // adding a consumer in-flight slot (RFC 0006 section 5.1).
+                self.processed += 1;
+                self.metrics
+                    .processed
+                    .store(self.processed, Ordering::Relaxed);
                 spin(self.cfg.update_cost);
                 if seq % self.sample_every == 0 {
                     Metrics::push_latency(&self.metrics.update_lat_ns, sent_at);
                 }
                 self.last_processed = Some((seq, sent_at));
-                self.processed += 1;
-                self.metrics
-                    .processed
-                    .store(self.processed, Ordering::Relaxed);
                 let request_quit = match self.cfg.quit_at_seq {
                     Some(quit_seq) => seq == quit_seq,
                     None => self.processed == self.cfg.total,
@@ -910,7 +920,7 @@ fn peak_rss_bytes() -> Option<u64> {
     None
 }
 
-fn main() {
+fn main() -> ExitCode {
     // Positional arguments select scenarios by name; flags (e.g. the
     // `--bench` cargo passes) are ignored.
     let selected: Vec<String> = env::args()
@@ -938,7 +948,7 @@ fn main() {
             )
             .collect();
         println!("no matching scenario; available: {}", names.join(", "));
-        return;
+        return ExitCode::FAILURE;
     }
 
     // Quit trials read delivery instants from the runtime's tracing events;
@@ -957,8 +967,20 @@ fn main() {
         let report = runtime.block_on(run_scenario(cfg));
         print_report(&report);
     }
+    let mut failed_trials = 0u32;
     for scenario in quit_to_run {
         let report = runtime.block_on(run_quit_scenario(&scenario));
         print_quit_report(&report);
+        failed_trials += report.timeouts + report.missing_delivery;
     }
+    // Quit-trial statistics feed RFC 0006 acceptance criteria, so a partial
+    // sample must fail the run (and the CI Benchmarks check) instead of
+    // silently reporting percentiles over fewer trials than configured.
+    if failed_trials > 0 {
+        eprintln!(
+            "error: {failed_trials} quit trial(s) failed (timed out or missing delivery event)"
+        );
+        return ExitCode::FAILURE;
+    }
+    ExitCode::SUCCESS
 }

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -9,7 +9,11 @@
 //!
 //! - **Queue depth**: pending messages (produced - processed), sampled while
 //!   the scenario runs; all runtime channels are unbounded today, so this is
-//!   the direct driver of memory growth under overload.
+//!   the direct driver of memory growth under overload. `produced` counts
+//!   source emissions, not channel admissions, so under a future bounded
+//!   configuration the observable bound is `capacity + producers` — each
+//!   producer blocked in `send` holds one in-flight message outside the
+//!   channel (RFC 0006 section 5.1).
 //! - **Update latency**: message emission to `Application::update`.
 //! - **Render latency**: message emission to the first `Application::view`
 //!   call that observes it (input-to-screen staleness).
@@ -29,13 +33,15 @@
 //! unbiased, a single run says nothing about the tail; the report therefore
 //! aggregates per-trial values into percentiles across trials:
 //!
-//! - **quit -> last work**: quit request to the end of the last `update` or
-//!   `view` call — a lower bound on quit *delivery* (the loop breaks right
-//!   after the last work item, before teardown).
-//! - **quit -> exit**: quit request to `Runtime::run` returning — an upper
-//!   bound that additionally includes shutdown and backlog deallocation,
-//!   which scales with queue depth and must not be misread as delivery
-//!   latency.
+//! - **quit -> delivered**: quit request to the event loop's quit branch
+//!   observing it. Delivery is not observable through the public API, so a
+//!   process-global tracing subscriber timestamps the runtime's own
+//!   `quit signal received` / `keyed quit signal received` debug events
+//!   (target `tears::runtime`) — the delivery instant itself, suitable as
+//!   an INV-L4 acceptance measurement.
+//! - **quit -> exit**: quit request to `Runtime::run` returning, which
+//!   additionally includes shutdown and backlog deallocation; the latter
+//!   scales with queue depth and must not be misread as delivery latency.
 //!
 //! The keyed variant sends the quit through a cancellable command's private
 //! channel instead of the dedicated quit channel, quantifying the INV-14
@@ -60,6 +66,7 @@
     clippy::cast_sign_loss
 )]
 
+use std::fmt::Debug;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -76,6 +83,11 @@ use tears::{BoxStream, SubscriptionSource};
 use tokio::runtime::Builder;
 use tokio::time::{MissedTickBehavior, interval, timeout};
 use tokio_stream::wrappers::IntervalStream;
+use tracing::field::{Field, Visit};
+use tracing::level_filters::LevelFilter;
+use tracing::span::{Attributes, Id, Record};
+use tracing::subscriber::set_global_default;
+use tracing::{Event, Level, Metadata, Subscriber};
 
 /// Message rate for scenarios that emit their whole load in one burst.
 const BURST: u64 = 0;
@@ -274,6 +286,80 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
     ]
 }
 
+/// The quit trial whose [`Metrics`] receive the next quit-delivery event;
+/// `None` outside quit trials, so load scenarios' completion quits are
+/// ignored. Trials run sequentially, so a single slot suffices.
+static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
+
+/// Records the instant the event loop's quit branch fires.
+///
+/// The runtime logs `debug!(target: "tears::runtime", "quit signal
+/// received")` (dedicated-channel quit) or `"keyed quit signal received"`
+/// (keyed quit surfacing through the input mux) at the moment its `select!`
+/// observes the quit — the delivery instant INV-L4 is about, which is not
+/// observable through the public API. This subscriber is installed once as
+/// the process-global tracing subscriber and timestamps that event into the
+/// current trial's metrics. If the runtime's message strings ever change,
+/// quit trials fail loudly as "no delivery event" instead of silently
+/// reporting skewed numbers.
+struct QuitDeliverySubscriber;
+
+impl Subscriber for QuitDeliverySubscriber {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.is_event()
+            && metadata.target() == "tears::runtime"
+            && *metadata.level() == Level::DEBUG
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        Some(LevelFilter::DEBUG)
+    }
+
+    fn new_span(&self, _span: &Attributes<'_>) -> Id {
+        Id::from_u64(1)
+    }
+
+    fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+    fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+    fn event(&self, event: &Event<'_>) {
+        let mut visitor = QuitMessageVisitor { matched: false };
+        event.record(&mut visitor);
+        if !visitor.matched {
+            return;
+        }
+        if let Some(metrics) = TRIAL_METRICS
+            .lock()
+            .expect("trial metrics slot poisoned")
+            .as_ref()
+        {
+            metrics
+                .quit_delivered_ns
+                .store(metrics.elapsed_ns(), Ordering::Relaxed);
+        }
+    }
+
+    fn enter(&self, _span: &Id) {}
+
+    fn exit(&self, _span: &Id) {}
+}
+
+struct QuitMessageVisitor {
+    matched: bool,
+}
+
+impl Visit for QuitMessageVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        if field.name() == "message" {
+            let text = format!("{value:?}");
+            if text == "quit signal received" || text == "keyed quit signal received" {
+                self.matched = true;
+            }
+        }
+    }
+}
+
 struct Metrics {
     start: Instant,
     produced: AtomicU64,
@@ -292,10 +378,10 @@ struct Metrics {
     quit_requested_ns: AtomicU64,
     /// Queue depth at the moment the quit was requested.
     depth_at_quit: AtomicU64,
-    /// Nanoseconds from `start` at which the most recent `update` or `view`
-    /// call finished; the loop breaks right after the last one, so this
-    /// lower-bounds the quit delivery instant without runtime instrumentation.
-    last_work_ns: AtomicU64,
+    /// Nanoseconds from `start` at which the event loop's quit branch
+    /// observed the quit, recorded by [`QuitDeliverySubscriber`] from the
+    /// runtime's own tracing events; 0 while undelivered.
+    quit_delivered_ns: AtomicU64,
 }
 
 impl Metrics {
@@ -312,10 +398,16 @@ impl Metrics {
             keyed_lat_ns: Mutex::new(Vec::new()),
             quit_requested_ns: AtomicU64::new(0),
             depth_at_quit: AtomicU64::new(0),
-            last_work_ns: AtomicU64::new(0),
+            quit_delivered_ns: AtomicU64::new(0),
         }
     }
 
+    /// Pending messages as `produced - processed`. `produced` counts source
+    /// emissions, not channel admissions, so under a future bounded
+    /// configuration a producer blocked in `send` contributes the one
+    /// in-flight message it holds outside the channel: the observable bound
+    /// is `capacity + producers`, not raw channel occupancy (RFC 0006
+    /// section 5.1).
     fn queue_depth(&self) -> u64 {
         let produced = self.produced.load(Ordering::Relaxed);
         let processed = self.processed.load(Ordering::Relaxed);
@@ -324,12 +416,6 @@ impl Metrics {
 
     fn elapsed_ns(&self) -> u64 {
         u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
-    }
-
-    /// Records that an `update` or `view` call just finished.
-    fn mark_work(&self) {
-        self.last_work_ns
-            .store(self.elapsed_ns(), Ordering::Relaxed);
     }
 
     fn push_latency(bucket: &Mutex<Vec<u64>>, sent_at: Instant) {
@@ -445,7 +531,6 @@ impl Application for LoadApp {
                 self.metrics
                     .processed
                     .store(self.processed, Ordering::Relaxed);
-                self.metrics.mark_work();
                 let request_quit = match self.cfg.quit_at_seq {
                     Some(quit_seq) => seq == quit_seq,
                     None => self.processed == self.cfg.total,
@@ -470,7 +555,6 @@ impl Application for LoadApp {
             }
             Msg::KeyedProbe { sent_at } => {
                 Metrics::push_latency(&self.metrics.keyed_lat_ns, sent_at);
-                self.metrics.mark_work();
                 Command::none()
             }
         }
@@ -489,7 +573,6 @@ impl Application for LoadApp {
                 Metrics::push_latency(&self.metrics.render_lat_ns, sent_at);
             }
         }
-        self.metrics.mark_work();
     }
 
     fn subscriptions(&self) -> Vec<Subscription<Msg>> {
@@ -598,24 +681,33 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
 }
 
 /// One successful quit trial: queue depth at the quit request plus the two
-/// latency bounds bracketing quit delivery (see the module docs).
+/// latencies described in the module docs (delivery, and exit including
+/// teardown).
 struct QuitTrialSample {
     depth: u64,
-    to_last_work_ns: u64,
+    to_delivered_ns: u64,
     to_exit_ns: u64,
+}
+
+enum QuitTrialFailure {
+    TimedOut,
+    /// The runtime never emitted its quit-delivery tracing event; see
+    /// [`QuitDeliverySubscriber`].
+    NoDeliveryEvent,
 }
 
 struct QuitReport {
     cfg: ScenarioCfg,
     trials: u32,
     timeouts: u32,
+    missing_delivery: u32,
     /// Sorted per-trial values.
     depths: Vec<u64>,
-    to_last_work_ns: Vec<u64>,
+    to_delivered_ns: Vec<u64>,
     to_exit_ns: Vec<u64>,
 }
 
-async fn run_quit_trial(cfg: ScenarioCfg) -> Option<QuitTrialSample> {
+async fn run_quit_trial(cfg: ScenarioCfg) -> Result<QuitTrialSample, QuitTrialFailure> {
     let metrics = Arc::new(Metrics::new());
     let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
         .expect("60 FPS is a valid frame rate");
@@ -623,52 +715,58 @@ async fn run_quit_trial(cfg: ScenarioCfg) -> Option<QuitTrialSample> {
     let mut terminal =
         Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
 
+    *TRIAL_METRICS.lock().expect("trial metrics slot poisoned") = Some(Arc::clone(&metrics));
     let timed_out = timeout(cfg.max_wall, runtime.run(&mut terminal))
         .await
         .is_err();
     let exit_ns = metrics.elapsed_ns();
+    *TRIAL_METRICS.lock().expect("trial metrics slot poisoned") = None;
 
-    let quit_ns = metrics.quit_requested_ns.load(Ordering::Relaxed);
-    if timed_out || quit_ns == 0 {
-        return None;
+    if timed_out {
+        return Err(QuitTrialFailure::TimedOut);
     }
-    Some(QuitTrialSample {
+    let quit_ns = metrics.quit_requested_ns.load(Ordering::Relaxed);
+    let delivered_ns = metrics.quit_delivered_ns.load(Ordering::Relaxed);
+    if quit_ns == 0 || delivered_ns == 0 {
+        return Err(QuitTrialFailure::NoDeliveryEvent);
+    }
+    Ok(QuitTrialSample {
         depth: metrics.depth_at_quit.load(Ordering::Relaxed),
-        to_last_work_ns: metrics
-            .last_work_ns
-            .load(Ordering::Relaxed)
-            .saturating_sub(quit_ns),
+        to_delivered_ns: delivered_ns.saturating_sub(quit_ns),
         to_exit_ns: exit_ns.saturating_sub(quit_ns),
     })
 }
 
 async fn run_quit_scenario(scenario: &QuitScenarioCfg) -> QuitReport {
     let mut timeouts = 0;
+    let mut missing_delivery = 0;
     let mut depths = Vec::new();
-    let mut to_last_work_ns = Vec::new();
+    let mut to_delivered_ns = Vec::new();
     let mut to_exit_ns = Vec::new();
 
     for _ in 0..scenario.trials {
         match run_quit_trial(scenario.base.clone()).await {
-            Some(sample) => {
+            Ok(sample) => {
                 depths.push(sample.depth);
-                to_last_work_ns.push(sample.to_last_work_ns);
+                to_delivered_ns.push(sample.to_delivered_ns);
                 to_exit_ns.push(sample.to_exit_ns);
             }
-            None => timeouts += 1,
+            Err(QuitTrialFailure::TimedOut) => timeouts += 1,
+            Err(QuitTrialFailure::NoDeliveryEvent) => missing_delivery += 1,
         }
     }
 
     depths.sort_unstable();
-    to_last_work_ns.sort_unstable();
+    to_delivered_ns.sort_unstable();
     to_exit_ns.sort_unstable();
 
     QuitReport {
         cfg: scenario.base.clone(),
         trials: scenario.trials,
         timeouts,
+        missing_delivery,
         depths,
-        to_last_work_ns,
+        to_delivered_ns,
         to_exit_ns,
     }
 }
@@ -689,9 +787,10 @@ fn print_quit_report(report: &QuitReport) {
         cfg.keyed_quit,
     );
     println!(
-        "   trials: {} ok, {} timed out",
-        report.trials - report.timeouts,
+        "   trials: {} ok, {} timed out, {} missing delivery event",
+        report.trials - report.timeouts - report.missing_delivery,
         report.timeouts,
+        report.missing_delivery,
     );
     if report.depths.is_empty() {
         return;
@@ -703,8 +802,8 @@ fn print_quit_report(report: &QuitReport) {
         report.depths.last().expect("non-empty"),
     );
     println!(
-        "   quit -> last work: {}",
-        format_lat(&report.to_last_work_ns)
+        "   quit -> delivered: {}",
+        format_lat(&report.to_delivered_ns)
     );
     println!("   quit -> exit:      {}", format_lat(&report.to_exit_ns));
     println!();
@@ -841,6 +940,12 @@ fn main() {
         println!("no matching scenario; available: {}", names.join(", "));
         return;
     }
+
+    // Quit trials read delivery instants from the runtime's tracing events;
+    // installed unconditionally because its filter rejects everything but
+    // rare debug events on the `tears::runtime` target.
+    set_global_default(QuitDeliverySubscriber)
+        .expect("no other global tracing subscriber is installed");
 
     let runtime = Builder::new_multi_thread()
         .enable_all()

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -19,11 +19,34 @@
 //! - **Memory**: peak RSS delta per scenario plus an estimate of the backlog
 //!   footprint from the maximum observed queue depth.
 //!
+//! # Quit-latency scenarios (`quit_*`)
+//!
+//! The `quit_*` scenarios measure quit responsiveness under a shared-channel
+//! backlog (RFC 0006 INV-L4 / open question 8). Each one runs many short
+//! trials: a trial floods the shared channel, then `update` returns
+//! [`Command::quit`] while the backlog is still deep, mirroring how a real
+//! key press quits an application. Because the event loop's `select!` is
+//! unbiased, a single run says nothing about the tail; the report therefore
+//! aggregates per-trial values into percentiles across trials:
+//!
+//! - **quit -> last work**: quit request to the end of the last `update` or
+//!   `view` call — a lower bound on quit *delivery* (the loop breaks right
+//!   after the last work item, before teardown).
+//! - **quit -> exit**: quit request to `Runtime::run` returning — an upper
+//!   bound that additionally includes shutdown and backlog deallocation,
+//!   which scales with queue depth and must not be misread as delivery
+//!   latency.
+//!
+//! The keyed variant sends the quit through a cancellable command's private
+//! channel instead of the dedicated quit channel, quantifying the INV-14
+//! shared-first bias for in-band quit (RFC 0006 open question 7).
+//!
 //! Run all scenarios, or name a subset:
 //!
 //! ```bash
 //! cargo bench --bench runtime_load
 //! cargo bench --bench runtime_load -- overload keyed_overload
+//! cargo bench --bench runtime_load -- quit_idle quit_backlog_300k
 //! ```
 //!
 //! Peak RSS is process-wide and monotone, so for clean memory numbers run a
@@ -70,8 +93,23 @@ struct ScenarioCfg {
     render_cost: Duration,
     /// Whether to run a keyed command emitting probe messages every 25ms.
     keyed_probe: bool,
+    /// Have `update` return [`Command::quit`] when it processes the flood
+    /// message with this seq, instead of quitting at `total`. The flood keeps
+    /// the backlog deep past this point, so the quit races a loaded loop.
+    quit_at_seq: Option<u64>,
+    /// Route the triggered quit through a keyed (cancellable) command, i.e.
+    /// the command's private channel, instead of an unkeyed command's direct
+    /// send to the dedicated quit channel.
+    keyed_quit: bool,
     /// Wall-clock guard; the scenario is aborted and reported as timed out.
     max_wall: Duration,
+}
+
+/// A quit-latency scenario: `base` is run `trials` times and per-trial quit
+/// latencies are aggregated into one report.
+struct QuitScenarioCfg {
+    base: ScenarioCfg,
+    trials: u32,
 }
 
 fn scenarios() -> Vec<ScenarioCfg> {
@@ -84,6 +122,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(2),
             render_cost: Duration::from_micros(500),
             keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(30),
         },
         // Paced load near consumer capacity.
@@ -94,6 +134,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(2),
             render_cost: Duration::from_micros(500),
             keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(30),
         },
         // One burst dumped into the unbounded channel at t=0; measures drain
@@ -105,6 +147,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(2),
             render_cost: Duration::from_micros(500),
             keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(30),
         },
         // Sustained producer faster than the consumer: queue depth and
@@ -116,6 +160,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(25),
             render_cost: Duration::from_micros(500),
             keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(60),
         },
         // Control: keyed command outputs while the shared channel is lightly
@@ -127,6 +173,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(2),
             render_cost: Duration::from_micros(500),
             keyed_probe: true,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(30),
         },
         // Keyed command outputs while the shared channel is overloaded; the
@@ -139,7 +187,89 @@ fn scenarios() -> Vec<ScenarioCfg> {
             update_cost: Duration::from_micros(25),
             render_cost: Duration::from_micros(500),
             keyed_probe: true,
+            quit_at_seq: None,
+            keyed_quit: false,
             max_wall: Duration::from_secs(60),
+        },
+    ]
+}
+
+/// Trials for unkeyed quit scenarios. INV-L4's unbiased-select tie-break
+/// makes quit latency a distribution, so the tail needs many short trials.
+const QUIT_TRIALS: u32 = 200;
+
+/// Trials for the keyed quit scenario. Each trial drains the whole backlog
+/// before the quit is delivered, so trials are long and the expected effect
+/// (latency ~ drain time) is orders of magnitude above trial noise.
+const KEYED_QUIT_TRIALS: u32 = 20;
+
+fn quit_scenarios() -> Vec<QuitScenarioCfg> {
+    // All quit scenarios use the overload update cost (25µs) so the backlog
+    // drains slowly (~38k msg/s on the reference machine) and the depth at
+    // the quit request is dominated by `total - quit_at_seq`.
+    let base = ScenarioCfg {
+        name: "",
+        rate: BURST,
+        total: 0,
+        update_cost: Duration::from_micros(25),
+        render_cost: Duration::from_micros(500),
+        keyed_probe: false,
+        quit_at_seq: Some(5_000),
+        keyed_quit: false,
+        max_wall: Duration::from_secs(30),
+    };
+    vec![
+        // Control: quit with an empty queue; baseline delivery latency.
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_idle",
+                total: 1,
+                quit_at_seq: Some(0),
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+        },
+        // Quit while ~50k messages are still queued.
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_backlog_50k",
+                total: 55_000,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+        },
+        // Quit while ~300k messages are still queued; if quit latency were
+        // backlog-dependent, it must separate from the 50k scenario here.
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_backlog_300k",
+                total: 305_000,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+        },
+        // Quit while the producer is still actively refilling the shared
+        // channel (sustained overload rather than a draining burst).
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_overload",
+                rate: 100_000,
+                total: 500_000,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+        },
+        // Keyed quit under the 50k backlog: delivered through the command's
+        // private channel, so INV-14 shared-first pull defers it until the
+        // shared backlog drains (expected latency ~ full drain time).
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_keyed_backlog_50k",
+                total: 55_000,
+                keyed_quit: true,
+                ..base
+            },
+            trials: KEYED_QUIT_TRIALS,
         },
     ]
 }
@@ -157,6 +287,15 @@ struct Metrics {
     update_lat_ns: Mutex<Vec<u64>>,
     render_lat_ns: Mutex<Vec<u64>>,
     keyed_lat_ns: Mutex<Vec<u64>>,
+    /// Nanoseconds from `start` at which `update` requested the quit; 0 while
+    /// no quit has been requested.
+    quit_requested_ns: AtomicU64,
+    /// Queue depth at the moment the quit was requested.
+    depth_at_quit: AtomicU64,
+    /// Nanoseconds from `start` at which the most recent `update` or `view`
+    /// call finished; the loop breaks right after the last one, so this
+    /// lower-bounds the quit delivery instant without runtime instrumentation.
+    last_work_ns: AtomicU64,
 }
 
 impl Metrics {
@@ -171,6 +310,9 @@ impl Metrics {
             update_lat_ns: Mutex::new(Vec::new()),
             render_lat_ns: Mutex::new(Vec::new()),
             keyed_lat_ns: Mutex::new(Vec::new()),
+            quit_requested_ns: AtomicU64::new(0),
+            depth_at_quit: AtomicU64::new(0),
+            last_work_ns: AtomicU64::new(0),
         }
     }
 
@@ -178,6 +320,16 @@ impl Metrics {
         let produced = self.produced.load(Ordering::Relaxed);
         let processed = self.processed.load(Ordering::Relaxed);
         produced.saturating_sub(processed)
+    }
+
+    fn elapsed_ns(&self) -> u64 {
+        u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
+    }
+
+    /// Records that an `update` or `view` call just finished.
+    fn mark_work(&self) {
+        self.last_work_ns
+            .store(self.elapsed_ns(), Ordering::Relaxed);
     }
 
     fn push_latency(bucket: &Mutex<Vec<u64>>, sent_at: Instant) {
@@ -293,13 +445,32 @@ impl Application for LoadApp {
                 self.metrics
                     .processed
                     .store(self.processed, Ordering::Relaxed);
-                if self.processed == self.cfg.total {
-                    return Command::quit();
+                self.metrics.mark_work();
+                let request_quit = match self.cfg.quit_at_seq {
+                    Some(quit_seq) => seq == quit_seq,
+                    None => self.processed == self.cfg.total,
+                };
+                if request_quit {
+                    self.metrics
+                        .depth_at_quit
+                        .store(self.metrics.queue_depth(), Ordering::Relaxed);
+                    self.metrics
+                        .quit_requested_ns
+                        .store(self.metrics.elapsed_ns(), Ordering::Relaxed);
+                    // The unkeyed quit is sent by its command task straight to
+                    // the dedicated quit channel; the keyed variant travels the
+                    // command's private channel instead (RFC 0006 section 4.2).
+                    return if self.cfg.keyed_quit {
+                        Command::quit().cancellable(CommandId::new("quit"))
+                    } else {
+                        Command::quit()
+                    };
                 }
                 Command::none()
             }
             Msg::KeyedProbe { sent_at } => {
                 Metrics::push_latency(&self.metrics.keyed_lat_ns, sent_at);
+                self.metrics.mark_work();
                 Command::none()
             }
         }
@@ -318,6 +489,7 @@ impl Application for LoadApp {
                 Metrics::push_latency(&self.metrics.render_lat_ns, sent_at);
             }
         }
+        self.metrics.mark_work();
     }
 
     fn subscriptions(&self) -> Vec<Subscription<Msg>> {
@@ -423,6 +595,119 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
         },
         cfg,
     }
+}
+
+/// One successful quit trial: queue depth at the quit request plus the two
+/// latency bounds bracketing quit delivery (see the module docs).
+struct QuitTrialSample {
+    depth: u64,
+    to_last_work_ns: u64,
+    to_exit_ns: u64,
+}
+
+struct QuitReport {
+    cfg: ScenarioCfg,
+    trials: u32,
+    timeouts: u32,
+    /// Sorted per-trial values.
+    depths: Vec<u64>,
+    to_last_work_ns: Vec<u64>,
+    to_exit_ns: Vec<u64>,
+}
+
+async fn run_quit_trial(cfg: ScenarioCfg) -> Option<QuitTrialSample> {
+    let metrics = Arc::new(Metrics::new());
+    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
+        .expect("60 FPS is a valid frame rate");
+    let runtime = Runtime::<LoadApp>::new((cfg.clone(), Arc::clone(&metrics)), frame_rate);
+    let mut terminal =
+        Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
+
+    let timed_out = timeout(cfg.max_wall, runtime.run(&mut terminal))
+        .await
+        .is_err();
+    let exit_ns = metrics.elapsed_ns();
+
+    let quit_ns = metrics.quit_requested_ns.load(Ordering::Relaxed);
+    if timed_out || quit_ns == 0 {
+        return None;
+    }
+    Some(QuitTrialSample {
+        depth: metrics.depth_at_quit.load(Ordering::Relaxed),
+        to_last_work_ns: metrics
+            .last_work_ns
+            .load(Ordering::Relaxed)
+            .saturating_sub(quit_ns),
+        to_exit_ns: exit_ns.saturating_sub(quit_ns),
+    })
+}
+
+async fn run_quit_scenario(scenario: &QuitScenarioCfg) -> QuitReport {
+    let mut timeouts = 0;
+    let mut depths = Vec::new();
+    let mut to_last_work_ns = Vec::new();
+    let mut to_exit_ns = Vec::new();
+
+    for _ in 0..scenario.trials {
+        match run_quit_trial(scenario.base.clone()).await {
+            Some(sample) => {
+                depths.push(sample.depth);
+                to_last_work_ns.push(sample.to_last_work_ns);
+                to_exit_ns.push(sample.to_exit_ns);
+            }
+            None => timeouts += 1,
+        }
+    }
+
+    depths.sort_unstable();
+    to_last_work_ns.sort_unstable();
+    to_exit_ns.sort_unstable();
+
+    QuitReport {
+        cfg: scenario.base.clone(),
+        trials: scenario.trials,
+        timeouts,
+        depths,
+        to_last_work_ns,
+        to_exit_ns,
+    }
+}
+
+fn print_quit_report(report: &QuitReport) {
+    let cfg = &report.cfg;
+    println!("## {}", cfg.name);
+    let rate = if cfg.rate == BURST {
+        "burst".to_owned()
+    } else {
+        format!("{}/s", cfg.rate)
+    };
+    println!(
+        "   load: rate={rate} total={} update_cost={:?} quit_at_seq={} keyed_quit={}",
+        cfg.total,
+        cfg.update_cost,
+        cfg.quit_at_seq.expect("quit scenarios set quit_at_seq"),
+        cfg.keyed_quit,
+    );
+    println!(
+        "   trials: {} ok, {} timed out",
+        report.trials - report.timeouts,
+        report.timeouts,
+    );
+    if report.depths.is_empty() {
+        return;
+    }
+    println!(
+        "   depth at quit: min={} p50={} max={}",
+        report.depths.first().expect("non-empty"),
+        percentile(&report.depths, 0.50),
+        report.depths.last().expect("non-empty"),
+    );
+    println!(
+        "   quit -> last work: {}",
+        format_lat(&report.to_last_work_ns)
+    );
+    println!("   quit -> exit:      {}", format_lat(&report.to_exit_ns));
+    println!();
 }
 
 fn percentile(sorted: &[u64], p: f64) -> u64 {
@@ -534,12 +819,25 @@ fn main() {
         .filter(|arg| !arg.starts_with('-'))
         .collect();
 
-    let to_run: Vec<ScenarioCfg> = scenarios()
+    let matches = |name: &str| selected.is_empty() || selected.iter().any(|s| s == name);
+    let load_to_run: Vec<ScenarioCfg> = scenarios()
         .into_iter()
-        .filter(|cfg| selected.is_empty() || selected.iter().any(|name| name == cfg.name))
+        .filter(|cfg| matches(cfg.name))
         .collect();
-    if to_run.is_empty() {
-        let names: Vec<&str> = scenarios().iter().map(|cfg| cfg.name).collect();
+    let quit_to_run: Vec<QuitScenarioCfg> = quit_scenarios()
+        .into_iter()
+        .filter(|scenario| matches(scenario.base.name))
+        .collect();
+    if load_to_run.is_empty() && quit_to_run.is_empty() {
+        let names: Vec<&str> = scenarios()
+            .into_iter()
+            .map(|cfg| cfg.name)
+            .chain(
+                quit_scenarios()
+                    .into_iter()
+                    .map(|scenario| scenario.base.name),
+            )
+            .collect();
         println!("no matching scenario; available: {}", names.join(", "));
         return;
     }
@@ -550,8 +848,12 @@ fn main() {
         .expect("tokio runtime");
 
     println!("# tears runtime load harness\n");
-    for cfg in to_run {
+    for cfg in load_to_run {
         let report = runtime.block_on(run_scenario(cfg));
         print_report(&report);
+    }
+    for scenario in quit_to_run {
+        let report = runtime.block_on(run_quit_scenario(&scenario));
+        print_quit_report(&report);
     }
 }

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -10,6 +10,9 @@
 - CHANGELOG: `Added` entry lands at the load-control implementation release
   (opt-in `RuntimeConfig`); 0.10.0 itself needs no CHANGELOG entry for this
   RFC (see section 3)
+- Amendments: 2026-07-17 — open question 8 resolved: quit-under-backlog
+  scenarios added and measured (section 2, F6/F7), bounded-vs-unbounded
+  acceptance matrix defined (section 5.1)
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
@@ -137,6 +140,29 @@ rustc 1.97.0, `cargo bench --bench runtime_load`, 60 FPS target.
 | `keyed_steady` | as `steady_20k` + keyed probe | 680 | 0.05ms / 2.2ms | 0.63ms / 8.9ms | 0.10ms / 5.2ms | 60 |
 | `keyed_overload` | as `overload` + keyed probe | 308,733 | 4.0s / 7.9s | 4.0s / 7.9s | **9.2s / 13.0s** | 60 |
 
+Quit responsiveness under backlog is measured by the `quit_*` scenarios
+(added 2026-07-17 for open question 8). Each scenario runs many short trials
+— the event loop's `select!` is unbiased, so quit latency is a distribution
+and only tail statistics across trials are meaningful. A trial floods the
+shared channel (burst or paced), then `update` returns `Command::quit()`
+while the backlog is still deep, mirroring a real quit key press: the
+unkeyed variant reaches the dedicated quit channel through its command task
+(section 1.1); the keyed variant travels its command's private channel
+instead (section 4.2). Two per-trial values bracket delivery, which is not
+directly observable from outside the runtime: **quit→last-work** (quit
+request to the end of the last `update`/`view` call; the loop breaks right
+after, so this lower-bounds delivery) and **quit→exit** (to `run()`
+returning; an upper bound that adds teardown, including backlog
+deallocation that scales with depth and must not be misread as delivery).
+
+| Scenario | Load at quit | Trials | Depth at quit | Quit→last-work p50 / p99 / max | Quit→exit p50 / max |
+| --- | --- | --- | --- | --- | --- |
+| `quit_idle` | none | 200 | 0 | 0.51ms / 0.69ms / 1.0ms | 0.62ms / 2.1ms |
+| `quit_backlog_50k` | draining burst | 200 | ~50k | 0.11ms / 0.74ms / 0.90ms | 0.61ms / 5.4ms |
+| `quit_backlog_300k` | draining burst | 200 | ~300k | 0.13ms / 0.59ms / 1.0ms | 3.0ms / 4.2ms |
+| `quit_overload` | producer at 100k/s | 200 | ~8–9.5k | 0.11ms / 0.59ms / 1.2ms | 0.20ms / 1.3ms |
+| `quit_keyed_backlog_50k` | draining burst | 20 | ~50k | 1305ms / 1310ms / 1310ms | 1305ms / 1310ms |
+
 Findings:
 
 - **F1 — In-capacity behavior is healthy.** At up to 200k msg/s within
@@ -168,12 +194,31 @@ Findings:
 - **F5 — The frame branch survives overload.** The unbiased select plus the
   100µs batch cap kept the frame branch at 60 FPS through every overload
   scenario; no structural event-loop change is required for frame
-  scheduling. The harness does **not** measure quit responsiveness under
-  backlog: its quit is generated only after the last load message is
-  processed. A quit-under-backlog scenario is required before implementation
-  to validate INV-L4 and the quit-path contract (open question 8); because
-  the select is unbiased, that scenario needs tail latency across many
-  trials, not a single run, to say anything about INV-L4.
+  scheduling. Quit responsiveness under backlog is measured separately by
+  the `quit_*` trial scenarios above (F6, F7), added for open question 8.
+- **F6 — Unkeyed quit delivery is backlog-independent under the unbiased
+  select.** Across 600 loaded trials at depths from ~8k to ~300k,
+  quit→last-work stays at p50 0.11–0.13ms, p99 ≤ 0.74ms, max ≤ 1.2ms, with
+  no separation between the 50k and 300k depths and none between a draining
+  burst and an actively refilling producer. The idle baseline is *higher* at
+  p50 (0.51ms) because the quit request also marks a redraw and one 500µs
+  `view` usually runs before the quit branch wins; under load that render is
+  amortized into work already happening. The cost of a lost unbiased
+  tie-break is therefore a few micro-batches, not a function of queue depth.
+  Quit→exit *does* scale with depth (p50 0.61ms at 50k vs 3.0ms at 300k) —
+  that is shutdown-time backlog deallocation, not delivery. This is the
+  measurement basis INV-L4 was waiting for: the statistical formulation
+  (INV-L4 option (b)) is already satisfiable by the current implementation,
+  while a deterministic quit priority (option (a)) would buy a hard per-run
+  bound, not depth-independence, which the data shows the unbiased select
+  provides on its own.
+- **F7 — A keyed quit waits for the full shared drain.** With ~50k queued,
+  the keyed variant's quit→last-work is p50 1.305s — the full drain of the
+  remaining backlog at ~26µs per message — with spread across 20 trials
+  under 0.5%. This is F4's shared-first starvation applied to quit: delivery
+  scales linearly with backlog depth. It quantifies the status quo that open
+  question 7 weighs against re-routing a front-of-stream keyed quit to the
+  dedicated channel.
 
 ## 3. Release-gate decision for 0.10.0
 
@@ -390,9 +435,15 @@ To be finalized as contract tests before implementation:
   counts as passing), since a single harness run cannot validate a claim of
   the form "always independent of backlog." Quit requests still inside
   command streams are outside this invariant and follow their stream's
-  delivery semantics (section 4.2). The new quit-under-backlog scenario
-  (open question 8) needs to settle which of the two this invariant is
-  before it becomes an acceptance measurement.
+  delivery semantics (section 4.2). The quit-under-backlog scenarios now
+  exist and are measured (section 2, F6): delivery latency shows no depth
+  dependence from 0 to ~300k queued messages, so formulation (b) is
+  satisfiable by the current unbiased select with no structural change,
+  with measurement conditions of the form "≥ 200 trials per scenario,
+  quit→last-work p99 ≤ 1ms at every measured depth"; (a) remains the
+  fallback if a hard per-run bound is ever required. Choosing between (a)
+  and (b) is the remaining step before INV-L4 becomes an acceptance
+  measurement; F6 removes the empirical uncertainty from that choice.
 - **INV-L5**: All RFC 0003 invariants hold unchanged in bounded mode.
 - **INV-L6**: Default configuration (`app_channel_capacity: None`,
   `keyed_channel_capacity: None`, `batch_max_messages: None`) reproduces
@@ -418,10 +469,29 @@ integration test. The overload scenario is the acceptance measurement for
 INV-L1/L3: bounded queue depth and shared update latency must flatten where
 the unbounded baseline grows linearly. The keyed-probe scenario becomes an
 acceptance measurement only once the fairness policy (open question 6) fixes
-what keyed latency bound, if any, to expect; INV-L4 needs the new
-quit-under-backlog scenario (open question 8). INV-L7 is structural rather
-than load-dependent and is checked by code review of every runtime-internal
-send site, not by a bench scenario.
+what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
+are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
+INV-L7 is structural rather than load-dependent and is checked by code
+review of every runtime-internal send site, not by a bench scenario.
+
+### 5.1 Bounded vs. unbounded acceptance matrix
+
+The bounded mode's acceptance measurement is a re-run of the harness under a
+bounded `RuntimeConfig`, compared cell by cell against the unbounded
+baseline below (measured 2026-07-17, reference machine of section 2). The
+unbounded column is fixed now so the implementation has a pinned before/after
+comparison; the bounded column states the acceptance criterion each cell
+must meet and is filled with measured values when the implementation lands.
+
+| Scenario | Metric | Unbounded baseline | Bounded acceptance criterion |
+| --- | --- | --- | --- |
+| `overload` | max queue depth | ~308k, grows linearly with overload duration (F3) | ≤ configured `app_channel_capacity` (INV-L1) |
+| `overload` | update latency p99 | 7.9s, grows with overload duration (F3) | bounded by the drain time of one full queue plus admission wait (INV-L3, its producer-count premise given) |
+| `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ capacity; producer waits instead; no message dropped (INV-L1, INV-L2) |
+| `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
+| `quit_backlog_300k`, `quit_overload` | quit→last-work p99 | ≤ 0.74ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
+| `quit_keyed_backlog_50k` | quit→last-work p50 | ≈ full shared drain, 1.31s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
+| `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 ## 6. Open questions (to resolve before implementation)
 
@@ -468,6 +538,14 @@ send site, not by a bench scenario.
    which of the two shapes it delivers.
 8. Harness follow-up: add a quit-under-backlog scenario (F5) and a bounded
    vs. unbounded comparison matrix before implementation.
+   **Resolved (2026-07-17).** `benches/runtime_load.rs` now runs the
+   `quit_*` trial scenarios — unkeyed quit at three backlog depths plus an
+   actively refilling overload, and a keyed-quit control — with per-trial
+   tail statistics (section 2, F6/F7). The bounded-vs-unbounded comparison
+   matrix is defined in section 5.1 with the unbounded column measured; the
+   bounded column is filled when the implementation lands. F6 is the input
+   for INV-L4's (a)/(b) formulation choice; F7 is the quantified status quo
+   for open question 7.
 
 ## 7. References
 

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -499,14 +499,20 @@ must meet and is filled with measured values when the implementation lands.
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -
-processed`, which counts a message from the moment the source stream yields
-it. Raw channel occupancy is not observable through the public API, and a
-producer blocked in a bounded `send` holds its one in-flight message
-*outside* the channel — exactly the per-producer accounting INV-L1 already
-makes. The observable acceptance bound is therefore `app_channel_capacity +
-concurrent shared-channel producers` (`capacity + 1` in these
-single-flood-producer scenarios), not `capacity` alone; an observed depth of
-`capacity + 1` with one producer is compliant, and depth exceeding
+processed`. Raw channel occupancy is not observable through the public API,
+so two in-flight positions outside the channel had to be settled
+explicitly. A producer blocked in a bounded `send` holds one message
+outside the channel — exactly the per-producer accounting INV-L1 already
+makes — and the depth *includes* it, because `produced` counts a message
+when the source stream yields it. The consumer side holds up to one more
+message inside `Application::update`, and the depth *excludes* it, because
+`processed` counts a message when `update` begins, i.e. once it has left
+the channel; counting at update completion instead would let a compliant
+implementation read `capacity + producers + 1` (channel full, one blocked
+producer refills the freed slot while the pulled message is still being
+processed) and be flagged as a regression. The observable acceptance bound
+is therefore `app_channel_capacity + concurrent shared-channel producers`
+(`capacity + 1` in these single-flood-producer scenarios); depth exceeding
 `capacity + producers` is the regression signal.
 
 ## 6. Open questions (to resolve before implementation)

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -148,20 +148,22 @@ shared channel (burst or paced), then `update` returns `Command::quit()`
 while the backlog is still deep, mirroring a real quit key press: the
 unkeyed variant reaches the dedicated quit channel through its command task
 (section 1.1); the keyed variant travels its command's private channel
-instead (section 4.2). Two per-trial values bracket delivery, which is not
-directly observable from outside the runtime: **quit→last-work** (quit
-request to the end of the last `update`/`view` call; the loop breaks right
-after, so this lower-bounds delivery) and **quit→exit** (to `run()`
-returning; an upper bound that adds teardown, including backlog
-deallocation that scales with depth and must not be misread as delivery).
+instead (section 4.2). Two per-trial values are recorded: **quit→delivered**
+(quit request to the event loop's quit branch observing it — the harness
+installs a process-global `tracing` subscriber and timestamps the runtime's
+own "quit signal received" / "keyed quit signal received" debug events on
+the `tears::runtime` target, so this is the delivery instant itself, not a
+bound, and is usable as an acceptance measurement) and **quit→exit** (to
+`run()` returning, which adds teardown, including backlog deallocation that
+scales with depth and must not be misread as delivery).
 
-| Scenario | Load at quit | Trials | Depth at quit | Quit→last-work p50 / p99 / max | Quit→exit p50 / max |
+| Scenario | Load at quit | Trials | Depth at quit | Quit→delivered p50 / p99 / max | Quit→exit p50 / max |
 | --- | --- | --- | --- | --- | --- |
-| `quit_idle` | none | 200 | 0 | 0.51ms / 0.69ms / 1.0ms | 0.62ms / 2.1ms |
-| `quit_backlog_50k` | draining burst | 200 | ~50k | 0.11ms / 0.74ms / 0.90ms | 0.61ms / 5.4ms |
-| `quit_backlog_300k` | draining burst | 200 | ~300k | 0.13ms / 0.59ms / 1.0ms | 3.0ms / 4.2ms |
-| `quit_overload` | producer at 100k/s | 200 | ~8–9.5k | 0.11ms / 0.59ms / 1.2ms | 0.20ms / 1.3ms |
-| `quit_keyed_backlog_50k` | draining burst | 20 | ~50k | 1305ms / 1310ms / 1310ms | 1305ms / 1310ms |
+| `quit_idle` | none | 200 | 0 | 0.59ms / 0.71ms / 1.9ms | 0.60ms / 1.9ms |
+| `quit_backlog_50k` | draining burst | 200 | ~50k | 0.11ms / 0.49ms / 0.64ms | 0.58ms / 1.1ms |
+| `quit_backlog_300k` | draining burst | 200 | ~300k | 0.11ms / 0.61ms / 0.61ms | 2.9ms / 3.4ms |
+| `quit_overload` | producer at 100k/s | 200 | ~8k | 0.11ms / 0.62ms / 0.84ms | 0.19ms / 0.92ms |
+| `quit_keyed_backlog_50k` | draining burst | 20 | ~50k | 1300ms / 1302ms / 1302ms | 1300ms / 1302ms |
 
 Findings:
 
@@ -198,14 +200,14 @@ Findings:
   the `quit_*` trial scenarios above (F6, F7), added for open question 8.
 - **F6 — Unkeyed quit delivery is backlog-independent under the unbiased
   select.** Across 600 loaded trials at depths from ~8k to ~300k,
-  quit→last-work stays at p50 0.11–0.13ms, p99 ≤ 0.74ms, max ≤ 1.2ms, with
-  no separation between the 50k and 300k depths and none between a draining
+  quit→delivered stays at p50 0.11ms, p99 ≤ 0.62ms, max ≤ 0.84ms, with no
+  separation between the 50k and 300k depths and none between a draining
   burst and an actively refilling producer. The idle baseline is *higher* at
-  p50 (0.51ms) because the quit request also marks a redraw and one 500µs
+  p50 (0.59ms) because the quit request also marks a redraw and one 500µs
   `view` usually runs before the quit branch wins; under load that render is
   amortized into work already happening. The cost of a lost unbiased
   tie-break is therefore a few micro-batches, not a function of queue depth.
-  Quit→exit *does* scale with depth (p50 0.61ms at 50k vs 3.0ms at 300k) —
+  Quit→exit *does* scale with depth (p50 0.58ms at 50k vs 2.9ms at 300k) —
   that is shutdown-time backlog deallocation, not delivery. This is the
   measurement basis INV-L4 was waiting for: the statistical formulation
   (INV-L4 option (b)) is already satisfiable by the current implementation,
@@ -213,9 +215,9 @@ Findings:
   bound, not depth-independence, which the data shows the unbiased select
   provides on its own.
 - **F7 — A keyed quit waits for the full shared drain.** With ~50k queued,
-  the keyed variant's quit→last-work is p50 1.305s — the full drain of the
+  the keyed variant's quit→delivered is p50 1.300s — the full drain of the
   remaining backlog at ~26µs per message — with spread across 20 trials
-  under 0.5%. This is F4's shared-first starvation applied to quit: delivery
+  under 0.2%. This is F4's shared-first starvation applied to quit: delivery
   scales linearly with backlog depth. It quantifies the status quo that open
   question 7 weighs against re-routing a front-of-stream keyed quit to the
   dedicated channel.
@@ -436,11 +438,14 @@ To be finalized as contract tests before implementation:
   the form "always independent of backlog." Quit requests still inside
   command streams are outside this invariant and follow their stream's
   delivery semantics (section 4.2). The quit-under-backlog scenarios now
-  exist and are measured (section 2, F6): delivery latency shows no depth
+  exist and are measured (section 2, F6), and they record the delivery
+  instant itself — the quit branch firing, timestamped from the runtime's
+  tracing events — not a proxy bound, so a regression in the quit branch's
+  scheduling would show up directly. Delivery latency shows no depth
   dependence from 0 to ~300k queued messages, so formulation (b) is
   satisfiable by the current unbiased select with no structural change,
   with measurement conditions of the form "≥ 200 trials per scenario,
-  quit→last-work p99 ≤ 1ms at every measured depth"; (a) remains the
+  quit→delivered p99 ≤ 1ms at every measured depth"; (a) remains the
   fallback if a hard per-run bound is ever required. Choosing between (a)
   and (b) is the remaining step before INV-L4 becomes an acceptance
   measurement; F6 removes the empirical uncertainty from that choice.
@@ -485,13 +490,24 @@ must meet and is filled with measured values when the implementation lands.
 
 | Scenario | Metric | Unbounded baseline | Bounded acceptance criterion |
 | --- | --- | --- | --- |
-| `overload` | max queue depth | ~308k, grows linearly with overload duration (F3) | ≤ configured `app_channel_capacity` (INV-L1) |
+| `overload` | max queue depth | ~308k, grows linearly with overload duration (F3) | ≤ `app_channel_capacity` + concurrent producers — `capacity + 1` here; see the depth-accounting note below (INV-L1) |
 | `overload` | update latency p99 | 7.9s, grows with overload duration (F3) | bounded by the drain time of one full queue plus admission wait (INV-L3, its producer-count premise given) |
-| `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ capacity; producer waits instead; no message dropped (INV-L1, INV-L2) |
+| `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ `capacity + 1` by the same depth accounting; producer waits instead; no message dropped (INV-L1, INV-L2) |
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
-| `quit_backlog_300k`, `quit_overload` | quit→last-work p99 | ≤ 0.74ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
-| `quit_keyed_backlog_50k` | quit→last-work p50 | ≈ full shared drain, 1.31s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
+| `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
+| `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
+
+Queue-depth cells use the harness's depth definition, `produced -
+processed`, which counts a message from the moment the source stream yields
+it. Raw channel occupancy is not observable through the public API, and a
+producer blocked in a bounded `send` holds its one in-flight message
+*outside* the channel — exactly the per-producer accounting INV-L1 already
+makes. The observable acceptance bound is therefore `app_channel_capacity +
+concurrent shared-channel producers` (`capacity + 1` in these
+single-flood-producer scenarios), not `capacity` alone; an observed depth of
+`capacity + 1` with one producer is compliant, and depth exceeding
+`capacity + producers` is the regression signal.
 
 ## 6. Open questions (to resolve before implementation)
 


### PR DESCRIPTION
## Summary

Resolves RFC 0006 §6 open question 8 (harness follow-up) — the first of the pre-implementation open questions for S4.

**Harness** (`benches/runtime_load.rs`):
- New `quit_*` multi-trial scenarios: `update` returns `Command::quit()` while the shared backlog is still deep, mirroring a real quit key press. The unbiased `select!` makes quit latency a distribution, so each scenario reports tail percentiles across 200 trials (20 for the keyed control).
- Two per-trial metrics: `quit->delivered` — the delivery instant itself, timestamped by a process-global tracing subscriber from the runtime's own `quit signal received` / `keyed quit signal received` debug events (target `tears::runtime`) — and `quit->exit`, which adds teardown (its backlog deallocation scales with depth and is reported separately so it cannot be misread as delivery). If the runtime's message strings change, trials fail loudly as "missing delivery event".
- Coverage: unkeyed quit at ~0 / ~50k / ~300k queued, unkeyed quit under an actively refilling producer, and a keyed-quit control through the private channel.

**RFC 0006 amendment**:
- F6: unkeyed quit delivery is backlog-independent — `quit->delivered` p50 0.11ms, p99 ≤ 0.62ms, max ≤ 0.84ms across 600 loaded trials, no separation between depths. This is the measurement basis for INV-L4: the statistical formulation (b) is satisfiable by the current implementation with no structural change, and a quit-branch scheduling regression is directly detectable because the metric is the delivery instant, not a proxy bound.
- F7: a keyed quit waits for the full shared drain (p50 1.300s at ~50k) — quantified status quo for open question 7.
- §5.1: bounded-vs-unbounded acceptance matrix with the unbounded baselines pinned; the bounded column is filled when the `RuntimeConfig` implementation lands. Queue-depth cells follow the harness's `produced - processed` definition and INV-L1's per-producer accounting: the observable bound is `capacity + concurrent producers` (`capacity + 1` for the single-flood-producer scenarios), not raw channel occupancy.
- F5's stale note (harness cannot measure quit under backlog) removed; OQ8 marked resolved.

The INV-L4 (a)/(b) formulation choice itself is deliberately left open; F6 removes the empirical uncertainty and the choice will be settled together with OQ7.

## Test plan

- `cargo clippy --bench runtime_load --all-features` clean; `cargo fmt` applied.
- All five `quit_*` scenarios run to completion with 0 timeouts and 0 missing delivery events (numbers in the RFC tables are from this run, Apple M1 Max reference machine).
- `steady_20k` re-run matches the RFC §2 reference numbers, confirming the added instrumentation does not perturb existing scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)