### PR TITLE
Address RFC 0007 review feedback

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -69,7 +69,16 @@
   left to `tracing` filtering and any future aggregate event kept
   additive (section 4.4); and "active `CommandId`" in R1's `m` is
   defined as an entry existing in the keyed map, including a
-  finished-but-undrained run (section 1.2)
+  finished-but-undrained run (section 1.2). 2026-07-22 — cross-reference
+  fix (no contract change, RFC 0007 review follow-up): INV-L4's acceptance
+  conditions (section 5) and the section 5.1 matrix row both named
+  `quit_backlog_50k` / `quit_backlog_300k` as if those names applied
+  unchanged in bounded mode, which lagged the 2026-07-18 amendment above
+  redefining the bounded quit rows around blocked-producer count and
+  channel-full churn; both now state explicitly that the four names are
+  the unbounded scenario names and that the bounded rows the same
+  criterion applies to are the `RuntimeConfig` RFC's redefined ones, not
+  these names reused unchanged
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
@@ -1023,7 +1032,13 @@ To be finalized as contract tests before implementation:
   quit→delivered p99 ≤ 1 ms at every measured depth, in both
   delivery modes** — the unbounded default (already measured, section 2)
   and the bounded re-run of the section 5.1 matrix, where the same
-  criterion applies because the quit channel is never bounded (R4).
+  criterion applies because the quit channel is never bounded (R4). The
+  four names above are the unbounded scenario names; per this section's
+  own reproducibility rule (section 5.1), the bounded re-run does not
+  reuse `quit_backlog_50k` / `quit_backlog_300k` unchanged — the
+  `RuntimeConfig` RFC names and defines the bounded rows this same
+  criterion applies to, varying blocked-producer count and channel-full
+  churn instead of depth.
   `quit_keyed_backlog_50k` is outside these conditions: it is the keyed
   control — a keyed quit never enters the dedicated channel (sections
   4.2, 4.6) — and its full-drain latency is intended behavior, recorded
@@ -1251,7 +1266,7 @@ measurement rather than an implementation-time choice:
 | `overload` | update latency p99 | 7.9s, grows with overload duration (F3) | bounded by the drain time of one full queue plus admission wait (INV-L3, its producer-count premise given) |
 | `burst_200k` | peak backlog / drain | 193k peak, drains in 0.43s (F2) | backlog ≤ `capacity + 1` by the same depth accounting; producer waits instead; no message dropped (INV-L1, INV-L2) |
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | no latency criterion — open question 6 resolved: no fairness policy and no keyed-delivery bound under this contract (section 4.7); the bounded run is recorded as a measurement (deferral persists while shared stays ready, and admission-window deliveries are legal, section 4.6), with the unbounded baseline the regression reference for F4 |
-| `quit_idle`, `quit_backlog_50k`, `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.71ms at every measured depth, depth-independent (F6; section 2 table) | quit→delivered p99 ≤ 1 ms at every measured depth over ≥ 200 trials per scenario — INV-L4's resolved statistical conditions, same criterion as the unbounded default because the quit channel is never bounded (R4); the keyed control `quit_keyed_backlog_50k` is outside INV-L4 (next row) |
+| `quit_idle`, `quit_backlog_50k`, `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.71ms at every measured depth, depth-independent (F6; section 2 table) | quit→delivered p99 ≤ 1 ms at every measured depth over ≥ 200 trials per scenario — INV-L4's resolved statistical conditions, same criterion as the unbounded default because the quit channel is never bounded (R4); named here are the unbounded rows, and the bounded rows this criterion applies to are the `RuntimeConfig` RFC's redefined ones (blocked-producer count and channel-full churn, not the `quit_backlog_*` depths — reproducibility rules above), not these names reused unchanged; the keyed control `quit_keyed_backlog_50k` is outside INV-L4 (next row) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | no latency criterion — keyed quit stays in the private channel (open question 7, section 4.6), but that contract is routing and delivery order (INV-L10/INV-L11, checked structurally and at the unit layer), not a latency number: in bounded mode a compliant implementation may deliver the keyed quit while producer backlog remains, because a pull can leave the shared channel momentarily empty while the woken producer's next send is still in flight (at `capacity = 1`, after every pull) — delivering the buffered keyed quit then outruns no *ready* input. F7's full-drain p50 therefore stays a regression check for the **unbounded default only** (re-run unbounded: p50 ≈ full shared drain); the bounded run is recorded as a statistical measurement when the implementation lands, under the capacity, depth, and trial count the `RuntimeConfig` RFC pins (reproducibility rules above) |
 | `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency carries no bound, open question 6 resolved, section 4.7) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -39,10 +39,11 @@ RFC is that document. It decides:
 2. **Recommended defaults**: documentation-only guidance — the runtime's
    defaults stay unbounded (`None`); the documented starting point for
    applications that opt in is `app_channel_capacity = 1024` (a
-   measurement-informed margin choice bounded at both ends by the RFC 0006
-   section 2 measurements), `keyed_channel_capacity = 16` (a margin choice,
-   not measurement-derived), and `batch_max_messages` unset (evidenced by
-   F5), each basis stated in full in section 3.1.
+   measurement-informed margin choice: the RFC 0006 section 2 measurements
+   give a lower-bound signal and a latency estimate at that value, not a
+   uniquely pinned number), `keyed_channel_capacity = 16` (a margin
+   choice, not measurement-derived), and `batch_max_messages` unset
+   (evidenced by F5), each basis stated in full in section 3.1.
 3. **Restart-rate control**: stays subscription-level; `RuntimeConfig`
    carries no restart-rate field and reserves none.
 4. **Bounded acceptance-run parameters**: one configuration under test
@@ -249,8 +250,9 @@ Documented starting values, each with its basis stated:
   measurements rule out other values against — it is 1024's own cost, not
   evidence that a larger capacity would be wrong. 1024 is the round number
   chosen above the lower-bound signal, at a latency its own estimate shows
-  is small relative to a frame period; 512 or 2048 would be defensible on
-  the same measurements. Applications with larger expected bursts scale up
+  is a small number of frame periods (~1.6 at 60 FPS), not a large
+  multiple of one; 512 or 2048 would be defensible on the same
+  measurements. Applications with larger expected bursts scale up
   by the same rule; `burst_200k` shows the cost of undersizing is producer
   wait, not loss.
 - **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
@@ -353,15 +355,17 @@ holds outside the channel) caps at `capacity + concurrent producers`.
 Either way, depth is capped near capacity, so the unbounded
 `quit_backlog_50k` / `quit_backlog_300k` rows have no bounded counterpart
 at their ~50k/~300k depths. Per the delegated obligation, the bounded
-quit rows vary blocked-producer count and channel-full churn instead:
+quit rows vary blocked-producer count and channel-full churn instead —
+the independent variable is the blocked-producer *count*, not raw
+channel occupancy, per the note on that distinction below the table:
 
 | Scenario (bounded run) | What it varies | Definition | Valid-trial predicate (checked at the quit instant) | Trials | Criterion (RFC 0006 INV-L4) |
 | --- | --- | --- | --- | --- | --- |
-| `quit_idle` | baseline | unchanged from RFC 0006 §2 | none — no blocked-producer or channel-full precondition | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_blocked_1` | one blocked producer | one flood subscription holds the shared channel at capacity and is blocked in `send`; `update` returns `Command::quit()` while the channel is full | the RFC 0006 §4.4 producer gauge reads `blocked == 1` | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` on the full shared channel at quit | the producer gauge reads `blocked == 64` | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_idle` | baseline | unchanged from RFC 0006 §2 | none — no blocked-producer precondition | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_1` | one blocked producer | one flood subscription is blocked in `send`, awaiting capacity on the shared channel; `update` returns `Command::quit()` while it remains blocked | the RFC 0006 §4.4 producer gauge reads `blocked == 1` | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` awaiting capacity on the shared channel, at quit | the producer gauge reads `blocked == 64` | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case | at least one shared-channel capacity-wait event recorded in each of the four 5ms windows immediately preceding the quit instant (20ms total, chosen to be several orders of magnitude longer than the harness's ~26µs per-message drain rate under this scenario's 25µs `update` cost — RFC 0006 §2 — so a single momentary fill cannot satisfy it by chance) | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription holds the shared channel at capacity while a keyed command's stream emits `Action::Quit` | the producer gauge reads `blocked >= 1` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
+| `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription is blocked in `send`, awaiting capacity on the shared channel, while a keyed command's stream emits `Action::Quit` | the producer gauge reads `blocked >= 1` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
 
 - The unbounded `quit_*` rows themselves (including `quit_backlog_50k` /
   `quit_backlog_300k`) are unchanged and stay the unbounded-mode acceptance
@@ -402,14 +406,26 @@ quit rows vary blocked-producer count and channel-full churn instead:
   one instant does not by itself distinguish sustained churn from a
   momentary fill, which is why its predicate is stated over the
   four-window count above rather than a single `blocked` or occupancy
-  read. `quit_blocked_1`/`quit_blocked_64`'s `blocked` reading needs no
-  separate occupancy check alongside it: tokio's bounded `mpsc` blocks a
-  sender only when the channel holds no free permit, so `blocked >= 1` at
-  an instant is itself proof the channel was at `app_channel_capacity` at
-  that same instant — the two preconditions these rows name (channel-full,
-  blocked-producer count) collapse to the one gauge reading. The
-  acceptance run reports each row's count as that many *valid* trials,
-  not that many attempts.
+  read. `quit_blocked_1`/`quit_blocked_64`/`quit_keyed_bounded` name only
+  a blocked-producer count as their precondition, deliberately not raw
+  channel occupancy: a `blocked` reading does not by itself establish
+  that the shared channel held `app_channel_capacity` messages at the
+  same instant, because the admission window (RFC 0006 §4.6) applies here
+  too, not only across a barrier boundary. Once a pull frees a slot, that
+  slot is handed to a woken producer whose own send may still be
+  in-flight — RFC 0006 §4.4 lowers `blocked` for that producer only when
+  its send is accepted, so `blocked` can still read the pre-pull count
+  for an instant in which occupancy has already dropped to `capacity -
+  1`. A predicate strong enough to rule this out would need the harness's
+  depth accounting (`produced - processed`) alongside the gauge —
+  `blocked == N && produced - processed == app_channel_capacity + N` —
+  but these rows do not require it: their independent variable is the
+  blocked-producer count (the mechanism F4/F7 already establish as what
+  drives keyed starvation and quit deferral), not a claim about
+  instantaneous raw occupancy, so `blocked == N` (or `>= 1` for
+  `quit_keyed_bounded`) is the whole predicate. The acceptance run
+  reports each row's count as that many *valid* trials, not that many
+  attempts.
 
 ### 5.3 Remaining bounded rows
 

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -38,9 +38,11 @@ RFC is that document. It decides:
    delegates to `with_config` with a load-control-unset configuration.
 2. **Recommended defaults**: documentation-only guidance — the runtime's
    defaults stay unbounded (`None`); the documented starting point for
-   applications that opt in is `app_channel_capacity = 1024`,
-   `keyed_channel_capacity = 16`, `batch_max_messages` unset, derived from
-   the RFC 0006 section 2 measurements via a stated sizing rule.
+   applications that opt in is `app_channel_capacity = 1024` (a
+   measurement-informed margin choice bounded at both ends by the RFC 0006
+   section 2 measurements), `keyed_channel_capacity = 16` (a margin choice,
+   not measurement-derived), and `batch_max_messages` unset (evidenced by
+   F5), each basis stated in full in section 3.1.
 3. **Restart-rate control**: stays subscription-level; `RuntimeConfig`
    carries no restart-rate field and reserves none.
 4. **Bounded acceptance-run parameters**: one configuration under test
@@ -65,7 +67,7 @@ section that discharges it here:
 | Public `RuntimeConfig` shape: constructor signature, field set, naming, construction/validation style | §3.2, §4.1 | §2 |
 | Recommended default capacity values (documentation; open question 1) | §6 OQ1 | §3 |
 | Documentation-guidance notes of §§4.5, 4.6, 4.7 land with that documentation | §6 OQ1 | §3.3 |
-| Whether a non-`None` `batch_max_messages` default is recommended (default-value half of open question 2) | §6 OQ2 | §3.2 |
+| Whether a non-`None` `batch_max_messages` default is recommended (default-value half of open question 2) | §6 OQ2 | §3.1 |
 | Restart-rate-control interaction (open question 5) | §6 OQ5 | §4 |
 | Bounded-run configuration under test | §5.1 | §5.1 |
 | Bounded quit scenarios redefined around blocked-producer count and channel-full churn, not queue depth | §5.1 | §5.2 |
@@ -96,9 +98,13 @@ pub struct RuntimeConfig {
 }
 
 impl RuntimeConfig {
+    #[must_use]
     pub fn new(frame_rate: FrameRate) -> Self;
+    #[must_use = "app_channel_capacity returns a modified config and does not mutate in place"]
     pub fn app_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    #[must_use = "keyed_channel_capacity returns a modified config and does not mutate in place"]
     pub fn keyed_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    #[must_use = "batch_max_messages returns a modified config and does not mutate in place"]
     pub fn batch_max_messages(self, max: NonZeroUsize) -> Self;
 }
 ```
@@ -127,6 +133,18 @@ impl RuntimeConfig {
   one inside a `Default` would smuggle a policy value into a derive.
   Should a default frame rate ever be adopted, adding `Default` then is
   additive.
+- **Consuming-call misuse guard**: `RuntimeConfig` is `Copy`, so a
+  consuming setter call whose return value is discarded compiles silently
+  and leaves the original, unmodified value in play — the caller's
+  in-hand `config` is untouched, and a chained
+  `Runtime::with_config(flags, config)` after a discarded setter call
+  silently uses an unbounded (or otherwise unintended) configuration.
+  `new` and every setter therefore carry `#[must_use]`, each setter with
+  an explanatory message, matching the crate's existing consuming-modifier
+  convention (`RetryPolicy::with_backoff`, `RetryPolicy::with_fixed_backoff`
+  — `src/command/retry.rs`); `Runtime::with_config` carries `#[must_use]`
+  too, matching `Runtime::new`'s existing attribute. Pinned as INV-C6
+  (§7).
 - **Validation style**: none, by construction. Every capacity is
   `NonZeroUsize`, so a zero capacity is unrepresentable, and the frame
   rate arrives as the already-validated `FrameRate` type — validation
@@ -148,6 +166,7 @@ impl RuntimeConfig {
 ```rust
 impl<App: Application> Runtime<App> {
     pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self;   // unchanged
+    #[must_use]
     pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self;  // new
 }
 ```
@@ -158,6 +177,12 @@ impl<App: Application> Runtime<App> {
   through: one code path constructs the channels, and the load-control-
   unset configuration selects the unchanged unbounded construction within
   it.
+- `with_config` builds the `FrameScheduler` from `config.frame_rate` at
+  that single construction site — the delegation above only relocates
+  where the frame rate is supplied from (a parameter to a config field);
+  it does not by itself guarantee the value flows through to the
+  scheduler. Pinned as INV-C5 (§7): a config carrying one frame rate must
+  not silently produce a scheduler paced at another.
 - Each constructor takes the frame rate exactly once: `new` as a
   parameter, `with_config` inside the config. Rejected shapes, recorded:
   - `with_config(flags, frame_rate, config)` with a load-control-only
@@ -212,12 +237,15 @@ service time, not from this rule.
 
 Documented starting values, each with its basis stated:
 
-- **`app_channel_capacity = 1024`.** Measurement-derived at both ends:
-  large enough that the in-capacity regime never engages backpressure
-  (`steady_200k` peaks at depth 400), and small enough that a full queue
-  adds ~27ms of estimated queueing latency (~1.6 frame periods at 60 FPS)
-  at the harness's observed average drain rate under its heavy 25µs
-  `update` cost — an estimate per the rule above, not an upper bound.
+- **`app_channel_capacity = 1024`.** A measurement-informed margin choice,
+  not a value the measurements pin uniquely: the harness bounds the choice
+  at both ends — large enough that the in-capacity regime never engages
+  backpressure (`steady_200k` peaks at depth 400), and small enough that a
+  full queue adds ~27ms of estimated queueing latency (~1.6 frame periods
+  at 60 FPS) at the harness's observed average drain rate under its heavy
+  25µs `update` cost (an estimate per the rule above, not an upper bound)
+  — but neither bound distinguishes 1024 from other values in the same
+  range (512, 2048); 1024 is the round number chosen within it.
   Applications with larger expected bursts scale up by the same rule;
   `burst_200k` shows the cost of undersizing is producer wait, not loss.
 - **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
@@ -327,7 +355,7 @@ quit rows vary blocked-producer count and channel-full churn instead:
 | `quit_idle` | baseline | unchanged from RFC 0006 §2 | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_blocked_1` | one blocked producer | one flood subscription holds the shared channel at capacity and is blocked in `send`; `update` returns `Command::quit()` while the channel is full | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` on the full shared channel at quit | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): every pull's freed slot is immediately refilled, so the channel oscillates at capacity — the churn case | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case, confirmed per-trial via the capacity-wait events below, not assumed from the configured rate | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription holds the shared channel at capacity while a keyed command's stream emits `Action::Quit` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
 
 - The unbounded `quit_*` rows themselves (including `quit_backlog_50k` /
@@ -345,6 +373,20 @@ quit rows vary blocked-producer count and channel-full churn instead:
 - Trial counts are RFC 0006's normative floor for INV-L4 (≥ 200 per
   acceptance scenario; 20 for the keyed control, matching its unbounded
   baseline row).
+- Each row's stated precondition (the blocked-producer count for
+  `quit_blocked_1`/`quit_blocked_64`, the channel-full churn for
+  `quit_overload`) is part of the scenario's definition, not merely
+  descriptive, and a trial does not count toward its 200 unless the
+  precondition held at the instant `update` returns `Command::quit()`.
+  This is an acceptance-run implementation obligation, checked against
+  the RFC 0006 §4.4 producer gauges (`blocked`) and capacity-wait events
+  already defined for this purpose — by either (a) a barrier that
+  structurally guarantees the stated blocked count before the quit is
+  issued, or (b) recording the observed `blocked` value (and, for
+  `quit_overload`, the observed capacity-wait pattern) at the quit
+  instant and excluding non-matching trials from the reported count.
+  Either satisfies this obligation; the acceptance run reports 200 valid
+  trials per scenario, not 200 attempts.
 
 ### 5.3 Remaining bounded rows
 
@@ -465,13 +507,32 @@ Enforcement classes follow the pre-review checklist's definitions
   single-canonical-path and prelude-membership rules, not a surface
   snapshot); it applies to this RFC only in that the §2.3 re-exports must
   satisfy those two rules.
+- **INV-C5**: `with_config` constructs its `FrameScheduler` from
+  `config.frame_rate` — the frame rate that reaches the scheduler is
+  exactly the value the caller supplied to `RuntimeConfig::new`, never a
+  hardcoded or unrelated one. Structural: review of the single
+  scheduler-construction site `with_config` reaches, confirming the
+  `FrameScheduler::new` call reads `config.frame_rate`. Behavioral: an
+  integration test constructs runtimes via `with_config` at two different
+  frame rates (e.g. 30 FPS and 60 FPS) and asserts the resulting
+  frame-tick timing differs accordingly — a check INV-C1 and INV-C2 do
+  not provide on their own, since both hold for an implementation where
+  `RuntimeConfig` stores one frame rate while `with_config` builds a
+  scheduler from a different, fixed one.
+- **INV-C6**: `RuntimeConfig::new` and its three setters, plus
+  `Runtime::with_config`, carry `#[must_use]` — each `RuntimeConfig`
+  setter with an explanatory message — so a chained call that discards a
+  setter's return value is a compiler warning, not a silent no-op that
+  reaches `with_config` unmodified (§2.1's consuming-call misuse guard).
+  Structural: review of the five signatures for the attribute and, on
+  each `RuntimeConfig` setter, a non-empty message.
 
 Surface–invariant coverage: the struct and `RuntimeConfig::new` map to
-INV-C2/C3, each setter to INV-C2/C3/C4, `with_config` and the unchanged
-`new` to INV-C1. The frame rate's runtime semantics are `FrameRate`'s,
-unchanged by relocation; the load controls' runtime *semantics* are
-covered by RFC 0006's invariants (INV-L1, INV-L3, INV-L6, INV-L12), not
-duplicated here.
+INV-C2/C3/C6, each setter to INV-C2/C3/C4/C6, `with_config` and the
+unchanged `new` to INV-C1/C5/C6. The frame rate's runtime semantics are
+`FrameRate`'s, unchanged by relocation; the load controls' runtime
+*semantics* are covered by RFC 0006's invariants (INV-L1, INV-L3, INV-L6,
+INV-L12), not duplicated here.
 
 ## 8. Open questions
 

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -238,16 +238,21 @@ service time, not from this rule.
 Documented starting values, each with its basis stated:
 
 - **`app_channel_capacity = 1024`.** A measurement-informed margin choice,
-  not a value the measurements pin uniquely: the harness bounds the choice
-  at both ends — large enough that the in-capacity regime never engages
-  backpressure (`steady_200k` peaks at depth 400), and small enough that a
-  full queue adds ~27ms of estimated queueing latency (~1.6 frame periods
-  at 60 FPS) at the harness's observed average drain rate under its heavy
-  25µs `update` cost (an estimate per the rule above, not an upper bound)
-  — but neither bound distinguishes 1024 from other values in the same
-  range (512, 2048); 1024 is the round number chosen within it.
-  Applications with larger expected bursts scale up by the same rule;
-  `burst_200k` shows the cost of undersizing is producer wait, not loss.
+  not a value the measurements pin uniquely. The harness measurements give
+  a lower-bound signal — large enough that the in-capacity regime never
+  engages backpressure (`steady_200k` peaks at depth 400) — and a latency
+  estimate *at* 1024, not a demonstrated upper bound: a full queue at that
+  capacity adds ~27ms of estimated queueing latency (~1.6 frame periods at
+  60 FPS) at the harness's observed average drain rate under its heavy
+  25µs `update` cost (an estimate per the rule above, not an upper bound).
+  No stated maximum acceptable latency makes that figure a ceiling the
+  measurements rule out other values against — it is 1024's own cost, not
+  evidence that a larger capacity would be wrong. 1024 is the round number
+  chosen above the lower-bound signal, at a latency its own estimate shows
+  is small relative to a frame period; 512 or 2048 would be defensible on
+  the same measurements. Applications with larger expected bursts scale up
+  by the same rule; `burst_200k` shows the cost of undersizing is producer
+  wait, not loss.
 - **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
   not measurement-derived: in the measured workloads a keyed channel never
   buffers more than one message (`keyed_steady`'s probe fires every 25ms
@@ -350,13 +355,13 @@ Either way, depth is capped near capacity, so the unbounded
 at their ~50k/~300k depths. Per the delegated obligation, the bounded
 quit rows vary blocked-producer count and channel-full churn instead:
 
-| Scenario (bounded run) | What it varies | Definition | Trials | Criterion (RFC 0006 INV-L4) |
-| --- | --- | --- | --- | --- |
-| `quit_idle` | baseline | unchanged from RFC 0006 §2 | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_blocked_1` | one blocked producer | one flood subscription holds the shared channel at capacity and is blocked in `send`; `update` returns `Command::quit()` while the channel is full | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` on the full shared channel at quit | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case, confirmed per-trial via the capacity-wait events below, not assumed from the configured rate | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription holds the shared channel at capacity while a keyed command's stream emits `Action::Quit` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
+| Scenario (bounded run) | What it varies | Definition | Valid-trial predicate (checked at the quit instant) | Trials | Criterion (RFC 0006 INV-L4) |
+| --- | --- | --- | --- | --- | --- |
+| `quit_idle` | baseline | unchanged from RFC 0006 §2 | none — no blocked-producer or channel-full precondition | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_1` | one blocked producer | one flood subscription holds the shared channel at capacity and is blocked in `send`; `update` returns `Command::quit()` while the channel is full | the RFC 0006 §4.4 producer gauge reads `blocked == 1` | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` on the full shared channel at quit | the producer gauge reads `blocked == 64` | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case | at least one shared-channel capacity-wait event recorded in each of the four 5ms windows immediately preceding the quit instant (20ms total, chosen to be several orders of magnitude longer than the harness's ~26µs per-message drain rate under this scenario's 25µs `update` cost — RFC 0006 §2 — so a single momentary fill cannot satisfy it by chance) | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription holds the shared channel at capacity while a keyed command's stream emits `Action::Quit` | the producer gauge reads `blocked >= 1` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
 
 - The unbounded `quit_*` rows themselves (including `quit_backlog_50k` /
   `quit_backlog_300k`) are unchanged and stay the unbounded-mode acceptance
@@ -372,21 +377,39 @@ quit rows vary blocked-producer count and channel-full churn instead:
   `capacity + 1`.
 - Trial counts are RFC 0006's normative floor for INV-L4 (≥ 200 per
   acceptance scenario; 20 for the keyed control, matching its unbounded
-  baseline row).
-- Each row's stated precondition (the blocked-producer count for
-  `quit_blocked_1`/`quit_blocked_64`, the channel-full churn for
-  `quit_overload`) is part of the scenario's definition, not merely
-  descriptive, and a trial does not count toward its 200 unless the
-  precondition held at the instant `update` returns `Command::quit()`.
-  This is an acceptance-run implementation obligation, checked against
-  the RFC 0006 §4.4 producer gauges (`blocked`) and capacity-wait events
-  already defined for this purpose — by either (a) a barrier that
-  structurally guarantees the stated blocked count before the quit is
-  issued, or (b) recording the observed `blocked` value (and, for
-  `quit_overload`, the observed capacity-wait pattern) at the quit
-  instant and excluding non-matching trials from the reported count.
-  Either satisfies this obligation; the acceptance run reports 200 valid
-  trials per scenario, not 200 attempts.
+  baseline row) — the per-row figures above are the same floor, restated
+  per row so no row is read against another's count.
+- Every row with a non-`none` valid-trial predicate is subject to the
+  same rule: a trial does not count toward the row's required trial count
+  unless its predicate holds at the instant `update` returns
+  `Command::quit()`, checked via the RFC 0006 §4.4 producer gauges
+  (`blocked`) and capacity-wait events — this applies to `quit_keyed_bounded`
+  and its 20 trials exactly as it does to the four 200-trial rows, not
+  only to the blocked-producer and churn rows named in earlier drafts of
+  this section. A barrier arranged before `update` returns
+  `Command::quit()` narrows the scheduling window a trial can land in,
+  but does not by itself guarantee the predicate holds at the quit
+  instant: RFC 0006 §4.6 already documents an admission window in which a
+  pull frees a slot that a woken producer has not yet refilled, so the
+  channel state (and with it the `blocked` count) can differ between "the
+  moment the barrier released" and "the moment `update` returns" a
+  scheduling step later. The predicate is therefore always checked by
+  observing the gauges/events at the quit instant itself — a barrier may
+  be used to make satisfying it likely, but never as a substitute for the
+  observation. `quit_overload`'s predicate is a windowed observation
+  rather than an instantaneous one because churn is a property of a time
+  interval, not a single instant: a channel observed full or non-full at
+  one instant does not by itself distinguish sustained churn from a
+  momentary fill, which is why its predicate is stated over the
+  four-window count above rather than a single `blocked` or occupancy
+  read. `quit_blocked_1`/`quit_blocked_64`'s `blocked` reading needs no
+  separate occupancy check alongside it: tokio's bounded `mpsc` blocks a
+  sender only when the channel holds no free permit, so `blocked >= 1` at
+  an instant is itself proof the channel was at `app_channel_capacity` at
+  that same instant — the two preconditions these rows name (channel-full,
+  blocked-producer count) collapse to the one gauge reading. The
+  acceptance run reports each row's count as that many *valid* trials,
+  not that many attempts.
 
 ### 5.3 Remaining bounded rows
 
@@ -512,11 +535,19 @@ Enforcement classes follow the pre-review checklist's definitions
   exactly the value the caller supplied to `RuntimeConfig::new`, never a
   hardcoded or unrelated one. Structural: review of the single
   scheduler-construction site `with_config` reaches, confirming the
-  `FrameScheduler::new` call reads `config.frame_rate`. Behavioral: an
-  integration test constructs runtimes via `with_config` at two different
-  frame rates (e.g. 30 FPS and 60 FPS) and asserts the resulting
-  frame-tick timing differs accordingly — a check INV-C1 and INV-C2 do
-  not provide on their own, since both hold for an implementation where
+  `FrameScheduler::new` call reads `config.frame_rate`. Behavioral, at the
+  runtime-module unit layer (not an integration test, and not measured
+  against wall-clock timing, which the existing
+  `test_runtime_frame_scheduler_period_is_accurate` (`src/runtime.rs`)
+  already establishes as the crate's pattern for this exact class of
+  claim): construct a `Runtime` via `with_config` at a given frame rate
+  and assert `runtime.scheduler.frame_period() ==
+  config_frame_rate.frame_duration()` for at least two distinct frame
+  rates (e.g. 30 and 144 FPS). This is a direct, deterministic value
+  comparison — no elapsed-time observation, no tolerance window, and
+  nothing for idle-wakeup elision or scheduler jitter to flake — and it
+  fails an implementation that ignores `config.frame_rate` in exactly the
+  way INV-C1 and INV-C2 cannot: both hold for an implementation where
   `RuntimeConfig` stores one frame rate while `with_config` builds a
   scheduler from a different, fixed one.
 - **INV-C6**: `RuntimeConfig::new` and its three setters, plus

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -364,7 +364,7 @@ channel occupancy, per the note on that distinction below the table:
 | `quit_idle` | baseline | unchanged from RFC 0006 §2 | none — no blocked-producer precondition | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_blocked_1` | one blocked producer | one flood subscription is blocked in `send`, awaiting capacity on the shared channel; `update` returns `Command::quit()` while it remains blocked | the RFC 0006 §4.4 producer gauge reads `blocked == 1` | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_blocked_64` | many blocked producers | 64 flood subscriptions, all blocked in `send` awaiting capacity on the shared channel, at quit | the producer gauge reads `blocked == 64` | 200 | quit→delivered p99 ≤ 1 ms |
-| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case | at least one shared-channel capacity-wait event recorded in each of the four 5ms windows immediately preceding the quit instant (20ms total, chosen to be several orders of magnitude longer than the harness's ~26µs per-message drain rate under this scenario's 25µs `update` cost — RFC 0006 §2 — so a single momentary fill cannot satisfy it by chance) | 200 | quit→delivered p99 ≤ 1 ms |
+| `quit_overload` | channel-full churn | unchanged from RFC 0006 §2 (producer at 100k/s): the producer rate is configured to exceed drain capacity, so the channel is intended to oscillate at or near capacity — the churn case | at least two shared-channel capacity-wait events recorded in the 5ms window immediately preceding the quit instant | 200 | quit→delivered p99 ≤ 1 ms |
 | `quit_keyed_bounded` | keyed control | the RFC 0006 §2 keyed-quit trial under the §5.1 configuration: a flood subscription is blocked in `send`, awaiting capacity on the shared channel, while a keyed command's stream emits `Action::Quit` | the producer gauge reads `blocked >= 1` | 20 | none — measurement recorded, no acceptance bound (RFC 0006 §§4.6, 5.1) |
 
 - The unbounded `quit_*` rows themselves (including `quit_backlog_50k` /
@@ -400,13 +400,18 @@ channel occupancy, per the note on that distinction below the table:
   scheduling step later. The predicate is therefore always checked by
   observing the gauges/events at the quit instant itself — a barrier may
   be used to make satisfying it likely, but never as a substitute for the
-  observation. `quit_overload`'s predicate is a windowed observation
-  rather than an instantaneous one because churn is a property of a time
-  interval, not a single instant: a channel observed full or non-full at
-  one instant does not by itself distinguish sustained churn from a
-  momentary fill, which is why its predicate is stated over the
-  four-window count above rather than a single `blocked` or occupancy
-  read. `quit_blocked_1`/`quit_blocked_64`/`quit_keyed_bounded` name only
+  observation. `quit_overload`'s predicate is a windowed count, not a
+  single reading, because churn is a property of a time interval, not an
+  instant: one capacity-wait event only shows the channel was full once,
+  which a momentary fill also produces, while a second event within the
+  same short window shows a producer's send was accepted into the slot
+  the first event's completion freed — the refilling that "oscillate at
+  capacity" names. Two is the minimum count that distinguishes the two
+  cases; the 5ms window is two orders of magnitude longer than the
+  harness's ~26µs per-message drain cost under this scenario's 25µs
+  `update` cost (RFC 0006 §2), long enough to contain both events without
+  being so short that scheduling jitter could suppress the second one by
+  chance. `quit_blocked_1`/`quit_blocked_64`/`quit_keyed_bounded` name only
   a blocked-producer count as their precondition, deliberately not raw
   channel occupancy: a `blocked` reading does not by itself establish
   that the shared channel held `app_channel_capacity` messages at the


### PR DESCRIPTION
## Summary

Fixes to RFC 0007 (and one lagging cross-reference in RFC 0006) from two rounds of review feedback, after verifying each finding against the current text and code. Includes one self-correction: an earlier commit on this branch asserted `blocked >= 1` proves the shared channel was at capacity, which is false (see below) and has been fixed.

**RFC 0007 (`docs/rfcs/0007-runtime-config.md`)**

- **INV-C5 (new)**: pins that `with_config` must build its `FrameScheduler` from `config.frame_rate`, not a hardcoded value. INV-C1 (delegation) and INV-C2 (field-holding tests) alone would let an implementation store 30 FPS in the config while `with_config` always builds a 60 FPS scheduler. The behavioral check is a direct, deterministic value comparison (`runtime.scheduler.frame_period() == config_frame_rate.frame_duration()` at two distinct frame rates), matching the existing `test_runtime_frame_scheduler_period_is_accurate` (`src/runtime.rs`) pattern — not a wall-clock timing observation, which would have no defined tolerance and would be exposed to scheduler jitter.
- **INV-C6 (new)**: requires `#[must_use]` on `RuntimeConfig::new`, its three setters, and `Runtime::with_config`, matching `RetryPolicy`'s existing consuming-modifier convention (`src/command/retry.rs`). `RuntimeConfig` is `Copy`, so a discarded setter call today compiles silently and reaches `with_config` unmodified.
- §5.2: the bounded quit scenario table now has an explicit **valid-trial predicate** column, checked at the quit instant via the RFC 0006 §4.4 producer gauges and capacity-wait events — not assumed from setup. Two corrections went into this column after the first pass:
  - A barrier arranged before `update` returns `Command::quit()` narrows the scheduling window but cannot by itself guarantee the predicate at the quit instant, because RFC 0006 §4.6's admission window can unblock a producer between barrier release and `update` returning — so every predicate is checked by observation, always, never assumed from a barrier alone.
  - `quit_blocked_1`/`quit_blocked_64`/`quit_keyed_bounded` name only a blocked-producer count as their precondition, not raw channel occupancy: `blocked == N` does not by itself prove the channel held `app_channel_capacity` messages at that instant, since the same admission window lets `blocked` still read the pre-pull count for an instant in which occupancy has already dropped by one. Their Definition-column wording no longer claims the channel "is full"/"at capacity". `quit_overload`'s churn precondition is a windowed count (≥ 2 capacity-wait events in the 5ms preceding the quit instant — one event alone can't distinguish sustained churn from a momentary fill) rather than a single instantaneous reading.
- Corrected the delegated-obligations table's `batch_max_messages` cross-reference (§3.2 → §3.1, where the value and its rationale are actually decided).
- Reworded the Summary and the `app_channel_capacity` write-up: the RFC 0006 measurements give a lower-bound signal and a latency estimate *at* 1024, not a demonstrated upper bound — no stated maximum acceptable latency makes ~27ms a ceiling that rules out 512 or 2048 on the same data.

**RFC 0006 (`docs/rfcs/0006-runtime-load-control.md`)**

- Fixed INV-L4's acceptance-condition text and the §5.1 matrix row, both of which still named `quit_backlog_50k`/`quit_backlog_300k` as if unchanged in bounded mode — lagging the 2026-07-18 amendment that delegated redefining the bounded quit rows to the `RuntimeConfig` RFC. Both now state explicitly that those four names are the unbounded scenario names, and that the `RuntimeConfig` RFC's redefined bounded rows carry the same criterion.
- Recorded as a new Amendments entry (no contract change).

Two other review findings were considered and not applied as RFC changes: an earlier Blocker claiming RFC 0007 lacked authority to redefine the bounded quit scenarios was withdrawn once RFC 0006 §5.1's existing reproducibility rule (and its own 2026-07-18 amendment) turned out to already delegate this — fixed instead as the RFC 0006 cross-reference above; a finding about verifying bounded-scenario preconditions was resolved directly in §5.2's valid-trial predicate column rather than left as an implementation-time obligation.

Self-reviewed against `docs/rfcs/pre-review-checklist.md` before this update: fixed a stale-terminology issue (`drain rate` vs. the RFC's established `drain cost`) and an under-justified specific number (an earlier draft of the churn predicate required an event in each of 4 separate 5ms windows with no basis for "4"; replaced with "≥ 2 events in one 5ms window," which has a stated reason for the threshold and the window size).

## Test plan

- [ ] Docs-only change; no code or tests affected.
- [ ] Review that INV-C5/INV-C6 read consistently with §2.1/§2.2's prose and the surface–invariant coverage note.
- [ ] Review that the RFC 0006 amendment doesn't alter any normative criterion, only names which scenario set it applies to.
- [ ] Review that the §5.2 valid-trial predicates are each achievable by the RFC 0006 §4.4 gauges/events without inventing new observability surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)