### PR TITLE
docs(rfc): scope the hedge scan to each bullet's opening claim

### DIFF
--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -155,6 +155,15 @@ PR #215:
   aside. (§3.2/§4.1 held the `RuntimeConfig` API at "for example" / "at
   least" with the owning task recorded nowhere as a gate; §4.4 specified
   observability as "or similar" / "should" with no definition of done.)
+
+  Scope this to the claim itself: within a labeled invariant or requirement
+  bullet (`- **INV-Lx**:` / `- **Rx**:`), write the opening sentence as the
+  complete, hedge-free claim, and carry qualification, rationale, and
+  resolved history in the sentences that follow within the same bullet.
+  When triaging a hit, a hedge in that opening sentence is a finding; a
+  hedge later in the same bullet usually is not — confirm it is doing
+  rationale work, not smuggling an unresolved qualification into the claim,
+  before waving it through.
 - **No pending choices inside invariants.** An invariant that still
   contains a decision to make — "resolving this needs either (a) … or
   (b) …", "the remaining step" — is not yet an invariant. Either resolve


### PR DESCRIPTION
## Summary
- Formalizes a convention already followed across RFCs 0001-0006: within a labeled invariant/requirement bullet (`- **INV-Lx**:` / `- **Rx**:`), the opening sentence is the complete, hedge-free claim, and later sentences in the same bullet carry qualification, rationale, and resolved history.
- Gives the "Hedge scan" checklist item a triage rule: a hedge in the opening sentence is a finding; a hedge later in the same bullet usually is not, pending confirmation it's doing rationale work rather than smuggling an unresolved qualification into the claim.

This came out of evaluating mechanical tooling (Vale) for the hedge scan: restricting a scan to each bullet's first sentence across all six RFCs produced near-zero false positives, confirming the existing writing convention already supports this without any format change. Mechanical enforcement is out of scope for this PR (accuracy/maintenance tradeoffs didn't clear the bar) — this only records the convention for human triage.

## Test plan
- [x] `typos` clean
- [x] `git diff --check` clean
- [x] English-only (repository artifact)