### PR TITLE
Resolve RFC 0006 open question 3: producer-count bounding

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -601,16 +601,18 @@ behavioral *regression* check, not a proof, and it is built to catch
 bounded pools rather than merely a second key: several keyed channels are
 held at capacity with their next sends pending — saturating any modest
 pool — while the two probe channels stay untouched until then. It checks
-send *admission* only, and proves the invariant's two halves separately:
+send *admission* only, and exercises the invariant's two halves separately:
 (a) keyed→keyed — a previously idle key's first `keyed_channel_capacity`
 sends complete, and only its `capacity + 1`-th send is pending, on that
 key's own occupancy; (b) keyed→shared — the shared producer's first
 `app_channel_capacity` sends complete, with only its next send pending on
 the shared channel's own occupancy. Delivery is deliberately outside the
-scenario: the event loop's keyed pull drains every ready keyed receiver
-through one `StreamMap`, so observing one key's delivery necessarily
-drains the others too, and delivery latency belongs to the fairness
-question (open question 6), which INV-L9 does not answer. INV-L7 and
+scenario: the event loop's keyed pull goes through one `StreamMap` over
+every keyed receiver and cannot drain a chosen key selectively — each poll
+returns one ready element from whichever key is picked, so waiting for the
+probe's delivery may drain the saturated keys instead — and delivery
+latency belongs to the fairness question (open question 6), which INV-L9
+does not answer. INV-L7 and
 INV-L8 are structural rather than load-dependent and are checked by code
 review of every runtime-internal send and spawn site, not by a bench
 scenario; INV-L9 sits in both camps as described above.
@@ -632,7 +634,7 @@ must meet and is filled with measured values when the implementation lands.
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
-| `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` drains all ready receivers; delivery latency is open question 6's territory) (INV-L9) |
+| `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -13,20 +13,22 @@
 - Amendments: 2026-07-17 — open question 8 resolved: quit-under-backlog
   scenarios added and measured (section 2, F6/F7), bounded-vs-unbounded
   acceptance matrix defined (section 5.1). 2026-07-17 — open question 3
-  resolved: no producer admission limit — R1/R3 stay scoped to channel
-  buffers with an application-owned, observable producer-count premise, and
-  keyed channels are bounded per command, not by a shared pool (sections
-  1.2, 4.4, 4.5, 5)
+  resolved: no producer admission limit — R1 is scoped to per-channel
+  bounds with the active-`CommandId` count an application-owned contract
+  input, the producer-count premise is application-owned and observable,
+  and keyed channels are bounded per command, not by a shared pool
+  (INV-L8/L9; sections 1.2, 4.4, 4.5, 5, 5.1)
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
 > sections 4–6 turns out to be unimplementable without breaking the public
 > API. Sections 4–6 fix the direction of the load-control contract but their
 > details (capacities, batching caps, per-source classes) remain open until
-> implementation. In particular, cross-channel fairness (section 4.3), the
-> quit delivery path (section 4.2), and the exact scope of the memory bound
-> (INV-L1) are contracts to settle before the post-0.10.0 implementation;
-> none of them gates the 0.10.0 release.
+> implementation. In particular, cross-channel fairness (section 4.3) and
+> the quit delivery path (section 4.2) are contracts to settle before the
+> post-0.10.0 implementation; the exact scope of the memory bound (INV-L1)
+> was the third such contract and is now settled (open question 3, section
+> 4.5). None of them gates the 0.10.0 release.
 
 ## Summary
 
@@ -89,17 +91,22 @@ Scheduling facts that interact with load:
 
 ### 1.2 Requirements carried into the contract
 
-- **R1**: Memory used by pending runtime-owned channel buffers must be
-  boundable by configuration. This is a bound on buffered messages waiting
-  in a channel, not on all pending-work memory: each producer blocked
-  awaiting channel capacity additionally holds one in-flight message
-  outside the channel, and the number of concurrent producers (active
-  subscriptions, running commands) is controlled by the application, not by
-  `RuntimeConfig`. A full memory bound also requires bounding producer
+- **R1**: Memory used by *each* pending runtime-owned channel buffer must be
+  boundable by configuration. The bound is per channel, not aggregate:
+  `RuntimeConfig` alone bounds the shared channel and each keyed channel
+  individually, and the buffer total is `app_channel_capacity + m ×
+  keyed_channel_capacity`, where `m` — the number of active `CommandId`s —
+  is a contract input the application must bound, not something
+  `RuntimeConfig` controls (it is one component of the producer-count
+  premise, section 4.5). Nor is this a bound on all pending-work memory:
+  each producer blocked awaiting channel capacity additionally holds one
+  in-flight message outside the channel, and the number of concurrent
+  producers (active subscriptions, running commands) is likewise controlled
+  by the application. A full memory bound also requires bounding producer
   count, which this RFC's channel-capacity controls do not deliver on their
-  own; open question 3 resolved this by keeping R1 scoped to channel
-  buffers, with the producer-count premise application-owned and observable
-  (INV-L1, section 4.5).
+  own; open question 3 resolved this by keeping R1 scoped as stated —
+  per-channel bounds from configuration, with the producer-count premise
+  (including `m`) application-owned and observable (INV-L1, section 4.5).
 - **R2**: A configured bound must not silently drop messages by default;
   backpressure (slowing the producer) is the default overload response.
 - **R3**: Input-to-screen latency under load must be observable and, with a
@@ -453,11 +460,14 @@ orthogonal. A pool also cannot rescue a total bound: the number of active
 `CommandId`s is application-owned, so with or without a pool the premise
 stays with the application. Per-command capacity matches the per-command
 FIFO contract and the existing one-private-channel-per-`CommandId`
-structure, at the cost of a looser conceptual total (INV-L1's
-`Σ(per-command keyed capacity)`).
+structure, at a deliberate cost R1 states explicitly: the keyed buffer
+total is `m × keyed_channel_capacity` with `m` — the number of active
+`CommandId`s — an application-owned contract input, not a `RuntimeConfig`
+knob.
 
-The decision is captured as INV-L8: load control paces sends, never
-producer admission.
+The decision is captured in two invariants: INV-L8 (load control paces
+sends, never producer admission) and INV-L9 (keyed backpressure is
+isolated per command — the testable form of the no-shared-pool choice).
 
 ## 5. Invariants (draft)
 
@@ -472,7 +482,8 @@ To be finalized as contract tests before implementation:
   Σ(per-command keyed capacity)`. A single global memory bound would require
   a global permit pool or a cap on active producers; open question 3
   resolved against both, so this conceptual total *is* the contract, with
-  the producer count application-owned and observable (section 4.5).
+  the producer count — including `m`, the number of active `CommandId`s in
+  R1's buffer total — application-owned and observable (section 4.5).
 - **INV-L2**: Bounded mode never drops a message to relieve backpressure —
   capacity pressure is resolved only by the producer waiting, never by the
   runtime discarding queued or in-flight output. This does not override RFC
@@ -553,6 +564,13 @@ To be finalized as contract tests before implementation:
   future admission limit, and — because producers are created on the event
   loop task — it is also what keeps INV-L7's no-self-deadlock argument
   closed at spawn sites, not just send sites.
+- **INV-L9**: Keyed backpressure is isolated per command. A send blocked on
+  one keyed channel's full capacity never delays admission into the shared
+  channel or into any other keyed channel; each keyed channel's admission
+  depends only on that channel's own occupancy. This is the no-shared-pool
+  resolution of open question 3 (section 4.5) in testable form — a global
+  permit pool would satisfy INV-L1's per-channel capacity cells while
+  violating this one, so INV-L9 is what pins the isolation choice.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
 integration test. The overload scenario is the acceptance measurement for
@@ -561,9 +579,12 @@ the unbounded baseline grows linearly. The keyed-probe scenario becomes an
 acceptance measurement only once the fairness policy (open question 6) fixes
 what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
 are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
-INV-L7 and INV-L8 are structural rather than load-dependent and are checked
-by code review of every runtime-internal send and spawn site, not by a
-bench scenario.
+INV-L9's acceptance scenario is `keyed_isolation` (section 5.1), added with
+the implementation: hold one keyed channel at capacity and verify an
+independent key still fills and delivers up to its own capacity. INV-L7 and
+INV-L8 are structural rather than load-dependent and are checked by code
+review of every runtime-internal send and spawn site, not by a bench
+scenario.
 
 ### 5.1 Bounded vs. unbounded acceptance matrix
 
@@ -582,6 +603,7 @@ must meet and is filled with measured values when the implementation lands.
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
+| `keyed_isolation` (new scenario, added with the implementation) | key B send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | key B's producer fills and delivers up to its own `keyed_channel_capacity` while key A's channel stays full; any key-B admission wait correlated with key A's occupancy is the regression signal (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -
@@ -620,11 +642,15 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    synchronous on the event loop task, so a waiting limit is INV-L7's
    self-deadlock at the spawn site, and the non-waiting alternatives
    (reject, drop, defer) break the RFC 0005 reconciliation contract or
-   silently discard effects. R1 and R3 stay scoped to channel buffers; the
-   producer-count premise becomes an explicit, application-owned,
-   observable responsibility (producer gauges in section 4.4), and keyed
-   channels are bounded per command rather than by a shared pool. Full
-   rationale in section 4.5; the contract is captured as INV-L8.
+   silently discard effects. R1 is explicitly weakened to per-channel
+   bounds: the buffer total is `app_channel_capacity + m ×
+   keyed_channel_capacity` with `m` (active `CommandId`s) an
+   application-owned contract input, part of the producer-count premise
+   that becomes an explicit, observable responsibility (producer gauges in
+   section 4.4). Keyed channels are bounded per command rather than by a
+   shared pool, pinned as testable isolation (INV-L9, `keyed_isolation`
+   scenario in section 5.1). Full rationale in section 4.5; the
+   no-admission-limit contract itself is INV-L8.
 4. Where backpressure-wait telemetry lives (`tracing` only, or counters
    exposed by future profiling-hook work).
 5. Restart-rate-control interaction: whether a future restart-rate-control

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -94,11 +94,10 @@ Scheduling facts that interact with load:
 - **R1**: Memory used by each pending *app-facing* runtime-owned channel
   buffer — the shared app channel and each keyed command channel — must be
   boundable by configuration. The dedicated quit channel is deliberately
-  outside R1: it is never bounded (R4, section 4.1) and does not appear in
-  the buffer total below; its occupancy needs no configuration knob because
-  each command task sends at most one quit signal before terminating, so it
-  is bounded by the producer count, the same application-owned premise as
-  the rest of this requirement. The bound is per channel, not aggregate:
+  outside R1: it is R4's unbounded exception — quit signals must never
+  participate in backpressure — so it is never bounded (section 4.1), does
+  not appear in the buffer total below, and R1 makes no occupancy claim
+  for it. The bound is per channel, not aggregate:
   `RuntimeConfig` alone bounds the shared channel and each keyed channel
   individually, and the buffer total is `app_channel_capacity + m ×
   keyed_channel_capacity`, where `m` — the number of active `CommandId`s —
@@ -588,10 +587,15 @@ acceptance measurement only once the fairness policy (open question 6) fixes
 what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
 are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
 INV-L9's acceptance scenario is `keyed_isolation` (section 5.1), added with
-the implementation, and it checks send *admission* only: with key A held at
-capacity and its next send pending, key B's first `capacity` sends must
-complete and only its `capacity + 1`-th send may be pending — pending on
-key B's own occupancy. Delivery is deliberately outside the scenario: the
+the implementation, and it checks send *admission* only, on both halves of
+the invariant: with key A held at capacity and its next send pending, key
+B's first `capacity` sends must complete and only its `capacity + 1`-th
+send may be pending — pending on key B's own occupancy — and a shared
+producer's first `app_channel_capacity` sends must likewise complete, with
+only its next send pending on the shared channel's own occupancy. The
+shared half is what rules out an implementation whose keyed channels share
+permits with the shared channel while keyed-to-keyed stays isolated.
+Delivery is deliberately outside the scenario: the
 event loop's keyed pull drains every ready keyed receiver through one
 `StreamMap`, so observing key B's delivery necessarily drains key A too,
 and delivery latency belongs to the fairness question (open question 6),
@@ -617,7 +621,7 @@ must meet and is filled with measured values when the implementation lands.
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
-| `keyed_isolation` (new scenario, added with the implementation) | key B send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | with key A at capacity and its `capacity + 1`-th send pending, key B's first `keyed_channel_capacity` sends complete and only its `capacity + 1`-th send is pending, on key B's own occupancy; admission only — delivery is excluded (draining B also drains A via the keyed `StreamMap`, and delivery latency is open question 6's territory) (INV-L9) |
+| `keyed_isolation` (new scenario, added with the implementation) | key B and shared send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | with key A at capacity and its `capacity + 1`-th send pending: key B's first `keyed_channel_capacity` sends complete and only its `capacity + 1`-th send is pending, on key B's own occupancy; a shared producer's first `app_channel_capacity` sends complete and only its next send is pending, on the shared channel's own occupancy; admission only — delivery is excluded (draining B also drains A via the keyed `StreamMap`, and delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -575,9 +575,12 @@ To be finalized as contract tests before implementation:
   one keyed channel's full capacity never delays admission into the shared
   channel or into any other keyed channel; each keyed channel's admission
   depends only on that channel's own occupancy. This is the no-shared-pool
-  resolution of open question 3 (section 4.5) in testable form — a global
+  resolution of open question 3 (section 4.5) in enforceable form — a global
   permit pool would satisfy INV-L1's per-channel capacity cells while
-  violating this one, so INV-L9 is what pins the isolation choice.
+  violating this one, so INV-L9 is what pins the isolation choice. Its
+  primary check is structural (channel-local capacity, no cross-channel
+  permit sharing), with `keyed_isolation` as a behavioral regression
+  scenario — see below for why a scenario alone cannot prove pool absence.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
 integration test. The overload scenario is the acceptance measurement for
@@ -586,23 +589,31 @@ the unbounded baseline grows linearly. The keyed-probe scenario becomes an
 acceptance measurement only once the fairness policy (open question 6) fixes
 what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
 are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
-INV-L9's acceptance scenario is `keyed_isolation` (section 5.1), added with
-the implementation, and it checks send *admission* only, on both halves of
-the invariant: with key A held at capacity and its next send pending, key
-B's first `capacity` sends must complete and only its `capacity + 1`-th
-send may be pending — pending on key B's own occupancy — and a shared
-producer's first `app_channel_capacity` sends must likewise complete, with
-only its next send pending on the shared channel's own occupancy. The
-shared half is what rules out an implementation whose keyed channels share
-permits with the shared channel while keyed-to-keyed stays isolated.
-Delivery is deliberately outside the scenario: the
-event loop's keyed pull drains every ready keyed receiver through one
-`StreamMap`, so observing key B's delivery necessarily drains key A too,
-and delivery latency belongs to the fairness question (open question 6),
-which INV-L9 does not answer. INV-L7 and
+INV-L9's *primary* check is structural, like INV-L7's and INV-L8's: every
+bounded channel is constructed with its own capacity, and no permit,
+semaphore, or budget is shared across channels — checked by code review of
+the channel-construction and send sites. It has to be structural because
+no finite scenario can prove the absence of a shared pool: any scenario
+that saturates `j` channels is passed by a per-channel-capacity-plus-pool
+implementation whose pool exceeds `j × capacity`. The `keyed_isolation`
+scenario (section 5.1), added with the implementation, is therefore a
+behavioral *regression* check, not a proof, and it is built to catch
+bounded pools rather than merely a second key: several keyed channels are
+held at capacity with their next sends pending — saturating any modest
+pool — while the two probe channels stay untouched until then. It checks
+send *admission* only, and proves the invariant's two halves separately:
+(a) keyed→keyed — a previously idle key's first `keyed_channel_capacity`
+sends complete, and only its `capacity + 1`-th send is pending, on that
+key's own occupancy; (b) keyed→shared — the shared producer's first
+`app_channel_capacity` sends complete, with only its next send pending on
+the shared channel's own occupancy. Delivery is deliberately outside the
+scenario: the event loop's keyed pull drains every ready keyed receiver
+through one `StreamMap`, so observing one key's delivery necessarily
+drains the others too, and delivery latency belongs to the fairness
+question (open question 6), which INV-L9 does not answer. INV-L7 and
 INV-L8 are structural rather than load-dependent and are checked by code
 review of every runtime-internal send and spawn site, not by a bench
-scenario.
+scenario; INV-L9 sits in both camps as described above.
 
 ### 5.1 Bounded vs. unbounded acceptance matrix
 
@@ -621,7 +632,7 @@ must meet and is filled with measured values when the implementation lands.
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
-| `keyed_isolation` (new scenario, added with the implementation) | key B and shared send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | with key A at capacity and its `capacity + 1`-th send pending: key B's first `keyed_channel_capacity` sends complete and only its `capacity + 1`-th send is pending, on key B's own occupancy; a shared producer's first `app_channel_capacity` sends complete and only its next send is pending, on the shared channel's own occupancy; admission only — delivery is excluded (draining B also drains A via the keyed `StreamMap`, and delivery latency is open question 6's territory) (INV-L9) |
+| `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` drains all ready receivers; delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -91,8 +91,14 @@ Scheduling facts that interact with load:
 
 ### 1.2 Requirements carried into the contract
 
-- **R1**: Memory used by *each* pending runtime-owned channel buffer must be
-  boundable by configuration. The bound is per channel, not aggregate:
+- **R1**: Memory used by each pending *app-facing* runtime-owned channel
+  buffer — the shared app channel and each keyed command channel — must be
+  boundable by configuration. The dedicated quit channel is deliberately
+  outside R1: it is never bounded (R4, section 4.1) and does not appear in
+  the buffer total below; its occupancy needs no configuration knob because
+  each command task sends at most one quit signal before terminating, so it
+  is bounded by the producer count, the same application-owned premise as
+  the rest of this requirement. The bound is per channel, not aggregate:
   `RuntimeConfig` alone bounds the shared channel and each keyed channel
   individually, and the buffer total is `app_channel_capacity + m ×
   keyed_channel_capacity`, where `m` — the number of active `CommandId`s —
@@ -479,7 +485,9 @@ To be finalized as contract tests before implementation:
   each producer task blocked on a full channel additionally holds one
   in-flight message, and keyed channels exist per active `CommandId`, so the
   conceptual total is `shared capacity + number of blocked producers +
-  Σ(per-command keyed capacity)`. A single global memory bound would require
+  Σ(per-command keyed capacity)`; the dedicated quit channel is exempt from
+  capacity configuration and from this total (R1, R4). A single global
+  memory bound would require
   a global permit pool or a cap on active producers; open question 3
   resolved against both, so this conceptual total *is* the contract, with
   the producer count — including `m`, the number of active `CommandId`s in
@@ -580,8 +588,14 @@ acceptance measurement only once the fairness policy (open question 6) fixes
 what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
 are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
 INV-L9's acceptance scenario is `keyed_isolation` (section 5.1), added with
-the implementation: hold one keyed channel at capacity and verify an
-independent key still fills and delivers up to its own capacity. INV-L7 and
+the implementation, and it checks send *admission* only: with key A held at
+capacity and its next send pending, key B's first `capacity` sends must
+complete and only its `capacity + 1`-th send may be pending — pending on
+key B's own occupancy. Delivery is deliberately outside the scenario: the
+event loop's keyed pull drains every ready keyed receiver through one
+`StreamMap`, so observing key B's delivery necessarily drains key A too,
+and delivery latency belongs to the fairness question (open question 6),
+which INV-L9 does not answer. INV-L7 and
 INV-L8 are structural rather than load-dependent and are checked by code
 review of every runtime-internal send and spawn site, not by a bench
 scenario.
@@ -603,7 +617,7 @@ must meet and is filled with measured values when the implementation lands.
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
-| `keyed_isolation` (new scenario, added with the implementation) | key B send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | key B's producer fills and delivers up to its own `keyed_channel_capacity` while key A's channel stays full; any key-B admission wait correlated with key A's occupancy is the regression signal (INV-L9) |
+| `keyed_isolation` (new scenario, added with the implementation) | key B send admission while key A's channel is held full | trivially isolated — unbounded sends never wait | with key A at capacity and its `capacity + 1`-th send pending, key B's first `keyed_channel_capacity` sends complete and only its `capacity + 1`-th send is pending, on key B's own occupancy; admission only — delivery is excluded (draining B also drains A via the keyed `StreamMap`, and delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -12,7 +12,11 @@
   RFC (see section 3)
 - Amendments: 2026-07-17 — open question 8 resolved: quit-under-backlog
   scenarios added and measured (section 2, F6/F7), bounded-vs-unbounded
-  acceptance matrix defined (section 5.1)
+  acceptance matrix defined (section 5.1). 2026-07-17 — open question 3
+  resolved: no producer admission limit — R1/R3 stay scoped to channel
+  buffers with an application-owned, observable producer-count premise, and
+  keyed channels are bounded per command, not by a shared pool (sections
+  1.2, 4.4, 4.5, 5)
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
@@ -93,13 +97,16 @@ Scheduling facts that interact with load:
   subscriptions, running commands) is controlled by the application, not by
   `RuntimeConfig`. A full memory bound also requires bounding producer
   count, which this RFC's channel-capacity controls do not deliver on their
-  own (INV-L1, open question 3).
+  own; open question 3 resolved this by keeping R1 scoped to channel
+  buffers, with the producer-count premise application-owned and observable
+  (INV-L1, section 4.5).
 - **R2**: A configured bound must not silently drop messages by default;
   backpressure (slowing the producer) is the default overload response.
 - **R3**: Input-to-screen latency under load must be observable and, with a
   bounded configuration, bounded by queue capacity rather than by overload
-  duration — given a bounded number of concurrent producers, the same
-  premise INV-L3 and open question 3 depend on.
+  duration — given a bounded number of concurrent producers, the
+  application-owned premise INV-L3 depends on (open question 3, resolved in
+  section 4.5).
 - **R4**: A quit signal already in the dedicated quit channel must be
   delivered with latency independent of app backlog (the dedicated channel
   and its always-armed select branch must remain — see INV-L4 for the
@@ -382,9 +389,75 @@ merged" are known.
 
 Bounded or not, the runtime should expose load signals under `tracing`
 targets (`tears::runtime::load` or similar): queue depth high-water marks,
-batch sizes, and time spent awaiting capacity. Whether more than `tracing`
-is needed (for example dedicated profiling-hook counters) is a decision for
-that future work; the load harness already demonstrates what to measure.
+batch sizes, and time spent awaiting capacity. Producer-count gauges belong
+in the same signal set — active subscriptions, running unkeyed command
+tasks, active keyed entries, and, in bounded mode, how many producers are
+currently blocked awaiting capacity — because the producer-count premise
+INV-L1 and INV-L3 rest on is observable rather than enforced (section 4.5).
+Whether more than `tracing` is needed (for example dedicated
+profiling-hook counters) is a decision for that future work; the load
+harness already demonstrates what to measure.
+
+### 4.5 Producer-count premise (open question 3 resolved)
+
+INV-L1 and INV-L3 bound channel buffers and drain-side latency on a
+premise: the number of concurrent producers — subscription forwarding
+tasks, unkeyed command tasks, keyed command tasks — is bounded. Open
+question 3 asked whether the runtime should enforce that premise with an
+admission limit, upgrading R1/R3 from channel-buffer claims to
+total-pending-work guarantees. The resolution: **no admission limit — the
+premise stays with the application, and the runtime makes it observable
+instead of enforced.**
+
+An admission limit is structurally unsound in this runtime:
+
+- Every producer is created synchronously on the event loop task. A
+  command returned from `update` is dispatched (`enqueue_command`) before
+  the loop pulls its next input, and subscription reconciliation spawns
+  forwarding tasks inside the frame branch. An admission limit that
+  *waits* for a free producer slot would therefore have the event loop
+  await capacity that only its own draining can release — the self-deadlock
+  INV-L7 exists to prevent, moved from send sites to spawn sites.
+- The non-waiting alternatives change contracts this RFC promised to
+  preserve. Rejecting a subscription breaks the reconciliation contract
+  (a declared subscription runs, including restart of finished ones —
+  RFC 0005 and `SubscriptionManager::update`). Rejecting or dropping a
+  command silently discards an effect, a strictly worse loss than the
+  message loss R2 forbids. Parking un-admitted producers in a queue only
+  moves the unbounded buffer up one level, from messages to un-started
+  streams and closures, and defers effects for an unbounded time besides.
+
+Leaving the premise to the application is acceptable because producer
+count is a property of application structure, not of external load. A hot
+source raises the message *rate* through a fixed producer set — that is
+exactly what bounded channel capacity controls (F3). Producer *count*
+grows only through the application's own choices: the size of
+`subscriptions()` and how fast it spawns commands relative to how fast
+they complete. This is the same trust class as `update`'s CPU cost, which
+the runtime measures but does not bound. One load-coupled amplification
+deserves documentation as an anti-pattern: an application that spawns a
+command per processed message can, under bounded-mode overload, accumulate
+*blocked* command tasks — bounded channels convert message backlog into
+blocked-producer backlog for that pattern, and no channel capacity bounds
+it. The producer gauges in section 4.4 make that pattern visible; the
+recommended-defaults documentation (open question 1) should carry the
+anti-pattern note.
+
+Within the same question, keyed channels are bounded **per command**, not
+by a shared permit pool. A pool would couple backpressure across
+independent `CommandId`s — one hot command's backlog would block unrelated
+commands' sends, a producer-side analogue of F4's starvation — and permit
+accounting would have to reclaim permits from producers aborted by
+cancellation (RFC 0003), coupling two mechanisms this RFC otherwise keeps
+orthogonal. A pool also cannot rescue a total bound: the number of active
+`CommandId`s is application-owned, so with or without a pool the premise
+stays with the application. Per-command capacity matches the per-command
+FIFO contract and the existing one-private-channel-per-`CommandId`
+structure, at the cost of a looser conceptual total (INV-L1's
+`Σ(per-command keyed capacity)`).
+
+The decision is captured as INV-L8: load control paces sends, never
+producer admission.
 
 ## 5. Invariants (draft)
 
@@ -397,7 +470,9 @@ To be finalized as contract tests before implementation:
   in-flight message, and keyed channels exist per active `CommandId`, so the
   conceptual total is `shared capacity + number of blocked producers +
   Σ(per-command keyed capacity)`. A single global memory bound would require
-  a global permit pool or a cap on active producers (open question 3).
+  a global permit pool or a cap on active producers; open question 3
+  resolved against both, so this conceptual total *is* the contract, with
+  the producer count application-owned and observable (section 4.5).
 - **INV-L2**: Bounded mode never drops a message to relieve backpressure —
   capacity pressure is resolved only by the producer waiting, never by the
   runtime discarding queued or in-flight output. This does not override RFC
@@ -417,11 +492,12 @@ To be finalized as contract tests before implementation:
   drain-equivalents, where `k` is the number of producers already queued
   for a permit ahead of it — end to end, acceptance plus drain-side is at
   most `(k + 1) + n`. This is only a bound if `k` itself is
-  bounded — i.e. the number of concurrent producers is bounded — which is
-  the same open premise as INV-L1's per-producer accounting (open
-  question 3); INV-L3 as a whole does not hold without it. No such bound
-  exists for keyed delivery unless the fairness policy (open question 6)
-  defines one.
+  bounded — i.e. the number of concurrent producers is bounded — the same
+  premise as INV-L1's per-producer accounting, resolved by open question 3
+  as explicit, application-owned, and observable rather than
+  runtime-enforced (section 4.5); INV-L3 as a whole does not hold for an
+  application that violates it. No such bound exists for keyed delivery
+  unless the fairness policy (open question 6) defines one.
 - **INV-L4**: A quit signal already in the dedicated quit channel is
   delivered with latency independent of app-channel backlog. This is not
   automatically a hard worst-case bound under the current implementation:
@@ -468,6 +544,15 @@ To be finalized as contract tests before implementation:
   enforces — a future change that has the event loop inject a message
   directly into a shared or keyed channel it also drains would deadlock as
   soon as that channel fills.
+- **INV-L8**: The runtime never blocks, rejects, or defers producer
+  admission. Every subscription the reconciliation contract says should
+  run is started, and every command returned from `update` (or
+  `Application::new`) is dispatched, synchronously and unconditionally —
+  load control paces sends, never producer creation (section 4.5). This
+  protects the RFC 0005 reconciliation contract and effect delivery from a
+  future admission limit, and — because producers are created on the event
+  loop task — it is also what keeps INV-L7's no-self-deadlock argument
+  closed at spawn sites, not just send sites.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
 integration test. The overload scenario is the acceptance measurement for
@@ -476,8 +561,9 @@ the unbounded baseline grows linearly. The keyed-probe scenario becomes an
 acceptance measurement only once the fairness policy (open question 6) fixes
 what keyed latency bound, if any, to expect; INV-L4's acceptance scenarios
 are the `quit_*` trials (section 2), pending the (a)/(b) formulation choice.
-INV-L7 is structural rather than load-dependent and is checked by code
-review of every runtime-internal send site, not by a bench scenario.
+INV-L7 and INV-L8 are structural rather than load-dependent and are checked
+by code review of every runtime-internal send and spawn site, not by a
+bench scenario.
 
 ### 5.1 Bounded vs. unbounded acceptance matrix
 
@@ -530,6 +616,15 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    FIFO; a pool bounds total memory more tightly). Without an answer, R1's
    and R3's boundable-memory and bounded-latency claims hold only for
    channel buffers, not total pending-work memory or latency.
+   **Resolved (2026-07-17).** No admission limit. Producer creation is
+   synchronous on the event loop task, so a waiting limit is INV-L7's
+   self-deadlock at the spawn site, and the non-waiting alternatives
+   (reject, drop, defer) break the RFC 0005 reconciliation contract or
+   silently discard effects. R1 and R3 stay scoped to channel buffers; the
+   producer-count premise becomes an explicit, application-owned,
+   observable responsibility (producer gauges in section 4.4), and keyed
+   channels are bounded per command rather than by a shared pool. Full
+   rationale in section 4.5; the contract is captured as INV-L8.
 4. Where backpressure-wait telemetry lives (`tracing` only, or counters
    exposed by future profiling-hook work).
 5. Restart-rate-control interaction: whether a future restart-rate-control


### PR DESCRIPTION
## Summary

Resolves RFC 0006 §6 open question 3 (producer-count bounding) — the heaviest remaining contract decision before the S4 bounded-mode implementation. Docs-only amendment; no code changes.

**Decision: no admission limit.** R1/R3 stay scoped to channel buffers instead of being upgraded to total-pending-work guarantees; the producer-count premise behind INV-L1/L3 becomes an explicit, application-owned, *observable* responsibility.

**Why an admission limit is structurally unsound** (new §4.5):
- Every producer is created synchronously on the event loop task — `update`'s command is dispatched via `enqueue_command` before the loop pulls its next input, and subscription reconciliation spawns forwarding tasks inside the frame branch. A *waiting* limit would have the event loop await capacity only its own draining can release: INV-L7's self-deadlock, moved from send sites to spawn sites.
- The non-waiting alternatives break preserved contracts: rejecting a subscription violates the RFC 0005 reconciliation contract (declared ⇒ running, including restarts); rejecting a command silently discards an effect — strictly worse than the message loss R2 forbids; queueing un-admitted producers just moves the unbounded buffer up one level, from messages to un-started streams and closures.
- Producer count is a property of application structure, not external load: a hot source raises message *rate* through a fixed producer set (which bounded capacity handles, F3); the *count* grows only through the app's own `subscriptions()` size and command-spawn discipline — the same trust class as `update`'s CPU cost.

**Contract shape (refined through review):**
- **R1 is explicitly per-channel, over the app-facing channels only** (shared app channel + each keyed command channel). The buffer total is `app_channel_capacity + m × keyed_channel_capacity`, where `m` — the number of active `CommandId`s — is a named application-owned contract input, not a `RuntimeConfig` knob. The dedicated quit channel is R4's deliberate unbounded exception: outside R1's scope and the buffer total, with no occupancy claim made for it.
- **Keyed channels are bounded per command**, not by a shared permit pool. A pool couples backpressure across independent `CommandId`s (a producer-side analogue of F4's starvation), forces permit reclamation on cancellation abort (RFC 0003 coupling), and cannot rescue a total bound anyway since `m` is application-owned.
- The spawn-per-message anti-pattern is documented: under bounded-mode overload it converts message backlog into blocked-producer backlog, which no channel capacity bounds; the recommended-defaults docs (OQ1) should carry the note.

**RFC changes:**
- New §4.5 with the full rationale; §6 OQ3 marked resolved (same format as OQ8); the decision-scope preamble now records the INV-L1 memory-bound scope as settled (fairness and quit routing remain the open pre-implementation contracts).
- New **INV-L8**: the runtime never blocks, rejects, or defers producer admission — load control paces sends, never producer creation. Structural invariant, checked by code review at spawn sites the way INV-L7 is at send sites.
- New **INV-L9**: keyed backpressure is isolated per command — a send blocked on one keyed channel's capacity never delays admission into the shared channel or any other keyed channel. Its **primary check is structural** (every bounded channel is constructed with its own capacity; no permit, semaphore, or budget spans channels), because no finite scenario can prove pool absence — a per-channel-capacity-plus-pool implementation whose pool exceeds what a scenario saturates passes any behavioral check.
- §5.1 gains a `keyed_isolation` scenario (added with the implementation) as INV-L9's **behavioral regression check**, built to catch bounded pools: several unrelated keyed channels are held at capacity (saturating any modest hypothetical pool) while two untouched probes verify send admission separately for the invariant's two halves — a previously idle key's first `capacity` sends complete (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete (keyed→shared), each with only the next send pending on its own channel's occupancy. Delivery is deliberately excluded: the keyed pull goes through one `StreamMap` and cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead — and delivery latency is OQ6's territory.
- §4.4: producer-count gauges (active subscriptions, running unkeyed command tasks, active keyed entries, blocked producers in bounded mode) added to the load-signal list, since the premise is observable rather than enforced.
- R1/R3 and INV-L1/L3 cross-references rewritten to the resolved form: INV-L1's conceptual total (`shared capacity + blocked producers + Σ per-command keyed capacity`, quit channel exempt) *is* the contract; INV-L3's `k` premise is explicitly application-owned.

## Review history

Four review passes, all resolved:
1. R1's configuration-bound claim didn't hold with `m` app-controlled → R1 explicitly weakened to per-channel bounds with `m` a contract input; per-command isolation pinned as INV-L9 + acceptance scenario; decision-scope preamble reconciled.
2. R1's "each runtime-owned channel" contradicted the never-bounded quit channel → quit channel named as R4's exception, outside R1 and the buffer total; `keyed_isolation` narrowed to send admission (delivery would drag in OQ6 fairness and cannot observe one key in isolation).
3. The quit-occupancy-bounded-by-producer-count justification was wrong (terminated tasks leave signals queued) → claim dropped, exception stated plainly; `keyed_isolation` extended to the shared-channel half of INV-L9, which the key-B-only scenario left unverified.
4. A two-key scenario cannot prove pool absence (a pool larger than the scenario saturates passes it) → INV-L9's primary check made structural alongside INV-L7/L8; `keyed_isolation` repositioned as a regression check that saturates several unrelated channels with the probe channels untouched, proving keyed→keyed and keyed→shared separately.

## Test plan

- Docs-only; `typos` and `git diff --check` clean on every commit.
- Cross-references checked: every remaining "open question 3" mention points at the resolution (§4.5), and the §5.1 depth-accounting bound (`capacity + concurrent producers`) is consistent with the resolved INV-L1 accounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
