### PR TITLE
docs(rfc): fix RFC 0007 second-round review findings

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -64,7 +64,8 @@
   bounded-run parameter obligations now include redefining the bounded
   `quit_backlog_*` scenarios around blocked-producer count and
   channel-full churn rather than queue depth, since bounded depth caps
-  at `capacity + 1` (section 5.1); the capacity-wait event's per-send
+  at `capacity + concurrent producers` (`capacity + 1` only for a single
+  producer; section 5.1); the capacity-wait event's per-send
   firing granularity is pinned as a deliberate choice, with aggregation
   left to `tracing` filtering and any future aggregate event kept
   additive (section 4.4); and "active `CommandId`" in R1's `m` is
@@ -78,7 +79,16 @@
   channel-full churn; both now state explicitly that the four names are
   the unbounded scenario names and that the bounded rows the same
   criterion applies to are the `RuntimeConfig` RFC's redefined ones, not
-  these names reused unchanged
+  these names reused unchanged. 2026-07-22 — general depth-cap correction
+  (no contract change, RFC 0007 review follow-up): the 2026-07-18
+  changelog entry above and section 5.1's reproducibility-rule prose both
+  stated the bounded depth cap as `capacity + 1` in general; section
+  5.1's own depth-accounting note already gives the general bound as
+  `capacity + concurrent producers`, with `capacity + 1` holding only for
+  the single-producer scenarios measured there (a gap the `RuntimeConfig`
+  RFC's `quit_blocked_64` row, at `capacity + 64`, would otherwise
+  contradict) — both passages now state the general bound and scope
+  `capacity + 1` to the single-producer case explicitly
 
 > **Decision scope.** Section 3 (the release-gate verdict) is the part of this
 > draft that 0.10.0 depends on, and it is final unless the contract design in
@@ -1238,8 +1248,10 @@ measurement rather than an implementation-time choice:
   already owns (open question 1) — which these test values need not
   equal. A bounded column measured under parameters chosen at
   implementation time would not be a reviewable acceptance run. Bounded
-  queue depth caps at `capacity + 1` (the depth-accounting note below),
-  so the unbounded `quit_backlog_50k` / `quit_backlog_300k` scenarios —
+  queue depth caps at `capacity + concurrent producers` (`capacity + 1`
+  for the single-flood-producer scenarios measured in this section; the
+  depth-accounting note below), so the unbounded `quit_backlog_50k` /
+  `quit_backlog_300k` scenarios —
   which reach those depths by flooding an unbounded channel before
   quitting — have no bounded-mode counterpart at the same depths: this
   prerequisite obligation includes redefining what the bounded quit

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -251,39 +251,60 @@ Documented starting values, each with its basis stated:
 
 - **`app_channel_capacity = 1024`.** A measurement-informed margin choice,
   not a value the measurements pin uniquely. The harness measurements give
-  a lower-bound signal — large enough that the in-capacity regime never
-  engages backpressure (`steady_200k` peaks at depth 400) — and a latency
-  estimate *at* 1024, not a demonstrated upper bound: a full queue at that
-  capacity adds ~27ms of estimated queueing latency (~1.6 frame periods at
-  60 FPS) at the harness's observed average drain rate under its heavy
-  25µs `update` cost (an estimate per the rule above, not an upper bound).
-  No stated maximum acceptable latency makes that figure a ceiling the
-  measurements rule out other values against — it is 1024's own cost, not
-  evidence that a larger capacity would be wrong. 1024 is the round number
-  chosen above the lower-bound signal, at a latency its own estimate shows
-  is a small number of frame periods (~1.6 at 60 FPS), not a large
-  multiple of one; 512 or 2048 would be defensible on the same
-  measurements. Applications with larger expected bursts scale up
-  by the same rule; `burst_200k` shows the cost of undersizing is producer
-  wait, not loss.
+  a lower-bound signal, not a proof of sufficiency: `steady_200k`'s queue
+  depth, sampled every 5ms by the harness's depth sampler
+  (`benches/runtime_load.rs`), reaches at most 400 among its samples — the
+  largest *sampled* depth, not a proven instantaneous maximum, since a
+  peak narrower than the 5ms sampling interval can fall between samples
+  unrecorded. 1024 carries roughly 2.5× headroom over that largest
+  sampled depth, not a demonstrated bound the in-capacity regime can never
+  cross. It also carries a latency estimate *at* 1024, not a demonstrated
+  upper bound: a full queue at that capacity adds ~27ms of estimated
+  queueing latency (~1.6 frame periods at 60 FPS) at the harness's
+  observed average drain rate under its heavy 25µs `update` cost (an
+  estimate per the rule above, not an upper bound). No stated maximum
+  acceptable latency makes that figure a ceiling the measurements rule out
+  other values against — it is 1024's own cost, not evidence that a
+  larger capacity would be wrong. 1024 is the round number chosen above
+  the sampled lower-bound signal, at a latency its own estimate shows is a
+  small number of frame periods (~1.6 at 60 FPS), not a large multiple of
+  one; 512 or 2048 would be defensible on the same measurements.
+  Applications with larger expected bursts scale up by the same rule;
+  `burst_200k` shows the cost of undersizing is producer wait, not loss.
 - **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
-  not measurement-derived, for two distinct reasons rather than one.
-  `keyed_steady`'s probe (firing every 25ms, observed worst-case delivery
-  5.2ms) never leaves its keyed channel holding more than one message, so
-  that measurement cannot distinguish 16 from 1 — a steady, low-delay
-  workload is silent on the question. `keyed_overload`'s same 25ms probe,
-  by contrast, is delayed 9.2–13.0s by shared-queue backlog (RFC 0006 §2)
-  because shared-first pull leaves the keyed channel undrained while the
-  always-ready shared channel stays non-empty (RFC 0006 §4.7); at that
-  delay a probe firing every 25ms would need to buffer on the order of
-  hundreds of messages before drain, so every finite capacity — 16
-  included — eventually fills and the probe's own producing stream
-  blocks in `send`. That measurement shows saturation under sustained
-  keyed overload is unavoidable at any bounded capacity, not that 16 is
-  the capacity that avoids it, so it derives no number either. Absent a
-  measured basis, 16 is fixed as a policy value from the trade read on
-  both sides: a command can emit a burst of up to 16 outputs into an
-  otherwise-empty channel without awaiting the consumer, and the
+  not measurement-derived. Two claims about it must stay separate: what
+  this scenario's own numbers show, and a further point RFC 0006 already
+  establishes at the mechanism level, independent of any run's length.
+  - What the numbers show. `keyed_steady`'s probe (firing every 25ms,
+    worst-case delivery 5.2ms) never leaves its keyed channel holding
+    more than one message, so that measurement cannot distinguish 16 from
+    1. `keyed_overload`'s same 25ms probe waits far longer instead — p50
+    9.2s, max 13.0s (RFC 0006 §2) — because shared-first pull leaves the
+    keyed channel undrained while the shared channel stays ready (RFC
+    0006 F4, §4.7). A 9.2s median wait against a 25ms tick spacing means
+    roughly 9.2s / 25ms ≈ 368 further ticks land before a typical probe
+    clears, most of them also undelivered under the same starvation —
+    enough to say a capacity as small as 16 would very likely have been
+    exceeded somewhere in this run. That is as far as this run's own
+    numbers reach: its own ticks over its ~13s length (13s / 25ms ≈ 520
+    total) never approach 1024, so the same run cannot show whether a
+    capacity that large would ever fill, and it does not pin 16 either —
+    several smaller capacities are equally consistent with the same data.
+  - A further point, independent of this run's own length. RFC 0006's F4
+    already establishes that keyed delivery is deferred until the shared
+    backlog *fully drains*, not for some duration this measurement
+    happens to bound. If overload persisted indefinitely, the shared
+    backlog would never drain, so by that same mechanism keyed delivery
+    would be deferred indefinitely too — and with the probe still ticking
+    every 25ms into a channel that never drains, its occupancy grows
+    without bound, so every finite keyed capacity eventually fills in
+    that hypothetical limit. This is a direct consequence of F4's own
+    mechanism (RFC 0006 §4.3's refill argument, §4.7), not a reading of
+    the 13.0s figure this particular run happens to have measured.
+
+  Absent a measured basis, 16 is fixed as a policy value from the trade
+  read on both sides: a command can emit a burst of up to 16 outputs into
+  an otherwise-empty channel without awaiting the consumer, and the
   per-command share of the application's `m × capacity` buffer total (RFC
   0006 R1) is bounded at 16 messages. Applications whose keyed commands
   emit larger bursts size up by that same absorption-versus-memory
@@ -457,6 +478,34 @@ channel occupancy, per the note on that distinction below the table:
   `quit_keyed_bounded`) is the whole predicate. The acceptance run
   reports each row's count as that many *valid* trials, not that many
   attempts.
+- Counting only valid trials means an implementation may need more
+  attempts than the row's required count whenever some attempts fail
+  their predicate, and nothing said so far bounds how many. Left
+  unbounded, a row whose predicate rarely holds — by scheduling
+  misfortune, or by an implementation defect that makes the precondition
+  rare or unreachable — could retry forever without ever timing out: a
+  per-attempt timeout (`max_wall`) only catches an attempt that itself
+  hangs, not a run of attempts that each complete normally but fail the
+  predicate. Every row with a non-`none` valid-trial predicate therefore
+  carries an attempt cap: at most `10 × trials` attempts, using the row's
+  own required trial count from the table above (2,000 for each of the
+  three 200-trial rows with a predicate — `quit_blocked_1`,
+  `quit_blocked_64`, `quit_overload`; 200 for `quit_keyed_bounded`'s 20).
+  `quit_idle`'s `none` predicate makes every attempt valid by definition,
+  so it carries no cap and none is needed. An attempt counts
+  against the cap whether it times out, misses its delivery event, or
+  completes but fails the predicate; attempts stop as soon as the row's
+  required valid-trial count is reached, whichever comes first. If the
+  cap is exhausted first, the row fails outright — reported distinctly
+  from a per-attempt timeout, and never reported as a shorter but still
+  valid sample. This bounds every row's worst-case wall time at
+  `10 × trials × max_wall` regardless of how rarely the predicate holds,
+  even though a compliant run finishes far faster in practice: the
+  predicate is expected to hold on nearly every attempt (the admission-
+  window discussion above scopes the narrow case where it does not), so
+  the 10× headroom is not spent attempt-for-attempt against the required
+  count on a working implementation. The same rule applies unchanged to
+  the §6 smoke profile's reduced trial counts.
 
 ### 5.3 Remaining bounded rows
 
@@ -505,11 +554,11 @@ invocation is unchanged.
   shortened to 0.5s, a 20k-message bounded burst under the §5.1
   configuration, `quit_idle` and `quit_blocked_1` at 5 *valid* trials each
   — `quit_idle`'s predicate is `none` (§5.2's table), so every attempt
-  counts toward its 5, but `quit_blocked_1` counts only attempts whose
-  §5.2 valid-trial predicate (`blocked == 1` at the quit instant) held; an
-  attempt that fails to reach that state does not count toward the 5,
-  exactly as §5.2 defines trial counting for the full run, just at a
-  smaller trial count. CI
+  counts toward its 5; `quit_blocked_1` counts only attempts whose §5.2
+  predicate (`blocked == 1` at the quit instant) held, under §5.2's
+  attempt cap scaled to this row's 5-trial count (a 50-attempt cap,
+  `10 × 5`), which fails the smoke run outright rather than retrying past
+  it. CI
   invokes it through a `just` recipe (`just bench-smoke`) in the existing
   Benchmarks job, so the local and CI invocations are identical.
 - **Pass/fail**: two assertion classes, split by what the observation
@@ -539,7 +588,13 @@ invocation is unchanged.
   hangs after processing its last scripted message times out with
   `processed` equal to the scripted total. The guard is the completion
   gate itself: a machine slow enough to exceed it fails on
-  non-completion, never on a latency criterion.
+  non-completion, never on a latency criterion. `quit_blocked_1` carries
+  a second, independent failure condition on top of that guard: §5.2's
+  attempt cap (50 attempts here, `10 × 5`), which fails the run if 5 valid
+  trials are not collected within it — reachable even when every
+  individual attempt completes well inside `max_wall`, which is exactly
+  the case a per-attempt timeout alone cannot catch (§5.2's rationale for
+  the cap).
 - **What it is not**: not an acceptance run, not a regression baseline, and
   its numbers are not recorded anywhere. It exists to prove the harness
   still builds (all scenarios compile in the one binary) and the smoke
@@ -578,11 +633,23 @@ Enforcement classes follow the pre-review checklist's definitions
   function bodies.
 - **INV-C4**: the public surface of `RuntimeConfig` consists of exactly the
   frame rate and the three RFC 0006 §4.1 controls — in particular, no
-  restart-rate field (§4). Structural: review of the type's public items.
-  The existing `api_surface` test does not check this (it enforces the
-  single-canonical-path and prelude-membership rules, not a surface
-  snapshot); it applies to this RFC only in that the §2.3 re-exports must
-  satisfy those two rules.
+  restart-rate field (§4) — and its re-export placement is exactly §2.3's:
+  reachable at `tears::RuntimeConfig` and *not* through
+  `tears::prelude::*`. Structural, in two parts: review of the type's
+  public items for the field/method surface, and review of `src/lib.rs`
+  (the root re-export exists) and `src/prelude.rs` (no `RuntimeConfig`
+  re-export and no mention in its "What's included" doc comment) for
+  placement. The existing `api_surface` test does not check either half:
+  `no_public_item_has_two_non_prelude_paths` and
+  `prelude_is_a_subset_of_root_level_items` (`tests/api_surface.rs`) both
+  check reachability *from* the prelude *toward* the root, never the
+  reverse. An item wrongly re-exported through the prelude while also
+  present at the root has exactly one non-prelude path (the root itself)
+  and is reachable at the root as its prelude membership requires, so it
+  satisfies both tests unchanged — a `RuntimeConfig` re-exported from both
+  modules would pass the test suite as written. This review step is
+  therefore the only check for §2.3's placement decision, not a
+  restatement of one the tests already perform.
 - **INV-C5**: `with_config` constructs its `FrameScheduler` from
   `config.frame_rate` — the frame rate that reaches the scheduler is
   exactly the value the caller supplied to `RuntimeConfig::new`, never a
@@ -613,10 +680,11 @@ Enforcement classes follow the pre-review checklist's definitions
 
 Surface–invariant coverage: the struct and `RuntimeConfig::new` map to
 INV-C2/C3/C6, each setter to INV-C2/C3/C4/C6, `with_config` and the
-unchanged `new` to INV-C1/C5/C6. The frame rate's runtime semantics are
-`FrameRate`'s, unchanged by relocation; the load controls' runtime
-*semantics* are covered by RFC 0006's invariants (INV-L1, INV-L3, INV-L6,
-INV-L12), not duplicated here.
+unchanged `new` to INV-C1/C5/C6, and the §2.3 re-export placement
+(crate-root only, no prelude) to INV-C4. The frame rate's runtime
+semantics are `FrameRate`'s, unchanged by relocation; the load controls'
+runtime *semantics* are covered by RFC 0006's invariants (INV-L1, INV-L3,
+INV-L6, INV-L12), not duplicated here.
 
 ## 8. Open questions
 

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -203,8 +203,19 @@ impl<App: Application> Runtime<App> {
 
 - Module: `src/runtime/config.rs` (`pub mod config` under `runtime`),
   matching `runtime::frame_rate`.
-- Re-exports: `tears::RuntimeConfig` at the crate root and
-  `tears::prelude::RuntimeConfig`, matching `FrameRate`'s pattern.
+- Re-exports: `tears::RuntimeConfig` at the crate root, as
+  `Runtime::with_config`'s companion type, but *not*
+  `tears::prelude::RuntimeConfig`. Crate-root placement and prelude
+  membership are different tests (`docs/api-guidelines.md`'s "Prelude
+  Membership"): the prelude asks whether a *minimal* skeleton app writes
+  the item out literally, and a minimal app calling
+  `Runtime::new(flags, frame_rate)` never names `RuntimeConfig` — only an
+  app that opts into `with_config` does. That is the same reasoning that
+  keeps `FrameRateError` out of the prelude despite its crate-root
+  re-export, not the reasoning that puts `FrameRate` in it (a minimal app
+  always writes `FrameRate::new(...)`, unconditionally). Should load
+  control become a minimal skeleton's default path in some future RFC,
+  adding `RuntimeConfig` to the prelude then is additive.
 - The bench harness (`benches/runtime_load.rs`) constructs its bounded runs
   through this public surface only; `bench-internals` gains no
   config-related items.
@@ -256,17 +267,28 @@ Documented starting values, each with its basis stated:
   by the same rule; `burst_200k` shows the cost of undersizing is producer
   wait, not loss.
 - **`keyed_channel_capacity = 16`.** A margin choice, stated as such —
-  not measurement-derived: in the measured workloads a keyed channel never
-  buffers more than one message (`keyed_steady`'s probe fires every 25ms
-  and its observed worst-case delivery is 5.2ms), so those measurements
-  cannot distinguish 16 from 1, and the harness has no keyed-burst
-  scenario that would size the value. What 16 fixes is the trade read
-  from both sides: a command can emit a burst of up to 16 outputs without
-  awaiting the consumer, and the per-command share of the application's
-  `m × capacity` buffer total (RFC 0006 R1) is bounded at 16 messages.
-  Applications whose keyed commands emit larger bursts size up by that
-  same absorption-versus-memory reading; adding a keyed-burst harness
-  scenario, should field experience demand a measured basis, is additive.
+  not measurement-derived, for two distinct reasons rather than one.
+  `keyed_steady`'s probe (firing every 25ms, observed worst-case delivery
+  5.2ms) never leaves its keyed channel holding more than one message, so
+  that measurement cannot distinguish 16 from 1 — a steady, low-delay
+  workload is silent on the question. `keyed_overload`'s same 25ms probe,
+  by contrast, is delayed 9.2–13.0s by shared-queue backlog (RFC 0006 §2)
+  because shared-first pull leaves the keyed channel undrained while the
+  always-ready shared channel stays non-empty (RFC 0006 §4.7); at that
+  delay a probe firing every 25ms would need to buffer on the order of
+  hundreds of messages before drain, so every finite capacity — 16
+  included — eventually fills and the probe's own producing stream
+  blocks in `send`. That measurement shows saturation under sustained
+  keyed overload is unavoidable at any bounded capacity, not that 16 is
+  the capacity that avoids it, so it derives no number either. Absent a
+  measured basis, 16 is fixed as a policy value from the trade read on
+  both sides: a command can emit a burst of up to 16 outputs into an
+  otherwise-empty channel without awaiting the consumer, and the
+  per-command share of the application's `m × capacity` buffer total (RFC
+  0006 R1) is bounded at 16 messages. Applications whose keyed commands
+  emit larger bursts size up by that same absorption-versus-memory
+  reading; adding a keyed-burst harness scenario, should field experience
+  demand a measured basis, is additive.
 - **`batch_max_messages`: unset.** This resolves the default-value half of
   RFC 0006 open question 2 as delegated: no non-`None` value is
   recommended. F5 is the evidence — the 100µs time cap alone held the frame
@@ -404,8 +426,12 @@ channel occupancy, per the note on that distinction below the table:
   single reading, because churn is a property of a time interval, not an
   instant: one capacity-wait event only shows the channel was full once,
   which a momentary fill also produces, while a second event within the
-  same short window shows a producer's send was accepted into the slot
-  the first event's completion freed — the refilling that "oscillate at
+  same short window shows that the channel filled again after draining —
+  a capacity-wait event fires at the moment its send is accepted, i.e.
+  once it has consumed a slot a consumer pull already freed (RFC 0006
+  §4.4), so the second event's send was accepted into a slot freed by a
+  pull that happened between the two events, not by the first event's
+  own completion. That intervening pull-then-refill is what "oscillate at
   capacity" names. Two is the minimum count that distinguishes the two
   cases; the 5ms window is two orders of magnitude longer than the
   harness's ~26µs per-message drain cost under this scenario's 25µs
@@ -477,7 +503,13 @@ invocation is unchanged.
 - **Invocation**: a `--smoke` argument to the harness binary (which already
   takes scenario-name arguments), selecting reduced variants: `steady_20k`
   shortened to 0.5s, a 20k-message bounded burst under the §5.1
-  configuration, `quit_idle` and `quit_blocked_1` at 5 trials each. CI
+  configuration, `quit_idle` and `quit_blocked_1` at 5 *valid* trials each
+  — `quit_idle`'s predicate is `none` (§5.2's table), so every attempt
+  counts toward its 5, but `quit_blocked_1` counts only attempts whose
+  §5.2 valid-trial predicate (`blocked == 1` at the quit instant) held; an
+  attempt that fails to reach that state does not count toward the 5,
+  exactly as §5.2 defines trial counting for the full run, just at a
+  smaller trial count. CI
   invokes it through a `just` recipe (`just bench-smoke`) in the existing
   Benchmarks job, so the local and CI invocations are identical.
 - **Pass/fail**: two assertion classes, split by what the observation

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -290,17 +290,28 @@ Documented starting values, each with its basis stated:
     total) never approach 1024, so the same run cannot show whether a
     capacity that large would ever fill, and it does not pin 16 either —
     several smaller capacities are equally consistent with the same data.
-  - A further point, independent of this run's own length. RFC 0006's F4
-    already establishes that keyed delivery is deferred until the shared
-    backlog *fully drains*, not for some duration this measurement
-    happens to bound. If overload persisted indefinitely, the shared
-    backlog would never drain, so by that same mechanism keyed delivery
-    would be deferred indefinitely too — and with the probe still ticking
-    every 25ms into a channel that never drains, its occupancy grows
-    without bound, so every finite keyed capacity eventually fills in
-    that hypothetical limit. This is a direct consequence of F4's own
-    mechanism (RFC 0006 §4.3's refill argument, §4.7), not a reading of
-    the 13.0s figure this particular run happens to have measured.
+  - A further point, independent of this run's own length, but weaker
+    than a certainty. RFC 0006's §4.3 refill argument establishes that
+    shared readiness — and with it keyed starvation — "can persist for as
+    long as overload lasts, independent of the configured capacity":
+    nothing bounds how long that persistence runs, so a long-enough
+    overload *can* hold any finite keyed capacity full, one probe tick at
+    a time, no matter how large. That licenses an existence claim only —
+    no finite capacity comes with a guarantee of staying safe — not the
+    stronger claim that every execution of sustained overload saturates
+    every capacity: bounded mode's admission windows (RFC 0006 §4.6) are
+    a real, scheduling-dependent chance for the shared channel to read
+    momentarily empty right after a pull and before the woken producer
+    refills it, letting a keyed output — and with it some keyed drain —
+    through. RFC 0006 §4.7 declines to guarantee a keyed-delivery bound
+    from those windows precisely because they are scheduling-dependent,
+    not because they cannot occur, and that same fact cuts both ways:
+    it is exactly why "eventually saturates" cannot be strengthened to
+    "always saturates" either. What follows from §4.3 is only that no
+    capacity is guaranteed safe against a long-enough overload, not that
+    saturation is certain — a reading of the 13.0s figure this
+    particular run happens to have measured would claim more than
+    either RFC establishes.
 
   Absent a measured basis, 16 is fixed as a policy value from the trade
   read on both sides: a command can emit a burst of up to 16 outputs into
@@ -498,14 +509,26 @@ channel occupancy, per the note on that distinction below the table:
   required valid-trial count is reached, whichever comes first. If the
   cap is exhausted first, the row fails outright — reported distinctly
   from a per-attempt timeout, and never reported as a shorter but still
-  valid sample. This bounds every row's worst-case wall time at
-  `10 × trials × max_wall` regardless of how rarely the predicate holds,
-  even though a compliant run finishes far faster in practice: the
-  predicate is expected to hold on nearly every attempt (the admission-
-  window discussion above scopes the narrow case where it does not), so
-  the 10× headroom is not spent attempt-for-attempt against the required
-  count on a working implementation. The same rule applies unchanged to
-  the §6 smoke profile's reduced trial counts.
+  valid sample. What the cap guarantees is termination, not a wall-clock
+  ceiling: it bounds the number of attempts to a fixed, finite count, so
+  a row can no longer retry forever waiting on a rare predicate — the
+  actual failure mode this rule exists to close. It is not itself a
+  bound on the row's total wall time, and `10 × trials × max_wall`
+  overstates what is guarded: `max_wall` (`benches/runtime_load.rs`)
+  times out only the `runtime.run(&mut terminal)` call inside a single
+  attempt (`run_quit_trial`), not the `Runtime`/`Terminal` construction
+  before it, the sample extraction after it, or the per-attempt loop
+  overhead in `run_quit_scenario` — so `10 × trials × max_wall` bounds
+  only the cumulative time those `runtime.run` calls can spend across
+  the capped attempts, not the row's actual wall time. A strict
+  wall-clock ceiling on the whole row would need a separate, row-level
+  aggregate timeout wrapping every attempt together, which this RFC does
+  not add: the un-guarded overhead per attempt is expected to be
+  negligible next to `max_wall`, and the attempt cap alone already rules
+  out the unbounded-retry failure mode. Adding an aggregate guard later,
+  should that overhead prove not negligible, is additive. The same
+  attempt-count cap applies unchanged to the §6 smoke profile's reduced
+  trial counts.
 
 ### 5.3 Remaining bounded rows
 


### PR DESCRIPTION
## Summary
- `keyed_channel_capacity = 16`'s rationale cited only `keyed_steady` (which can't distinguish 1 from 16). Added `keyed_overload` as a second measurement, scoped precisely to what that run's own numbers support ("capacity 16 likely saturates under this load" — its own probe count never approaches 1024). A separate, explicitly-labeled point from RFC 0006's §4.3 refill argument establishes only an *existence* claim beyond the measurement (no capacity is guaranteed safe against a long-enough overload) — not that every execution of sustained overload saturates every capacity, since bounded mode's admission windows (§4.6) give keyed delivery a real, scheduling-dependent chance to drain even then (the same fact §4.7 already leans on to decline a keyed-delivery latency guarantee). 16 stays a stated policy value throughout.
- `app_channel_capacity = 1024`'s rationale claimed the in-capacity regime "never engages backpressure" from `steady_200k`'s depth-400 peak, but that peak is a 5ms-sampled maximum, not a proven instantaneous one. Reframed as "~2.5x headroom over the largest sampled depth."
- RFC 0006 stated "bounded depth caps at `capacity + 1`" as a general rule in two spots; scoped both to the single-producer scenarios they were measured on, matching the RFC's own `capacity + concurrent producers` depth-accounting note (and avoiding a contradiction with RFC 0007's `quit_blocked_64` row at `capacity + 64`). Added a changelog entry to RFC 0006 recording the correction.
- Fixed the capacity-wait event's causal description in RFC 0007 §5.2: the event fires at send-acceptance (having consumed a slot a consumer pull already freed), not at "the first event's completion" freeing a slot for the second.
- Added a stopping/failure condition for §5.2's valid-trial predicates: a per-attempt timeout doesn't catch a run of attempts that each finish normally but keep failing their predicate, so a row could otherwise retry forever waiting on valid trials. Added a shared attempt-cap rule (10x the row's trial count) applying to both the full acceptance run and the CI smoke profile, and wired the smoke profile's pass/fail section to the new failure mode. Corrected the cap's own claim about what it bounds: it guarantees a finite attempt count (termination), not a strict wall-clock ceiling — `max_wall` only wraps the `runtime.run()` call inside one attempt, not construction/teardown/loop overhead around it.
- Dropped `RuntimeConfig` from the prelude (kept at the crate root): a minimal skeleton app never names it directly — only `Runtime::with_config` callers do — the same reasoning that already excludes `FrameRateError` from the prelude. Extended INV-C4 with an explicit structural check for this placement, since the existing `api_surface` test only checks prelude-subset-of-root, not the reverse (it would pass `RuntimeConfig` wrongly added to both).

## Test plan
- [x] Self-reviewed against `docs/rfcs/pre-review-checklist.md`, re-derived (not patched) every claim flagged as over-generalized or unbounded across three review rounds, per item 6
- [x] `typos` clean, `git diff --check` clean
- [ ] Author re-review of this round's findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)