### PR TITLE
docs(rfc): fix RFC 0007 full-run scoping, smoke rationale, and timeout claim

### DIFF
--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -50,7 +50,10 @@ RFC is that document. It decides:
    trial counts carried over from RFC 0006's normative conditions, and the
    `keyed_isolation` saturation parameters (8 keys).
 5. **CI smoke profile**: yes — a reduced, latency-assertion-free harness
-   profile runs in CI and gates on completion only.
+   profile runs in CI and gates on completion (within the harness's
+   wall-clock guards) and lossless drain delivery, never on a latency
+   percentile; full runs leave CI and any machine may run them, with
+   acceptance force reserved to the reference machine per RFC 0006.
 
 ## 1. Delegated obligations (inventory)
 
@@ -358,8 +361,12 @@ quit rows vary blocked-producer count and channel-full churn instead:
   probes exactly as RFC 0006 §5.1's row defines them (a previously idle
   key's first 16 sends, and the shared producer's first 1024 sends). Eight
   saturated keys is the scale chosen to defeat a pooled implementation
-  sized near per-channel capacity while keeping the scenario cheap enough
-  for the smoke profile's build check (§6).
+  sized near per-channel capacity while keeping the row cheap to execute
+  in the full acceptance and regression runs it belongs to.
+  `keyed_isolation` is not part of the §6 smoke profile: the smoke build
+  compiles it along with every other scenario in the one harness binary,
+  but never runs it, so the key count is an acceptance-run cost choice,
+  not a smoke constraint.
 
 ## 6. CI smoke profile
 
@@ -374,9 +381,12 @@ open question was therefore never *whether* the harness runs in CI but
 statistical row this RFC adds (200-trial quit runs, the bounded matrix
 re-runs) while their latency numbers gate nothing on a CI machine. The
 resolution: the Benchmarks job's `runtime_load` invocation switches to
-the smoke profile, and the full scenarios run only as deliberate
-acceptance or regression runs on the reference machine (§5). The job's
-`subscription` bench invocation is unchanged.
+the smoke profile, and the full scenarios leave CI: they run as
+deliberate acceptance or regression runs (§5), on any machine, with RFC
+0006 §5.1's scoping unchanged — a full run carries acceptance force only
+on the reference machine, and runs on other machines are
+regression-informative, never acceptance. The job's `subscription` bench
+invocation is unchanged.
 
 - **Invocation**: a `--smoke` argument to the harness binary (which already
   takes scenario-name arguments), selecting reduced variants: `steady_20k`
@@ -396,12 +406,27 @@ acceptance or regression runs on the reference machine (§5). The job's
   observation point a legal shutdown discard is indistinguishable from an
   illegal drop — a lossless assertion there would either pass illegal
   drops or fail legal discards — so the lossless gate lives on the
-  draining scenarios alone. No latency value is compared against
-  anything; a slow CI machine cannot fail the profile on speed.
+  draining scenarios alone. No latency percentile is compared against
+  anything — the profile carries no latency assertion. One wall-clock
+  condition remains: every smoke scenario carries the harness's
+  per-scenario completion guard (`max_wall` in `benches/runtime_load.rs`)
+  at 30 s — the existing `steady_20k` and `quit_idle` keep their current
+  value, and the new bounded burst and `quit_blocked_1` (§5.2) take the
+  same — and the smoke run fails when any scenario times out. That
+  timeout-failure rule is part of the profile's definition, not
+  something the harness fully provides today: quit trials already fail
+  the run on timeout, but a timed-out load scenario is currently
+  report-only, so the smoke implementation promotes it to a failure —
+  the lossless assertion alone does not cover it, because a run that
+  hangs after processing its last scripted message times out with
+  `processed` equal to the scripted total. The guard is the completion
+  gate itself: a machine slow enough to exceed it fails on
+  non-completion, never on a latency criterion.
 - **What it is not**: not an acceptance run, not a regression baseline, and
   its numbers are not recorded anywhere. It exists to prove the harness
-  still builds and its scenarios still terminate, at a wall time that
-  stays viable as the scenario set grows.
+  still builds (all scenarios compile in the one binary) and the smoke
+  scenarios still terminate, at a wall time that stays viable as the
+  scenario set grows.
 
 ## 7. Invariants
 

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -43,6 +43,19 @@ that includes the keyed control `quit_keyed_backlog_50k`, whose ~1.3s
 full-drain delivery is intended behavior — so the stated criterion could
 never pass.
 
+An execution profile is an inventory too. A claim that a scenario,
+test, or check is *part of* a profile — a CI job, a smoke selector, a
+feature-gated run — is checked by expanding the profile's actual member
+set (the selector's argument list, the job's invocation) and finding
+the named element in it. Being compiled is not being run: a scenario
+built into the binary a profile invokes is compiled under that profile
+without executing, so a rationale that needs the scenario to *run*
+cannot lean on a profile that merely builds it. *From PR #221:* eight
+`keyed_isolation` keys were justified as "cheap
+enough for the smoke profile's build check" while the `--smoke`
+selector's set never contained the scenario — and if the appeal was to
+compilation instead, key count never affected build cost at all.
+
 ## 2. Adversarial counterexample per invariant
 
 For each requirement and invariant, deliberately construct at least one
@@ -177,6 +190,20 @@ measured. Two classes from PR #220:
   25ms-cadence probe never buffers two messages and thus cannot
   distinguish 16 from 1.)
 
+Operational absolutes are code claims about a whole mechanism. A
+normative *only*, *never*, or *cannot fail* over a workflow, harness,
+or run profile is verified by enumerating every branch and every
+failure exit of the mechanism it quantifies over — timeout guards,
+exit-code paths, and abort conditions included, not only the assertions
+the sentence has in mind. And when the absolute restates another
+document's rule, it is checked against that rule's exact scope, which
+the restatement may silently narrow or widen. *From PR #221:* "a slow
+CI machine cannot fail the profile on speed" missed
+the harness's per-scenario `max_wall` timeout-failure exit, and "full
+scenarios run only on the reference machine" narrowed RFC 0006's
+scoping, which admits full runs on any machine and reserves only
+acceptance force to the reference machine.
+
 ## 5. Normative force and readiness
 
 An RFC or amendment that gates implementation carries no soft spots in
@@ -248,6 +275,19 @@ implementation passes, and a stale open-question description of a
 decision the same amendment had made — were introduced by first-round
 patch text and sit squarely in classes items 1, 2, and 7 already name.
 
+Make the re-check mechanical rather than remembered: for every
+review-fix commit, write out its changed-claims list — each claim the
+fix adds, strengthens, or rewords — and run items 1–5 on exactly that
+list as if it were new RFC text, before pushing. The list is the
+enforcement; without it the pass silently shrinks to the sentences the
+finding pointed at, and a small patch is precisely the patch whose
+re-check gets skipped. *From PR #221:* two of the three findings sat
+in claims PR #220's review-fix commit had added or reshaped
+— the reference-machine-exclusivity sentence, and the rewritten
+pass/fail derivation that carried "cannot fail on speed" into new
+surroundings — and both would have appeared on that commit's
+changed-claims list.
+
 ## 7. Mechanical pass
 
 - Cross-references: open-question numbers point at their resolutions;
@@ -265,5 +305,11 @@ patch text and sit squarely in classes items 1, 2, and 7 already name.
   question's resolution text, and the amendment header (from PR #215:
   open question 8 still described F6 as the input to a choice the same
   amendment had already made).
+- The PR title, body, and stated review focus match the final RFC text
+  after the last fix commit: a claim corrected during review is
+  corrected in the PR description too, and rationale or conclusions the
+  fixes removed from the RFC do not survive in the body. Re-read the
+  description at the end of each review round, not only when opening
+  the PR.
 - `typos` and `git diff --check` are clean.
 - English only (repository artifact).


### PR DESCRIPTION
## Summary

Addresses three P2 re-review findings on RFC 0007 (post-#220), and generalizes the pre-review checklist so each finding class is caught before review next time.

### RFC 0007 fixes

- **§6 full-run scoping**: the resolution no longer excludes non-reference-machine full runs. Full scenarios leave CI and run as deliberate acceptance or regression runs on any machine; per RFC 0006 §5.1's unchanged scoping, only reference-machine runs carry acceptance force and runs elsewhere are regression-informative. Summary item 5 updated to match.
- **§5.3 `keyed_isolation` rationale**: the 8-key scale is an acceptance-run cost choice, not a smoke constraint — the `--smoke` selector never runs the scenario (the smoke build compiles it along with every other scenario in the one harness binary), and key count does not affect build cost.
- **§6 smoke pass/fail**: "a slow CI machine cannot fail the profile on speed" narrowed to what actually holds — no latency percentile is asserted, but every smoke scenario keeps a 30 s `max_wall` completion guard and a timed-out scenario fails the run. Timeout-failure is stated as part of the profile's definition: quit trials already fail on timeout, load-scenario timeouts are promoted from report-only, and the lossless assertion alone cannot cover a run that hangs after processing its last scripted message.

### Checklist generalizations (per the living-document rule)

- **§1**: execution profiles are inventories — expand the selector's actual member set; being compiled is not being run.
- **§4**: operational absolutes (*only* / *never* / *cannot fail*) require enumerating every failure exit of the mechanism (timeout guards, exit-code paths, aborts) and checking restated rules against the source document's exact scope.
- **§6**: a mandatory changed-claims list per review-fix commit, re-checked under items 1–5 as if it were new RFC text.
- **§7**: PR title/body/review focus must match the final RFC text after the last fix commit.

Provenance was verified against git history: the reference-machine-exclusivity sentence was introduced and the pass/fail derivation reshaped by the first-round fix commit (21ea69e) — both would have appeared on a changed-claims list — while the `keyed_isolation` rationale was untouched draft text, caught instead by the new §1 profile-membership rule.

## Review focus

- §6 resolution paragraph and pass/fail bullet: does the narrowed wall-clock claim match the harness's actual failure exits (`max_wall`, quit-trial `failed_trials`)?
- Whether pinning all four smoke scenarios' `max_wall` at 30 s is the right level of specification for a non-acceptance CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)