### PR TITLE
Add pre-review checklist for RFC and amendment text

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,12 @@ Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for detai
 
 Contributions are welcome! Please feel free to submit issues or pull requests.
 
+Design contracts and invariants live in [docs/rfcs](docs/rfcs/README.md).
+If you are writing or amending an RFC, run the
+[pre-review checklist](docs/rfcs/pre-review-checklist.md) before
+requesting review. Testing conventions are documented in
+[docs/testing.md](docs/testing.md).
+
 ---
 
 Built with ❤️ using [ratatui](https://ratatui.rs/)

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -1,0 +1,26 @@
+# RFCs
+
+Design contracts, invariants, and decision records for tears. When code
+and an accepted RFC disagree, the RFC states the intended contract; fix
+one or the other explicitly.
+
+## Process
+
+- Each RFC carries its own `Status` in its header — it is not duplicated
+  here, so the file is always the source of truth.
+- Resolutions of an RFC's open questions land as amendments to the RFC
+  body itself (recorded in the header's `Amendments` line), not as
+  separate documents.
+- Before requesting review on a new RFC or an amendment, run the
+  [pre-review checklist](pre-review-checklist.md).
+
+## Index
+
+| RFC | Scope |
+| --- | --- |
+| [0001](0001-http-module-redesign.md) | HTTP module redesign |
+| [0002](0002-redraw-suppression.md) | Redraw suppression (message / redraw separation) |
+| [0003](0003-command-cancellation.md) | Command cancellation, keyed delivery, FIFO invariants |
+| [0004](0004-command-timeout-retry.md) | Command timeout and retry |
+| [0005](0005-structural-lifecycle-identity.md) | Structural lifecycle identity and composition scope |
+| [0006](0006-runtime-load-control.md) | Runtime load control, backpressure, latency guarantees |

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -49,8 +49,14 @@ Every invariant states how it is checked at the point it is introduced,
 using the established classes:
 
 - **structural** — code review of specific sites (construction, send,
-  spawn); the property is not observable from behavior.
-- **behavioral** — a bench or integration scenario with a stated
+  spawn), for properties that finite behavioral tests cannot fully prove
+  — a test can fail to refute such a property, but passing it is not
+  proof.
+- **behavioral** — a test at the narrowest layer that proves the
+  contract (see [docs/testing.md](../testing.md)): unit or property
+  tests for pure transition logic, internal state, and edge cases
+  needing private access; bench or integration scenarios for end-to-end
+  runtime behavior and public-API contracts. Either way, with a stated
   pass/fail criterion.
 - **statistical** — trials with defined measurement conditions (count,
   load profile, percentile threshold).
@@ -59,6 +65,12 @@ Ask explicitly: *can a behavioral test distinguish a compliant
 implementation from a non-compliant one?* If not, the primary check is
 structural and any scenario is a regression check — say so, and do not
 present the scenario as proof.
+
+Whatever the class, name the production seam the check goes through: the
+concrete construction/send/spawn sites for a structural review, or, for a
+behavioral test, the production code path it exercises or the transition
+logic it shares with production. A test that exercises a parallel model
+of the mechanism proves nothing about the runtime.
 
 ## 4. Code claims verified against code
 
@@ -76,11 +88,16 @@ receivers.
 
 ## 5. Re-derive, don't patch
 
-When review finds a substantive defect (P1) in a clause, treat it as "the
-clause's derivation is broken", not "one sentence is wrong": rewrite the
-clause from its premises (the inventory, the requirements it serves), then
-run items 1–4 on the result as if it were new text. Sentence-level patches
-under review pressure are how one finding becomes a chain of findings.
+When a review finding changes a clause's premises, scope, invariants, or
+proof method — regardless of the severity label it carries — treat it as
+"the clause's derivation is broken", not "one sentence is wrong": rewrite
+the clause from its premises (the inventory, the requirements it serves),
+then run items 1–4 on the result as if it were new text. Severity is
+about impact, not about how deep the fix must go: PR #211's proof-method
+gap (a scenario presented as proof of pool absence) was filed as a P2 and
+still required re-deriving the invariant's entire enforcement story.
+Sentence-level patches under review pressure are how one finding becomes
+a chain of findings.
 
 ## 6. Mechanical pass
 

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -1,0 +1,91 @@
+# RFC pre-review checklist
+
+Run this before requesting review on a new RFC or an amendment to an
+existing one. It exists because contract text fails review in predictable
+ways: the checklist internalizes the reviewer's method — *construct an
+implementation or execution that satisfies everything stated but violates
+the intent* — so those findings surface before review instead of during
+it. It distills the review of the RFC 0006 open-question-3 amendment
+(PR #211), where three of five passes were preventable in hindsight.
+
+This is a living document: when a review pass finds a defect class this
+checklist should have caught, add an item (or a prompt under an existing
+item) in the same PR that fixes the finding.
+
+## 1. Quantifiers against the inventory
+
+For every universal claim — *each*, *every*, *all*, *never*, *always*,
+*bounded by* — enumerate the concrete set it quantifies over and check
+each member. If the RFC has an inventory table (channels, producers,
+tasks, send sites), walk every row; if it does not, the claim probably
+needs one. Name the exceptions in the claim itself rather than leaving
+them implied elsewhere in the document.
+
+*From PR #211:* R1 said "each runtime-owned channel" while the same RFC's
+§1.1 table listed the quit channel as unbounded by design.
+
+## 2. Adversarial counterexample per invariant
+
+For each requirement and invariant, deliberately construct at least one
+implementation or execution that passes every stated test yet violates
+the intent. If one exists, strengthen the text or scope the claim; either
+way, record the models considered and why each is excluded (an
+"Adversarial models considered" note, inline or as a section).
+
+Prompts that have already paid off:
+
+- A pooled or shared-resource implementation behind per-unit interfaces
+  (a global permit pool passing per-channel capacity checks).
+- A scheduler adversary: unbiased `select!` tie-breaks, batching windows,
+  poll ordering.
+- A lifecycle edge: a task that terminates while its effects (queued
+  messages, held permits) outlive it.
+- A bounded test against an unbounded parameter: any finite scenario that
+  saturates `j` units is passed by a pool larger than `j × capacity`.
+
+## 3. Enforcement class, declared up front
+
+Every invariant states how it is checked at the point it is introduced,
+using the established classes:
+
+- **structural** — code review of specific sites (construction, send,
+  spawn); the property is not observable from behavior.
+- **behavioral** — a bench or integration scenario with a stated
+  pass/fail criterion.
+- **statistical** — trials with defined measurement conditions (count,
+  load profile, percentile threshold).
+
+Ask explicitly: *can a behavioral test distinguish a compliant
+implementation from a non-compliant one?* If not, the primary check is
+structural and any scenario is a regression check — say so, and do not
+present the scenario as proof.
+
+## 4. Code claims verified against code
+
+Every sentence of the form "X holds because the code does Y" gets a fresh
+read of the relevant code before the text is pushed — including the
+concurrency schedule (who runs on which task, what happens between send
+and receive). This applies with double force to text added while
+responding to review: patch text tends to get less verification than the
+original draft, and it is where false justifications creep in.
+
+*From PR #211:* "quit occupancy is bounded by producer count" — false,
+because a task terminates after `send` while its signal stays queued —
+and a misdescription of `StreamMap::poll_next` as draining all ready
+receivers.
+
+## 5. Re-derive, don't patch
+
+When review finds a substantive defect (P1) in a clause, treat it as "the
+clause's derivation is broken", not "one sentence is wrong": rewrite the
+clause from its premises (the inventory, the requirements it serves), then
+run items 1–4 on the result as if it were new text. Sentence-level patches
+under review pressure are how one finding becomes a chain of findings.
+
+## 6. Mechanical pass
+
+- Cross-references: open-question numbers point at their resolutions;
+  preamble/decision-scope status agrees with the body; the amendment
+  header line is updated.
+- `typos` and `git diff --check` are clean.
+- English only (repository artifact).


### PR DESCRIPTION
## Summary

Adds `docs/rfcs/pre-review-checklist.md`, distilled from the PR #211 retrospective (five review passes on the RFC 0006 open question 3 amendment, two to three of them preventable), plus the entry points that make it reachable: a new `docs/rfcs/README.md` (RFC index + process) and a link from the top-level README's Contributing section.

The checklist internalizes the reviewer's method — *construct an implementation or execution that satisfies everything stated but violates the intent* — as steps run before requesting review:

1. **Quantifiers against the inventory** — every each/every/never/bounded-by claim is walked against the concrete set it quantifies over (caught late in #211: "each runtime-owned channel" vs the §1.1 table's unbounded quit channel).
2. **Adversarial counterexample per invariant** — with prompts that already paid off: pooled implementations behind per-unit interfaces, scheduler adversaries, lifecycle edges, bounded tests vs unbounded parameters.
3. **Enforcement class declared up front** — structural / behavioral / statistical. Behavioral follows docs/testing.md's narrowest-layer rule (unit/property tests for pure transition logic, bench/integration for end-to-end behavior); structural is defined as "finite behavioral tests cannot fully prove it", and every check must name the production seam it goes through, so a parallel-model test cannot pass as proof.
4. **Code claims verified against code** — doubly for text added while responding to review, which is where the false quit-occupancy claim and the StreamMap misdescription crept in.
5. **Re-derive, don't patch** — triggered by any finding that changes a clause's premises, scope, invariants, or proof method, regardless of severity label (#211's proof-method gap was itself a P2); rewrite from premises and re-run items 1–4 on the result.
6. **Mechanical pass** — cross-references, `typos`, `git diff --check`, English only.

`docs/rfcs/README.md` also fixes two process facts in one place: RFC status lives in each RFC's header (not duplicated in the index), and open-question resolutions land as amendments to the RFC body.

Declared a living document: a review pass that finds a class the checklist should have caught extends it in the same PR that fixes the finding.

## Review history

1. Item 5's re-derive trigger was keyed to P1 severity, excluding the motivating case; the checklist was linked from no existing entry point; item 3's behavioral class contradicted docs/testing.md's narrowest-layer rule and misdefined structural → all three fixed as described above.

## Test plan

- Docs-only; `typos` and `git diff --check` clean.
- Links verified: README → docs/rfcs/README.md → checklist → ../testing.md, and all six RFC index links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)