### PR TITLE
feat(command,subscription): add Command::scoped and Subscription::scoped (RFC 0005 Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Subscription::scoped` and `Command::scoped` qualify a subscription's or
+  command's lifecycle identity with one structural scope segment, so composed
+  child instances that reuse the same local source/key or `CommandId` no
+  longer alias each other's lifecycle (RFC 0005 Phase B)
+  - `Command::scoped` qualifies the keyed spawn id (if `cancellable`/
+    `cancellable_with` was already called) and every explicit cancel id
+    already present at the call boundary; it does not retroactively cover
+    ids attached by a later modifier call — see the ordering examples on
+    `Command::cancellable`'s rustdoc
+  - Scoping is additive: unscoped subscriptions and commands keep their
+    existing 0.10.0 behavior unchanged
+
 ## [0.10.0] - 2026-07-17
 
 ### Changed

--- a/benches/subscription.rs
+++ b/benches/subscription.rs
@@ -7,6 +7,9 @@
 //!   keep the existing tasks running.
 //! - **reconcile (churn)**: `update` when the whole set is replaced — measures
 //!   the abort + spawn bookkeeping.
+//! - **reconcile (steady, scoped)**: the steady-state case with
+//!   [`Subscription::scoped`] applied, comparing an empty, one-segment, and a
+//!   representative nested scope path (RFC 0005 section 7).
 //!
 //! `SubscriptionManager` is crate-private, so this benchmark goes through
 //! [`BenchSubscriptionManager`], a thin bench-only wrapper gated behind the
@@ -102,5 +105,50 @@ fn bench_reconcile_churn(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_reconcile_steady, bench_reconcile_churn);
+/// Builds subscriptions with `depth` nested scope segments applied, so a
+/// larger `depth` measures a longer scope path rather than a different
+/// subscription count.
+fn subscriptions_scoped(ids: impl IntoIterator<Item = u64>, depth: u32) -> Vec<Subscription<()>> {
+    ids.into_iter()
+        .map(|id| {
+            (0..depth).fold(Subscription::new(BenchSource { id }), |sub, segment| {
+                sub.scoped(segment)
+            })
+        })
+        .collect()
+}
+
+fn bench_reconcile_steady_scoped(c: &mut Criterion) {
+    let rt = Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .expect("bench runtime should build");
+    let _guard = rt.enter();
+
+    let mut group = c.benchmark_group("subscription_reconcile_steady_scoped");
+    let count = 64u64;
+    // 0: unscoped baseline; 1: a single composition boundary; 4: a
+    // representative nested path (a few levels of child composition).
+    for depth in [0u32, 1, 4] {
+        group.bench_with_input(BenchmarkId::from_parameter(depth), &depth, |b, &depth| {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            let mut manager = BenchSubscriptionManager::new(tx);
+            manager.update(subscriptions_scoped(0..count, depth));
+
+            b.iter(|| {
+                manager.update(subscriptions_scoped(0..count, depth));
+            });
+
+            manager.shutdown();
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_reconcile_steady,
+    bench_reconcile_churn,
+    bench_reconcile_steady_scoped
+);
 criterion_main!(benches);

--- a/docs/rfcs/0005-structural-lifecycle-identity.md
+++ b/docs/rfcs/0005-structural-lifecycle-identity.md
@@ -1,6 +1,7 @@
 # RFC 0005: Structural Lifecycle Identity and Composition Scopes
 
-- Status: Partially Implemented (Phase A); Phase B pending
+- Status: Implemented (Phase A shipped in 0.10.0; Phase B shipped additively
+  after 0.10.0)
 - Target: Phase A in 0.10.0 (breaking); Phase B after 0.10.0 (additive)
 - Scope: collision-safe subscription identity and hierarchical identity
   namespacing for composed command and subscription lifecycles

--- a/src/command/cancellation.rs
+++ b/src/command/cancellation.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-use crate::structural_key::StructuralKey;
+use crate::structural_key::{ScopePath, StructuralKey};
 
 /// Identifies one cancellable command-output lifecycle.
 ///
@@ -11,6 +11,7 @@ use crate::structural_key::StructuralKey;
 #[derive(Clone)]
 pub struct CommandId {
     inner: StructuralKey,
+    scope: ScopePath,
 }
 
 impl CommandId {
@@ -21,6 +22,18 @@ impl CommandId {
     {
         Self {
             inner: StructuralKey::new(value),
+            scope: ScopePath::empty(),
+        }
+    }
+
+    /// Returns a new id with an already-erased scope segment appended (see
+    /// RFC 0005 section 4.3). Used by [`Command::scoped`](super::Command::scoped)
+    /// to apply one scope value to every lifecycle id present at its call
+    /// boundary without requiring the scope type to be `Clone`.
+    pub(super) fn scoped_with(&self, segment: StructuralKey) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            scope: self.scope.appended_key(segment),
         }
     }
 }
@@ -36,7 +49,7 @@ impl fmt::Debug for CommandId {
 
 impl PartialEq for CommandId {
     fn eq(&self, other: &Self) -> bool {
-        self.inner == other.inner
+        self.inner == other.inner && self.scope == other.scope
     }
 }
 
@@ -45,6 +58,7 @@ impl Eq for CommandId {}
 impl Hash for CommandId {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner.hash(state);
+        self.scope.hash(state);
     }
 }
 
@@ -121,5 +135,42 @@ mod tests {
     #[test]
     fn default_policy_cancels_in_flight_work() {
         assert_eq!(CancelPolicy::default(), CancelPolicy::CancelInFlight);
+    }
+
+    #[test]
+    fn scoped_with_differs_from_unscoped() {
+        let unscoped = CommandId::new("load");
+        let scoped = unscoped.scoped_with(StructuralKey::new("pane-1"));
+
+        assert_ne!(unscoped, scoped);
+    }
+
+    #[test]
+    fn scoped_with_makes_independent_child_instances_distinct() {
+        let base = CommandId::new("load");
+        let first = base.scoped_with(StructuralKey::new("pane-1"));
+        let second = base.scoped_with(StructuralKey::new("pane-2"));
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn scoped_with_equal_scope_is_equal() {
+        let base = CommandId::new("load");
+        let first = base.scoped_with(StructuralKey::new("pane-1"));
+        let second = base.scoped_with(StructuralKey::new("pane-1"));
+
+        assert_eq!(first, second);
+        assert_eq!(hash(&first), hash(&second));
+    }
+
+    #[test]
+    fn scoped_with_applies_one_shared_erasure_to_different_ids() {
+        let segment = StructuralKey::new("pane-1");
+        let first = CommandId::new("load").scoped_with(segment.clone());
+        let second = CommandId::new("save").scoped_with(segment);
+
+        // Different local ids under the same scope segment remain distinct.
+        assert_ne!(first, second);
     }
 }

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -3,11 +3,16 @@
 //! while closing the `command::Command` path. See `runtime::frame_rate` for
 //! the same pattern applied to `Runtime`'s scheduling input.
 
+use std::hash::Hash;
+#[cfg(test)]
+use std::hash::Hasher;
 use std::time::Duration;
 
 #[cfg(test)]
 use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt};
+
+use crate::structural_key::StructuralKey;
 
 use super::Action;
 use super::cancellation::{CancelPolicy, CancellableCommand, CommandCancellation, CommandId};
@@ -164,6 +169,28 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// A cancellation key applies to this top-level command only. If this
     /// command is later passed as a child to [`Command::batch`], its key is
     /// ignored; apply `cancellable` to the resulting batch instead.
+    ///
+    /// # Ordering with `scoped`
+    ///
+    /// [`Command::scoped`] only qualifies lifecycle ids already present when
+    /// it is called; it is a boundary operation, not a mode inherited by
+    /// later modifiers. Calling `cancellable` *after* `scoped` therefore
+    /// installs a new, unscoped, root-global key:
+    ///
+    /// ```
+    /// use tears::prelude::*;
+    /// use tears::command::CommandId;
+    ///
+    /// // Scoped key: `scoped` qualifies the id already attached by `cancellable`.
+    /// let scoped_first = Command::message(1)
+    ///     .cancellable(CommandId::new("load"))
+    ///     .scoped("pane-1");
+    ///
+    /// // Root-global key: `cancellable` runs after `scoped`, so its id is not scoped.
+    /// let scoped_then_global = Command::message(1)
+    ///     .scoped("pane-1")
+    ///     .cancellable(CommandId::new("load"));
+    /// ```
     #[must_use = "cancellable returns a modified command and does not mutate in place"]
     pub fn cancellable(self, id: CommandId) -> Self {
         self.cancellable_with(id, CancelPolicy::CancelInFlight)
@@ -178,9 +205,88 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// A cancellation key applies to this top-level command only. Child keys
     /// are ignored by [`Command::batch`]; key the resulting batch when the whole
     /// batch should share one lifecycle.
+    ///
+    /// # Ordering with `scoped`
+    ///
+    /// [`Command::scoped`] only qualifies lifecycle ids already present when
+    /// it is called; it is a boundary operation, not a mode inherited by
+    /// later modifiers. Calling `cancellable_with` *after* `scoped` therefore
+    /// installs a new, unscoped, root-global key:
+    ///
+    /// ```
+    /// use tears::prelude::*;
+    /// use tears::command::{CancelPolicy, CommandId};
+    ///
+    /// // Scoped key: `scoped` qualifies the id already attached by `cancellable_with`.
+    /// let scoped_first = Command::message(1)
+    ///     .cancellable_with(CommandId::new("load"), CancelPolicy::KeepInFlight)
+    ///     .scoped("pane-1");
+    ///
+    /// // Root-global key: `cancellable_with` runs after `scoped`, so its id is not scoped.
+    /// let scoped_then_global = Command::message(1)
+    ///     .scoped("pane-1")
+    ///     .cancellable_with(CommandId::new("load"), CancelPolicy::KeepInFlight);
+    /// ```
     #[must_use = "cancellable_with returns a modified command and does not mutate in place"]
     pub fn cancellable_with(mut self, id: CommandId, policy: CancelPolicy) -> Self {
         self.cancellation.key = Some(CancellableCommand { id, policy });
+        self
+    }
+
+    /// Qualifies this command's lifecycle ids with one structural scope
+    /// segment, expressing that this command belongs to a distinct child
+    /// composition boundary (see RFC 0005 section 4.3).
+    ///
+    /// `scoped` prepends `scope` to the keyed spawn id (if
+    /// [`Command::cancellable`] or [`Command::cancellable_with`] was already
+    /// called) and to every explicit cancel id already present, for example
+    /// from [`Command::cancel`] or a folded [`Command::batch`]. It does not
+    /// touch the effect stream, message mapping, redraw directive, timeout,
+    /// retry wrapper, or output.
+    ///
+    /// [`Command::none().scoped(scope)`](Command::none) is lifecycle-inert:
+    /// there is no spawn key or explicit cancel to qualify.
+    ///
+    /// # Ordering
+    ///
+    /// `scoped` is a boundary operation over lifecycle metadata already
+    /// present at the call site, not a persistent mode inherited by later
+    /// modifiers. `work.cancellable(id).scoped(scope)` scopes `id`, while
+    /// `work.scoped(scope).cancellable(id)` attaches `id` as a new,
+    /// unscoped, root-global key — see the ordering examples on
+    /// [`Command::cancellable`] and [`Command::cancellable_with`]. No
+    /// diagnostic is emitted when `cancellable` follows `scoped`, because a
+    /// later root-global key can be an intentional composition (a
+    /// pane-scoped effect participating in an application-wide slot), not
+    /// only a mistake.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tears::prelude::*;
+    /// use tears::command::CommandId;
+    ///
+    /// let cmd: Command<i32> = Command::cancel(CommandId::new("load")).scoped("pane-1");
+    /// ```
+    #[must_use = "scoped returns a modified command and does not mutate in place"]
+    pub fn scoped<Scope>(mut self, scope: Scope) -> Self
+    where
+        Scope: Eq + Hash + Send + Sync + 'static,
+    {
+        let segment = StructuralKey::new(scope);
+
+        self.cancellation.key = self.cancellation.key.map(|cancellable| CancellableCommand {
+            id: cancellable.id.scoped_with(segment.clone()),
+            policy: cancellable.policy,
+        });
+
+        self.cancellation.cancels = self
+            .cancellation
+            .cancels
+            .into_iter()
+            .map(|id| id.scoped_with(segment.clone()))
+            .collect();
+
         self
     }
 
@@ -574,6 +680,156 @@ mod tests {
 
         assert_eq!(key.id, CommandId::new("second"));
         assert_eq!(key.policy, CancelPolicy::CancelInFlight);
+    }
+
+    #[test]
+    fn test_unscoped_tuple_local_id_does_not_alias_a_scoped_identity() {
+        let tupled = CommandId::new(("pane-1", "load"));
+        let scoped = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-1");
+        let scoped_id = scoped.cancellation.key.expect("key should be present").id;
+
+        assert_ne!(tupled, scoped_id);
+    }
+
+    #[test]
+    fn test_scoped_none_is_lifecycle_inert() {
+        let command = Command::<i32>::none().scoped("pane-1");
+
+        assert!(command.is_none());
+        assert!(command.cancellation.key.is_none());
+        assert!(command.cancellation.cancels.is_empty());
+    }
+
+    #[test]
+    fn test_scoped_qualifies_the_cancellable_key() {
+        let scoped = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-1");
+        let key = scoped.cancellation.key.expect("key should be present");
+
+        assert_ne!(key.id, CommandId::new("load"));
+        assert_eq!(key.policy, CancelPolicy::CancelInFlight);
+    }
+
+    #[test]
+    fn test_scoped_independent_child_instances_do_not_alias() {
+        let pane_a = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-a");
+        let pane_b = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-b");
+
+        assert_ne!(
+            pane_a.cancellation.key.expect("key should be present").id,
+            pane_b.cancellation.key.expect("key should be present").id
+        );
+    }
+
+    #[test]
+    fn test_scoped_with_equal_scope_produces_equal_ids() {
+        let first = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-1");
+        let second = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped("pane-1");
+
+        assert_eq!(
+            first.cancellation.key.expect("key should be present").id,
+            second.cancellation.key.expect("key should be present").id
+        );
+    }
+
+    #[test]
+    fn test_scoped_qualifies_explicit_cancels() {
+        let id = CommandId::new("load");
+        let scoped = Command::<i32>::cancel(id.clone()).scoped("pane-1");
+
+        assert_eq!(scoped.cancellation.cancels.len(), 1);
+        assert_ne!(scoped.cancellation.cancels[0], id);
+    }
+
+    #[test]
+    fn test_scoped_hash_collision_does_not_alias_scopes() {
+        #[derive(Eq, PartialEq)]
+        struct Collision(u8);
+
+        impl Hash for Collision {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        let first = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped(Collision(1));
+        let second = Command::message(1)
+            .cancellable(CommandId::new("load"))
+            .scoped(Collision(2));
+
+        assert_ne!(
+            first.cancellation.key.expect("key should be present").id,
+            second.cancellation.key.expect("key should be present").id
+        );
+    }
+
+    #[test]
+    fn test_cancellable_after_scoped_installs_a_root_global_key() {
+        let command = Command::message(1)
+            .scoped("pane-1")
+            .cancellable(CommandId::new("load"));
+        let key = command.cancellation.key.expect("key should be present");
+
+        assert_eq!(key.id, CommandId::new("load"));
+    }
+
+    #[test]
+    fn test_mixed_scoped_cancels_stay_scoped_while_later_global_key_does_not() {
+        let cancel_id = CommandId::new("old");
+        let command = Command::<i32>::cancel(cancel_id.clone())
+            .scoped("pane-1")
+            .cancellable(CommandId::new("global"));
+        let key = command.cancellation.key.expect("key should be present");
+
+        // The explicit cancel present before `scoped` remains pane-scoped.
+        assert_ne!(command.cancellation.cancels[0], cancel_id);
+        // The spawn key attached after `scoped` is root-global.
+        assert_eq!(key.id, CommandId::new("global"));
+    }
+
+    #[test]
+    fn test_scoped_batch_preserves_scoped_cancels_and_still_ignores_child_keys() {
+        let left_cancel = CommandId::new("left");
+        let right_cancel = CommandId::new("right");
+
+        let batch = Command::batch([
+            Command::<i32>::cancel(left_cancel.clone()).scoped("left-pane"),
+            Command::cancel(right_cancel.clone())
+                .scoped("right-pane")
+                .cancellable(CommandId::new("ignored")),
+        ]);
+
+        assert_eq!(batch.cancellation.cancels.len(), 2);
+        assert!(batch.cancellation.key.is_none());
+        assert_ne!(batch.cancellation.cancels[0], left_cancel);
+        assert_ne!(batch.cancellation.cancels[1], right_cancel);
+    }
+
+    #[test]
+    fn test_scoped_after_batch_scopes_the_folded_cancels() {
+        let first = CommandId::new("first");
+        let second = CommandId::new("second");
+        let batch = Command::batch([
+            Command::<i32>::cancel(first.clone()),
+            Command::cancel(second.clone()),
+        ])
+        .scoped("outer");
+
+        assert_ne!(batch.cancellation.cancels[0], first);
+        assert_ne!(batch.cancellation.cancels[1], second);
     }
 
     #[test]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -444,6 +444,7 @@ mod tests {
     use super::*;
 
     use std::future::pending;
+    use std::hash::{Hash, Hasher};
     use std::num::NonZeroU32;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -884,7 +885,10 @@ mod tests {
     /// Derives the scoped `CommandId` that `.cancellable(CommandId::new(local)).scoped(scope)`
     /// would install as its keyed spawn id, without depending on `CommandId`'s
     /// internal shape.
-    fn scoped_local_id(local: &'static str, scope: &'static str) -> CommandId {
+    fn scoped_local_id<Scope>(local: &'static str, scope: Scope) -> CommandId
+    where
+        Scope: Eq + Hash + Send + Sync + 'static,
+    {
         let (cancels, _, _) = Command::<TestMessage>::cancel(CommandId::new(local))
             .scoped(scope)
             .into_runtime_parts()
@@ -893,6 +897,21 @@ mod tests {
             .into_iter()
             .next()
             .expect("cancel id should be present")
+    }
+
+    /// A scope segment type whose `Hash` implementation always writes the
+    /// same value, so its `PartialEq`/`Eq` (compared by `id`) is the only
+    /// thing distinguishing two instances. Used to pin RFC 0005 section 6.4's
+    /// requirement that constant-hash scope values still keep command
+    /// replacement, `KeepInFlight` suppression, and explicit cancellation
+    /// isolated per scope.
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    struct CollidingScope(u8);
+
+    impl Hash for CollidingScope {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            0_u8.hash(state);
+        }
     }
 
     // RFC 0005 Phase B: `Command::scoped` must make the same local
@@ -991,6 +1010,176 @@ mod tests {
         assert!(
             !pane_a_dropped.load(Ordering::SeqCst),
             "pane-a's in-flight command must not be cancelled by pane-b"
+        );
+
+        runtime.core.shutdown();
+    }
+
+    // RFC 0005 section 6.4: "the same constant-hash scope values keep
+    // command replacement, suppression, and explicit cancellation isolated."
+    // The tests above already cover ordinary (non-colliding) scope values;
+    // these three repeat that coverage under `CollidingScope`, whose `Hash`
+    // always writes the same byte, to pin that scope equality — not merely
+    // scope inequality — drives isolation.
+    #[tokio::test]
+    async fn scoped_explicit_cancel_is_isolated_under_hash_colliding_scopes() {
+        let scope_a = scoped_local_id("search", CollidingScope(1));
+        let scope_b = scoped_local_id("search", CollidingScope(2));
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable(CommandId::new("search"))
+                .scoped(CollidingScope(1))
+                .into_runtime_parts(),
+        );
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable(CommandId::new("search"))
+                .scoped(CollidingScope(2))
+                .into_runtime_parts(),
+        );
+
+        wait_until(
+            || {
+                runtime.core.app_inputs.has_closed_buffered(&scope_a)
+                    && runtime.core.app_inputs.has_closed_buffered(&scope_b)
+            },
+            "both hash-colliding scopes' keyed results should buffer independently",
+        )
+        .await;
+
+        runtime.core.app_inputs.cancel_keyed(&scope_a);
+
+        assert!(!runtime.core.app_inputs.has_closed_buffered(&scope_a));
+        assert!(
+            runtime.core.app_inputs.has_closed_buffered(&scope_b),
+            "cancelling one hash-colliding scope's id must not affect the other"
+        );
+    }
+
+    #[tokio::test]
+    async fn scoped_keep_in_flight_is_isolated_under_hash_colliding_scopes() {
+        struct DropGuard(Arc<AtomicBool>);
+
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let scope_a_dropped = Arc::new(AtomicBool::new(false));
+        let (scope_a_started_tx, scope_a_started_rx) = oneshot::channel();
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        let guard = DropGuard(Arc::clone(&scope_a_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = guard;
+                let _ = scope_a_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable_with(CommandId::new("search"), CancelPolicy::KeepInFlight)
+            .scoped(CollidingScope(1))
+            .into_runtime_parts(),
+        );
+        timeout(Duration::from_secs(1), scope_a_started_rx)
+            .await
+            .expect("scope-1 command should start before the timeout")
+            .expect("scope-1 command should signal that it started");
+
+        // Same local id ("search") under a different, hash-colliding scope,
+        // also `KeepInFlight`. If scope equality fell back to the collided
+        // hash, both would alias one slot and scope-1's occupancy would
+        // silently discard this stream instead of delivering it.
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable_with(CommandId::new("search"), CancelPolicy::KeepInFlight)
+                .scoped(CollidingScope(2))
+                .into_runtime_parts(),
+        );
+
+        let scope_b = scoped_local_id("search", CollidingScope(2));
+        wait_until(
+            || runtime.core.app_inputs.has_closed_buffered(&scope_b),
+            "scope-2's stream must deliver instead of being suppressed by scope-1's occupancy",
+        )
+        .await;
+
+        assert!(
+            !scope_a_dropped.load(Ordering::SeqCst),
+            "scope-1's in-flight command must not be cancelled by scope-2"
+        );
+
+        runtime.core.shutdown();
+    }
+
+    #[tokio::test]
+    async fn scoped_replacement_is_isolated_under_hash_colliding_scopes() {
+        struct DropGuard(Arc<AtomicBool>);
+
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let scope_a_dropped = Arc::new(AtomicBool::new(false));
+        let scope_b_dropped = Arc::new(AtomicBool::new(false));
+        let (scope_a_started_tx, scope_a_started_rx) = oneshot::channel();
+        let (scope_b_started_tx, scope_b_started_rx) = oneshot::channel();
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        // Both use the default `CancelPolicy::CancelInFlight`, so a same-scope
+        // replacement is expected to cancel the prior occupant of that scope.
+        let guard_a = DropGuard(Arc::clone(&scope_a_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = guard_a;
+                let _ = scope_a_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable(CommandId::new("search"))
+            .scoped(CollidingScope(1))
+            .into_runtime_parts(),
+        );
+        let guard_b = DropGuard(Arc::clone(&scope_b_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = guard_b;
+                let _ = scope_b_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable(CommandId::new("search"))
+            .scoped(CollidingScope(2))
+            .into_runtime_parts(),
+        );
+        timeout(Duration::from_secs(1), scope_a_started_rx)
+            .await
+            .expect("scope-1 command should start before the timeout")
+            .expect("scope-1 command should signal that it started");
+        timeout(Duration::from_secs(1), scope_b_started_rx)
+            .await
+            .expect("scope-2 command should start before the timeout")
+            .expect("scope-2 command should signal that it started");
+
+        // Replace the same local id under scope-1 again. If scope equality
+        // fell back to the collided hash, this would also cancel scope-2.
+        runtime.core.enqueue_command(
+            Command::future(pending::<TestMessage>())
+                .cancellable(CommandId::new("search"))
+                .scoped(CollidingScope(1))
+                .into_runtime_parts(),
+        );
+
+        wait_until(
+            || scope_a_dropped.load(Ordering::SeqCst),
+            "the replaced scope-1 command should be cancelled",
+        )
+        .await;
+        assert!(
+            !scope_b_dropped.load(Ordering::SeqCst),
+            "replacing scope-1's occupant must not cancel scope-2's command"
         );
 
         runtime.core.shutdown();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -881,6 +881,121 @@ mod tests {
         .await;
     }
 
+    /// Derives the scoped `CommandId` that `.cancellable(CommandId::new(local)).scoped(scope)`
+    /// would install as its keyed spawn id, without depending on `CommandId`'s
+    /// internal shape.
+    fn scoped_local_id(local: &'static str, scope: &'static str) -> CommandId {
+        let (cancels, _, _) = Command::<TestMessage>::cancel(CommandId::new(local))
+            .scoped(scope)
+            .into_runtime_parts()
+            .into_execution_parts();
+        cancels
+            .into_iter()
+            .next()
+            .expect("cancel id should be present")
+    }
+
+    // RFC 0005 Phase B: `Command::scoped` must make the same local
+    // `CommandId` independent across composition boundaries, so cancelling
+    // one scope's slot cannot affect an equal local id under another scope.
+    #[tokio::test]
+    async fn scoped_keyed_commands_do_not_cross_cancel_or_replace() {
+        let pane_a = scoped_local_id("search", "pane-a");
+        let pane_b = scoped_local_id("search", "pane-b");
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        // Both panes reuse the same local id ("search"); if scoping failed to
+        // qualify it, the second spawn would replace the first under
+        // `CancelPolicy::CancelInFlight` instead of buffering independently.
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable(CommandId::new("search"))
+                .scoped("pane-a")
+                .into_runtime_parts(),
+        );
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable(CommandId::new("search"))
+                .scoped("pane-b")
+                .into_runtime_parts(),
+        );
+
+        wait_until(
+            || {
+                runtime.core.app_inputs.has_closed_buffered(&pane_a)
+                    && runtime.core.app_inputs.has_closed_buffered(&pane_b)
+            },
+            "both pane-scoped keyed results should buffer independently",
+        )
+        .await;
+
+        runtime.core.app_inputs.cancel_keyed(&pane_a);
+
+        assert!(!runtime.core.app_inputs.has_closed_buffered(&pane_a));
+        assert!(
+            runtime.core.app_inputs.has_closed_buffered(&pane_b),
+            "cancelling one pane's scoped id must not affect the other pane"
+        );
+    }
+
+    // RFC 0005 Phase B (INV-19): reusing the same local `CommandId` under
+    // `CancelPolicy::KeepInFlight` in two different scopes must not let one
+    // pane's occupancy suppress the other pane's stream.
+    #[tokio::test]
+    async fn scoped_keep_in_flight_does_not_suppress_a_different_pane() {
+        struct DropGuard(Arc<AtomicBool>);
+
+        impl Drop for DropGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let pane_a_dropped = Arc::new(AtomicBool::new(false));
+        let (pane_a_started_tx, pane_a_started_rx) = oneshot::channel();
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+
+        let guard = DropGuard(Arc::clone(&pane_a_dropped));
+        runtime.core.enqueue_command(
+            Command::future(async move {
+                let _guard = guard;
+                let _ = pane_a_started_tx.send(());
+                pending::<TestMessage>().await
+            })
+            .cancellable_with(CommandId::new("search"), CancelPolicy::KeepInFlight)
+            .scoped("pane-a")
+            .into_runtime_parts(),
+        );
+        timeout(Duration::from_secs(1), pane_a_started_rx)
+            .await
+            .expect("pane-a command should start before the timeout")
+            .expect("pane-a command should signal that it started");
+
+        // Same local id ("search") under pane-b, also `KeepInFlight`. If
+        // scoping failed and both aliased to one slot, pane-a's occupancy
+        // would silently discard this stream instead of delivering it.
+        runtime.core.enqueue_command(
+            Command::stream(iter([TestMessage::Increment]))
+                .cancellable_with(CommandId::new("search"), CancelPolicy::KeepInFlight)
+                .scoped("pane-b")
+                .into_runtime_parts(),
+        );
+
+        let pane_b = scoped_local_id("search", "pane-b");
+        wait_until(
+            || runtime.core.app_inputs.has_closed_buffered(&pane_b),
+            "pane-b's stream must deliver instead of being suppressed by pane-a's occupancy",
+        )
+        .await;
+
+        assert!(
+            !pane_a_dropped.load(Ordering::SeqCst),
+            "pane-a's in-flight command must not be cancelled by pane-b"
+        );
+
+        runtime.core.shutdown();
+    }
+
     #[tokio::test]
     async fn live_keyed_quit_exits_the_runtime() -> Result<()> {
         struct KeyedQuitApp;

--- a/src/structural_key.rs
+++ b/src/structural_key.rs
@@ -4,6 +4,7 @@
 //! letting each ID apply the namespace rules required by its lifecycle model.
 
 use std::any::{Any, TypeId, type_name};
+use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -15,6 +16,15 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct StructuralKey {
     inner: Arc<dyn ErasedStructuralKey>,
+}
+
+impl fmt::Debug for StructuralKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("StructuralKey")
+            .field("type", &self.type_name())
+            .finish_non_exhaustive()
+    }
 }
 
 impl StructuralKey {
@@ -65,6 +75,46 @@ impl Hash for StructuralKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.type_id().hash(state);
         self.hash_value(state);
+    }
+}
+
+/// An ordered sequence of structural composition-boundary segments.
+///
+/// This implements the scope path described in RFC 0005 section 2.3.
+/// Segments are recorded in call order (the order successive `scoped()`
+/// calls append them), which is a stable internal convention: comparing two
+/// paths only needs to agree with itself, not with any particular
+/// outermost-to-innermost display order. Path equality therefore compares
+/// segment count and each segment in order, so reversing two unequal
+/// segments changes identity while reversing two equal segments preserves
+/// it.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct ScopePath(Vec<StructuralKey>);
+
+impl ScopePath {
+    pub const fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Returns a new path with `scope` appended after this path's existing
+    /// segments, erasing it into a fresh [`StructuralKey`].
+    pub fn appended<Scope>(&self, scope: Scope) -> Self
+    where
+        Scope: Eq + Hash + Send + Sync + 'static,
+    {
+        self.appended_key(StructuralKey::new(scope))
+    }
+
+    /// Returns a new path with an already-erased `segment` appended.
+    ///
+    /// Lets a caller erase one scope value once and apply it to several ids
+    /// sharing one composition boundary (for example a command's spawn key
+    /// and every explicit cancel id), without requiring the scope type
+    /// itself to be `Clone`.
+    pub fn appended_key(&self, segment: StructuralKey) -> Self {
+        let mut segments = self.0.clone();
+        segments.push(segment);
+        Self(segments)
     }
 }
 
@@ -125,9 +175,9 @@ mod tests {
 
     #[test]
     fn equality_is_structural_and_type_sensitive() {
-        assert!(StructuralKey::new(7_u64) == StructuralKey::new(7_u64));
-        assert!(StructuralKey::new(7_u64) != StructuralKey::new(8_u64));
-        assert!(StructuralKey::new(7_u64) != StructuralKey::new(7_i64));
+        assert_eq!(StructuralKey::new(7_u64), StructuralKey::new(7_u64));
+        assert_ne!(StructuralKey::new(7_u64), StructuralKey::new(8_u64));
+        assert_ne!(StructuralKey::new(7_u64), StructuralKey::new(7_i64));
         assert!(!StructuralKey::new(7_u64).value_eq(&StructuralKey::new(7_i64)));
     }
 
@@ -146,7 +196,7 @@ mod tests {
         let second = StructuralKey::new(Collision(2));
 
         assert_eq!(hash(&first), hash(&second));
-        assert!(first != second);
+        assert_ne!(first, second);
     }
 
     #[test]
@@ -173,5 +223,79 @@ mod tests {
             hash_value(&StructuralKey::new(First)),
             hash_value(&StructuralKey::new(Second))
         );
+    }
+
+    fn hash_path(path: &ScopePath) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        path.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn empty_path_is_distinct_from_a_one_segment_path() {
+        let empty = ScopePath::empty();
+        let one = ScopePath::empty().appended(1_u64);
+
+        assert_ne!(empty, one);
+    }
+
+    #[test]
+    fn equal_segments_in_equal_order_are_equal() {
+        let first = ScopePath::empty().appended(1_u64).appended(2_u64);
+        let second = ScopePath::empty().appended(1_u64).appended(2_u64);
+
+        assert_eq!(first, second);
+        assert_eq!(hash_path(&first), hash_path(&second));
+    }
+
+    #[test]
+    fn reversing_two_unequal_segments_changes_identity() {
+        let forward = ScopePath::empty().appended(1_u64).appended(2_u64);
+        let backward = ScopePath::empty().appended(2_u64).appended(1_u64);
+
+        assert_ne!(forward, backward);
+    }
+
+    #[test]
+    fn reversing_two_equal_segments_preserves_identity() {
+        let forward = ScopePath::empty().appended(1_u64).appended(1_u64);
+        let backward = ScopePath::empty().appended(1_u64).appended(1_u64);
+
+        assert_eq!(forward, backward);
+    }
+
+    #[test]
+    fn segment_type_differences_affect_equality() {
+        let as_u64 = ScopePath::empty().appended(1_u64);
+        let as_i64 = ScopePath::empty().appended(1_i64);
+
+        assert_ne!(as_u64, as_i64);
+    }
+
+    #[test]
+    fn hash_collisions_do_not_make_unequal_paths_equal() {
+        #[derive(Eq, PartialEq)]
+        struct Collision(u8);
+
+        impl Hash for Collision {
+            fn hash<H: Hasher>(&self, state: &mut H) {
+                0_u8.hash(state);
+            }
+        }
+
+        let first = ScopePath::empty().appended(Collision(1));
+        let second = ScopePath::empty().appended(Collision(2));
+
+        assert_eq!(hash_path(&first), hash_path(&second));
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn appended_key_shares_one_erasure_across_paths() {
+        let segment = StructuralKey::new(7_u64);
+        let first = ScopePath::empty().appended_key(segment.clone());
+        let second = ScopePath::empty().appended_key(segment);
+
+        assert_eq!(first, second);
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -984,6 +984,60 @@ mod tests {
         );
     }
 
+    // RFC 0005 Phase B / section 6.4: "two unequal values of one scope type
+    // whose `Hash` implementation writes a constant value still start
+    // independent subscriptions." This exercises scope equality itself
+    // under collision, not just source/key collision as in
+    // `hash_colliding_subscriptions_start_and_map_independently` above.
+    #[tokio::test]
+    async fn same_local_id_with_hash_colliding_scopes_starts_two_independent_streams() -> Result<()>
+    {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+
+        manager.update(vec![
+            Subscription::new(ProbedCollidingSource::once(1, 10)).scoped(ManagerCollisionKey(1)),
+            Subscription::new(ProbedCollidingSource::once(1, 20)).scoped(ManagerCollisionKey(2)),
+        ]);
+
+        let first = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let second = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let messages = [first, second];
+
+        assert!(messages.contains(&Some(10)));
+        assert!(messages.contains(&Some(20)));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn removing_one_hash_colliding_scope_stops_only_its_own_stream() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+        let source = ProbedCollidingSource::pending(1);
+
+        manager.update(vec![
+            Subscription::new(source.clone()).scoped(ManagerCollisionKey(1)),
+            Subscription::new(source.clone()).scoped(ManagerCollisionKey(2)),
+        ]);
+        assert_eq!(source.probe.starts.load(Ordering::SeqCst), 2);
+
+        manager.update(vec![
+            Subscription::new(source.clone()).scoped(ManagerCollisionKey(2)),
+        ]);
+
+        wait_until(
+            || source.probe.drops.load(Ordering::SeqCst) == 1,
+            "removed hash-colliding scope's stream should be dropped after abort",
+        )
+        .await;
+        assert_eq!(
+            source.probe.starts.load(Ordering::SeqCst),
+            2,
+            "the remaining hash-colliding scope's stream must not be restarted"
+        );
+    }
+
     #[tokio::test]
     async fn test_subscription_manager_starts_new_subscriptions_in_input_order() {
         struct OrderedStart {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -935,6 +935,55 @@ mod tests {
         Ok(())
     }
 
+    // RFC 0005 Phase B: `Subscription::scoped` must make the same local
+    // source and key independent across composition boundaries, so two
+    // child instances that reuse one local id run as separate lifecycles.
+    #[tokio::test]
+    async fn same_local_id_in_two_scopes_starts_two_independent_streams() -> Result<()> {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+
+        manager.update(vec![
+            Subscription::new(ProbedCollidingSource::once(1, 10)).scoped("pane-a"),
+            Subscription::new(ProbedCollidingSource::once(1, 20)).scoped("pane-b"),
+        ]);
+
+        let first = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let second = timeout(Duration::from_millis(100), rx.recv()).await?;
+        let messages = [first, second];
+
+        assert!(messages.contains(&Some(10)));
+        assert!(messages.contains(&Some(20)));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn removing_one_pane_stops_only_its_scoped_stream() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut manager = SubscriptionManager::new(tx);
+        let source = ProbedCollidingSource::pending(1);
+
+        manager.update(vec![
+            Subscription::new(source.clone()).scoped("pane-a"),
+            Subscription::new(source.clone()).scoped("pane-b"),
+        ]);
+        assert_eq!(source.probe.starts.load(Ordering::SeqCst), 2);
+
+        manager.update(vec![Subscription::new(source.clone()).scoped("pane-b")]);
+
+        wait_until(
+            || source.probe.drops.load(Ordering::SeqCst) == 1,
+            "removed pane's scoped stream should be dropped after abort",
+        )
+        .await;
+        assert_eq!(
+            source.probe.starts.load(Ordering::SeqCst),
+            2,
+            "the remaining pane's stream must not be restarted"
+        );
+    }
+
     #[tokio::test]
     async fn test_subscription_manager_starts_new_subscriptions_in_input_order() {
         struct OrderedStart {

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -12,7 +12,7 @@ use std::panic::AssertUnwindSafe;
 
 use futures::{StreamExt, stream::BoxStream};
 
-use crate::structural_key::StructuralKey;
+use crate::structural_key::{ScopePath, StructuralKey};
 
 /// A subscription represents an ongoing source of messages.
 ///
@@ -101,6 +101,48 @@ impl<Msg: 'static> Subscription<Msg> {
             }),
         }
     }
+
+    /// Qualifies this subscription's identity with one structural scope
+    /// segment, expressing that this instance belongs to a distinct child
+    /// composition boundary (see RFC 0005 section 4.2).
+    ///
+    /// Chaining `scoped` calls nests segments in call order: the last call
+    /// becomes the outermost segment. Reversing the order of two unequal
+    /// scope values produces a different identity, so
+    /// `sub.scoped(a).scoped(b)` and `sub.scoped(b).scoped(a)` are distinct
+    /// subscriptions when `a != b`. `scoped` and [`Subscription::map`]
+    /// commute: applying them in either order around the same call produces
+    /// the same identity and output.
+    ///
+    /// Applying the same scope to two composed child instances that reuse
+    /// the same local source and key still aliases them; give each instance
+    /// its own scope value (for example a per-instance id) to keep them
+    /// independent.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::num::NonZeroU64;
+    /// use tears::Subscription;
+    /// use tears::subscription::time::Timer;
+    ///
+    /// enum Message {
+    ///     Tick(u32),
+    /// }
+    ///
+    /// let pane_id = 1;
+    /// let sub = Subscription::new(Timer::new(NonZeroU64::new(1000).expect("non-zero")))
+    ///     .map(move |_| Message::Tick(pane_id))
+    ///     .scoped(pane_id);
+    /// ```
+    #[must_use = "scoped returns a modified subscription and does not mutate in place"]
+    pub fn scoped<Scope>(mut self, scope: Scope) -> Self
+    where
+        Scope: Eq + Hash + Send + Sync + 'static,
+    {
+        self.id.scope = AssertUnwindSafe(self.id.scope.appended(scope));
+        self
+    }
 }
 
 impl<A: SubscriptionSource<Output = Msg> + 'static, Msg> From<A> for Subscription<Msg> {
@@ -174,6 +216,7 @@ pub struct SubscriptionId {
     pub(super) source_type_id: TypeId,
     source_type_name: &'static str,
     key: AssertUnwindSafe<StructuralKey>,
+    scope: AssertUnwindSafe<ScopePath>,
 }
 
 impl Clone for SubscriptionId {
@@ -182,6 +225,7 @@ impl Clone for SubscriptionId {
             source_type_id: self.source_type_id,
             source_type_name: self.source_type_name,
             key: AssertUnwindSafe(self.key.0.clone()),
+            scope: AssertUnwindSafe(self.scope.0.clone()),
         }
     }
 }
@@ -195,6 +239,7 @@ impl SubscriptionId {
             source_type_id: TypeId::of::<Source>(),
             source_type_name: type_name::<Source>(),
             key: AssertUnwindSafe(StructuralKey::new(key)),
+            scope: AssertUnwindSafe(ScopePath::empty()),
         }
     }
 }
@@ -213,7 +258,9 @@ impl PartialEq for SubscriptionId {
     fn eq(&self, other: &Self) -> bool {
         // One concrete source type has exactly one associated `Key` type, so
         // the source namespace already fixes the erased key type.
-        self.source_type_id == other.source_type_id && self.key.0.value_eq(&other.key.0)
+        self.source_type_id == other.source_type_id
+            && self.key.0.value_eq(&other.key.0)
+            && self.scope.0 == other.scope.0
     }
 }
 
@@ -225,6 +272,7 @@ impl Hash for SubscriptionId {
         // need a second type namespace in this identity.
         self.source_type_id.hash(state);
         self.key.0.hash_value(state);
+        self.scope.0.hash(state);
     }
 }
 
@@ -332,5 +380,112 @@ mod tests {
     fn subscription_id_preserves_marker_traits() {
         fn assert_traits<T: Send + Sync + UnwindSafe + RefUnwindSafe>() {}
         assert_traits::<SubscriptionId>();
+    }
+
+    #[test]
+    fn unscoped_tuple_local_key_does_not_alias_a_scoped_identity() {
+        struct TupleKeyedSource;
+
+        impl SubscriptionSource for TupleKeyedSource {
+            type Output = ();
+            type Key = (&'static str, u8);
+
+            fn stream(&self) -> BoxStream<'static, Self::Output> {
+                stream::empty().boxed()
+            }
+
+            fn key(&self) -> Self::Key {
+                ("pane-1", 1)
+            }
+        }
+
+        let tupled = Subscription::new(TupleKeyedSource).id;
+        let scoped = Subscription::new(SourceA(1)).scoped("pane-1").id;
+
+        assert_ne!(tupled, scoped);
+    }
+
+    #[test]
+    fn scoped_makes_independent_child_instances_distinct() {
+        let first = Subscription::new(SourceA(1)).scoped("pane-1").id;
+        let second = Subscription::new(SourceA(1)).scoped("pane-2").id;
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn scoped_with_equal_scope_and_local_key_is_equal() {
+        let first = Subscription::new(SourceA(1)).scoped("pane-1").id;
+        let second = Subscription::new(SourceA(1)).scoped("pane-1").id;
+
+        assert_eq!(first, second);
+        assert_eq!(hash(&first), hash(&second));
+    }
+
+    #[test]
+    fn scoped_differs_from_unscoped() {
+        let unscoped = Subscription::new(SourceA(1)).id;
+        let scoped = Subscription::new(SourceA(1)).scoped("pane-1").id;
+
+        assert_ne!(unscoped, scoped);
+    }
+
+    #[test]
+    fn scope_segment_type_differences_affect_equality() {
+        let as_str = Subscription::new(SourceA(1)).scoped("1").id;
+        let as_u32 = Subscription::new(SourceA(1)).scoped(1_u32).id;
+
+        assert_ne!(as_str, as_u32);
+    }
+
+    #[test]
+    fn reversing_two_unequal_scope_segments_changes_identity() {
+        let forward = Subscription::new(SourceA(1))
+            .scoped("inner")
+            .scoped("outer")
+            .id;
+        let backward = Subscription::new(SourceA(1))
+            .scoped("outer")
+            .scoped("inner")
+            .id;
+
+        assert_ne!(forward, backward);
+    }
+
+    #[test]
+    fn reversing_two_equal_scope_segments_preserves_identity() {
+        let forward = Subscription::new(SourceA(1))
+            .scoped("pane")
+            .scoped("pane")
+            .id;
+        let backward = Subscription::new(SourceA(1))
+            .scoped("pane")
+            .scoped("pane")
+            .id;
+
+        assert_eq!(forward, backward);
+    }
+
+    #[test]
+    fn map_and_scoped_placement_are_equivalent() {
+        let before = Subscription::new(SourceA(1))
+            .map(|()| 1)
+            .scoped("pane-1")
+            .id;
+        let after = Subscription::new(SourceA(1))
+            .scoped("pane-1")
+            .map(|()| 1)
+            .id;
+
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn scope_hash_collisions_do_not_make_scoped_ids_equal() {
+        let first = Subscription::new(SourceA(1)).scoped(Collision(1)).id;
+        let second = Subscription::new(SourceA(1)).scoped(Collision(2)).id;
+
+        assert_eq!(hash(&first), hash(&second));
+        assert_ne!(first, second);
     }
 }


### PR DESCRIPTION
## Summary

- Implements RFC 0005 Phase B: `Subscription::scoped` and `Command::scoped`, the composition-boundary operators that qualify a subscription's or command's lifecycle identity with one structural scope segment.
- `SubscriptionId` and `CommandId` each gain an ordered `ScopePath` alongside their existing structural key. Scope segments are order-sensitive and collision-safe (same guarantees as Phase A's structural key), and are stored in a field separate from the local key so a scoped identity can never be confused with a plain local key of matching shape.
- `Command::scoped` qualifies the keyed spawn id (if `cancellable`/`cancellable_with` was already called) and every explicit cancel id already present at its call boundary — it does not retroactively cover ids attached by a later modifier, consistent with RFC 0003's last-call-wins rule. `cancellable`/`cancellable_with` rustdoc documents both call orders with runnable examples.
- Additive change; unscoped subscriptions and commands keep their existing 0.10.0 behavior unchanged.

## Test plan

- [x] `cargo test --all-features` (341+ tests, including new structural, subscription-manager, and runtime-level scope-isolation tests)
- [x] Sanity check: temporarily neutered `Command::scoped` to confirm the new tests fail as expected, then restored the real implementation
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --test api_surface -- --ignored` (public API shape/reachability)
- [x] `cargo bench --bench subscription --features bench-internals -- --test` (new scoped steady-state case compiles and runs)
- [x] `cargo doc --all-features --no-deps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)