### PR TITLE
docs(rfc): add RFC 0007 draft — RuntimeConfig API and acceptance parameters

### DIFF
--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -195,24 +195,40 @@ one exception that the sizing rule below must stay consistent with RFC
 ### 3.1 Sizing rule and starting values
 
 The documented rule: a bounded channel's capacity buys burst absorption and
-costs worst-case latency — once the queue is full, a newly accepted
-message waits up to `capacity × per-message drain cost` before reaching
-`update`. Per-message drain cost is application-dependent and measurable
-(RFC 0006 §2: ~2.2µs/message at 2µs `update` cost, ~26µs/message at 25µs —
-drain time tracks `update` cost, which the application controls).
+costs queueing latency — once the queue is full, a newly accepted message
+waits roughly `capacity × per-message drain cost` before reaching
+`update`, where the drain cost is the *observed average* service time of
+the application's own loop, application-dependent and measurable (RFC 0006
+§2: ~2.2µs/message average at 2µs `update` cost, ~26µs/message at 25µs —
+drain time tracks `update` cost, which the application controls). The
+product is an estimate on the measured workload, not a worst-case bound:
+an average cannot bound the tail, and neither RFC 0006 nor this RFC
+defines a per-message worst-case service time to build a hard bound on.
+An application that needs one derives it from its own measured tail
+service time, not from this rule.
 
-Documented starting values, derived from the section 2 reference numbers:
+Documented starting values, each with its basis stated:
 
-- **`app_channel_capacity = 1024`.** Large enough that the in-capacity
-  regime never engages backpressure (`steady_200k` peaks at depth 400), and
-  small enough that a full queue adds at most ~27ms (~1.6 frame periods at
-  60 FPS) even at the harness's heavy 25µs `update` cost. Applications with
-  larger expected bursts scale up by the rule above; `burst_200k` shows the
-  cost of undersizing is producer wait, not loss.
-- **`keyed_channel_capacity = 16`.** Keyed outputs are per-command result
-  streams, low-rate by construction in the measured workloads
-  (`keyed_steady`); 16 bounds each command's buffer share of `m × capacity`
-  (RFC 0006 R1) while leaving headroom above the harness's probe cadence.
+- **`app_channel_capacity = 1024`.** Measurement-derived at both ends:
+  large enough that the in-capacity regime never engages backpressure
+  (`steady_200k` peaks at depth 400), and small enough that a full queue
+  adds ~27ms of estimated queueing latency (~1.6 frame periods at 60 FPS)
+  at the harness's observed average drain rate under its heavy 25µs
+  `update` cost — an estimate per the rule above, not an upper bound.
+  Applications with larger expected bursts scale up by the same rule;
+  `burst_200k` shows the cost of undersizing is producer wait, not loss.
+- **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
+  not measurement-derived: in the measured workloads a keyed channel never
+  buffers more than one message (`keyed_steady`'s probe fires every 25ms
+  and its observed worst-case delivery is 5.2ms), so those measurements
+  cannot distinguish 16 from 1, and the harness has no keyed-burst
+  scenario that would size the value. What 16 fixes is the trade read
+  from both sides: a command can emit a burst of up to 16 outputs without
+  awaiting the consumer, and the per-command share of the application's
+  `m × capacity` buffer total (RFC 0006 R1) is bounded at 16 messages.
+  Applications whose keyed commands emit larger bursts size up by that
+  same absorption-versus-memory reading; adding a keyed-burst harness
+  scenario, should field experience demand a measured basis, is additive.
 - **`batch_max_messages`: unset.** This resolves the default-value half of
   RFC 0006 open question 2 as delegated: no non-`None` value is
   recommended. F5 is the evidence — the 100µs time cap alone held the frame
@@ -293,9 +309,14 @@ batch_max_messages     = None
 
 ### 5.2 Bounded quit scenarios
 
-Bounded queue depth caps at `capacity + 1`, so the unbounded
+Two bounded depth quantities must not be conflated (RFC 0006 §5.1's
+depth-accounting note): shared-channel *occupancy* caps at
+`app_channel_capacity`, while the harness's *observed depth* (`produced -
+processed`, which counts the one in-flight message each blocked producer
+holds outside the channel) caps at `capacity + concurrent producers`.
+Either way, depth is capped near capacity, so the unbounded
 `quit_backlog_50k` / `quit_backlog_300k` rows have no bounded counterpart
-at their depths (RFC 0006 §5.1). Per the delegated obligation, the bounded
+at their ~50k/~300k depths. Per the delegated obligation, the bounded
 quit rows vary blocked-producer count and channel-full churn instead:
 
 | Scenario (bounded run) | What it varies | Definition | Trials | Criterion (RFC 0006 INV-L4) |
@@ -313,7 +334,11 @@ quit rows vary blocked-producer count and channel-full churn instead:
   scheduling artifact on the 10-core reference machine while remaining a
   realistic subscription count; the intent is to show quit→delivered does
   not scale with blocked-producer count, the bounded analogue of F6's
-  depth-independence.
+  depth-independence. Its depth accounting: channel occupancy stays
+  ≤ 1024, observed depth ≤ `1024 + 64` = 1088 (one in-flight message per
+  blocked producer). The row's criterion is quit latency, not depth, but
+  any depth it records is read against `capacity + producers`, never
+  `capacity + 1`.
 - Trial counts are RFC 0006's normative floor for INV-L4 (≥ 200 per
   acceptance scenario; 20 for the keyed control, matching its unbounded
   baseline row).
@@ -324,7 +349,8 @@ quit rows vary blocked-producer count and channel-full churn instead:
   `steady_200k`**: re-run under the §5.1 configuration with their RFC 0006
   §2 load parameters unchanged (rates, durations, `update`/`view` costs,
   probe cadence). Their criteria are RFC 0006 §5.1's cells verbatim; the
-  depth-accounting bound instantiates to `1024 + 1` for the
+  depth-accounting bound (`capacity + concurrent producers`, §5.2's
+  observed-depth quantity) instantiates to `1024 + 1` for these
   single-flood-producer rows.
 - **`keyed_isolation`**: 8 keyed channels are saturated (each holding
   16 messages with its next send pending — 128 buffered messages plus 8
@@ -337,28 +363,45 @@ quit rows vary blocked-producer count and channel-full churn instead:
 
 ## 6. CI smoke profile
 
-**Resolved: yes — a smoke profile of the harness runs in CI, gating on
-completion only.** RFC 0006 fixed that CI gates on no latency criterion;
-the open half was whether a latency-assertion-free profile runs at all. It
-does, because the alternative leaves the harness — now the carrier of every
-acceptance scenario — compiling and running only on the reference machine,
-where bit-rot is discovered at acceptance time.
+**Resolved: yes — CI runs a smoke profile of the harness, replacing the
+full-scenario run it performs today.** RFC 0006 fixed that CI gates on no
+latency criterion. CI already builds and runs the full harness on every
+push: `ci.yml`'s Benchmarks job runs `cargo test --bench runtime_load`,
+and the harness's custom `main` ignores `cargo test`'s filtering and
+executes its full scenarios (the job's own comment records this). The
+open question was therefore never *whether* the harness runs in CI but
+*which profile*: the full scenarios' wall time grows with every
+statistical row this RFC adds (200-trial quit runs, the bounded matrix
+re-runs) while their latency numbers gate nothing on a CI machine. The
+resolution: the Benchmarks job's `runtime_load` invocation switches to
+the smoke profile, and the full scenarios run only as deliberate
+acceptance or regression runs on the reference machine (§5). The job's
+`subscription` bench invocation is unchanged.
 
 - **Invocation**: a `--smoke` argument to the harness binary (which already
   takes scenario-name arguments), selecting reduced variants: `steady_20k`
   shortened to 0.5s, a 20k-message bounded burst under the §5.1
-  configuration, `quit_idle` and `quit_blocked_1` at 5 trials each.
-- **Assertions**: scenario completion and the harness's internal
-  consistency counters (every produced message processed or accounted for
-  at shutdown — the lossless claim's bookkeeping); no latency value is
-  compared against anything. A slow CI machine cannot fail the profile on
-  speed alone.
-- **CI placement**: a step in the existing `ci.yml` test job, invoked
-  through a `just` recipe (`just bench-smoke`) so the local and CI
-  invocations are identical.
+  configuration, `quit_idle` and `quit_blocked_1` at 5 trials each. CI
+  invokes it through a `just` recipe (`just bench-smoke`) in the existing
+  Benchmarks job, so the local and CI invocations are identical.
+- **Pass/fail**: two assertion classes, split by what the observation
+  point can actually distinguish. The draining scenarios (`steady_20k`,
+  the bounded burst) assert `produced == processed == the scenario's
+  scripted total` after the drain — every scripted message delivered —
+  which is what makes an illegal bounded-mode drop (RFC 0006 INV-L2)
+  observable: a silently dropped message leaves `processed` short of the
+  scripted total. The quit scenarios assert completion only: after a
+  quit, undelivered messages are legally discarded at shutdown (INV-L2's
+  shutdown carve-out), and at the harness's `produced - processed`
+  observation point a legal shutdown discard is indistinguishable from an
+  illegal drop — a lossless assertion there would either pass illegal
+  drops or fail legal discards — so the lossless gate lives on the
+  draining scenarios alone. No latency value is compared against
+  anything; a slow CI machine cannot fail the profile on speed.
 - **What it is not**: not an acceptance run, not a regression baseline, and
   its numbers are not recorded anywhere. It exists to prove the harness
-  still builds and its scenarios still terminate.
+  still builds and its scenarios still terminate, at a wall time that
+  stays viable as the scenario set grows.
 
 ## 7. Invariants
 
@@ -380,11 +423,16 @@ Enforcement classes follow the pre-review checklist's definitions
   set field and the unchanged others).
 - **INV-C3**: no `RuntimeConfig` construction or setter can produce an
   invalid configuration, and none returns a `Result` or panics on any
-  input. Structural at the type level: every capacity field is
+  input. Structural, at the signatures *and* the bodies — a signature
+  check alone admits a setter that panics on a chosen value while staying
+  infallible in its type. Signatures: every capacity field is
   `Option<NonZeroUsize>`, so the sole invalid value (zero) is
-  unrepresentable in the argument types, and the frame rate arrives as the
-  already-validated `FrameRate`; the check is that no fallible signature
-  exists on the type.
+  unrepresentable in the argument types, the frame rate arrives as the
+  already-validated `FrameRate`, and no fallible signature exists on the
+  type. Bodies: `new` and each setter is a plain field write — no
+  branching on the argument's value, no arithmetic, no
+  `panic!`/`assert!`/`unwrap` path — checked by review of the four
+  function bodies.
 - **INV-C4**: the public surface of `RuntimeConfig` consists of exactly the
   frame rate and the three RFC 0006 §4.1 controls — in particular, no
   restart-rate field (§4). Structural: review of the type's public items.

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -1,0 +1,418 @@
+# RFC 0007: RuntimeConfig public API and load-control acceptance parameters
+
+- Status: Draft
+- Target: sole remaining prerequisite of the RFC 0006 load-control
+  implementation PR (RFC 0006 sections 3.2, 6); implementation starts when
+  this RFC is Accepted
+- Scope: the public `RuntimeConfig` surface (type, construction, constructor
+  integration), the recommended-defaults documentation, the restart-rate
+  interaction position, the RFC 0006 section 5.1 bounded-run parameters,
+  and the CI smoke-profile decision
+- Feature flag: none
+- CHANGELOG: `Added` entries (`RuntimeConfig`, `Runtime::with_config`) land
+  at the load-control implementation release, not with this RFC
+- Amendments: none
+
+> **Decision scope.** This RFC fixes only what RFC 0006 delegated to it. The
+> load-control semantics themselves — what each control means, the
+> backpressure contract, every INV-L invariant — are RFC 0006's and are not
+> restated here; where this RFC names a control, RFC 0006's semantics are
+> incorporated by reference, so no clause of this RFC can amend them. If a
+> statement here and RFC 0006 disagree, RFC 0006 wins and the discrepancy is
+> a defect in this RFC.
+
+## Summary
+
+RFC 0006 fixed the direction of the load-control contract and resolved every
+open question except those it delegated to "the separate `RuntimeConfig`
+RFC": the public API shape, the recommended defaults, the restart-rate
+position (its open questions 1, 5, and the default-value half of 2), the
+section 5.1 bounded-run parameters, and the CI smoke-profile question. This
+RFC is that document. It decides:
+
+1. **Public API**: a `RuntimeConfig` struct carrying the frame rate and the
+   three load controls — private fields, `RuntimeConfig::new(frame_rate)`
+   as the sole constructor (no `Default`: the crate has no default frame
+   rate), three infallible consuming setters — consumed by
+   `Runtime::with_config(flags, config)`; `Runtime::new` is unchanged and
+   delegates to `with_config` with a load-control-unset configuration.
+2. **Recommended defaults**: documentation-only guidance — the runtime's
+   defaults stay unbounded (`None`); the documented starting point for
+   applications that opt in is `app_channel_capacity = 1024`,
+   `keyed_channel_capacity = 16`, `batch_max_messages` unset, derived from
+   the RFC 0006 section 2 measurements via a stated sizing rule.
+3. **Restart-rate control**: stays subscription-level; `RuntimeConfig`
+   carries no restart-rate field and reserves none.
+4. **Bounded acceptance-run parameters**: one configuration under test
+   (equal to the recommended starting point), the bounded quit scenarios
+   redefined around blocked-producer count and channel-full churn (1 and 64
+   blocked producers; churn covered by the bounded `quit_overload` re-run),
+   trial counts carried over from RFC 0006's normative conditions, and the
+   `keyed_isolation` saturation parameters (8 keys).
+5. **CI smoke profile**: yes — a reduced, latency-assertion-free harness
+   profile runs in CI and gates on completion only.
+
+## 1. Delegated obligations (inventory)
+
+The complete set of obligations RFC 0006 places on this RFC, each with the
+section that discharges it here:
+
+| Obligation | RFC 0006 source | Discharged in |
+| --- | --- | --- |
+| Public `RuntimeConfig` shape: constructor signature, field set, naming, construction/validation style | §3.2, §4.1 | §2 |
+| Recommended default capacity values (documentation; open question 1) | §6 OQ1 | §3 |
+| Documentation-guidance notes of §§4.5, 4.6, 4.7 land with that documentation | §6 OQ1 | §3.3 |
+| Whether a non-`None` `batch_max_messages` default is recommended (default-value half of open question 2) | §6 OQ2 | §3.2 |
+| Restart-rate-control interaction (open question 5) | §6 OQ5 | §4 |
+| Bounded-run configuration under test | §5.1 | §5.1 |
+| Bounded quit scenarios redefined around blocked-producer count and channel-full churn, not queue depth | §5.1 | §5.2 |
+| Backlog depths and trial counts of the statistical rows | §5.1 | §5.2, §5.3 |
+| CI smoke-profile decision | §5.1, §6 | §6 |
+
+No other clause of RFC 0006 is delegated here; in particular the semantics
+of the three controls (RFC 0006 §4.1, INV-L12) and every acceptance
+*criterion* (as opposed to the run *parameters* fixed here) stay in RFC
+0006.
+
+## 2. Public API
+
+### 2.1 Type and construction
+
+```rust
+/// Construction-time configuration for the runtime: the frame rate and
+/// the opt-in load controls (RFC 0006).
+///
+/// With the load controls unset, the configuration reproduces the
+/// unbounded delivery mode exactly (RFC 0006 INV-L6).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RuntimeConfig {
+    frame_rate: FrameRate,
+    app_channel_capacity: Option<NonZeroUsize>,
+    keyed_channel_capacity: Option<NonZeroUsize>,
+    batch_max_messages: Option<NonZeroUsize>,
+}
+
+impl RuntimeConfig {
+    pub fn new(frame_rate: FrameRate) -> Self;
+    pub fn app_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    pub fn keyed_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    pub fn batch_max_messages(self, max: NonZeroUsize) -> Self;
+}
+```
+
+- **Scope of the type**: `RuntimeConfig` is the runtime's construction-time
+  configuration, not a load-control namespace. The frame rate is, from the
+  caller's side, exactly a runtime setting — it already travels every
+  constructor call — so it lives in the type the name promises, and future
+  runtime knobs accrete here without growing `Runtime`'s constructor
+  signatures. RFC 0006's `with_config(flags, frame_rate, config)` was
+  explicitly an example ("for example", its §3.2), and its §4.1 delegates
+  regrouping to this RFC; the load-control semantics are untouched by the
+  grouping.
+- **Field set and names**: the frame rate plus exactly RFC 0006 §4.1's
+  three controls, under RFC 0006's working names, which this RFC adopts
+  unchanged. Adopting the working names keeps every cross-reference in RFC
+  0006 (INV-L1, INV-L3, INV-L6, INV-L12, §5.1) literal.
+- **Construction style**: `RuntimeConfig::new(frame_rate)` is the sole
+  constructor — it takes the one setting that has no meaningful default
+  and leaves the three load controls unset — followed by consuming setters
+  named after their fields, following the crate's existing combinator
+  convention (`Command::timeout`, `Command::cancellable` carry no `with_`
+  prefix). Each setter sets exactly its own field. There is deliberately
+  no `Default` impl: the crate has no default frame rate — `Runtime::new`
+  has always required an explicit, validated `FrameRate` — and inventing
+  one inside a `Default` would smuggle a policy value into a derive.
+  Should a default frame rate ever be adopted, adding `Default` then is
+  additive.
+- **Validation style**: none, by construction. Every capacity is
+  `NonZeroUsize`, so a zero capacity is unrepresentable, and the frame
+  rate arrives as the already-validated `FrameRate` type — validation
+  stays at `FrameRate::new`, whose validity condition is a range a
+  `NonZeroU32` cannot express. No `RuntimeConfig` constructor, setter, or
+  consuming call returns a `Result`.
+- **Fields are private**: literal construction and struct-update syntax are
+  unavailable outside the crate, so adding a field later is additive
+  without `#[non_exhaustive]`. No getters are provided initially; adding
+  them is additive.
+- **Derives**: `Copy` is included deliberately — `FrameRate` is `Copy` and
+  the load controls are word-sized options, and `Copy` keeps harness and
+  test code free of clones. Adding a non-`Copy` field later would require
+  removing the derive, which is a breaking change; that cost is accepted
+  and recorded here.
+
+### 2.2 Constructor integration
+
+```rust
+impl<App: Application> Runtime<App> {
+    pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self;   // unchanged
+    pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self;  // new
+}
+```
+
+- `Runtime::new` keeps its signature and semantics and is implemented as a
+  delegation to `Self::with_config(flags, RuntimeConfig::new(frame_rate))`.
+  The delegation is the structural seam RFC 0006's INV-L6 check goes
+  through: one code path constructs the channels, and the load-control-
+  unset configuration selects the unchanged unbounded construction within
+  it.
+- Each constructor takes the frame rate exactly once: `new` as a
+  parameter, `with_config` inside the config. Rejected shapes, recorded:
+  - `with_config(flags, frame_rate, config)` with a load-control-only
+    config (RFC 0006's example shape): leaves the frame rate outside a
+    type named `RuntimeConfig`, misnaming the type from the caller's
+    perspective, and fixes a third constructor parameter forever while
+    every future knob still lands in the config (§2.1's scope rationale).
+  - An optional `frame_rate` field with a defaulted value (e.g. 60 FPS):
+    introduces a default frame rate the crate deliberately does not have,
+    and makes the two constructors disagree on whether the frame rate is
+    explicit (§2.1's no-`Default` rationale).
+- No other constructor is added and no existing signature changes,
+  preserving RFC 0006 §3.2's additivity verdict, which requires only that
+  `Runtime::new` stay unchanged.
+
+### 2.3 Placement
+
+- Module: `src/runtime/config.rs` (`pub mod config` under `runtime`),
+  matching `runtime::frame_rate`.
+- Re-exports: `tears::RuntimeConfig` at the crate root and
+  `tears::prelude::RuntimeConfig`, matching `FrameRate`'s pattern.
+- The bench harness (`benches/runtime_load.rs`) constructs its bounded runs
+  through this public surface only; `bench-internals` gains no
+  config-related items.
+
+## 3. Recommended defaults (documentation)
+
+The runtime's own defaults are and remain unset (unbounded) for all three
+load controls — `RuntimeConfig::new` leaves them `None`, which is RFC
+0006's release-gate verdict (its §3.1) and INV-L6, not this section's
+subject. This section fixes the *documented
+recommendation* for applications that opt in. The recommendation is
+guidance, not contract: no invariant tests these values, and changing the
+recommendation later is a documentation change, not an amendment — with the
+one exception that the sizing rule below must stay consistent with RFC
+0006's measurements as long as it is published.
+
+### 3.1 Sizing rule and starting values
+
+The documented rule: a bounded channel's capacity buys burst absorption and
+costs worst-case latency — once the queue is full, a newly accepted
+message waits up to `capacity × per-message drain cost` before reaching
+`update`. Per-message drain cost is application-dependent and measurable
+(RFC 0006 §2: ~2.2µs/message at 2µs `update` cost, ~26µs/message at 25µs —
+drain time tracks `update` cost, which the application controls).
+
+Documented starting values, derived from the section 2 reference numbers:
+
+- **`app_channel_capacity = 1024`.** Large enough that the in-capacity
+  regime never engages backpressure (`steady_200k` peaks at depth 400), and
+  small enough that a full queue adds at most ~27ms (~1.6 frame periods at
+  60 FPS) even at the harness's heavy 25µs `update` cost. Applications with
+  larger expected bursts scale up by the rule above; `burst_200k` shows the
+  cost of undersizing is producer wait, not loss.
+- **`keyed_channel_capacity = 16`.** Keyed outputs are per-command result
+  streams, low-rate by construction in the measured workloads
+  (`keyed_steady`); 16 bounds each command's buffer share of `m × capacity`
+  (RFC 0006 R1) while leaving headroom above the harness's probe cadence.
+- **`batch_max_messages`: unset.** This resolves the default-value half of
+  RFC 0006 open question 2 as delegated: no non-`None` value is
+  recommended. F5 is the evidence — the 100µs time cap alone held the frame
+  branch at 60 FPS through every overload scenario — so the documentation
+  recommends the count cap only as a diagnostic knob, not as a default.
+
+### 3.2 Where the recommendation lives
+
+Rustdoc on `RuntimeConfig` and its three setters: the sizing rule on the
+type, each value recommendation on its setter. No separate guide document
+is added; crate-level docs link to the type.
+
+### 3.3 Guidance notes carried from RFC 0006
+
+The following documentation obligations from RFC 0006 land in the same
+rustdoc, as stated there:
+
+- The blocked-producer anti-pattern — a command spawned per processed
+  message converts message backlog into blocked-producer backlog under
+  bounded overload, which no channel capacity bounds; the producer gauges
+  make it visible (RFC 0006 §4.5).
+- Quit guidance — unkeyed `Command::quit()` for a prompt unconditional
+  quit; `.cancellable(id)` on a quit buys suppression at the cost of
+  waiting behind pending inputs under load (RFC 0006 §4.6).
+- Keyed-liveness guidance — keying buys cancellation at the cost of
+  deferral behind ready shared inputs; liveness-critical output belongs in
+  unkeyed commands, and keyed liveness under load comes from pacing hot
+  sources, not from bounded mode (RFC 0006 §4.7).
+
+## 4. Restart-rate control (RFC 0006 open question 5)
+
+**Resolved: restart-rate control does not consume the `RuntimeConfig`
+surface.** RFC 0006 already held the position that restart pacing is a
+subscription-level policy (a property of one subscription's source and
+lifecycle, like debounce/throttle — RFC 0006 §4.2's source-specific-policy
+class); this RFC confirms it for the surface question. `RuntimeConfig`
+carries no restart-rate field, reserves no name for one, and a future
+restart-rate feature is specified in its own RFC at the subscription layer.
+If that future RFC concludes a runtime-global knob is needed after all,
+adding a field here is mechanically additive (§2.1, private fields), but
+the contract decision to do so belongs to that RFC, not this one.
+
+## 5. Bounded acceptance-run parameters (RFC 0006 §5.1)
+
+These parameters make RFC 0006's bounded acceptance run reproducible and
+reviewer-checkable rather than implementer-chosen. The criteria each cell
+is measured against stay in RFC 0006 §5.1; every latency criterion is
+scoped to the RFC 0006 §2 reference machine (Apple M1 Max, 10 cores, rustc
+1.97.0), and CI gates on none of them — both rules are RFC 0006's and are
+restated here only for locality.
+
+### 5.1 Configuration under test
+
+One configuration is used for every bounded row:
+
+```text
+frame_rate             = 60 FPS (the RFC 0006 §2 harness target)
+app_channel_capacity   = 1024
+keyed_channel_capacity = 16
+batch_max_messages     = None
+```
+
+- The values equal the documented starting point (§3.1) deliberately: the
+  acceptance run then measures the configuration the documentation sends
+  new users to. RFC 0006 permits the test values to differ from the
+  recommended defaults; this RFC chooses not to differ. Both sets are fixed
+  here, before implementation, which is what the reproducibility rule
+  requires — the implementer chooses neither.
+- `batch_max_messages` stays `None` in the matrix because its contract is
+  INV-L12's, checked at the unit layer under the paused clock (RFC 0006
+  §§4.1, 5); a count cap in the acceptance run would change every row's
+  scheduling while verifying nothing INV-L12's tests do not already verify.
+- A second, smaller-capacity configuration is deliberately not added: the
+  admission-window behaviors a small capacity surfaces (RFC 0006 §4.6's
+  `capacity = 1` discussion) are legal in bounded mode at any capacity and
+  carry no acceptance criterion, so a second column would add runs without
+  adding a checkable cell.
+
+### 5.2 Bounded quit scenarios
+
+Bounded queue depth caps at `capacity + 1`, so the unbounded
+`quit_backlog_50k` / `quit_backlog_300k` rows have no bounded counterpart
+at their depths (RFC 0006 §5.1). Per the delegated obligation, the bounded
+quit rows vary blocked-producer count and channel-full churn instead:
+
+| Scenario (bounded run) | What it varies | Definition | Trials | Criterion (RFC 0006 INV-L4) |
+| --- | --- | --- | --- | --- |
+| `quit_idle` | baseline | unchanged from RFC 0006 §2 | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_1` | one blocked producer | one flood subscription holds the shared channel at capacity and is blocked in `send`; `update` returns `Command::quit()` while the channel is full | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` on the full shared channel at quit | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): every pull's freed slot is immediately refilled, so the channel oscillates at capacity — the churn case | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription holds the shared channel at capacity while a keyed command's stream emits `Action::Quit` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
+
+- The unbounded `quit_*` rows themselves (including `quit_backlog_50k` /
+  `quit_backlog_300k`) are unchanged and stay the unbounded-mode acceptance
+  scenarios; this table defines only the bounded re-run.
+- `quit_blocked_64`'s producer count: 64 exceeds any plausible per-core
+  scheduling artifact on the 10-core reference machine while remaining a
+  realistic subscription count; the intent is to show quit→delivered does
+  not scale with blocked-producer count, the bounded analogue of F6's
+  depth-independence.
+- Trial counts are RFC 0006's normative floor for INV-L4 (≥ 200 per
+  acceptance scenario; 20 for the keyed control, matching its unbounded
+  baseline row).
+
+### 5.3 Remaining bounded rows
+
+- **`overload`, `burst_200k`, `keyed_overload`, `steady_20k`,
+  `steady_200k`**: re-run under the §5.1 configuration with their RFC 0006
+  §2 load parameters unchanged (rates, durations, `update`/`view` costs,
+  probe cadence). Their criteria are RFC 0006 §5.1's cells verbatim; the
+  depth-accounting bound instantiates to `1024 + 1` for the
+  single-flood-producer rows.
+- **`keyed_isolation`**: 8 keyed channels are saturated (each holding
+  16 messages with its next send pending — 128 buffered messages plus 8
+  pending sends, exceeding any modest hypothetical pool), with the two
+  probes exactly as RFC 0006 §5.1's row defines them (a previously idle
+  key's first 16 sends, and the shared producer's first 1024 sends). Eight
+  saturated keys is the scale chosen to defeat a pooled implementation
+  sized near per-channel capacity while keeping the scenario cheap enough
+  for the smoke profile's build check (§6).
+
+## 6. CI smoke profile
+
+**Resolved: yes — a smoke profile of the harness runs in CI, gating on
+completion only.** RFC 0006 fixed that CI gates on no latency criterion;
+the open half was whether a latency-assertion-free profile runs at all. It
+does, because the alternative leaves the harness — now the carrier of every
+acceptance scenario — compiling and running only on the reference machine,
+where bit-rot is discovered at acceptance time.
+
+- **Invocation**: a `--smoke` argument to the harness binary (which already
+  takes scenario-name arguments), selecting reduced variants: `steady_20k`
+  shortened to 0.5s, a 20k-message bounded burst under the §5.1
+  configuration, `quit_idle` and `quit_blocked_1` at 5 trials each.
+- **Assertions**: scenario completion and the harness's internal
+  consistency counters (every produced message processed or accounted for
+  at shutdown — the lossless claim's bookkeeping); no latency value is
+  compared against anything. A slow CI machine cannot fail the profile on
+  speed alone.
+- **CI placement**: a step in the existing `ci.yml` test job, invoked
+  through a `just` recipe (`just bench-smoke`) so the local and CI
+  invocations are identical.
+- **What it is not**: not an acceptance run, not a regression baseline, and
+  its numbers are not recorded anywhere. It exists to prove the harness
+  still builds and its scenarios still terminate.
+
+## 7. Invariants
+
+Enforcement classes follow the pre-review checklist's definitions
+(structural / behavioral / statistical).
+
+- **INV-C1**: `Runtime::new(flags, frame_rate)` is
+  `Runtime::with_config(flags, RuntimeConfig::new(frame_rate))` — a
+  literal delegation, so exactly one construction path exists and the
+  load-control-unset configuration selects RFC 0006's unchanged unbounded
+  path within it. Structural: review of `Runtime::new`'s body and of the
+  single channel-construction site `with_config` reaches; this is the seam
+  RFC 0006's INV-L6 structural check goes through, and a second parallel
+  construction path is the violation to look for.
+- **INV-C2**: `RuntimeConfig::new(frame_rate)` carries the given frame
+  rate and leaves all three load controls unset, and each setter sets
+  exactly its own field and no other. Behavioral: unit tests on
+  `RuntimeConfig` (constructed state, one test per setter asserting the
+  set field and the unchanged others).
+- **INV-C3**: no `RuntimeConfig` construction or setter can produce an
+  invalid configuration, and none returns a `Result` or panics on any
+  input. Structural at the type level: every capacity field is
+  `Option<NonZeroUsize>`, so the sole invalid value (zero) is
+  unrepresentable in the argument types, and the frame rate arrives as the
+  already-validated `FrameRate`; the check is that no fallible signature
+  exists on the type.
+- **INV-C4**: the public surface of `RuntimeConfig` consists of exactly the
+  frame rate and the three RFC 0006 §4.1 controls — in particular, no
+  restart-rate field (§4). Structural: review of the type's public items.
+  The existing `api_surface` test does not check this (it enforces the
+  single-canonical-path and prelude-membership rules, not a surface
+  snapshot); it applies to this RFC only in that the §2.3 re-exports must
+  satisfy those two rules.
+
+Surface–invariant coverage: the struct and `RuntimeConfig::new` map to
+INV-C2/C3, each setter to INV-C2/C3/C4, `with_config` and the unchanged
+`new` to INV-C1. The frame rate's runtime semantics are `FrameRate`'s,
+unchanged by relocation; the load controls' runtime *semantics* are
+covered by RFC 0006's invariants (INV-L1, INV-L3, INV-L6, INV-L12), not
+duplicated here.
+
+## 8. Open questions
+
+None. This RFC exists to close RFC 0006's delegated questions; leaving one
+open would re-create the gate it removes. Matters deliberately left out —
+future getters, a possible aggregate capacity-wait event, restart-rate
+control's own design — are recorded above as additive follow-ups or
+explicitly assigned to future RFCs, with no implementation work waiting on
+them.
+
+## 9. References
+
+- RFC 0006 — runtime load control: the delegating document; §§3.2, 4.1, 5,
+  5.1, 6 name the obligations discharged here.
+- `benches/runtime_load.rs` — the harness every §5 parameter configures.
+- `docs/rfcs/pre-review-checklist.md` — enforcement-class definitions used
+  in §7.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -24,3 +24,4 @@ one or the other explicitly.
 | [0004](0004-command-timeout-retry.md) | Command timeout and retry |
 | [0005](0005-structural-lifecycle-identity.md) | Structural lifecycle identity and composition scope |
 | [0006](0006-runtime-load-control.md) | Runtime load control, backpressure, latency guarantees |
+| [0007](0007-runtime-config.md) | RuntimeConfig public API, load-control acceptance parameters |

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -158,6 +158,25 @@ for delivery-FIFO and quit precedence, but RFC 0003's INV-9 defines only
 post-dispatch suppression and INV-14 only same-pull-point ordering — the
 properties had to be pinned as new invariants with their own checks.
 
+Measurement citations are code claims too, and they prove only what they
+measured. Two classes from PR #220:
+
+- An observed average or p50 supports an estimate, never an *at most*.
+  Deriving a worst-case bound as `n × average cost` is invalid — the
+  tail is unbounded by the mean — so either present the product as an
+  estimate on the measured workload, or define and measure the
+  worst-case service time the bound actually needs. (From PR #220: a
+  capacity recommendation claimed "adds at most ~27ms" from the
+  harness's average drain rate.)
+- A value presented as measurement-driven cites a measurement that can
+  *distinguish* the chosen value from the alternatives it rejects; a
+  workload indifferent between the candidates sizes nothing. Either add
+  the discriminating measurement, or state the value as a convention
+  with its trade-off spelled out — not as measurement-derived. (From PR
+  #220: `keyed_channel_capacity = 16` was justified by a scenario whose
+  25ms-cadence probe never buffers two messages and thus cannot
+  distinguish 16 from 1.)
+
 ## 5. Normative force and readiness
 
 An RFC or amendment that gates implementation carries no soft spots in


### PR DESCRIPTION
## Summary

RFC 0006 names "the separate `RuntimeConfig` RFC" as the sole remaining prerequisite of the load-control implementation PR (its §§3.2, 6). This draft is that document. It discharges every delegated obligation, enumerated as an inventory in §1 with the section that closes each one:

- **Public API (§2)** — `RuntimeConfig` is the runtime's construction-time configuration: it carries the frame rate plus RFC 0006 §4.1's three load controls under their working names. Private fields; `RuntimeConfig::new(frame_rate)` as the sole constructor (deliberately no `Default`: the crate has no default frame rate, and inventing one inside a derive would smuggle in a policy value); infallible consuming setters in the crate's combinator convention. `Runtime::with_config(flags, config)` consumes it; `Runtime::new` is unchanged and becomes a literal delegation — the structural seam INV-L6's check goes through. Rejected shapes (RFC 0006's three-argument example, an optional frame rate with a defaulted value) are recorded with reasons.
- **Recommended defaults, documentation only (§3; RFC 0006 OQ1 + the default half of OQ2)** — sizing rule (capacity × per-message drain cost) plus starting values `app = 1024`, `keyed = 16`, `batch_max_messages` unset, all derived from the RFC 0006 §2 measurements; lands as rustdoc together with the §§4.5–4.7 guidance notes.
- **Restart-rate control (§4; OQ5)** — stays subscription-level; `RuntimeConfig` carries no restart-rate field and reserves none.
- **Bounded acceptance-run parameters (§5)** — one configuration under test (equal to the documented starting point, fixed here before implementation); bounded quit scenarios redefined around blocked-producer count (`quit_blocked_1`, `quit_blocked_64`) and channel-full churn (bounded `quit_overload`) per the RFC 0006 review follow-up; trial counts carried from INV-L4's normative floor; `keyed_isolation` pinned at 8 saturated keys.
- **CI smoke profile (§6)** — adopted: a `--smoke` harness profile gating on completion and lossless bookkeeping only, no latency assertions, so a slow CI machine cannot fail it on speed.

INV-C1..C4 pin the surface with declared enforcement classes; the load-control semantics stay in RFC 0006 by reference, so this RFC cannot amend them.

## Pre-review checklist

Run per `docs/rfcs/pre-review-checklist.md`. Notable outcomes: one code-claim finding was caught and fixed before this PR (the `api_surface` test enforces canonical-path/prelude rules, not a surface snapshot — INV-C4's check is review-only and the text now says so); the §2 constructor-integration clause was re-derived from premises after review feedback moved the frame rate into the config type, and the checklist was re-applied to the rewritten section.

## Review focus

- §2.1's scope decision: the frame rate lives inside `RuntimeConfig` (a type named for runtime configuration should carry the runtime's settings); the alternative shapes and their rejection rationale are in §2.2.
- §5.1's choice to make the configuration under test equal to the documented starting point.
- §5.2's bounded quit scenario definitions and producer counts (1 / 64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)