### PR TITLE
docs(rfc): resolve RFC 0006 open question 7 — keyed quit routing

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -23,7 +23,7 @@
   quit's delivery order is its cancellation semantics, and a reroute would
   outrun the ready shared cancelling inputs INV-L11 orders ahead of a
   keyed quit and defeat post-dispatch suppression (RFC 0003 INV-9); the
-  routing, per-run in-order delivery, and shared-first
+  private-channel routing, keyed-quit ordering, and shared-first
   precedence this rests on are pinned as INV-L10/INV-L11, and bounded-mode
   keyed-quit latency is capacity-dependent, so F7's regression check is
   scoped to the unbounded default (sections 4.2, 4.6, 5, 5.1)
@@ -147,10 +147,15 @@ Scheduling facts that interact with load:
   (section 4.2).
 - **R5**: RFC 0003's cancellation and ordering invariants
   (cancel-before-delivery, INV-14 shared-first pull, INV-10 one-item
-  drain) must be preserved or explicitly amended. Per-command in-order
-  delivery — which RFC 0003's model assumes but never states as an
+  drain) must be preserved or explicitly amended. Keyed-quit ordering —
+  a keyed run's `Action::Quit` is delivered only after the same run's
+  earlier outputs, which RFC 0003's model assumes but never states as an
   invariant — is pinned by this RFC as INV-L10 (section 5) and preserved
-  under the same rule.
+  under the same rule. An unkeyed quit has no such delivery order: it
+  travels the dedicated channel while the same command's earlier messages
+  travel the shared channel, so it can be observed first (section 4.2) —
+  that asymmetry is existing behavior and stays outside every ordering
+  claim in this RFC.
 - **R6**: The default (unconfigured) behavior of existing applications must
   not change in 0.10.0.
 
@@ -363,8 +368,8 @@ mode's send contract, by source class:
   matching what unkeyed `Action::Quit` already does — and resolved that it
   stays in the private channel: that channel's delivery order is what keeps
   a keyed quit cancellable, and a reroute in either shape would break
-  buffered-quit suppression (RFC 0003 INV-9) and the per-run in-order
-  delivery and shared-first precedence pinned as INV-L10/INV-L11
+  buffered-quit suppression (RFC 0003 INV-9) and the keyed-quit ordering
+  and shared-first precedence pinned as INV-L10/INV-L11
   (section 4.6). User-initiated quit
   itself was never part of that question: as an unkeyed command with no earlier
   actions ahead of it, it already gets R4's independence from
@@ -385,11 +390,18 @@ merged" are known.
 
 ### 4.3 Interaction with existing invariants
 
-- **Per-command and per-subscription in-order delivery**: unchanged;
-  awaiting a send preserves order. RFC 0003's model assumes this ordering
-  but states no FIFO invariant — the per-command form, quit included, is
-  pinned in this RFC as INV-L10 (section 5); the per-subscription form is
-  structural (one forwarding task sending into one FIFO channel).
+- **In-order delivery per source**: unchanged; awaiting a send preserves
+  order. The ordering that holds today is scoped per source class, and
+  bounded mode keeps each scope as it is: an unkeyed command's or a
+  subscription's *messages* are delivered in send order (one task
+  sending into the one shared FIFO channel), a keyed run's outputs
+  travel its one private FIFO channel, and the keyed-quit form — the
+  quit never overtakes the same run's earlier output — is pinned as
+  INV-L10 (section 5). An unkeyed `Action::Quit` is outside every one of
+  these claims: it travels the dedicated channel while the same
+  command's earlier messages travel the shared channel, so the event
+  loop can observe it first (sections 1.1, 4.2). RFC 0003's model
+  assumes stream-order consumption but states no FIFO invariant.
 - **INV-14 shared-first pull**: unchanged, and bounded mode adds no fairness
   guarantee on top of it. A full shared channel is refilled by a waiting
   producer each time the loop pulls one message, so shared readiness — and
@@ -487,9 +499,9 @@ accounting would have to reclaim permits from producers aborted by
 cancellation (RFC 0003), coupling two mechanisms this RFC otherwise keeps
 orthogonal. A pool also cannot rescue a total bound: the number of active
 `CommandId`s is application-owned, so with or without a pool the premise
-stays with the application. Per-command capacity matches the per-command
-in-order delivery contract (INV-L10) and the existing
-one-private-channel-per-`CommandId` structure, at a deliberate cost R1
+stays with the application. Per-command capacity matches the
+one-private-FIFO-channel-per-run delivery structure and its keyed-quit
+ordering contract (INV-L10), at a deliberate cost R1
 states explicitly: the keyed buffer
 total is `m × keyed_channel_capacity` with `m` — the number of active
 `CommandId`s — an application-owned contract input, not a `RuntimeConfig`
@@ -522,7 +534,7 @@ fast path, it would remove the cancellable one.
 
 The front-of-stream reroute breaks three delivery properties: the
 post-dispatch suppression and shared-first precedence that together make
-a keyed quit cancellable, and the per-run in-order delivery that keeps it
+a keyed quit cancellable, and the keyed-quit ordering that keeps it
 behind its own run's earlier output. RFC 0003's stated invariants carry
 only the first — INV-9 defines the suppression of an *already*-cancelled
 or superseded quit, while INV-14 orders ready inputs at a single
@@ -537,13 +549,17 @@ RFC, INV-L10 and INV-L11 (section 5):
   Today suppression works precisely because the quit sits in the keyed
   entry's private channel: cancellation removes the entry and drops the
   buffered `CommandOutput::Quit` with it.
-- **Per-run in-order delivery (INV-L10).** At the front of its stream, a
+- **Keyed-quit ordering (INV-L10).** At the front of its stream, a
   quit's earlier `Action::Message` items have been *sent* but not
   necessarily *delivered*: under shared backlog they wait behind the
   shared drain (F4) while a dedicated-channel quit would be delivered at
-  backlog-independent speed (F6). The quit would overtake its own
-  command's earlier output — a keyed stream emitting `[Message(saved),
-  Quit]` would exit the application before `saved` reaches `update`.
+  backlog-independent speed (F6). The quit would overtake its own run's
+  earlier output — a keyed stream emitting `[Message(saved), Quit]`
+  would exit the application before `saved` reaches `update`. (An
+  *unkeyed* `[Message(saved), Quit]` can already be observed in that
+  order today — its two actions travel different channels, section 4.2 —
+  which is exactly why the keyed ordering is a property of the private
+  channel, not of commands in general.)
 - **Shared-first precedence (INV-L11).** A rerouted quit arrives on the
   dedicated branch, which the event loop can select while ready shared
   inputs are still queued — and any of those inputs could be the one
@@ -593,8 +609,8 @@ Adversarial variants considered and excluded:
   infeasibility already recorded in open question 7: discovering a quit
   behind unsent items requires look-ahead buffering (unbounded memory,
   contra R1/R2) or an out-of-band signal that abandons the strict
-  stream-order consumption RFC 0003's model describes — the ordering
-  INV-L10 pins.
+  stream-order consumption RFC 0003's model describes — whose keyed
+  delivery-side form is the ordering INV-L10 pins.
 
 Consequences:
 
@@ -740,8 +756,15 @@ To be finalized as contract tests before implementation:
   scenario — see below for why a scenario alone cannot prove pool absence.
 - **INV-L10**: A keyed command's `Action::Quit` is sent into that command
   run's private channel — never into the dedicated quit channel — and is
-  delivered only after every output the same run sent before it (per-run
-  in-order delivery, quit included). This is what makes a keyed quit
+  delivered only after every output the same run sent before it: a keyed
+  quit never overtakes its own run's earlier output. That is this
+  invariant's whole scope — it says nothing about ordering among a run's
+  messages beyond what the single FIFO channel provides, and unkeyed
+  commands are outside it entirely: their quit travels the dedicated
+  channel while their messages travel the shared channel, so no
+  cross-channel delivery order exists and the always-armed quit branch
+  can observe an unkeyed quit before the same command's earlier messages
+  (sections 1.1, 4.2). This is what makes a keyed quit
   suppressible after dispatch — RFC 0003 INV-9 works by cancellation
   removing the keyed entry and dropping the buffered quit with it — and
   it is what a producer-side reroute would break (open question 7,
@@ -904,9 +927,9 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    contradicting R1/R2 — or an out-of-band quit signal that does not depend
    on stream position at all, which is a deliberate semantic change
    relative to the strict stream-order consumption RFC 0003's model
-   describes (stated as an invariant only later, by INV-L10). Any
-   resolution of this question should say which of the two shapes it
-   delivers.
+   describes (its keyed delivery-side form stated as an invariant only
+   later, by INV-L10). Any resolution of this question should say which
+   of the two shapes it delivers.
    **Resolved (2026-07-17).** Neither shape: a keyed `Action::Quit` stays
    in its command's private channel. Keying a quit is a request for
    cancellability, which decomposes into post-dispatch suppression (RFC
@@ -921,9 +944,11 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    messages, and the behind-stream shape was already infeasible as stated
    above. Prompt unconditional quit remains available as unkeyed
    `Command::quit()` (R4, F6). The properties the decision rests on are
-   pinned as INV-L10 (private-channel routing and per-run in-order
-   delivery: structural at the keyed send site, plus a unit-level
-   ordering test) and INV-L11 (a ready shared input wins the pull over a
+   pinned as INV-L10 (private-channel routing and keyed-quit ordering —
+   the quit never overtakes its own run's earlier output; unkeyed quit,
+   which travels a different channel from its command's messages, is
+   explicitly outside — structural at the keyed send site, plus a
+   unit-level ordering test) and INV-L11 (a ready shared input wins the pull over a
    ready keyed quit: unit-level tests on both pull paths, blocking and
    non-waiting) — INV-L5 alone does not carry them,
    since RFC 0003 states neither a delivery-FIFO invariant that includes
@@ -950,6 +975,6 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
 - RFC 0002 — redraw suppression (frame-branch behavior under load).
 - RFC 0003 — command cancellation (INV-14 shared-first pull,
   cancel-before-delivery, INV-9 buffered-quit suppression; it states no
-  FIFO invariant — per-run in-order delivery is this RFC's INV-L10).
+  FIFO invariant — keyed-quit delivery ordering is this RFC's INV-L10).
 - RFC 0005 — structural lifecycle identity (subscription reconciliation the
   load path feeds).

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -21,8 +21,9 @@
   7 resolved: keyed `Action::Quit` stays in its command's private channel,
   with no reroute to the dedicated quit channel in either shape — a keyed
   quit's delivery order is its cancellation semantics, and a reroute would
-  outrun both ready cancelling inputs and post-dispatch suppression (RFC
-  0003 INV-9); the routing, per-run in-order delivery, and shared-first
+  outrun the ready shared cancelling inputs INV-L11 orders ahead of a
+  keyed quit and defeat post-dispatch suppression (RFC 0003 INV-9); the
+  routing, per-run in-order delivery, and shared-first
   precedence this rests on are pinned as INV-L10/INV-L11, and bounded-mode
   keyed-quit latency is capacity-dependent, so F7's regression check is
   scoped to the unbounded default (sections 4.2, 4.6, 5, 5.1)
@@ -144,8 +145,12 @@ Scheduling facts that interact with load:
   different again — it travels through its command's private channel like
   any other keyed output — and follows that channel's delivery semantics
   (section 4.2).
-- **R5**: RFC 0003's cancellation and FIFO invariants (per-command FIFO,
-  cancel-before-delivery, INV-14) must be preserved or explicitly amended.
+- **R5**: RFC 0003's cancellation and ordering invariants
+  (cancel-before-delivery, INV-14 shared-first pull, INV-10 one-item
+  drain) must be preserved or explicitly amended. Per-command in-order
+  delivery — which RFC 0003's model assumes but never states as an
+  invariant — is pinned by this RFC as INV-L10 (section 5) and preserved
+  under the same rule.
 - **R6**: The default (unconfigured) behavior of existing applications must
   not change in 0.10.0.
 
@@ -380,8 +385,11 @@ merged" are known.
 
 ### 4.3 Interaction with existing invariants
 
-- **Per-command and per-subscription FIFO** (RFC 0003): unchanged; awaiting a
-  send preserves order.
+- **Per-command and per-subscription in-order delivery**: unchanged;
+  awaiting a send preserves order. RFC 0003's model assumes this ordering
+  but states no FIFO invariant — the per-command form, quit included, is
+  pinned in this RFC as INV-L10 (section 5); the per-subscription form is
+  structural (one forwarding task sending into one FIFO channel).
 - **INV-14 shared-first pull**: unchanged, and bounded mode adds no fairness
   guarantee on top of it. A full shared channel is refilled by a waiting
   producer each time the loop pulls one message, so shared readiness — and
@@ -480,8 +488,9 @@ cancellation (RFC 0003), coupling two mechanisms this RFC otherwise keeps
 orthogonal. A pool also cannot rescue a total bound: the number of active
 `CommandId`s is application-owned, so with or without a pool the premise
 stays with the application. Per-command capacity matches the per-command
-FIFO contract and the existing one-private-channel-per-`CommandId`
-structure, at a deliberate cost R1 states explicitly: the keyed buffer
+in-order delivery contract (INV-L10) and the existing
+one-private-channel-per-`CommandId` structure, at a deliberate cost R1
+states explicitly: the keyed buffer
 total is `m × keyed_channel_capacity` with `m` — the number of active
 `CommandId`s — an application-owned contract input, not a `RuntimeConfig`
 knob.
@@ -540,7 +549,9 @@ RFC, INV-L10 and INV-L11 (section 5):
   inputs are still queued — and any of those inputs could be the one
   whose `update` cancels the quit's command. Private-channel routing
   instead orders the quit behind every ready shared input at each pull
-  point, so the potential cancels run first.
+  point, so those potential cancels run first. Cancelling inputs of
+  other classes — ready keyed outputs, inputs not yet admitted — are
+  ordered by neither routing (see the identity-carrying variant below).
 
 Adversarial variants considered and excluded:
 
@@ -552,18 +563,22 @@ Adversarial variants considered and excluded:
   init command (before any keyed command exists) or from a command
   returned by `update` — and every `update` invocation consumes an input
   delivered through the shared channel or a keyed channel. Under backlog,
-  the input whose `update` would dispatch the cancel is therefore often
-  still queued — *ready but unprocessed* — and a liveness check at quit
-  delivery evaluates state that has not seen it; honoring those inputs
-  means processing them before the quit, which is exactly the
-  shared-first precedence (INV-L11) the reroute abandons. So the variant
-  still decides the quit-vs-cancel race for the quit against every
-  not-yet-processed cancelling input, ready or not. Under the unbounded
-  default the difference is starkest: every pending input is already
-  ready, so private-channel routing waits for the full drain — F7's 1.30s
-  at ~50k backlog is cancel-before-delivery holding under load, not
-  incidental starvation — while the rerouted quit would wait for none of
-  it.
+  the input whose `update` would dispatch the cancel can be sitting
+  *ready* in the shared channel, unprocessed, and a liveness check at
+  quit delivery evaluates state that has not seen it. Ready shared
+  inputs are exactly the class of cancelling input the runtime orders
+  ahead of a keyed quit — INV-L11 — and the class F7's backlog consists
+  of; the reroute delivers the quit ahead of them by construction. For
+  the other classes neither routing orders the race: a cancelling input
+  arriving through another keyed channel has no guaranteed position
+  against the quit inside the keyed `StreamMap`, and an input not yet
+  admitted (the bounded-mode window, section 4.3) is invisible to both
+  designs. The reroute therefore strictly weakens cancellation
+  precedence and strengthens nothing. Under the unbounded default the
+  loss is starkest: every pending shared input is already ready, so
+  private-channel routing waits for the full drain — F7's 1.30s at ~50k
+  backlog is cancel-before-delivery holding under load, not incidental
+  starvation — while the rerouted quit would wait for none of it.
 - **Reroute only when the private channel is empty** — avoids the
   in-order-delivery violation (INV-L10's ordering half) but not the
   suppression and precedence ones, which are independent of stream
@@ -577,8 +592,9 @@ Adversarial variants considered and excluded:
 - **The behind-stream shape** inherits every objection above and adds the
   infeasibility already recorded in open question 7: discovering a quit
   behind unsent items requires look-ahead buffering (unbounded memory,
-  contra R1/R2) or an out-of-band signal that abandons RFC 0003's
-  stream-order semantics.
+  contra R1/R2) or an out-of-band signal that abandons the strict
+  stream-order consumption RFC 0003's model describes — the ordering
+  INV-L10 pins.
 
 Consequences:
 
@@ -748,9 +764,12 @@ To be finalized as contract tests before implementation:
   channels; it makes no claim about inputs not yet admitted (the
   bounded-mode admission window, section 4.3), which is why bounded-mode
   keyed-quit latency is capacity-dependent and carries no acceptance
-  bound (section 5.1). Behavioral check at the `AppInputs` layer: a unit
-  test, added with this amendment, in which a queued shared message wins
-  the pull over an already-buffered keyed quit.
+  bound (section 5.1). Behavioral check at the `AppInputs` layer: unit
+  tests, added with this amendment, in which a queued shared message
+  wins the pull over an already-buffered keyed quit on *each* pull point
+  the invariant quantifies over — the blocking `poll_next` path and the
+  non-waiting `try_next_ready` path — since a quit-specific bypass could
+  be introduced on either one alone.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
 integration test. The overload scenario is the acceptance measurement for
@@ -884,17 +903,20 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    buffering of unsent items — reintroducing unbounded memory and
    contradicting R1/R2 — or an out-of-band quit signal that does not depend
    on stream position at all, which is a deliberate semantic change
-   relative to RFC 0003's FIFO. Any resolution of this question should say
-   which of the two shapes it delivers.
+   relative to the strict stream-order consumption RFC 0003's model
+   describes (stated as an invariant only later, by INV-L10). Any
+   resolution of this question should say which of the two shapes it
+   delivers.
    **Resolved (2026-07-17).** Neither shape: a keyed `Action::Quit` stays
    in its command's private channel. Keying a quit is a request for
    cancellability, which decomposes into post-dispatch suppression (RFC
-   0003 INV-9) and precedence for the inputs that could still dispatch a
-   cancel — every cancellation comes from an `update` invocation fed by a
-   shared or keyed input, so a reroute to the always-armed dedicated
-   branch (with or without an identity-and-liveness check, which can only
-   see cancels already dispatched) delivers the quit ahead of ready
-   inputs whose `update` would cancel it. The front-of-stream shape
+   0003 INV-9) and precedence for the ready shared inputs that could
+   still dispatch a cancel — the one class of cancelling input the
+   runtime orders ahead of a keyed quit (INV-L11; ready keyed and
+   un-admitted inputs are ordered by neither routing). A reroute to the
+   always-armed dedicated branch (with or without an identity-and-liveness
+   check, which can only see cancels already dispatched) delivers the
+   quit ahead of exactly that class. The front-of-stream shape
    additionally lets the quit overtake its own run's earlier buffered
    messages, and the behind-stream shape was already infeasible as stated
    above. Prompt unconditional quit remains available as unkeyed
@@ -902,7 +924,8 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    pinned as INV-L10 (private-channel routing and per-run in-order
    delivery: structural at the keyed send site, plus a unit-level
    ordering test) and INV-L11 (a ready shared input wins the pull over a
-   ready keyed quit: unit-level test) — INV-L5 alone does not carry them,
+   ready keyed quit: unit-level tests on both pull paths, blocking and
+   non-waiting) — INV-L5 alone does not carry them,
    since RFC 0003 states neither a delivery-FIFO invariant that includes
    quit nor a quit-specific precedence. F7's full-drain wait is a
    regression check for the unbounded default only; bounded-mode
@@ -925,7 +948,8 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
 - `benches/runtime_load.rs` — full-loop load harness and reference numbers
   (section 2).
 - RFC 0002 — redraw suppression (frame-branch behavior under load).
-- RFC 0003 — command cancellation (INV-14 shared-first pull, FIFO,
-  cancel-before-delivery).
+- RFC 0003 — command cancellation (INV-14 shared-first pull,
+  cancel-before-delivery, INV-9 buffered-quit suppression; it states no
+  FIFO invariant — per-run in-order delivery is this RFC's INV-L10).
 - RFC 0005 — structural lifecycle identity (subscription reconciliation the
   load path feeds).

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -20,11 +20,12 @@
   (INV-L8/L9; sections 1.2, 4.4, 4.5, 5, 5.1). 2026-07-17 — open question
   7 resolved: keyed `Action::Quit` stays in its command's private channel,
   with no reroute to the dedicated quit channel in either shape — a keyed
-  quit's delivery order is its cancellation semantics, so any
-  backlog-independent delivery path would decide the quit-vs-cancel race
-  in the quit's favor by construction, and prompt unconditional quit is
-  already available unkeyed (sections 4.2, 4.6; F7 pinned as a regression
-  canary in section 5.1)
+  quit's delivery order is its cancellation semantics, and a reroute would
+  outrun both ready cancelling inputs and post-dispatch suppression (RFC
+  0003 INV-9); the routing, per-run in-order delivery, and shared-first
+  precedence this rests on are pinned as INV-L10/INV-L11, and bounded-mode
+  keyed-quit latency is capacity-dependent, so F7's regression check is
+  scoped to the unbounded default (sections 4.2, 4.6, 5, 5.1)
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
@@ -247,8 +248,11 @@ Findings:
   scales linearly with backlog depth. It quantifies the status quo that
   open question 7 resolved to keep: the wait is cancel-before-delivery
   holding under load — any pending shared input could cancel the quit's
-  command, and shared-first pull processes them all before delivering it —
-  not incidental starvation (section 4.6).
+  command, and under the unbounded default every one of them is already
+  *ready* in the channel, so shared-first pull processes them all before
+  delivering it — not incidental starvation (section 4.6). The full-drain
+  wait is specific to the unbounded default; in bounded mode keyed-quit
+  delivery is capacity-dependent (section 5.1).
 
 ## 3. Release-gate decision for 0.10.0
 
@@ -353,8 +357,10 @@ mode's send contract, by source class:
   in-stream quit should instead be re-routed to the dedicated channel —
   matching what unkeyed `Action::Quit` already does — and resolved that it
   stays in the private channel: that channel's delivery order is what keeps
-  a keyed quit cancellable, and a reroute in either shape would break RFC
-  0003's INV-9 and per-command FIFO (section 4.6). User-initiated quit
+  a keyed quit cancellable, and a reroute in either shape would break
+  buffered-quit suppression (RFC 0003 INV-9) and the per-run in-order
+  delivery and shared-first precedence pinned as INV-L10/INV-L11
+  (section 4.6). User-initiated quit
   itself was never part of that question: as an unkeyed command with no earlier
   actions ahead of it, it already gets R4's independence from
   `app_channel_capacity`; only the input leg (the key press traveling
@@ -505,46 +511,63 @@ backlog-independent delivery (R4, F6). Both delivery behaviors therefore
 already exist in the API, chosen per command; a reroute would not add the
 fast path, it would remove the cancellable one.
 
-The front-of-stream shape — the one open question 7 called deliverable —
-breaks two contracts R5 promised to preserve:
+The front-of-stream reroute breaks three delivery properties: the
+post-dispatch suppression and shared-first precedence that together make
+a keyed quit cancellable, and the per-run in-order delivery that keeps it
+behind its own run's earlier output. RFC 0003's stated invariants carry
+only the first — INV-9 defines the suppression of an *already*-cancelled
+or superseded quit, while INV-14 orders ready inputs at a single
+`AppInputs` pull point without saying anything quit-specific or
+FIFO-shaped — so this resolution pins the other two as invariants of this
+RFC, INV-L10 and INV-L11 (section 5):
 
-- **Cancellability (RFC 0003 INV-9, buffered-output suppression).** The
-  dedicated quit channel carries no command identity (its payload is
-  `()`), and its select branch is always armed. Once a keyed quit is sent
-  into it, no later explicit cancel or `CancelInFlight` supersede can
-  suppress it. Today suppression works precisely because the quit sits in
-  the keyed entry's private channel: cancellation removes the entry and
-  drops the buffered `CommandOutput::Quit` with it.
-- **Per-command FIFO (RFC 0003).** At the front of its stream, a quit's
-  earlier `Action::Message` items have been *sent* but not necessarily
-  *delivered*: under shared backlog they wait for the shared drain (F4)
-  while a dedicated-channel quit would be delivered at
+- **Post-dispatch suppression (RFC 0003 INV-9).** The dedicated quit
+  channel carries no command identity (its payload is `()`), and its
+  select branch is always armed. Once a keyed quit is sent into it, no
+  later explicit cancel or `CancelInFlight` supersede can suppress it.
+  Today suppression works precisely because the quit sits in the keyed
+  entry's private channel: cancellation removes the entry and drops the
+  buffered `CommandOutput::Quit` with it.
+- **Per-run in-order delivery (INV-L10).** At the front of its stream, a
+  quit's earlier `Action::Message` items have been *sent* but not
+  necessarily *delivered*: under shared backlog they wait behind the
+  shared drain (F4) while a dedicated-channel quit would be delivered at
   backlog-independent speed (F6). The quit would overtake its own
-  command's earlier output — a command emitting `[Message(saved), Quit]`
-  would exit the application before `saved` reaches `update`.
+  command's earlier output — a keyed stream emitting `[Message(saved),
+  Quit]` would exit the application before `saved` reaches `update`.
+- **Shared-first precedence (INV-L11).** A rerouted quit arrives on the
+  dedicated branch, which the event loop can select while ready shared
+  inputs are still queued — and any of those inputs could be the one
+  whose `update` cancels the quit's command. Private-channel routing
+  instead orders the quit behind every ready shared input at each pull
+  point, so the potential cancels run first.
 
 Adversarial variants considered and excluded:
 
 - **Identity-carrying quit channel** — the quit channel carries
   `(CommandId, RunToken)` and the quit branch checks the keyed entry's
-  liveness at delivery. This fails precisely the case that motivates the
-  reroute. Every cancellation of a keyed command is dispatched through
-  `enqueue_command` — from the init command (before any keyed command
-  exists) or from a command returned by `update` — and every `update`
-  invocation consumes an input delivered through the shared channel or a
-  keyed channel. Under backlog, the cancel that should suppress the quit
-  is therefore itself an undelivered input; a liveness check at quit
-  delivery evaluates state that has not yet seen that cancel, and
-  honoring cancels still in the backlog means draining the backlog first
-  — the status quo. Backlog-independent keyed-quit delivery and
-  cancellability are mutually exclusive under backlog: any delivery path
-  faster than the input drain decides the quit-vs-cancel race in the
-  quit's favor by construction. F7's 1.30s at ~50k backlog is not
-  incidental starvation to engineer away; it is cancel-before-delivery
-  holding under load.
-- **Reroute only when the private channel is empty** — avoids the FIFO
-  violation but not the cancellability one, which is independent of
-  stream position; excluded for the same reason as the identity-carrying
+  liveness at delivery. The check restores post-dispatch suppression but
+  fails precisely the case that motivates the reroute. Every cancellation
+  of a keyed command is dispatched through `enqueue_command` — from the
+  init command (before any keyed command exists) or from a command
+  returned by `update` — and every `update` invocation consumes an input
+  delivered through the shared channel or a keyed channel. Under backlog,
+  the input whose `update` would dispatch the cancel is therefore often
+  still queued — *ready but unprocessed* — and a liveness check at quit
+  delivery evaluates state that has not seen it; honoring those inputs
+  means processing them before the quit, which is exactly the
+  shared-first precedence (INV-L11) the reroute abandons. So the variant
+  still decides the quit-vs-cancel race for the quit against every
+  not-yet-processed cancelling input, ready or not. Under the unbounded
+  default the difference is starkest: every pending input is already
+  ready, so private-channel routing waits for the full drain — F7's 1.30s
+  at ~50k backlog is cancel-before-delivery holding under load, not
+  incidental starvation — while the rerouted quit would wait for none of
+  it.
+- **Reroute only when the private channel is empty** — avoids the
+  in-order-delivery violation (INV-L10's ordering half) but not the
+  suppression and precedence ones, which are independent of stream
+  position; excluded for the same reasons as the identity-carrying
   variant.
 - **Drain-then-deliver at the quit branch** — the quit branch, on
   receiving a keyed quit, processes the pending backlog before honoring
@@ -559,22 +582,28 @@ Adversarial variants considered and excluded:
 
 Consequences:
 
-- **No new invariant.** The pinned contract is RFC 0003 INV-9 plus
-  per-command FIFO, both already carried by INV-L5 (behavioral anchor:
-  RFC 0003's buffered-quit suppression test,
-  `cancelling_buffered_quit_suppresses_it`). The `quit_keyed_backlog_50k`
-  scenario (F7) stays in the harness as a regression canary: keyed
-  quit→delivered dropping to backlog-independent values without an open
-  question 6 fairness policy indicates exactly the reroute this
-  resolution rejects.
-- **Bounded mode changes neither the analysis nor the acceptance
-  criterion.** Capacity controls backlog memory, not the number of inputs
-  ahead of a keyed output (F4): in the burst scenario the burst's inputs
-  drain ahead of the keyed quit whether they are queued in the channel or
-  held by blocked producers, up to the admission-window races bounded mode
-  already concedes for keyed delivery in general (section 4.3) — races too
-  rare to move a per-trial p50. The section 5.1 row is fixed at
-  "unchanged".
+- **Two new invariants pin the decision.** INV-L10 (keyed quit is routed
+  through, and delivered in order from, its command's private channel)
+  and INV-L11 (a ready shared input is delivered before a ready keyed
+  quit at every pull point) make the properties this resolution rests on
+  explicit and checkable — INV-L5 alone does not carry them, because RFC
+  0003's INV-9 covers only post-dispatch suppression (behavioral anchor:
+  `cancelling_buffered_quit_suppresses_it`) and states no delivery-FIFO
+  or quit-specific precedence invariant. Enforcement classes and checks
+  are declared with the invariants (section 5).
+- **Bounded mode keeps the contract but not the number.** The no-reroute
+  contract (INV-L10/INV-L11) is delivery-order and routing, not latency,
+  and holds in both modes. F7's full-drain wait, by contrast, is a
+  consequence of the unbounded default, where every pending input is
+  already ready in the channel. In bounded mode keyed-quit delivery
+  becomes capacity-dependent: every pull hands the freed slot to a woken
+  producer whose next send is still in flight, and when that leaves the
+  channel momentarily empty — at `capacity = 1`, after every pull — a
+  pull point that observes it may deliver the buffered keyed quit while
+  producer backlog remains. That execution preserves INV-14, INV-L10,
+  and INV-L11 (no *ready* input is outrun) and uses no reroute, so
+  bounded-mode keyed-quit latency is a measurement to record, never an
+  acceptance bound or a reroute detector (section 5.1).
 - **Latency, if ever wanted, goes through open question 6.** A fairness
   policy that bounds keyed-delivery latency would apply to keyed quit as
   to every other keyed output — and preserving cancel-before-delivery is
@@ -693,6 +722,35 @@ To be finalized as contract tests before implementation:
   primary check is structural (channel-local capacity, no cross-channel
   permit sharing), with `keyed_isolation` as a behavioral regression
   scenario — see below for why a scenario alone cannot prove pool absence.
+- **INV-L10**: A keyed command's `Action::Quit` is sent into that command
+  run's private channel — never into the dedicated quit channel — and is
+  delivered only after every output the same run sent before it (per-run
+  in-order delivery, quit included). This is what makes a keyed quit
+  suppressible after dispatch — RFC 0003 INV-9 works by cancellation
+  removing the keyed entry and dropping the buffered quit with it — and
+  it is what a producer-side reroute would break (open question 7,
+  section 4.6). The routing half's check is structural, like INV-L7's and
+  INV-L8's: the keyed task's send loop holds only its run's private
+  sender and has no handle to the dedicated quit channel, and it forwards
+  `Action::Quit` into that same private channel — checked by review of
+  the keyed spawn/send site. The ordering half has a behavioral
+  regression check at the keyed-manager layer, the narrowest layer with
+  the needed access (docs/testing.md): a unit test, added with this
+  amendment, in which a keyed stream emitting a message and then a quit
+  delivers the message first.
+- **INV-L11**: At every `AppInputs` pull point, a ready shared input is
+  delivered before a ready keyed quit — keyed `Action::Quit` participates
+  in INV-14's shared-first pull like any other keyed output, with no
+  quit-specific bypass. This is the precedence the open question 7
+  resolution rests on: any ready shared input could be the one whose
+  `update` cancels the quit's command, and it is processed first (section
+  4.6). Like INV-14, this is a pull-point property over inputs already in
+  channels; it makes no claim about inputs not yet admitted (the
+  bounded-mode admission window, section 4.3), which is why bounded-mode
+  keyed-quit latency is capacity-dependent and carries no acceptance
+  bound (section 5.1). Behavioral check at the `AppInputs` layer: a unit
+  test, added with this amendment, in which a queued shared message wins
+  the pull over an already-buffered keyed quit.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
 integration test. The overload scenario is the acceptance measurement for
@@ -727,7 +785,13 @@ latency belongs to the fairness question (open question 6), which INV-L9
 does not answer. INV-L7 and
 INV-L8 are structural rather than load-dependent and are checked by code
 review of every runtime-internal send and spawn site, not by a bench
-scenario; INV-L9 sits in both camps as described above.
+scenario; INV-L9 sits in both camps as described above, and so does
+INV-L10 — its routing half is structural at the keyed send site, its
+ordering half a unit-level test. INV-L11 is behavioral at the unit layer;
+neither INV-L10 nor INV-L11 needs a bench scenario, and in particular the
+`quit_keyed_backlog_50k` latency numbers are not a check for either — see
+section 5.1's row for why bounded-mode keyed-quit latency cannot serve as
+a reroute detector.
 
 ### 5.1 Bounded vs. unbounded acceptance matrix
 
@@ -745,7 +809,7 @@ must meet and is filled with measured values when the implementation lands.
 | `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ `capacity + 1` by the same depth accounting; producer waits instead; no message dropped (INV-L1, INV-L2) |
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
-| `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | unchanged — keyed quit stays in the private channel (open question 7, section 4.6), and bounded capacity does not reduce the inputs ahead of a keyed output (F4); a drop to backlog-independent delivery without an open question 6 fairness policy is the regression signal, not an improvement |
+| `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | no latency criterion — keyed quit stays in the private channel (open question 7, section 4.6), but that contract is routing and delivery order (INV-L10/INV-L11, checked structurally and at the unit layer), not a latency number: in bounded mode a compliant implementation may deliver the keyed quit while producer backlog remains, because a pull can leave the shared channel momentarily empty while the woken producer's next send is still in flight (at `capacity = 1`, after every pull) — delivering the buffered keyed quit then outruns no *ready* input. F7's full-drain p50 therefore stays a regression check for the **unbounded default only** (re-run unbounded: p50 ≈ full shared drain); the bounded run is recorded as a statistical measurement with pinned capacity, depth, and trial count when the implementation lands |
 | `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
@@ -824,18 +888,27 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    which of the two shapes it delivers.
    **Resolved (2026-07-17).** Neither shape: a keyed `Action::Quit` stays
    in its command's private channel. Keying a quit is a request for
-   cancellability (RFC 0003 INV-9), and under backlog every cancel is
-   itself an undelivered shared or keyed input, so any quit delivery path
-   faster than the input drain — including an identity-carrying quit
-   channel checked for liveness at delivery — decides the quit-vs-cancel
-   race in the quit's favor by construction. The front-of-stream shape
-   additionally lets the quit overtake its own command's earlier buffered
-   messages (per-command FIFO), and the behind-stream shape was already
-   infeasible as stated above. Prompt unconditional quit remains available
-   as unkeyed `Command::quit()` (R4, F6). No new invariant: INV-L5 (RFC
-   0003 INV-9, per-command FIFO) pins the contract, and F7's scenario is
-   kept as a regression canary (section 5.1). Full rationale, including
-   the adversarial variants considered, in section 4.6.
+   cancellability, which decomposes into post-dispatch suppression (RFC
+   0003 INV-9) and precedence for the inputs that could still dispatch a
+   cancel — every cancellation comes from an `update` invocation fed by a
+   shared or keyed input, so a reroute to the always-armed dedicated
+   branch (with or without an identity-and-liveness check, which can only
+   see cancels already dispatched) delivers the quit ahead of ready
+   inputs whose `update` would cancel it. The front-of-stream shape
+   additionally lets the quit overtake its own run's earlier buffered
+   messages, and the behind-stream shape was already infeasible as stated
+   above. Prompt unconditional quit remains available as unkeyed
+   `Command::quit()` (R4, F6). The properties the decision rests on are
+   pinned as INV-L10 (private-channel routing and per-run in-order
+   delivery: structural at the keyed send site, plus a unit-level
+   ordering test) and INV-L11 (a ready shared input wins the pull over a
+   ready keyed quit: unit-level test) — INV-L5 alone does not carry them,
+   since RFC 0003 states neither a delivery-FIFO invariant that includes
+   quit nor a quit-specific precedence. F7's full-drain wait is a
+   regression check for the unbounded default only; bounded-mode
+   keyed-quit latency is capacity-dependent and carries no acceptance
+   bound (section 5.1). Full rationale, including the adversarial
+   variants considered, in section 4.6.
 8. Harness follow-up: add a quit-under-backlog scenario (F5) and a bounded
    vs. unbounded comparison matrix before implementation.
    **Resolved (2026-07-17).** `benches/runtime_load.rs` now runs the

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -17,18 +17,25 @@
   bounds with the active-`CommandId` count an application-owned contract
   input, the producer-count premise is application-owned and observable,
   and keyed channels are bounded per command, not by a shared pool
-  (INV-L8/L9; sections 1.2, 4.4, 4.5, 5, 5.1)
+  (INV-L8/L9; sections 1.2, 4.4, 4.5, 5, 5.1). 2026-07-17 — open question
+  7 resolved: keyed `Action::Quit` stays in its command's private channel,
+  with no reroute to the dedicated quit channel in either shape — a keyed
+  quit's delivery order is its cancellation semantics, so any
+  backlog-independent delivery path would decide the quit-vs-cancel race
+  in the quit's favor by construction, and prompt unconditional quit is
+  already available unkeyed (sections 4.2, 4.6; F7 pinned as a regression
+  canary in section 5.1)
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
 > sections 4–6 turns out to be unimplementable without breaking the public
 > API. Sections 4–6 fix the direction of the load-control contract but their
 > details (capacities, batching caps, per-source classes) remain open until
-> implementation. In particular, cross-channel fairness (section 4.3) and
-> the quit delivery path (section 4.2) are contracts to settle before the
-> post-0.10.0 implementation; the exact scope of the memory bound (INV-L1)
-> was the third such contract and is now settled (open question 3, section
-> 4.5). None of them gates the 0.10.0 release.
+> implementation. In particular, cross-channel fairness (section 4.3)
+> remains a contract to settle before the post-0.10.0 implementation; the
+> quit delivery path and the exact scope of the memory bound (INV-L1) were
+> the other two such contracts and are now settled (open questions 7 and 3,
+> sections 4.6 and 4.5). None of them gates the 0.10.0 release.
 
 ## Summary
 
@@ -237,9 +244,11 @@ Findings:
   the keyed variant's quit→delivered is p50 1.300s — the full drain of the
   remaining backlog at ~26µs per message — with spread across 20 trials
   under 0.2%. This is F4's shared-first starvation applied to quit: delivery
-  scales linearly with backlog depth. It quantifies the status quo that open
-  question 7 weighs against re-routing a front-of-stream keyed quit to the
-  dedicated channel.
+  scales linearly with backlog depth. It quantifies the status quo that
+  open question 7 resolved to keep: the wait is cancel-before-delivery
+  holding under load — any pending shared input could cancel the quit's
+  command, and shared-first pull processes them all before delivering it —
+  not incidental starvation (section 4.6).
 
 ## 3. Release-gate decision for 0.10.0
 
@@ -340,12 +349,13 @@ mode's send contract, by source class:
   channel instead, so in bounded mode it can wait on
   `keyed_channel_capacity` like any other keyed output, and is additionally
   subject to INV-14 shared-first pull once delivered (keyed quit is already
-  subject to that ordering today). Whether keyed / in-stream quit should
-  instead be re-routed to the dedicated channel — matching what unkeyed
-  `Action::Quit` already does — is open question 7, which also covers why
-  that reroute is not a trivial channel swap for a quit that follows
-  not-yet-sent earlier items in the same stream. User-initiated quit itself
-  is not part of that open question: as an unkeyed command with no earlier
+  subject to that ordering today). Open question 7 asked whether keyed /
+  in-stream quit should instead be re-routed to the dedicated channel —
+  matching what unkeyed `Action::Quit` already does — and resolved that it
+  stays in the private channel: that channel's delivery order is what keeps
+  a keyed quit cancellable, and a reroute in either shape would break RFC
+  0003's INV-9 and per-command FIFO (section 4.6). User-initiated quit
+  itself was never part of that question: as an unkeyed command with no earlier
   actions ahead of it, it already gets R4's independence from
   `app_channel_capacity`; only the input leg (the key press traveling
   through the shared channel to `update`) is shared-channel traffic and
@@ -474,6 +484,107 @@ The decision is captured in two invariants: INV-L8 (load control paces
 sends, never producer admission) and INV-L9 (keyed backpressure is
 isolated per command — the testable form of the no-shared-pool choice).
 
+### 4.6 Keyed quit routing (open question 7 resolved)
+
+A keyed `Action::Quit` is delivered through its command's private channel,
+like every other keyed output (sections 1.1, 4.2). Open question 7 asked
+whether it should instead be re-routed to the dedicated quit channel at
+the producer side — matching what unkeyed `Action::Quit` already does —
+in either of two shapes: re-routing once the quit reaches the front of
+its own stream, or bypassing stream order for a quit still behind unsent
+earlier items. The resolution: **no reroute, in either shape — keyed quit
+stays in the private channel.**
+
+The decisive fact is that a keyed quit's delivery order *is* its
+cancellation semantics. Keying a quit is the API's way of saying "quit,
+unless this command is cancelled or superseded first" (RFC 0003 INV-9: a
+cancelled or superseded keyed `Action::Quit` does not quit the
+application). An application that wants an unconditional, prompt quit
+already has one — unkeyed `Command::quit()` — with measured
+backlog-independent delivery (R4, F6). Both delivery behaviors therefore
+already exist in the API, chosen per command; a reroute would not add the
+fast path, it would remove the cancellable one.
+
+The front-of-stream shape — the one open question 7 called deliverable —
+breaks two contracts R5 promised to preserve:
+
+- **Cancellability (RFC 0003 INV-9, buffered-output suppression).** The
+  dedicated quit channel carries no command identity (its payload is
+  `()`), and its select branch is always armed. Once a keyed quit is sent
+  into it, no later explicit cancel or `CancelInFlight` supersede can
+  suppress it. Today suppression works precisely because the quit sits in
+  the keyed entry's private channel: cancellation removes the entry and
+  drops the buffered `CommandOutput::Quit` with it.
+- **Per-command FIFO (RFC 0003).** At the front of its stream, a quit's
+  earlier `Action::Message` items have been *sent* but not necessarily
+  *delivered*: under shared backlog they wait for the shared drain (F4)
+  while a dedicated-channel quit would be delivered at
+  backlog-independent speed (F6). The quit would overtake its own
+  command's earlier output — a command emitting `[Message(saved), Quit]`
+  would exit the application before `saved` reaches `update`.
+
+Adversarial variants considered and excluded:
+
+- **Identity-carrying quit channel** — the quit channel carries
+  `(CommandId, RunToken)` and the quit branch checks the keyed entry's
+  liveness at delivery. This fails precisely the case that motivates the
+  reroute. Every cancellation of a keyed command is dispatched through
+  `enqueue_command` — from the init command (before any keyed command
+  exists) or from a command returned by `update` — and every `update`
+  invocation consumes an input delivered through the shared channel or a
+  keyed channel. Under backlog, the cancel that should suppress the quit
+  is therefore itself an undelivered input; a liveness check at quit
+  delivery evaluates state that has not yet seen that cancel, and
+  honoring cancels still in the backlog means draining the backlog first
+  — the status quo. Backlog-independent keyed-quit delivery and
+  cancellability are mutually exclusive under backlog: any delivery path
+  faster than the input drain decides the quit-vs-cancel race in the
+  quit's favor by construction. F7's 1.30s at ~50k backlog is not
+  incidental starvation to engineer away; it is cancel-before-delivery
+  holding under load.
+- **Reroute only when the private channel is empty** — avoids the FIFO
+  violation but not the cancellability one, which is independent of
+  stream position; excluded for the same reason as the identity-carrying
+  variant.
+- **Drain-then-deliver at the quit branch** — the quit branch, on
+  receiving a keyed quit, processes the pending backlog before honoring
+  it. Latency-equivalent to the status quo (the backlog is processed
+  either way), so it buys nothing and couples the quit branch to app
+  input processing.
+- **The behind-stream shape** inherits every objection above and adds the
+  infeasibility already recorded in open question 7: discovering a quit
+  behind unsent items requires look-ahead buffering (unbounded memory,
+  contra R1/R2) or an out-of-band signal that abandons RFC 0003's
+  stream-order semantics.
+
+Consequences:
+
+- **No new invariant.** The pinned contract is RFC 0003 INV-9 plus
+  per-command FIFO, both already carried by INV-L5 (behavioral anchor:
+  RFC 0003's buffered-quit suppression test,
+  `cancelling_buffered_quit_suppresses_it`). The `quit_keyed_backlog_50k`
+  scenario (F7) stays in the harness as a regression canary: keyed
+  quit→delivered dropping to backlog-independent values without an open
+  question 6 fairness policy indicates exactly the reroute this
+  resolution rejects.
+- **Bounded mode changes neither the analysis nor the acceptance
+  criterion.** Capacity controls backlog memory, not the number of inputs
+  ahead of a keyed output (F4): in the burst scenario the burst's inputs
+  drain ahead of the keyed quit whether they are queued in the channel or
+  held by blocked producers, up to the admission-window races bounded mode
+  already concedes for keyed delivery in general (section 4.3) — races too
+  rare to move a per-trial p50. The section 5.1 row is fixed at
+  "unchanged".
+- **Latency, if ever wanted, goes through open question 6.** A fairness
+  policy that bounds keyed-delivery latency would apply to keyed quit as
+  to every other keyed output — and preserving cancel-before-delivery is
+  already that question's stated constraint. There is no quit-specific
+  delivery path to design.
+- **Documentation guidance** (lands with open question 1's
+  recommended-defaults documentation): use unkeyed `Command::quit()` for
+  a prompt unconditional quit; `.cancellable(id)` on a quit buys
+  suppression at the cost of waiting behind pending inputs under load.
+
 ## 5. Invariants (draft)
 
 To be finalized as contract tests before implementation:
@@ -531,7 +642,8 @@ To be finalized as contract tests before implementation:
   counts as passing), since a single harness run cannot validate a claim of
   the form "always independent of backlog." Quit requests still inside
   command streams are outside this invariant and follow their stream's
-  delivery semantics (section 4.2). The quit-under-backlog scenarios now
+  delivery semantics (section 4.2) — a scope kept deliberately by open
+  question 7's resolution (section 4.6). The quit-under-backlog scenarios now
   exist and are measured (section 2, F6), and they record the delivery
   instant itself — the quit branch firing, timestamped from the runtime's
   tracing events — not a proxy bound, so a regression in the quit branch's
@@ -633,7 +745,7 @@ must meet and is filled with measured values when the implementation lands.
 | `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ `capacity + 1` by the same depth accounting; producer waits instead; no message dropped (INV-L1, INV-L2) |
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | unchanged — no keyed latency bound unless open question 6 adds a fairness policy (section 4.3) |
 | `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.62ms, depth-independent (F6) | unchanged from baseline — the quit channel is never bounded (R4, INV-L4) |
-| `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | per open question 7's resolution; unchanged if keyed quit stays in the private channel |
+| `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | unchanged — keyed quit stays in the private channel (open question 7, section 4.6), and bounded capacity does not reduce the inputs ahead of a keyed output (F4); a drop to backlog-independent delivery without an open question 6 fairness policy is the regression signal, not an improvement |
 | `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency is open question 6's territory) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
@@ -710,6 +822,20 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    on stream position at all, which is a deliberate semantic change
    relative to RFC 0003's FIFO. Any resolution of this question should say
    which of the two shapes it delivers.
+   **Resolved (2026-07-17).** Neither shape: a keyed `Action::Quit` stays
+   in its command's private channel. Keying a quit is a request for
+   cancellability (RFC 0003 INV-9), and under backlog every cancel is
+   itself an undelivered shared or keyed input, so any quit delivery path
+   faster than the input drain — including an identity-carrying quit
+   channel checked for liveness at delivery — decides the quit-vs-cancel
+   race in the quit's favor by construction. The front-of-stream shape
+   additionally lets the quit overtake its own command's earlier buffered
+   messages (per-command FIFO), and the behind-stream shape was already
+   infeasible as stated above. Prompt unconditional quit remains available
+   as unkeyed `Command::quit()` (R4, F6). No new invariant: INV-L5 (RFC
+   0003 INV-9, per-command FIFO) pins the contract, and F7's scenario is
+   kept as a regression canary (section 5.1). Full rationale, including
+   the adversarial variants considered, in section 4.6.
 8. Harness follow-up: add a quit-under-backlog scenario (F5) and a bounded
    vs. unbounded comparison matrix before implementation.
    **Resolved (2026-07-17).** `benches/runtime_load.rs` now runs the
@@ -719,7 +845,7 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
    matrix is defined in section 5.1 with the unbounded column measured; the
    bounded column is filled when the implementation lands. F6 is the input
    for INV-L4's (a)/(b) formulation choice; F7 is the quantified status quo
-   for open question 7.
+   that open question 7 has since resolved to keep (section 4.6).
 
 ## 7. References
 

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -20,7 +20,7 @@ one or the other explicitly.
 | --- | --- |
 | [0001](0001-http-module-redesign.md) | HTTP module redesign |
 | [0002](0002-redraw-suppression.md) | Redraw suppression (message / redraw separation) |
-| [0003](0003-command-cancellation.md) | Command cancellation, keyed delivery, FIFO invariants |
+| [0003](0003-command-cancellation.md) | Command cancellation, keyed delivery, delivery-order invariants |
 | [0004](0004-command-timeout-retry.md) | Command timeout and retry |
 | [0005](0005-structural-lifecycle-identity.md) | Structural lifecycle identity and composition scope |
 | [0006](0006-runtime-load-control.md) | Runtime load control, backpressure, latency guarantees |

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -42,6 +42,13 @@ Prompts that have already paid off:
   messages, held permits) outlive it.
 - A bounded test against an unbounded parameter: any finite scenario that
   saturates `j` units is passed by a pool larger than `j × capacity`.
+- An admission-window adversary: with bounded channels, the interval
+  between a consumer's pull and a blocked producer's re-send leaves the
+  channel momentarily empty, so orderings impossible under unbounded
+  sends become legal, compliant executions — an acceptance criterion
+  derived from unbounded behavior may falsely flag them (from PR #213: a
+  capacity-1 run delivers a keyed quit before the remaining producer
+  backlog while violating nothing).
 
 ## 3. Enforcement class, declared up front
 
@@ -85,6 +92,14 @@ original draft, and it is where false justifications creep in.
 because a task terminates after `send` while its signal stays queued —
 and a misdescription of `StreamMap::poll_next` as draining all ready
 receivers.
+
+Invariant citations are code claims too: "X is already carried by RFC
+N's INV-M" gets a fresh read of INV-M's exact statement, and an umbrella
+clause ("all RFC N invariants hold") covers only what RFC N actually
+states. *From PR #213:* a resolution leaned on "INV-L5 carries RFC 0003"
+for delivery-FIFO and quit precedence, but RFC 0003's INV-9 defines only
+post-dispatch suppression and INV-14 only same-pull-point ordering — the
+properties had to be pinned as new invariants with their own checks.
 
 ## 5. Re-derive, don't patch
 

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -77,7 +77,12 @@ Whatever the class, name the production seam the check goes through: the
 concrete construction/send/spawn sites for a structural review, or, for a
 behavioral test, the production code path it exercises or the transition
 logic it shares with production. A test that exercises a parallel model
-of the mechanism proves nothing about the runtime.
+of the mechanism proves nothing about the runtime. And when the invariant
+quantifies over several seams — *every* pull point, *every* send site —
+the check covers each member: a non-compliant implementation can add its
+bypass on exactly the seam the single test does not touch (from PR #213:
+an "every `AppInputs` pull point" invariant tested only on
+`try_next_ready` misses a quit-specific bypass in `poll_next`).
 
 ## 4. Code claims verified against code
 
@@ -119,5 +124,11 @@ a chain of findings.
 - Cross-references: open-question numbers point at their resolutions;
   preamble/decision-scope status agrees with the body; the amendment
   header line is updated.
+- Citations of another document's invariants name things that actually
+  exist there, and a corrected claim is corrected everywhere: grep for
+  the old term across the RFC, its references section, and the index
+  (from PR #213: "RFC 0003's FIFO" survived in R5, §4.3, the
+  open-question text, and the references after the body had already
+  conceded RFC 0003 states no FIFO invariant).
 - `typos` and `git diff --check` are clean.
 - English only (repository artifact).

--- a/src/runtime/app_input.rs
+++ b/src/runtime/app_input.rs
@@ -95,6 +95,7 @@ mod tests {
     use tokio::time::{Duration, timeout};
 
     use super::super::keyed_commands::{CommandOutput, ReceiverEvent};
+    use crate::test_support::wait_until;
 
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_shared_after_send() {
@@ -174,6 +175,30 @@ mod tests {
                 | AppInput::Keyed(ReceiverEvent::Output(_) | ReceiverEvent::Closed) => None,
             })
             .expect("keyed output should follow the shared input");
+    }
+
+    #[tokio::test]
+    async fn shared_input_wins_when_keyed_quit_is_also_ready() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut inputs = AppInputs::new(rx);
+        let id = CommandId::new("quit");
+        inputs.spawn_keyed(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            stream::iter([Action::Quit]).boxed(),
+        );
+        wait_until(
+            || inputs.has_closed_buffered(&id),
+            "keyed quit should be buffered before the pull",
+        )
+        .await;
+        tx.send(1).expect("receiver should be open");
+
+        assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(1)));
+        assert_eq!(
+            inputs.try_next_ready(),
+            Some(AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Quit)))
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/app_input.rs
+++ b/src/runtime/app_input.rs
@@ -202,6 +202,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shared_input_wins_the_blocking_pull_when_keyed_quit_is_also_ready() {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let mut inputs = AppInputs::new(rx);
+        let id = CommandId::new("quit");
+        inputs.spawn_keyed(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            stream::iter([Action::Quit]).boxed(),
+        );
+        wait_until(
+            || inputs.has_closed_buffered(&id),
+            "keyed quit should be buffered before the pull",
+        )
+        .await;
+        tx.send(1).expect("receiver should be open");
+
+        assert_eq!(inputs.next().await, Some(AppInput::Shared(1)));
+        assert_eq!(
+            inputs.next().await,
+            Some(AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Quit)))
+        );
+    }
+
+    #[tokio::test]
     async fn closed_shared_channel_and_same_poll_keyed_reconciliation_terminate_the_stream() {
         let (tx, rx) = mpsc::unbounded_channel::<i32>();
         let mut inputs = AppInputs::new(rx);

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -833,6 +833,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn keyed_quit_is_delivered_after_the_same_runs_earlier_output() {
+        let id = CommandId::new("save-then-quit");
+        let mut manager = KeyedCommands::new();
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1), Action::Quit]),
+        );
+        wait_for_closed_buffered(&mut manager, &id).await;
+
+        assert_eq!(take_message(&mut manager, &id), 1);
+        let (event_id, event) = manager
+            .try_next_ready()
+            .expect("keyed quit should be ready after the earlier message");
+        assert_eq!(event_id, id);
+        assert_eq!(event, ReceiverEvent::Output(CommandOutput::Quit));
+    }
+
+    #[tokio::test]
     async fn cancelling_buffered_quit_suppresses_it() {
         let id = CommandId::new("quit");
         let mut manager = KeyedCommands::new();


### PR DESCRIPTION
## Summary

Resolves RFC 0006 open question 7 (keyed quit delivery path): **no reroute, in either shape — a keyed `Action::Quit` stays in its command's private channel.**

The decisive argument: a keyed quit's delivery order is its cancellation semantics, which decomposes into post-dispatch suppression (RFC 0003 INV-9) and precedence for the **ready shared inputs** that could still dispatch a cancel — the one class of cancelling input the runtime orders ahead of a keyed quit (INV-L11; ready keyed outputs have no guaranteed `StreamMap` position against the quit, and un-admitted inputs are visible to neither routing). A reroute to the always-armed dedicated branch — with or without an identity-and-liveness check, which can only see cancels already dispatched — delivers the quit ahead of exactly that class, so it strictly weakens cancellation precedence and strengthens nothing. Under the unbounded default every pending shared input is already ready, so F7's 1.30s full-drain wait is cancel-before-delivery holding under load, not incidental starvation.

Additional grounds:

- The front-of-stream reroute breaks three delivery properties: post-dispatch suppression (RFC 0003 INV-9), keyed-quit ordering (the quit would overtake its own run's earlier buffered messages), and shared-first precedence for ready shared inputs.
- The behind-stream shape inherits those objections plus the infeasibility already recorded in the question.
- Prompt unconditional quit already exists in the API as unkeyed `Command::quit()` (R4, F6: p99 ≤ 0.62ms, depth-independent) — both delivery behaviors are chosen per command today; a reroute would remove the cancellable one, not add a fast one.

## Changes

- New section 4.6 with the resolution, the adversarial variants considered (identity-carrying channel, empty-channel-only reroute, drain-then-deliver, behind-stream), enforcement, and documentation guidance.
- **Two new invariants pin the decision** (review finding: INV-L5 alone does not carry these — RFC 0003 INV-9 covers only post-dispatch suppression, INV-14 is a pull-point ordering with nothing quit-specific or FIFO-shaped):
  - **INV-L10** — keyed quit is routed through its run's private channel and never overtakes that run's earlier output. Scoped tightly (review finding): it claims nothing about ordering among a run's messages beyond the single FIFO channel, and **unkeyed commands are explicitly outside** — an unkeyed `[Message, Quit]` sends its two actions to different channels, so the always-armed quit branch can observe the quit first (existing behavior, section 4.2). Routing half structural at the keyed send site; ordering half anchored by a unit test (`keyed_quit_is_delivered_after_the_same_runs_earlier_output`).
  - **INV-L11** — at every `AppInputs` pull point, a ready shared input is delivered before a ready keyed quit. Anchored by unit tests on **both pull paths** (review finding): blocking `poll_next` (`shared_input_wins_the_blocking_pull_when_keyed_quit_is_also_ready`) and non-waiting `try_next_ready` (`shared_input_wins_when_keyed_quit_is_also_ready`).
- **The section 5.1 `quit_keyed_backlog_50k` cell carries no latency criterion** (review finding: bounded mode cannot be held to "unchanged" — a compliant bounded implementation may deliver the keyed quit while producer backlog remains, via the admission window a pull opens when it leaves the shared channel momentarily empty; at `capacity = 1`, after every pull). F7's full-drain p50 stays a regression check for the unbounded default only; the bounded run is recorded as a statistical measurement with pinned capacity, depth, and trial count when the implementation lands.
- **All citations of a nonexistent "RFC 0003 FIFO invariant" swept** (review finding — RFC 0003 never uses the term): R5 names RFC 0003's actual ordering invariants (cancel-before-delivery, INV-14, INV-10 one-item drain); R5, sections 4.3/4.5, the open-question text, the references entry, and the RFC index line now use the per-source-class ordering scopes, with the unkeyed-quit exclusion stated outright.
- Amendments header, decision-scope note, F7, section 4.2, INV-L4 scope note, and the open question 7/8 entries updated accordingly.
- Pre-review checklist extended per its living-document rule with the defect classes from review: admission-window adversary, umbrella invariant citations, per-seam coverage of quantified checks, corrected-everywhere sweeps.

## Verification

Ran the pre-review checklist (docs/rfcs/pre-review-checklist.md):

- Universal claims verified against code with fresh reads: cancel dispatch sites (`enqueue_command`, src/runtime/core.rs:117-119 sole `cancel_keyed` caller), the single `update` call site fed by `AppInputs` (src/runtime.rs:259), shared-first pull at both pull points (src/runtime/app_input.rs:36-43, 75-87), the identity-less `()` quit channel and always-armed branch (src/runtime/core.rs:52, src/runtime.rs:427), the split unkeyed Message/Quit channels (src/runtime/core.rs:141-156), and buffered-quit suppression (`cancelling_buffered_quit_suppresses_it`).
- `rg` confirms no remaining "RFC 0003 FIFO" attribution and no remaining "per-command/per-run in-order delivery" phrasing.
- `cargo test --lib` (259 passed, including the three new anchors), `cargo fmt --check`, `clippy`, `typos`, `git diff --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)