### PR TITLE
feat(runtime): runtime load control (RuntimeConfig, bounded delivery, observability)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,20 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Run benchmarks
+      - uses: taiki-e/install-action@just
+      - name: Run subscription benchmark
         # `--bench <name>` (singular, per-target) rather than `--benches`
         # (plural): the plural form implicitly also runs the lib's unit
         # tests, duplicating what the `test` job's matrix already covers.
-        run: cargo test --bench subscription --bench runtime_load --all-features
+        run: cargo test --bench subscription --all-features
+      - name: Run runtime-load smoke profile
+        # The full `runtime_load` scenarios leave CI: they are deliberate
+        # acceptance/regression runs (RFC 0006 §5.1, RFC 0007 §5–6), and their
+        # latency numbers gate nothing on a CI machine. CI runs only the
+        # reduced, latency-assertion-free smoke profile, which gates on
+        # completion. Invoked via `just` so the local and CI invocations are
+        # identical (RFC 0007 §6).
+        run: just bench-smoke
 
   loom:
     name: Loom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Scoping is additive: unscoped subscriptions and commands keep their
     existing 0.10.0 behavior unchanged
 
+### Changed
+
+- The per-micro-batch trace event moved off the `tears::runtime` target: the
+  old `tears::runtime` event with the `messages` field is removed, replaced by
+  the richer `tears::runtime::load` batch event (`pulled`/`updated`/
+  `shared_pending`). A consumer filtering `tears::runtime` on `messages` must
+  switch to the `tears::runtime::load` target
+
 ## [0.10.0] - 2026-07-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RuntimeConfig` and `Runtime::with_config` add opt-in runtime load control
+  (RFC 0006, RFC 0007): a bounded delivery mode for the shared
+  application-message channel (`app_channel_capacity`) and each keyed command's
+  private channel (`keyed_channel_capacity`), plus a micro-batch count cap
+  (`batch_max_messages`), carried alongside the frame rate
+  - Bounded channels apply backpressure — a producer waits for capacity rather
+    than dropping — so memory and shared-input latency stay bounded under
+    overload; the dedicated quit channel is never bounded
+  - Load observability is emitted through `tracing` under the
+    `tears::runtime::load` target: a per-micro-batch event
+    (`pulled`/`updated`/`shared_pending`), a bounded-mode capacity-wait event
+    (`channel`/`wait_us`), and producer-count gauges (`subscriptions`,
+    `unkeyed_commands`, `keyed_commands`, `blocked`)
+  - Additive and non-breaking: `Runtime::new` is unchanged, and a
+    load-control-unset `RuntimeConfig` reproduces the previous unbounded
+    delivery path exactly
 - `Subscription::scoped` and `Command::scoped` qualify a subscription's or
   command's lifecycle identity with one structural scope segment, so composed
   child instances that reuse the same local source/key or `CommandId` no

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -500,6 +500,34 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
 /// ignored. Trials run sequentially, so a single slot suffices.
 static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 
+/// The most recent producer-gauge sum
+/// (`subscriptions + unkeyed_commands + keyed_commands + blocked`), updated by
+/// [`QuitDeliverySubscriber`] on every gauge event regardless of the trial
+/// slot. Reaches 0 only when the *current* runtime has fully torn its producers
+/// down; scenarios run one runtime at a time, so [`await_quiescence`] can wait
+/// on it as a common teardown barrier before the next runtime starts, keeping a
+/// late gauge/capacity event from one scenario out of the next scenario's slot.
+static LIVE_PRODUCERS: AtomicU64 = AtomicU64::new(0);
+
+/// Waits until the current runtime's producers have fully torn down (the gauge
+/// sum returns to 0) before the caller starts the next runtime — the teardown
+/// barrier shared by every runtime scenario. A teardown that never quiesces is
+/// a harness fault: this aborts the whole run rather than proceeding on a slot
+/// a straggler event could still corrupt.
+async fn await_quiescence() {
+    let quiesced = timeout(Duration::from_secs(5), async {
+        while LIVE_PRODUCERS.load(Ordering::Relaxed) != 0 {
+            yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        quiesced.is_ok(),
+        "harness fault: a scenario's producers did not quiesce within 5s; \
+         refusing to reuse the trial slot with a teardown still in flight",
+    );
+}
+
 /// Records the instant the event loop's quit branch fires.
 ///
 /// The runtime logs `debug!(target: "tears::runtime", "quit signal
@@ -540,6 +568,13 @@ impl Subscriber for QuitDeliverySubscriber {
         let mut visitor = LoadVisitor::default();
         event.record(&mut visitor);
 
+        // The teardown barrier is global and slot-independent: update it on every
+        // gauge event (a gauge event always carries `blocked`), so a scenario
+        // with no active trial slot still drives its producers' quiescence.
+        if is_load && visitor.blocked.is_some() {
+            LIVE_PRODUCERS.store(visitor.gauge_sum(), Ordering::Relaxed);
+        }
+
         let Some(metrics) = TRIAL_METRICS
             .lock()
             .expect("trial metrics slot poisoned")
@@ -549,15 +584,11 @@ impl Subscriber for QuitDeliverySubscriber {
         };
 
         if is_load {
-            // Producer-gauge event: track the live `blocked` count and the sum
-            // of all four gauges (the quiescence signal). A gauge event always
-            // carries `blocked`, so its presence identifies one. Shared
-            // capacity-wait event: log its instant for the churn window.
+            // Per-trial recording (only while a slot is active): the live
+            // `blocked` count for the predicate, and shared capacity-wait instants
+            // for the churn window.
             if let Some(blocked) = visitor.blocked {
                 metrics.blocked_live.store(blocked, Ordering::Relaxed);
-                metrics
-                    .live_producers
-                    .store(visitor.gauge_sum(), Ordering::Relaxed);
             }
             if visitor.channel.as_deref() == Some("shared") {
                 metrics
@@ -667,12 +698,6 @@ struct Metrics {
     /// The most recent `blocked` producer-gauge value, updated live by
     /// [`QuitDeliverySubscriber`] from each `tears::runtime::load` gauge event.
     blocked_live: AtomicU64,
-    /// The most recent sum of all four producer gauges
-    /// (`subscriptions + unkeyed_commands + keyed_commands + blocked`). Reaches
-    /// 0 only when this trial's runtime has fully torn its producers down; the
-    /// trial-boundary quiescence gate waits on it so a late gauge/capacity event
-    /// cannot leak into the next trial's slot (see [`run_quit_trial`]).
-    live_producers: AtomicU64,
     /// Nanoseconds from `start` of each shared-channel capacity-wait event,
     /// logged live by [`QuitDeliverySubscriber`]; the churn predicate counts
     /// those inside its window.
@@ -699,7 +724,6 @@ impl Metrics {
             blocked_at_quit: AtomicU64::new(0),
             capacity_waits_before_quit: AtomicU64::new(0),
             blocked_live: AtomicU64::new(0),
-            live_producers: AtomicU64::new(0),
             capacity_wait_shared_ns: Mutex::new(Vec::new()),
         }
     }
@@ -979,6 +1003,13 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
         .is_err();
     let wall = started.elapsed();
 
+    // Load scenarios also wait on the teardown barrier: this scenario's flood
+    // producer stays alive (its stream chains `pending()`) until shutdown aborts
+    // it, so its gauge decrements could otherwise attribute to the next
+    // scenario's trial slot (e.g. a quit trial that immediately follows in the
+    // smoke profile).
+    await_quiescence().await;
+
     stop.store(true, Ordering::Relaxed);
     let samples = sampler.await.expect("sampler task");
 
@@ -1083,21 +1114,15 @@ async fn run_quit_trial(
         .is_err();
     let exit_ns = metrics.elapsed_ns();
 
-    // Trial-boundary quiescence: `Runtime::run` returning (or being dropped on
-    // timeout) does not join the aborted producer tasks, so a late gauge or
-    // capacity-wait event could still fire on a worker thread. Keep the shared
-    // slot pointed at this trial and wait until its producers have fully torn
-    // down — the gauge sum returns to 0, which is terminal once no producer
-    // remains — before releasing the slot, so no straggler event lands in the
-    // next trial's metrics and skews its predicate (RFC 0007 §5.2). Bounded by
-    // the same wall guard so a stuck teardown cannot hang the trial.
-    let _ = timeout(cfg.max_wall, async {
-        while metrics.live_producers.load(Ordering::Relaxed) != 0 {
-            yield_now().await;
-        }
-    })
-    .await;
+    // Freeze this trial's slot, then wait on the shared teardown barrier so a
+    // late gauge/capacity event from this runtime cannot land in the next
+    // trial's slot and skew its predicate (RFC 0007 §5.2). Clearing the slot
+    // first stops late events from writing this trial's `blocked_live`/log; the
+    // barrier then confirms the producers are actually gone — and hard-fails the
+    // whole run if they are not, rather than releasing the slot to the next
+    // trial with a teardown still in flight.
     *TRIAL_METRICS.lock().expect("trial metrics slot poisoned") = None;
+    await_quiescence().await;
 
     if timed_out {
         return Err(QuitTrialFailure::TimedOut);
@@ -1466,48 +1491,73 @@ fn run_smoke(runtime: &TokioRuntime) -> bool {
 
 // ---- keyed_isolation scenario (RFC 0007 §5.3, INV-L9) ----------------------
 //
-// Eight keyed channels are saturated (each holding `keyed_channel_capacity`
-// messages with its next send pending) alongside a ninth probe key, all under
-// the §5.1 bounded configuration. A shared flood keeps the shared channel full
-// so the event loop stays shared-first and never drains the keyed channels, so
-// they hold saturated. The probe key admitting its full capacity while eight
-// others (128 messages) are held proves per-channel admission with no shared
-// pool — a behavioral regression check on INV-L9's structural pool-absence
-// proof. Delivery is excluded (the keyed `StreamMap` cannot drain a chosen key
-// selectively; no keyed-delivery bound exists, RFC 0006 §4.7). Compiled into
-// the harness but not part of the smoke profile (RFC 0007 §5.3).
+// Under the §5.1 bounded configuration, eight keyed channels are held saturated
+// (each with `keyed_channel_capacity` admitted and its next send blocked, so
+// the key's stream has yielded `capacity + 1`), and only *then* is a ninth,
+// previously idle probe key started. The probe admitting its own full capacity
+// while the eight others hold 128 messages is the keyed→keyed isolation check.
+// A shared flood keeps the shared channel full so the event loop stays
+// shared-first and never drains any keyed channel; its own admission — a peak
+// occupancy of `app_channel_capacity + 1` (the full channel plus one blocked
+// send) — is the keyed→shared side, verified while the keyed channels are held.
+// This is a behavioral regression check on INV-L9's structural pool-absence
+// proof: a shared pool sized near per-channel capacity could not admit all
+// `9 × capacity` keyed messages plus the shared channel's full capacity at once.
+// Compiled into the harness but not part of the §6 smoke profile.
 //
-// The shared-side probe RFC 0007 §5.3 also names — the shared producer's first
-// `app_channel_capacity` sends completing with only the next pending — is read
-// from the max sampled shared occupancy, `produced - processed`: since the one
-// shared flood producer's attempted sends are `produced` and `update`'s drains
-// are `processed`, this quantity is (in-channel + the one blocked send), so its
-// peak of `app_channel_capacity + 1` shows the shared channel admitted its full
-// `app_channel_capacity` with exactly the next send pending — independent of the
-// saturated keyed channels.
+// Delivery is excluded and gated at zero: the keyed `StreamMap` cannot drain a
+// chosen key selectively (no keyed-delivery bound exists, RFC 0006 §4.7), so a
+// drained keyed message would inflate a key's yield count past `capacity + 1`
+// and read as spurious extra admission — the run asserts no keyed message ever
+// reaches `update` and that every raw yield is exactly `capacity + 1`.
+//
+// One deviation from RFC 0007 §5.3's letter, noted for reconciliation: its
+// shared probe is worded as a producer started *after* the keyed saturation,
+// admitting its first `app_channel_capacity` sends into an empty shared channel.
+// That is not realizable here — the shared channel must stay full throughout to
+// keep the keyed channels from draining (shared-first), so it cannot be empty at
+// a later probe start. The shared producer therefore runs throughout as both the
+// saturation enabler and the shared probe, and its full-capacity admission is
+// verified concurrently with the held keyed saturation, which carries the same
+// isolation evidence.
 
-/// Saturated keyed channels plus the probe (8 + 1).
-const ISO_KEYS: usize = 9;
+/// Saturated keyed channels held before the probe starts.
+const ISO_SATURATED_KEYS: usize = 8;
+/// Total keyed channels: the saturated set plus the probe.
+const ISO_KEYS: usize = ISO_SATURATED_KEYS + 1;
 
 struct IsoMetrics {
-    /// Yields of each keyed command's stream; a saturated key reads
+    /// Yields of each keyed command's stream; a saturated key reads exactly
     /// `keyed_channel_capacity + 1` (capacity admitted, the next send blocked).
+    /// A value above that means the channel was drained — an isolation failure.
     /// Each is its own `Arc` so a `'static` keyed stream can own a clone.
     key_yields: Vec<Arc<AtomicU64>>,
+    /// Keyed outputs delivered to `update`; must stay 0 (no keyed delivery
+    /// during the measurement), else a key's yield count is not admission alone.
+    keyed_delivered: AtomicU64,
     shared_produced: AtomicU64,
     shared_processed: AtomicU64,
-    /// Max sampled shared occupancy (`produced - processed`) — the shared-side
-    /// isolation signal.
+    /// Max shared occupancy (`produced - processed`) over the whole run — a
+    /// display-only signal. Not the isolation gate: a global pool could reach it
+    /// before the keyed channels start and then shed capacity to hold them, so
+    /// a historical max says nothing about *simultaneous* occupancy.
     max_shared_depth: AtomicU64,
+    /// Max shared occupancy sampled *only while all keyed channels are
+    /// concurrently saturated* — the isolation gate. A shared pool cannot hold
+    /// the full shared channel and all `9 × capacity` keyed messages at once, so
+    /// its concurrent shared occupancy stays below `app_channel_capacity + 1`.
+    concurrent_shared_depth: AtomicU64,
 }
 
 impl IsoMetrics {
     fn new() -> Self {
         Self {
             key_yields: (0..ISO_KEYS).map(|_| Arc::new(AtomicU64::new(0))).collect(),
+            keyed_delivered: AtomicU64::new(0),
             shared_produced: AtomicU64::new(0),
             shared_processed: AtomicU64::new(0),
             max_shared_depth: AtomicU64::new(0),
+            concurrent_shared_depth: AtomicU64::new(0),
         }
     }
 
@@ -1516,11 +1566,21 @@ impl IsoMetrics {
             .load(Ordering::Relaxed)
             .saturating_sub(self.shared_processed.load(Ordering::Relaxed))
     }
+
+    /// A keyed channel is saturated once its stream has yielded more than
+    /// `capacity` — i.e. `capacity + 1`, capacity admitted with the next send
+    /// blocked (the final gate checks the count is *exactly* that).
+    fn saturated(&self, key: usize, keyed_cap: u64) -> bool {
+        self.key_yields[key].load(Ordering::Relaxed) > keyed_cap
+    }
 }
 
+/// Shared flood messages carry a seq; keyed outputs are a distinct variant so a
+/// keyed message reaching `update` (a delivery that must not happen) is caught.
 #[derive(Clone)]
 enum IsoMsg {
     Flood(u64),
+    KeyedOut,
 }
 
 /// Infinite shared flood keeping the shared channel saturated.
@@ -1546,62 +1606,106 @@ impl SubscriptionSource for IsoFloodSource {
 
 /// Infinite keyed-command stream: increments its yield counter per item, so its
 /// channel fills to capacity and the next send blocks (the counter then reads
-/// `capacity + 1`).
+/// `capacity + 1`). Yields the `KeyedOut` variant so any delivery to `update`
+/// is detectable.
 fn iso_keyed_stream(
     counter: Arc<AtomicU64>,
 ) -> impl futures::Stream<Item = IsoMsg> + Send + 'static {
     stream::repeat(()).map(move |()| {
         counter.fetch_add(1, Ordering::Relaxed);
-        IsoMsg::Flood(0)
+        IsoMsg::KeyedOut
     })
 }
 
 struct KeyedIsolationApp {
     iso: Arc<IsoMetrics>,
     keyed_cap: u64,
+    app_cap: u64,
+    /// How many of the eight saturating keys have been started.
+    saturators_started: usize,
+    /// The probe key has been started (only after all saturators saturated).
+    probe_started: bool,
+}
+
+impl KeyedIsolationApp {
+    fn spawn_key(&self, key: usize) -> Command<IsoMsg> {
+        let counter = Arc::clone(&self.iso.key_yields[key]);
+        Command::stream(iso_keyed_stream(counter)).cancellable(CommandId::new(key as u64))
+    }
 }
 
 impl Application for KeyedIsolationApp {
     type Message = IsoMsg;
-    type Flags = (Arc<IsoMetrics>, u64);
+    type Flags = (Arc<IsoMetrics>, u64, u64);
 
-    fn new((iso, keyed_cap): Self::Flags) -> (Self, Command<IsoMsg>) {
-        (Self { iso, keyed_cap }, Command::none())
+    fn new((iso, keyed_cap, app_cap): Self::Flags) -> (Self, Command<IsoMsg>) {
+        (
+            Self {
+                iso,
+                keyed_cap,
+                app_cap,
+                saturators_started: 0,
+                probe_started: false,
+            },
+            Command::none(),
+        )
     }
 
     fn update(&mut self, msg: IsoMsg) -> Command<IsoMsg> {
-        let IsoMsg::Flood(seq) = msg;
+        let seq = match msg {
+            // A keyed output reached `update`: keyed delivery occurred, which the
+            // scenario forbids during the measurement. Record it; the run fails.
+            IsoMsg::KeyedOut => {
+                self.iso.keyed_delivered.fetch_add(1, Ordering::Relaxed);
+                return Command::none();
+            }
+            IsoMsg::Flood(seq) => seq,
+        };
+        let _ = seq;
         // Keep the shared channel full so the event loop stays shared-first and
         // never drains the keyed channels; they must hold saturated.
         spin(Duration::from_micros(10));
         self.iso.shared_processed.fetch_add(1, Ordering::Relaxed);
-        // Sample the shared occupancy peak here, on every shared message, so it
-        // is captured deterministically even if saturation completes between two
-        // external sampler ticks.
+        // Sample the shared occupancy peak on every shared message.
         self.iso
             .max_shared_depth
             .fetch_max(self.iso.shared_depth(), Ordering::Relaxed);
 
-        let index = usize::try_from(seq).unwrap_or(usize::MAX);
-        if index < ISO_KEYS {
-            // Spawn keyed command `index` on its own key.
-            let counter = Arc::clone(&self.iso.key_yields[index]);
-            return Command::stream(iso_keyed_stream(counter)).cancellable(CommandId::new(seq));
+        // Stage 1: start the eight saturating keys, one per shared message.
+        if self.saturators_started < ISO_SATURATED_KEYS {
+            let key = self.saturators_started;
+            self.saturators_started += 1;
+            return self.spawn_key(key);
         }
-        // Every key spawned: quit once all keyed channels are saturated
-        // (yields reached capacity + 1 — capacity admitted, the next send
-        // blocked). A shared pool would keep some key below capacity, so
-        // saturation would never complete and the scenario would time out.
-        let saturated = self
-            .iso
-            .key_yields
-            .iter()
-            .all(|counter| counter.load(Ordering::Relaxed) > self.keyed_cap);
-        if saturated {
-            Command::quit()
-        } else {
-            Command::none()
+
+        // Stage 2: only once all eight are saturated, start the previously idle
+        // probe key (index ISO_SATURATED_KEYS).
+        let saturators_saturated =
+            (0..ISO_SATURATED_KEYS).all(|k| self.iso.saturated(k, self.keyed_cap));
+        if !self.probe_started {
+            if saturators_saturated {
+                self.probe_started = true;
+                return self.spawn_key(ISO_SATURATED_KEYS);
+            }
+            return Command::none();
         }
+
+        // Stage 3: sample the shared depth *only while every keyed channel is
+        // concurrently saturated*, and quit once that simultaneous value reaches
+        // `app_cap + 1` — the shared channel full at the same instant the nine
+        // keyed channels hold their `9 × capacity` messages. A shared pool can
+        // reach either alone but not both at once, so its concurrent shared
+        // depth never gets there and the scenario times out instead of passing.
+        let all_saturated = (0..ISO_KEYS).all(|k| self.iso.saturated(k, self.keyed_cap));
+        if all_saturated {
+            self.iso
+                .concurrent_shared_depth
+                .fetch_max(self.iso.shared_depth(), Ordering::Relaxed);
+            if self.iso.concurrent_shared_depth.load(Ordering::Relaxed) > self.app_cap {
+                return Command::quit();
+            }
+        }
+        Command::none()
     }
 
     fn view(&self, _frame: &mut ratatui::Frame<'_>) {}
@@ -1617,72 +1721,98 @@ struct IsoReport {
     keyed_cap: u64,
     app_cap: u64,
     timed_out: bool,
-    /// Admitted per key (`capacity` when saturated).
-    admitted: Vec<u64>,
+    /// Raw yield count per key (exactly `keyed_cap + 1` when cleanly saturated).
+    yields: Vec<u64>,
+    keyed_delivered: u64,
+    /// Whole-run peak shared occupancy — display only.
     max_shared_depth: u64,
+    /// Peak shared occupancy while all keyed channels were concurrently
+    /// saturated — the isolation gate.
+    concurrent_shared_depth: u64,
 }
 
 impl IsoReport {
-    /// Isolation held: every keyed channel admitted its full capacity and the
-    /// shared channel reached its own full occupancy — so no shared pool starved
-    /// any keyed key or the shared channel — and the scenario did not time out.
+    /// Isolation held, with every gate exact (RFC 0007 §5.3): the run did not
+    /// time out, every keyed channel yielded exactly `capacity + 1` (its full
+    /// capacity admitted and no drain past it), no keyed message was delivered,
+    /// and — the load-bearing gate — the shared channel reached exactly
+    /// `app_channel_capacity + 1` *while every keyed channel was concurrently
+    /// saturated*, which a shared pool cannot do (it lacks the permits for both
+    /// at once).
     fn isolated(&self) -> bool {
         !self.timed_out
-            && self.admitted.iter().all(|&a| a == self.keyed_cap)
-            && self.max_shared_depth >= self.app_cap
+            && self.keyed_delivered == 0
+            && self.yields.iter().all(|&y| y == self.keyed_cap + 1)
+            && self.concurrent_shared_depth == self.app_cap + 1
     }
 }
 
 async fn run_keyed_isolation() -> IsoReport {
     let keyed_cap: u64 = 16; // RFC 0007 §5.1 keyed_channel_capacity
+    let app_cap: u64 = 1024; // RFC 0007 §5.1 app_channel_capacity
     let iso = Arc::new(IsoMetrics::new());
-    let runtime =
-        Runtime::<KeyedIsolationApp>::with_config((Arc::clone(&iso), keyed_cap), bounded_config());
+    let runtime = Runtime::<KeyedIsolationApp>::with_config(
+        (Arc::clone(&iso), keyed_cap, app_cap),
+        bounded_config(),
+    );
     let mut terminal =
         Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
 
     let timed_out = timeout(Duration::from_secs(10), runtime.run(&mut terminal))
         .await
         .is_err();
+    await_quiescence().await;
 
-    let admitted = iso
+    let yields = iso
         .key_yields
         .iter()
-        .map(|counter| counter.load(Ordering::Relaxed).min(keyed_cap))
+        .map(|counter| counter.load(Ordering::Relaxed))
         .collect();
     IsoReport {
         keyed_cap,
-        app_cap: 1024, // RFC 0007 §5.1 app_channel_capacity
+        app_cap,
         timed_out,
-        admitted,
+        yields,
+        keyed_delivered: iso.keyed_delivered.load(Ordering::Relaxed),
         max_shared_depth: iso.max_shared_depth.load(Ordering::Relaxed),
+        concurrent_shared_depth: iso.concurrent_shared_depth.load(Ordering::Relaxed),
     }
 }
 
 fn print_iso_report(report: &IsoReport) {
     println!("## keyed_isolation");
     println!(
-        "   {} keyed channels, capacity {}",
-        report.admitted.len(),
+        "   {} keyed channels ({} saturated + 1 probe), capacity {}",
+        report.yields.len(),
+        ISO_SATURATED_KEYS,
         report.keyed_cap,
     );
     println!(
         "   status: {}",
         if report.timed_out {
-            "TIMED OUT — channels never all saturated (possible shared pool)"
+            "TIMED OUT — full saturation never coincided with a full shared channel \
+             (possible shared pool)"
         } else {
             "ok"
         },
     );
-    println!("   per-key admitted: {:?}", report.admitted);
     println!(
-        "   isolation: every key admitted its full capacity = {}",
-        report.isolated(),
+        "   per-key raw yields: {:?} (each must equal capacity + 1 = {})",
+        report.yields,
+        report.keyed_cap + 1,
     );
     println!(
-        "   max shared depth: {} (shared-side signal; ~app_channel_capacity)",
+        "   keyed delivered to update: {} (must be 0)",
+        report.keyed_delivered,
+    );
+    println!(
+        "   concurrent shared depth: {} (must equal app_channel_capacity + 1 = {}; \
+         whole-run max {})",
+        report.concurrent_shared_depth,
+        report.app_cap + 1,
         report.max_shared_depth,
     );
+    println!("   isolation: {}", report.isolated());
     println!();
 }
 

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -8,14 +8,13 @@
 //! throughput numbers alone hide:
 //!
 //! - **Queue depth**: pending messages (produced - processed), sampled while
-//!   the scenario runs; all runtime channels are unbounded today, so this is
-//!   the direct driver of memory growth under overload. `produced` counts a
-//!   message when the source stream yields it and `processed` counts it when
-//!   `update` begins (once it has left the channel), so under a future
-//!   bounded configuration the observable bound is `capacity + producers`:
-//!   each producer blocked in `send` holds one in-flight message outside the
-//!   channel, while the message currently inside `update` is already
-//!   excluded (RFC 0006 section 5.1).
+//!   the scenario runs; in the default (unbounded) mode this is the direct
+//!   driver of memory growth under overload. `produced` counts a message when
+//!   the source stream yields it and `processed` counts it when `update` begins
+//!   (once it has left the channel), so under the bounded configuration the
+//!   observable bound is `capacity + producers`: each producer blocked in
+//!   `send` holds one in-flight message outside the channel, while the message
+//!   currently inside `update` is already excluded (RFC 0006 section 5.1).
 //! - **Update latency**: message emission to `Application::update`.
 //! - **Render latency**: message emission to the first `Application::view`
 //!   call that observes it (input-to-screen staleness).
@@ -49,12 +48,20 @@
 //! channel instead of the dedicated quit channel, quantifying the INV-14
 //! shared-first bias for in-band quit (RFC 0006 open question 7).
 //!
-//! Run all scenarios, or name a subset:
+//! Scenarios come in the default (unbounded) mode and, for the rows RFC 0007
+//! §5 defines, bounded re-runs under the §5.1 configuration (the `*_bounded`
+//! scenarios and the `quit_blocked_*` / `quit_keyed_bounded` rows), built with
+//! `Runtime::with_config`. The bounded quit rows check a valid-trial predicate
+//! (a `blocked`-gauge or capacity-wait-churn reading) at the quit instant and
+//! retry predicate misses up to an attempt cap (RFC 0007 §5.2).
+//!
+//! Run all scenarios, name a subset, or run the CI smoke profile (RFC 0007 §6):
 //!
 //! ```bash
 //! cargo bench --bench runtime_load
 //! cargo bench --bench runtime_load -- overload keyed_overload
-//! cargo bench --bench runtime_load -- quit_idle quit_backlog_300k
+//! cargo bench --bench runtime_load -- quit_blocked_1 quit_keyed_bounded
+//! cargo bench --bench runtime_load -- --smoke   # or: just bench-smoke
 //! ```
 //!
 //! Peak RSS is process-wide and monotone, so for clean memory numbers run a
@@ -69,7 +76,7 @@
 )]
 
 use std::fmt::Debug;
-use std::num::NonZeroU32;
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::process::ExitCode;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -82,8 +89,9 @@ use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use tears::command::CommandId;
 use tears::prelude::*;
-use tears::{BoxStream, SubscriptionSource};
-use tokio::runtime::Builder;
+use tears::{BoxStream, RuntimeConfig, SubscriptionSource};
+use tokio::runtime::{Builder, Runtime as TokioRuntime};
+use tokio::task::yield_now;
 use tokio::time::{MissedTickBehavior, interval, timeout};
 use tokio_stream::wrappers::IntervalStream;
 use tracing::field::{Field, Visit};
@@ -94,6 +102,39 @@ use tracing::{Event, Level, Metadata, Subscriber};
 
 /// Message rate for scenarios that emit their whole load in one burst.
 const BURST: u64 = 0;
+
+/// The 60 FPS frame rate every scenario runs at (RFC 0006 §2 harness target).
+fn frame_rate() -> FrameRate {
+    FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
+        .expect("60 FPS is a valid frame rate")
+}
+
+/// The RFC 0007 §5.1 bounded configuration used for every bounded row:
+/// `app_channel_capacity = 1024`, `keyed_channel_capacity = 16`,
+/// `batch_max_messages = None`, at 60 FPS.
+fn bounded_config() -> RuntimeConfig {
+    RuntimeConfig::new(frame_rate())
+        .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
+        .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"))
+}
+
+/// Delivery mode a scenario's [`Runtime`] is built in.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// `Runtime::new` — the load-control-unset (unbounded) default path.
+    Default,
+    /// `Runtime::with_config` under the RFC 0007 §5.1 bounded configuration.
+    Bounded,
+}
+
+impl Mode {
+    fn build_runtime(self, flags: (ScenarioCfg, Arc<Metrics>)) -> Runtime<LoadApp> {
+        match self {
+            Self::Default => Runtime::new(flags, frame_rate()),
+            Self::Bounded => Runtime::with_config(flags, bounded_config()),
+        }
+    }
+}
 
 #[derive(Clone)]
 struct ScenarioCfg {
@@ -116,17 +157,56 @@ struct ScenarioCfg {
     /// the command's private channel, instead of an unkeyed command's direct
     /// send to the dedicated quit channel.
     keyed_quit: bool,
+    /// Delivery mode the runtime is built in (default/unbounded vs the §5.1
+    /// bounded configuration).
+    mode: Mode,
+    /// Number of concurrent flood subscriptions. Several producers all flood
+    /// the shared channel, so in bounded mode several block on `send` at once
+    /// (the `quit_blocked_*` scenarios' contention, RFC 0007 §5.2).
+    producers: u32,
     /// Wall-clock guard; the scenario is aborted and reported as timed out.
     max_wall: Duration,
 }
 
-/// A quit-latency scenario: `base` is run `trials` times and per-trial quit
-/// latencies are aggregated into one report.
+/// The valid-trial predicate a bounded quit scenario checks at the quit
+/// instant (RFC 0007 §5.2). Only a predicate *miss* is retried; a quit-contract
+/// failure (timeout or missing delivery) fails the row outright.
+#[derive(Clone, Copy)]
+enum ValidTrial {
+    /// `none` — every completed attempt is a valid trial (`quit_idle`).
+    Always,
+    /// The `blocked` producer gauge reads exactly this at the quit instant
+    /// (`quit_blocked_1` = 1, `quit_blocked_64` = 64).
+    BlockedEq(u64),
+    /// The `blocked` gauge reads at least this (`quit_keyed_bounded` = 1).
+    BlockedAtLeast(u64),
+    /// At least two shared-channel capacity-wait events in the 5ms preceding
+    /// the quit — `quit_overload`'s churn predicate.
+    Churn,
+}
+
+impl ValidTrial {
+    fn holds(self, metrics: &Metrics) -> bool {
+        match self {
+            Self::Always => true,
+            Self::BlockedEq(n) => metrics.blocked_at_quit.load(Ordering::Relaxed) == n,
+            Self::BlockedAtLeast(n) => metrics.blocked_at_quit.load(Ordering::Relaxed) >= n,
+            Self::Churn => metrics.capacity_waits_before_quit.load(Ordering::Relaxed) >= 2,
+        }
+    }
+}
+
+/// A quit-latency scenario: `base` is run until `trials` *valid* trials are
+/// collected (predicate misses are retried up to the attempt cap), and
+/// per-trial quit latencies are aggregated into one report.
 struct QuitScenarioCfg {
     base: ScenarioCfg,
     trials: u32,
+    /// Valid-trial predicate; `Always` needs no attempt cap.
+    valid_trial: ValidTrial,
 }
 
+#[allow(clippy::too_many_lines, reason = "a flat table of scenario literals")]
 fn scenarios() -> Vec<ScenarioCfg> {
     vec![
         // Paced load well below consumer capacity: the baseline contract.
@@ -139,6 +219,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: false,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
             max_wall: Duration::from_secs(30),
         },
         // Paced load near consumer capacity.
@@ -151,6 +233,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: false,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
             max_wall: Duration::from_secs(30),
         },
         // One burst dumped into the unbounded channel at t=0; measures drain
@@ -164,6 +248,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: false,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
             max_wall: Duration::from_secs(30),
         },
         // Sustained producer faster than the consumer: queue depth and
@@ -177,6 +263,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: false,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
             max_wall: Duration::from_secs(60),
         },
         // Control: keyed command outputs while the shared channel is lightly
@@ -190,6 +278,8 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: true,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
             max_wall: Duration::from_secs(30),
         },
         // Keyed command outputs while the shared channel is overloaded; the
@@ -204,6 +294,51 @@ fn scenarios() -> Vec<ScenarioCfg> {
             keyed_probe: true,
             quit_at_seq: None,
             keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
+            max_wall: Duration::from_secs(60),
+        },
+        // Bounded re-runs under the §5.1 configuration (RFC 0007 §5.3): the
+        // same RFC 0006 §2 load parameters, but built with `Runtime::with_config`
+        // so the shared channel is bounded to 1024 and each keyed channel to 16.
+        // Compared cell-by-cell against the unbounded rows above.
+        ScenarioCfg {
+            name: "burst_200k_bounded",
+            rate: BURST,
+            total: 200_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
+            producers: 1,
+            mode: Mode::Bounded,
+            max_wall: Duration::from_secs(30),
+        },
+        ScenarioCfg {
+            name: "overload_bounded",
+            rate: 100_000,
+            total: 500_000,
+            update_cost: Duration::from_micros(25),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
+            producers: 1,
+            mode: Mode::Bounded,
+            max_wall: Duration::from_secs(60),
+        },
+        ScenarioCfg {
+            name: "keyed_overload_bounded",
+            rate: 100_000,
+            total: 500_000,
+            update_cost: Duration::from_micros(25),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: true,
+            quit_at_seq: None,
+            keyed_quit: false,
+            producers: 1,
+            mode: Mode::Bounded,
             max_wall: Duration::from_secs(60),
         },
     ]
@@ -218,6 +353,7 @@ const QUIT_TRIALS: u32 = 200;
 /// (latency ~ drain time) is orders of magnitude above trial noise.
 const KEYED_QUIT_TRIALS: u32 = 20;
 
+#[allow(clippy::too_many_lines, reason = "a flat table of scenario literals")]
 fn quit_scenarios() -> Vec<QuitScenarioCfg> {
     // All quit scenarios use the overload update cost (25µs) so the backlog
     // drains slowly (~38k msg/s on the reference machine) and the depth at
@@ -231,6 +367,8 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
         keyed_probe: false,
         quit_at_seq: Some(5_000),
         keyed_quit: false,
+        producers: 1,
+        mode: Mode::Default,
         max_wall: Duration::from_secs(30),
     };
     vec![
@@ -243,6 +381,7 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
                 ..base.clone()
             },
             trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
         },
         // Quit while ~50k messages are still queued.
         QuitScenarioCfg {
@@ -252,6 +391,7 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
                 ..base.clone()
             },
             trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
         },
         // Quit while ~300k messages are still queued; if quit latency were
         // backlog-dependent, it must separate from the 50k scenario here.
@@ -262,6 +402,7 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
                 ..base.clone()
             },
             trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
         },
         // Quit while the producer is still actively refilling the shared
         // channel (sustained overload rather than a draining burst).
@@ -273,6 +414,7 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
                 ..base.clone()
             },
             trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
         },
         // Keyed quit under the 50k backlog: delivered through the command's
         // private channel, so INV-14 shared-first pull defers it until the
@@ -282,9 +424,73 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
                 name: "quit_keyed_backlog_50k",
                 total: 55_000,
                 keyed_quit: true,
+                ..base.clone()
+            },
+            trials: KEYED_QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
+        },
+        // Bounded quit rows (RFC 0007 §5.2). Under the §5.1 configuration the
+        // shared channel caps at 1024, so these vary the blocked-producer count
+        // and channel-full churn instead of raw depth. A large `total` keeps the
+        // burst producers blocked well past the quit at seq 5000; the valid-trial
+        // predicate is checked at the quit instant and misses are retried.
+        //
+        // The bounded `quit_idle` baseline: INV-L4 covers both delivery modes,
+        // so quit→delivered is measured bounded as well as unbounded. Its `none`
+        // predicate needs no blocked producers, so it keeps the empty-queue load.
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_idle_bounded",
+                total: 1,
+                quit_at_seq: Some(0),
+                mode: Mode::Bounded,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Always,
+        },
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_blocked_1",
+                total: 500_000,
+                mode: Mode::Bounded,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::BlockedEq(1),
+        },
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_blocked_64",
+                total: 500_000,
+                producers: 64,
+                mode: Mode::Bounded,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::BlockedEq(64),
+        },
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_overload_bounded",
+                rate: 100_000,
+                total: 500_000,
+                mode: Mode::Bounded,
+                ..base.clone()
+            },
+            trials: QUIT_TRIALS,
+            valid_trial: ValidTrial::Churn,
+        },
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_keyed_bounded",
+                total: 500_000,
+                keyed_quit: true,
+                mode: Mode::Bounded,
                 ..base
             },
             trials: KEYED_QUIT_TRIALS,
+            valid_trial: ValidTrial::BlockedAtLeast(1),
         },
     ]
 }
@@ -309,9 +515,12 @@ struct QuitDeliverySubscriber;
 
 impl Subscriber for QuitDeliverySubscriber {
     fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        // The quit-delivery message (`tears::runtime`) and the load gauges /
+        // capacity-wait events (`tears::runtime::load`) are all DEBUG; the
+        // batch event (TRACE) is not needed here.
         metadata.is_event()
-            && metadata.target() == "tears::runtime"
             && *metadata.level() == Level::DEBUG
+            && matches!(metadata.target(), "tears::runtime" | "tears::runtime::load")
     }
 
     fn max_level_hint(&self) -> Option<LevelFilter> {
@@ -327,16 +536,37 @@ impl Subscriber for QuitDeliverySubscriber {
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
     fn event(&self, event: &Event<'_>) {
-        let mut visitor = QuitMessageVisitor { matched: false };
+        let is_load = event.metadata().target() == "tears::runtime::load";
+        let mut visitor = LoadVisitor::default();
         event.record(&mut visitor);
-        if !visitor.matched {
-            return;
-        }
-        if let Some(metrics) = TRIAL_METRICS
+
+        let Some(metrics) = TRIAL_METRICS
             .lock()
             .expect("trial metrics slot poisoned")
-            .as_ref()
-        {
+            .clone()
+        else {
+            return;
+        };
+
+        if is_load {
+            // Producer-gauge event: track the live `blocked` count and the sum
+            // of all four gauges (the quiescence signal). A gauge event always
+            // carries `blocked`, so its presence identifies one. Shared
+            // capacity-wait event: log its instant for the churn window.
+            if let Some(blocked) = visitor.blocked {
+                metrics.blocked_live.store(blocked, Ordering::Relaxed);
+                metrics
+                    .live_producers
+                    .store(visitor.gauge_sum(), Ordering::Relaxed);
+            }
+            if visitor.channel.as_deref() == Some("shared") {
+                metrics
+                    .capacity_wait_shared_ns
+                    .lock()
+                    .expect("capacity-wait log poisoned")
+                    .push(metrics.elapsed_ns());
+            }
+        } else if visitor.matched_quit {
             metrics
                 .quit_delivered_ns
                 .store(metrics.elapsed_ns(), Ordering::Relaxed);
@@ -348,16 +578,49 @@ impl Subscriber for QuitDeliverySubscriber {
     fn exit(&self, _span: &Id) {}
 }
 
-struct QuitMessageVisitor {
-    matched: bool,
+#[derive(Default)]
+struct LoadVisitor {
+    matched_quit: bool,
+    subscriptions: Option<u64>,
+    unkeyed_commands: Option<u64>,
+    keyed_commands: Option<u64>,
+    blocked: Option<u64>,
+    channel: Option<String>,
 }
 
-impl Visit for QuitMessageVisitor {
+impl LoadVisitor {
+    /// Sum of the four producer gauges on this event (all present together on a
+    /// gauge event); 0 for non-gauge events.
+    fn gauge_sum(&self) -> u64 {
+        self.subscriptions.unwrap_or(0)
+            + self.unkeyed_commands.unwrap_or(0)
+            + self.keyed_commands.unwrap_or(0)
+            + self.blocked.unwrap_or(0)
+    }
+}
+
+impl Visit for LoadVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            "subscriptions" => self.subscriptions = Some(value),
+            "unkeyed_commands" => self.unkeyed_commands = Some(value),
+            "keyed_commands" => self.keyed_commands = Some(value),
+            "blocked" => self.blocked = Some(value),
+            _ => {}
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "channel" {
+            self.channel = Some(value.to_owned());
+        }
+    }
+
     fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
         if field.name() == "message" {
             let text = format!("{value:?}");
             if text == "quit signal received" || text == "keyed quit signal received" {
-                self.matched = true;
+                self.matched_quit = true;
             }
         }
     }
@@ -385,6 +648,35 @@ struct Metrics {
     /// observed the quit, recorded by [`QuitDeliverySubscriber`] from the
     /// runtime's own tracing events; 0 while undelivered.
     quit_delivered_ns: AtomicU64,
+    /// Next flood seq `update` expects to process. A single flood producer
+    /// feeds the shared FIFO in seq order, so a lossless in-order drain sees
+    /// `0, 1, …`; the smoke profile's draining scenarios assert this exactly
+    /// (RFC 0007 §6). Also the count of processed flood messages.
+    seq_next: AtomicU64,
+    /// Set if a processed flood seq ever differs from the expected next seq —
+    /// a drop, duplicate, reorder, or lost tail (RFC 0007 §6).
+    seq_broken: AtomicBool,
+    /// The `blocked` producer-gauge value observed at the instant `update`
+    /// requested the quit, captured by [`QuitDeliverySubscriber`] from the
+    /// live gauge; the bounded quit scenarios' valid-trial predicate reads it
+    /// (RFC 0007 §5.2).
+    blocked_at_quit: AtomicU64,
+    /// Count of shared-channel capacity-wait events in the 5ms preceding the
+    /// quit request — `quit_overload`'s churn predicate (RFC 0007 §5.2).
+    capacity_waits_before_quit: AtomicU64,
+    /// The most recent `blocked` producer-gauge value, updated live by
+    /// [`QuitDeliverySubscriber`] from each `tears::runtime::load` gauge event.
+    blocked_live: AtomicU64,
+    /// The most recent sum of all four producer gauges
+    /// (`subscriptions + unkeyed_commands + keyed_commands + blocked`). Reaches
+    /// 0 only when this trial's runtime has fully torn its producers down; the
+    /// trial-boundary quiescence gate waits on it so a late gauge/capacity event
+    /// cannot leak into the next trial's slot (see [`run_quit_trial`]).
+    live_producers: AtomicU64,
+    /// Nanoseconds from `start` of each shared-channel capacity-wait event,
+    /// logged live by [`QuitDeliverySubscriber`]; the churn predicate counts
+    /// those inside its window.
+    capacity_wait_shared_ns: Mutex<Vec<u64>>,
 }
 
 impl Metrics {
@@ -402,6 +694,13 @@ impl Metrics {
             quit_requested_ns: AtomicU64::new(0),
             depth_at_quit: AtomicU64::new(0),
             quit_delivered_ns: AtomicU64::new(0),
+            seq_next: AtomicU64::new(0),
+            seq_broken: AtomicBool::new(false),
+            blocked_at_quit: AtomicU64::new(0),
+            capacity_waits_before_quit: AtomicU64::new(0),
+            blocked_live: AtomicU64::new(0),
+            live_producers: AtomicU64::new(0),
+            capacity_wait_shared_ns: Mutex::new(Vec::new()),
         }
     }
 
@@ -439,11 +738,15 @@ enum Msg {
 struct FloodSource {
     cfg: ScenarioCfg,
     metrics: Arc<Metrics>,
+    /// Distinct per producer so several flood subscriptions coexist (the
+    /// subscription manager dedupes by key). Seqs stay globally ordered via the
+    /// shared `produced` counter regardless of producer count.
+    index: u32,
 }
 
 impl SubscriptionSource for FloodSource {
     type Output = Msg;
-    type Key = &'static str;
+    type Key = u32;
 
     fn stream(&self) -> BoxStream<'static, Msg> {
         let metrics = Arc::clone(&self.metrics);
@@ -481,7 +784,7 @@ impl SubscriptionSource for FloodSource {
     }
 
     fn key(&self) -> Self::Key {
-        "flood"
+        self.index
     }
 }
 
@@ -536,6 +839,13 @@ impl Application for LoadApp {
                 self.metrics
                     .processed
                     .store(self.processed, Ordering::Relaxed);
+                // Seq-integrity: a single flood producer feeds the shared FIFO
+                // in seq order, so a lossless in-order drain sees 0, 1, …. Any
+                // mismatch is a drop/duplicate/reorder/lost-tail (RFC 0007 §6).
+                let expected = self.metrics.seq_next.fetch_add(1, Ordering::Relaxed);
+                if seq != expected {
+                    self.metrics.seq_broken.store(true, Ordering::Relaxed);
+                }
                 spin(self.cfg.update_cost);
                 if seq % self.sample_every == 0 {
                     Metrics::push_latency(&self.metrics.update_lat_ns, sent_at);
@@ -549,6 +859,17 @@ impl Application for LoadApp {
                     self.metrics
                         .depth_at_quit
                         .store(self.metrics.queue_depth(), Ordering::Relaxed);
+                    // Snapshot the predicate input and the latency reference in
+                    // O(1), as the last thing before returning the quit, so both
+                    // reflect the actual quit instant (RFC 0007 §5.2): the live
+                    // `blocked` gauge, then `quit_requested_ns` last. The churn
+                    // predicate's window count is computed post-run from the
+                    // logged capacity-wait timestamps, off this hot path, so no
+                    // history scan sits between the reference reads and the send.
+                    self.metrics.blocked_at_quit.store(
+                        self.metrics.blocked_live.load(Ordering::Relaxed),
+                        Ordering::Relaxed,
+                    );
                     self.metrics
                         .quit_requested_ns
                         .store(self.metrics.elapsed_ns(), Ordering::Relaxed);
@@ -586,10 +907,15 @@ impl Application for LoadApp {
     }
 
     fn subscriptions(&self) -> Vec<Subscription<Msg>> {
-        vec![Subscription::new(FloodSource {
-            cfg: self.cfg.clone(),
-            metrics: Arc::clone(&self.metrics),
-        })]
+        (0..self.cfg.producers)
+            .map(|index| {
+                Subscription::new(FloodSource {
+                    cfg: self.cfg.clone(),
+                    metrics: Arc::clone(&self.metrics),
+                    index,
+                })
+            })
+            .collect()
     }
 }
 
@@ -618,6 +944,9 @@ struct Report {
     render_lat_ns: Vec<u64>,
     keyed_lat_ns: Vec<u64>,
     peak_rss_delta: Option<u64>,
+    /// A processed flood seq differed from the expected contiguous run — a
+    /// drop/duplicate/reorder/lost-tail (RFC 0007 §6 smoke seq-integrity).
+    seq_broken: bool,
 }
 
 async fn run_scenario(cfg: ScenarioCfg) -> Report {
@@ -640,9 +969,7 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
         })
     };
 
-    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
-        .expect("60 FPS is a valid frame rate");
-    let runtime = Runtime::<LoadApp>::new((cfg.clone(), Arc::clone(&metrics)), frame_rate);
+    let runtime = cfg.mode.build_runtime((cfg.clone(), Arc::clone(&metrics)));
     let mut terminal =
         Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
 
@@ -686,6 +1013,7 @@ async fn run_scenario(cfg: ScenarioCfg) -> Report {
             (Some(before), Some(after)) => Some(after.saturating_sub(before)),
             _ => None,
         },
+        seq_broken: metrics.seq_broken.load(Ordering::Relaxed),
         cfg,
     }
 }
@@ -700,28 +1028,52 @@ struct QuitTrialSample {
 }
 
 enum QuitTrialFailure {
+    /// Quit-contract failure: the run timed out. Fails the row outright, never
+    /// retried (RFC 0007 §5.2).
     TimedOut,
-    /// The runtime never emitted its quit-delivery tracing event; see
-    /// [`QuitDeliverySubscriber`].
+    /// Quit-contract failure: the runtime never emitted its quit-delivery
+    /// tracing event (see [`QuitDeliverySubscriber`]). Fails the row outright.
     NoDeliveryEvent,
+    /// Predicate miss: the quit was delivered, but the valid-trial predicate did
+    /// not hold at the quit instant. The *only* retryable outcome (RFC 0007
+    /// §5.2).
+    PredicateMiss,
 }
 
 struct QuitReport {
     cfg: ScenarioCfg,
+    /// Required valid trials (the row's configured count).
     trials: u32,
+    /// Total attempts made (valid trials + predicate misses + the failing one).
+    attempts: u32,
     timeouts: u32,
     missing_delivery: u32,
-    /// Sorted per-trial values.
+    predicate_misses: u32,
+    /// The attempt cap was reached before enough valid trials were collected.
+    cap_exhausted: bool,
+    /// Sorted per-trial values (valid trials only).
     depths: Vec<u64>,
     to_delivered_ns: Vec<u64>,
     to_exit_ns: Vec<u64>,
 }
 
-async fn run_quit_trial(cfg: ScenarioCfg) -> Result<QuitTrialSample, QuitTrialFailure> {
+impl QuitReport {
+    /// The row failed: a quit-contract failure, attempt-cap exhaustion, or an
+    /// incomplete sample. Feeds the harness's non-zero exit (RFC 0007 §5.2/§6).
+    const fn failed(&self) -> bool {
+        self.timeouts > 0
+            || self.missing_delivery > 0
+            || self.cap_exhausted
+            || (self.depths.len() as u32) < self.trials
+    }
+}
+
+async fn run_quit_trial(
+    cfg: ScenarioCfg,
+    valid_trial: ValidTrial,
+) -> Result<QuitTrialSample, QuitTrialFailure> {
     let metrics = Arc::new(Metrics::new());
-    let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero fps"))
-        .expect("60 FPS is a valid frame rate");
-    let runtime = Runtime::<LoadApp>::new((cfg.clone(), Arc::clone(&metrics)), frame_rate);
+    let runtime = cfg.mode.build_runtime((cfg.clone(), Arc::clone(&metrics)));
     let mut terminal =
         Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
 
@@ -730,6 +1082,21 @@ async fn run_quit_trial(cfg: ScenarioCfg) -> Result<QuitTrialSample, QuitTrialFa
         .await
         .is_err();
     let exit_ns = metrics.elapsed_ns();
+
+    // Trial-boundary quiescence: `Runtime::run` returning (or being dropped on
+    // timeout) does not join the aborted producer tasks, so a late gauge or
+    // capacity-wait event could still fire on a worker thread. Keep the shared
+    // slot pointed at this trial and wait until its producers have fully torn
+    // down — the gauge sum returns to 0, which is terminal once no producer
+    // remains — before releasing the slot, so no straggler event lands in the
+    // next trial's metrics and skews its predicate (RFC 0007 §5.2). Bounded by
+    // the same wall guard so a stuck teardown cannot hang the trial.
+    let _ = timeout(cfg.max_wall, async {
+        while metrics.live_producers.load(Ordering::Relaxed) != 0 {
+            yield_now().await;
+        }
+    })
+    .await;
     *TRIAL_METRICS.lock().expect("trial metrics slot poisoned") = None;
 
     if timed_out {
@@ -740,6 +1107,28 @@ async fn run_quit_trial(cfg: ScenarioCfg) -> Result<QuitTrialSample, QuitTrialFa
     if quit_ns == 0 || delivered_ns == 0 {
         return Err(QuitTrialFailure::NoDeliveryEvent);
     }
+    // Churn predicate: count shared capacity-wait events in the 5ms preceding
+    // the quit, from the logged timestamps. Computed here, off `update`'s hot
+    // path, so no history scan sits between the quit-instant snapshot and the
+    // quit send (RFC 0007 §5.2).
+    let window_start = quit_ns.saturating_sub(5_000_000);
+    let churn = metrics
+        .capacity_wait_shared_ns
+        .lock()
+        .expect("capacity-wait log poisoned")
+        .iter()
+        .filter(|&&at| at >= window_start && at <= quit_ns)
+        .count();
+    metrics
+        .capacity_waits_before_quit
+        .store(u64::try_from(churn).unwrap_or(u64::MAX), Ordering::Relaxed);
+
+    // Predicate checked at the quit instant, from the values `update` snapshot
+    // when it requested the quit plus the churn count just computed (RFC 0007
+    // §5.2).
+    if !valid_trial.holds(&metrics) {
+        return Err(QuitTrialFailure::PredicateMiss);
+    }
     Ok(QuitTrialSample {
         depth: metrics.depth_at_quit.load(Ordering::Relaxed),
         to_delivered_ns: delivered_ns.saturating_sub(quit_ns),
@@ -748,21 +1137,46 @@ async fn run_quit_trial(cfg: ScenarioCfg) -> Result<QuitTrialSample, QuitTrialFa
 }
 
 async fn run_quit_scenario(scenario: &QuitScenarioCfg) -> QuitReport {
+    // Only predicate misses are retried; a quit-contract failure fails the row
+    // immediately, and the attempt cap (10 × trials) bounds retries so a rarely
+    // held predicate terminates instead of looping forever (RFC 0007 §5.2). The
+    // `Always` predicate never misses, so it needs no cap.
+    let attempt_cap = match scenario.valid_trial {
+        ValidTrial::Always => u32::MAX,
+        _ => scenario.trials.saturating_mul(10),
+    };
+
+    let mut attempts = 0u32;
     let mut timeouts = 0;
     let mut missing_delivery = 0;
+    let mut predicate_misses = 0;
+    let mut cap_exhausted = false;
     let mut depths = Vec::new();
     let mut to_delivered_ns = Vec::new();
     let mut to_exit_ns = Vec::new();
 
-    for _ in 0..scenario.trials {
-        match run_quit_trial(scenario.base.clone()).await {
+    while (depths.len() as u32) < scenario.trials {
+        if attempts >= attempt_cap {
+            cap_exhausted = true;
+            break;
+        }
+        attempts += 1;
+        match run_quit_trial(scenario.base.clone(), scenario.valid_trial).await {
             Ok(sample) => {
                 depths.push(sample.depth);
                 to_delivered_ns.push(sample.to_delivered_ns);
                 to_exit_ns.push(sample.to_exit_ns);
             }
-            Err(QuitTrialFailure::TimedOut) => timeouts += 1,
-            Err(QuitTrialFailure::NoDeliveryEvent) => missing_delivery += 1,
+            Err(QuitTrialFailure::PredicateMiss) => predicate_misses += 1,
+            // Quit-contract failures fail the row outright — never retried.
+            Err(QuitTrialFailure::TimedOut) => {
+                timeouts += 1;
+                break;
+            }
+            Err(QuitTrialFailure::NoDeliveryEvent) => {
+                missing_delivery += 1;
+                break;
+            }
         }
     }
 
@@ -773,8 +1187,11 @@ async fn run_quit_scenario(scenario: &QuitScenarioCfg) -> QuitReport {
     QuitReport {
         cfg: scenario.base.clone(),
         trials: scenario.trials,
+        attempts,
         timeouts,
         missing_delivery,
+        predicate_misses,
+        cap_exhausted,
         depths,
         to_delivered_ns,
         to_exit_ns,
@@ -797,10 +1214,19 @@ fn print_quit_report(report: &QuitReport) {
         cfg.keyed_quit,
     );
     println!(
-        "   trials: {} ok, {} timed out, {} missing delivery event",
-        report.trials - report.timeouts - report.missing_delivery,
+        "   trials: {} valid / {} required ({} attempts, {} predicate misses, \
+         {} timed out, {} missing delivery){}",
+        report.depths.len(),
+        report.trials,
+        report.attempts,
+        report.predicate_misses,
         report.timeouts,
         report.missing_delivery,
+        if report.cap_exhausted {
+            ", ATTEMPT-CAP EXHAUSTED"
+        } else {
+            ""
+        },
     );
     if report.depths.is_empty() {
         return;
@@ -920,13 +1346,154 @@ fn peak_rss_bytes() -> Option<u64> {
     None
 }
 
+/// The RFC 0007 §6 smoke profile's draining scenarios: `steady_20k` under the
+/// default configuration, shortened to ~0.5s of load, and a 20k-message bounded
+/// burst under the §5.1 configuration.
+fn smoke_load_scenarios() -> Vec<ScenarioCfg> {
+    vec![
+        ScenarioCfg {
+            name: "steady_20k",
+            rate: 20_000,
+            total: 10_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
+            producers: 1,
+            mode: Mode::Default,
+            max_wall: Duration::from_secs(30),
+        },
+        ScenarioCfg {
+            name: "burst_20k_bounded",
+            rate: BURST,
+            total: 20_000,
+            update_cost: Duration::from_micros(2),
+            render_cost: Duration::from_micros(500),
+            keyed_probe: false,
+            quit_at_seq: None,
+            keyed_quit: false,
+            producers: 1,
+            mode: Mode::Bounded,
+            max_wall: Duration::from_secs(30),
+        },
+    ]
+}
+
+/// The RFC 0007 §6 smoke profile's quit scenarios: `quit_idle` and
+/// `quit_blocked_1` at 5 valid trials each (the attempt cap scales to 50).
+fn smoke_quit_scenarios() -> Vec<QuitScenarioCfg> {
+    vec![
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_idle",
+                rate: BURST,
+                total: 1,
+                update_cost: Duration::from_micros(25),
+                render_cost: Duration::from_micros(500),
+                keyed_probe: false,
+                quit_at_seq: Some(0),
+                keyed_quit: false,
+                producers: 1,
+                mode: Mode::Bounded,
+                max_wall: Duration::from_secs(30),
+            },
+            trials: 5,
+            valid_trial: ValidTrial::Always,
+        },
+        QuitScenarioCfg {
+            base: ScenarioCfg {
+                name: "quit_blocked_1",
+                rate: BURST,
+                total: 500_000,
+                update_cost: Duration::from_micros(25),
+                render_cost: Duration::from_micros(500),
+                keyed_probe: false,
+                quit_at_seq: Some(5_000),
+                keyed_quit: false,
+                producers: 1,
+                mode: Mode::Bounded,
+                max_wall: Duration::from_secs(30),
+            },
+            trials: 5,
+            valid_trial: ValidTrial::BlockedEq(1),
+        },
+    ]
+}
+
+/// Runs the smoke profile (RFC 0007 §6); returns whether it passed. Draining
+/// scenarios must complete with their exact scripted sequence `0..total`; quit
+/// scenarios must complete their required valid trials within the attempt cap.
+/// No latency is asserted.
+fn run_smoke(runtime: &TokioRuntime) -> bool {
+    println!("# tears runtime load harness — smoke profile\n");
+    let mut ok = true;
+
+    for cfg in smoke_load_scenarios() {
+        let report = runtime.block_on(run_scenario(cfg));
+        print_report(&report);
+        if report.timed_out {
+            eprintln!("smoke: draining scenario `{}` timed out", report.cfg.name);
+            ok = false;
+        }
+        // Seq-integrity: every scripted `Msg::Load` seq in `0..total`, once and
+        // in order — refutes any drop, duplicate, reorder, or lost tail. A
+        // total-only check would pass a drop-plus-duplicate (RFC 0007 §6).
+        if report.seq_broken || report.processed != report.cfg.total {
+            eprintln!(
+                "smoke: draining scenario `{}` did not deliver the exact sequence \
+                 0..{} (processed={}, seq_broken={})",
+                report.cfg.name, report.cfg.total, report.processed, report.seq_broken,
+            );
+            ok = false;
+        }
+    }
+
+    for scenario in smoke_quit_scenarios() {
+        let report = runtime.block_on(run_quit_scenario(&scenario));
+        print_quit_report(&report);
+        // Quit scenarios assert completion only: at the harness's observation
+        // point a legal shutdown discard is indistinguishable from an illegal
+        // drop, so no seq-integrity gate here (RFC 0007 §6).
+        if report.failed() {
+            eprintln!("smoke: quit scenario `{}` failed", report.cfg.name);
+            ok = false;
+        }
+    }
+
+    ok
+}
+
 fn main() -> ExitCode {
-    // Positional arguments select scenarios by name; flags (e.g. the
-    // `--bench` cargo passes) are ignored.
-    let selected: Vec<String> = env::args()
-        .skip(1)
+    // `--smoke` runs the reduced CI profile; otherwise positional arguments
+    // select full scenarios by name (other flags, e.g. cargo's `--bench`, are
+    // ignored).
+    let args: Vec<String> = env::args().skip(1).collect();
+    let smoke = args.iter().any(|arg| arg == "--smoke");
+    let selected: Vec<String> = args
+        .into_iter()
         .filter(|arg| !arg.starts_with('-'))
         .collect();
+
+    // Quit trials read delivery instants and the `blocked` gauge from the
+    // runtime's tracing events; installed unconditionally because its filter
+    // rejects everything but rare debug events on the runtime targets.
+    set_global_default(QuitDeliverySubscriber)
+        .expect("no other global tracing subscriber is installed");
+
+    let runtime = Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    if smoke {
+        return if run_smoke(&runtime) {
+            ExitCode::SUCCESS
+        } else {
+            eprintln!("error: smoke profile failed");
+            ExitCode::FAILURE
+        };
+    }
 
     let matches = |name: &str| selected.is_empty() || selected.iter().any(|s| s == name);
     let load_to_run: Vec<ScenarioCfg> = scenarios()
@@ -951,35 +1518,23 @@ fn main() -> ExitCode {
         return ExitCode::FAILURE;
     }
 
-    // Quit trials read delivery instants from the runtime's tracing events;
-    // installed unconditionally because its filter rejects everything but
-    // rare debug events on the `tears::runtime` target.
-    set_global_default(QuitDeliverySubscriber)
-        .expect("no other global tracing subscriber is installed");
-
-    let runtime = Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .expect("tokio runtime");
-
     println!("# tears runtime load harness\n");
     for cfg in load_to_run {
         let report = runtime.block_on(run_scenario(cfg));
         print_report(&report);
     }
-    let mut failed_trials = 0u32;
+    let mut any_failed = false;
     for scenario in quit_to_run {
         let report = runtime.block_on(run_quit_scenario(&scenario));
+        let failed = report.failed();
         print_quit_report(&report);
-        failed_trials += report.timeouts + report.missing_delivery;
+        any_failed |= failed;
     }
-    // Quit-trial statistics feed RFC 0006 acceptance criteria, so a partial
-    // sample must fail the run (and the CI Benchmarks check) instead of
-    // silently reporting percentiles over fewer trials than configured.
-    if failed_trials > 0 {
-        eprintln!(
-            "error: {failed_trials} quit trial(s) failed (timed out or missing delivery event)"
-        );
+    // Quit-trial statistics feed RFC 0006 acceptance criteria, so a row that
+    // failed its contract, exhausted its attempt cap, or collected a partial
+    // sample must fail the run (and the CI Benchmarks check).
+    if any_failed {
+        eprintln!("error: one or more quit scenarios failed");
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -109,13 +109,20 @@ fn frame_rate() -> FrameRate {
         .expect("60 FPS is a valid frame rate")
 }
 
+/// RFC 0007 §5.1 bounded capacities. Shared by [`bounded_config`] and the
+/// `keyed_isolation` gates so a retune moves the runtime config and the gate
+/// expectations (`yields == keyed_cap + 1`, `concurrent_shared_depth ==
+/// app_cap + 1`) together rather than leaving one stale.
+const APP_CHANNEL_CAPACITY: usize = 1024;
+const KEYED_CHANNEL_CAPACITY: usize = 16;
+
 /// The RFC 0007 §5.1 bounded configuration used for every bounded row:
 /// `app_channel_capacity = 1024`, `keyed_channel_capacity = 16`,
 /// `batch_max_messages = None`, at 60 FPS.
 fn bounded_config() -> RuntimeConfig {
     RuntimeConfig::new(frame_rate())
-        .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
-        .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"))
+        .app_channel_capacity(NonZeroUsize::new(APP_CHANNEL_CAPACITY).expect("non-zero"))
+        .keyed_channel_capacity(NonZeroUsize::new(KEYED_CHANNEL_CAPACITY).expect("non-zero"))
 }
 
 /// Delivery mode a scenario's [`Runtime`] is built in.
@@ -1405,13 +1412,16 @@ fn smoke_load_scenarios() -> Vec<ScenarioCfg> {
     ]
 }
 
-/// The RFC 0007 §6 smoke profile's quit scenarios: `quit_idle` and
-/// `quit_blocked_1` at 5 valid trials each (the attempt cap scales to 50).
+/// The RFC 0007 §6 smoke profile's quit scenarios: `quit_idle_bounded` and
+/// `quit_blocked_1` at 5 valid trials each (the attempt cap scales to 50). The
+/// row name matches the full quit table's bounded row (the full table also has
+/// a separate Default-mode `quit_idle`), so smoke and full report the same
+/// configuration under the same name.
 fn smoke_quit_scenarios() -> Vec<QuitScenarioCfg> {
     vec![
         QuitScenarioCfg {
             base: ScenarioCfg {
-                name: "quit_idle",
+                name: "quit_idle_bounded",
                 rate: BURST,
                 total: 1,
                 update_cost: Duration::from_micros(25),
@@ -1748,8 +1758,8 @@ impl IsoReport {
 }
 
 async fn run_keyed_isolation() -> IsoReport {
-    let keyed_cap: u64 = 16; // RFC 0007 §5.1 keyed_channel_capacity
-    let app_cap: u64 = 1024; // RFC 0007 §5.1 app_channel_capacity
+    let keyed_cap = KEYED_CHANNEL_CAPACITY as u64;
+    let app_cap = APP_CHANNEL_CAPACITY as u64;
     let iso = Arc::new(IsoMetrics::new());
     let runtime = Runtime::<KeyedIsolationApp>::with_config(
         (Arc::clone(&iso), keyed_cap, app_cap),

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -82,7 +82,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use std::{env, hint, mem};
+use std::{env, hint, iter, mem};
 
 use futures::stream::{self, StreamExt};
 use ratatui::Terminal;
@@ -1464,6 +1464,228 @@ fn run_smoke(runtime: &TokioRuntime) -> bool {
     ok
 }
 
+// ---- keyed_isolation scenario (RFC 0007 §5.3, INV-L9) ----------------------
+//
+// Eight keyed channels are saturated (each holding `keyed_channel_capacity`
+// messages with its next send pending) alongside a ninth probe key, all under
+// the §5.1 bounded configuration. A shared flood keeps the shared channel full
+// so the event loop stays shared-first and never drains the keyed channels, so
+// they hold saturated. The probe key admitting its full capacity while eight
+// others (128 messages) are held proves per-channel admission with no shared
+// pool — a behavioral regression check on INV-L9's structural pool-absence
+// proof. Delivery is excluded (the keyed `StreamMap` cannot drain a chosen key
+// selectively; no keyed-delivery bound exists, RFC 0006 §4.7). Compiled into
+// the harness but not part of the smoke profile (RFC 0007 §5.3).
+//
+// The shared-side probe RFC 0007 §5.3 also names — the shared producer's first
+// `app_channel_capacity` sends completing with only the next pending — is read
+// from the max sampled shared occupancy, `produced - processed`: since the one
+// shared flood producer's attempted sends are `produced` and `update`'s drains
+// are `processed`, this quantity is (in-channel + the one blocked send), so its
+// peak of `app_channel_capacity + 1` shows the shared channel admitted its full
+// `app_channel_capacity` with exactly the next send pending — independent of the
+// saturated keyed channels.
+
+/// Saturated keyed channels plus the probe (8 + 1).
+const ISO_KEYS: usize = 9;
+
+struct IsoMetrics {
+    /// Yields of each keyed command's stream; a saturated key reads
+    /// `keyed_channel_capacity + 1` (capacity admitted, the next send blocked).
+    /// Each is its own `Arc` so a `'static` keyed stream can own a clone.
+    key_yields: Vec<Arc<AtomicU64>>,
+    shared_produced: AtomicU64,
+    shared_processed: AtomicU64,
+    /// Max sampled shared occupancy (`produced - processed`) — the shared-side
+    /// isolation signal.
+    max_shared_depth: AtomicU64,
+}
+
+impl IsoMetrics {
+    fn new() -> Self {
+        Self {
+            key_yields: (0..ISO_KEYS).map(|_| Arc::new(AtomicU64::new(0))).collect(),
+            shared_produced: AtomicU64::new(0),
+            shared_processed: AtomicU64::new(0),
+            max_shared_depth: AtomicU64::new(0),
+        }
+    }
+
+    fn shared_depth(&self) -> u64 {
+        self.shared_produced
+            .load(Ordering::Relaxed)
+            .saturating_sub(self.shared_processed.load(Ordering::Relaxed))
+    }
+}
+
+#[derive(Clone)]
+enum IsoMsg {
+    Flood(u64),
+}
+
+/// Infinite shared flood keeping the shared channel saturated.
+struct IsoFloodSource {
+    iso: Arc<IsoMetrics>,
+}
+
+impl SubscriptionSource for IsoFloodSource {
+    type Output = IsoMsg;
+    type Key = u32;
+
+    fn stream(&self) -> BoxStream<'static, IsoMsg> {
+        let iso = Arc::clone(&self.iso);
+        stream::repeat(())
+            .map(move |()| IsoMsg::Flood(iso.shared_produced.fetch_add(1, Ordering::Relaxed)))
+            .boxed()
+    }
+
+    fn key(&self) -> Self::Key {
+        0
+    }
+}
+
+/// Infinite keyed-command stream: increments its yield counter per item, so its
+/// channel fills to capacity and the next send blocks (the counter then reads
+/// `capacity + 1`).
+fn iso_keyed_stream(
+    counter: Arc<AtomicU64>,
+) -> impl futures::Stream<Item = IsoMsg> + Send + 'static {
+    stream::repeat(()).map(move |()| {
+        counter.fetch_add(1, Ordering::Relaxed);
+        IsoMsg::Flood(0)
+    })
+}
+
+struct KeyedIsolationApp {
+    iso: Arc<IsoMetrics>,
+    keyed_cap: u64,
+}
+
+impl Application for KeyedIsolationApp {
+    type Message = IsoMsg;
+    type Flags = (Arc<IsoMetrics>, u64);
+
+    fn new((iso, keyed_cap): Self::Flags) -> (Self, Command<IsoMsg>) {
+        (Self { iso, keyed_cap }, Command::none())
+    }
+
+    fn update(&mut self, msg: IsoMsg) -> Command<IsoMsg> {
+        let IsoMsg::Flood(seq) = msg;
+        // Keep the shared channel full so the event loop stays shared-first and
+        // never drains the keyed channels; they must hold saturated.
+        spin(Duration::from_micros(10));
+        self.iso.shared_processed.fetch_add(1, Ordering::Relaxed);
+        // Sample the shared occupancy peak here, on every shared message, so it
+        // is captured deterministically even if saturation completes between two
+        // external sampler ticks.
+        self.iso
+            .max_shared_depth
+            .fetch_max(self.iso.shared_depth(), Ordering::Relaxed);
+
+        let index = usize::try_from(seq).unwrap_or(usize::MAX);
+        if index < ISO_KEYS {
+            // Spawn keyed command `index` on its own key.
+            let counter = Arc::clone(&self.iso.key_yields[index]);
+            return Command::stream(iso_keyed_stream(counter)).cancellable(CommandId::new(seq));
+        }
+        // Every key spawned: quit once all keyed channels are saturated
+        // (yields reached capacity + 1 — capacity admitted, the next send
+        // blocked). A shared pool would keep some key below capacity, so
+        // saturation would never complete and the scenario would time out.
+        let saturated = self
+            .iso
+            .key_yields
+            .iter()
+            .all(|counter| counter.load(Ordering::Relaxed) > self.keyed_cap);
+        if saturated {
+            Command::quit()
+        } else {
+            Command::none()
+        }
+    }
+
+    fn view(&self, _frame: &mut ratatui::Frame<'_>) {}
+
+    fn subscriptions(&self) -> Vec<Subscription<IsoMsg>> {
+        vec![Subscription::new(IsoFloodSource {
+            iso: Arc::clone(&self.iso),
+        })]
+    }
+}
+
+struct IsoReport {
+    keyed_cap: u64,
+    app_cap: u64,
+    timed_out: bool,
+    /// Admitted per key (`capacity` when saturated).
+    admitted: Vec<u64>,
+    max_shared_depth: u64,
+}
+
+impl IsoReport {
+    /// Isolation held: every keyed channel admitted its full capacity and the
+    /// shared channel reached its own full occupancy — so no shared pool starved
+    /// any keyed key or the shared channel — and the scenario did not time out.
+    fn isolated(&self) -> bool {
+        !self.timed_out
+            && self.admitted.iter().all(|&a| a == self.keyed_cap)
+            && self.max_shared_depth >= self.app_cap
+    }
+}
+
+async fn run_keyed_isolation() -> IsoReport {
+    let keyed_cap: u64 = 16; // RFC 0007 §5.1 keyed_channel_capacity
+    let iso = Arc::new(IsoMetrics::new());
+    let runtime =
+        Runtime::<KeyedIsolationApp>::with_config((Arc::clone(&iso), keyed_cap), bounded_config());
+    let mut terminal =
+        Terminal::new(TestBackend::new(120, 40)).expect("test backend terminal creation");
+
+    let timed_out = timeout(Duration::from_secs(10), runtime.run(&mut terminal))
+        .await
+        .is_err();
+
+    let admitted = iso
+        .key_yields
+        .iter()
+        .map(|counter| counter.load(Ordering::Relaxed).min(keyed_cap))
+        .collect();
+    IsoReport {
+        keyed_cap,
+        app_cap: 1024, // RFC 0007 §5.1 app_channel_capacity
+        timed_out,
+        admitted,
+        max_shared_depth: iso.max_shared_depth.load(Ordering::Relaxed),
+    }
+}
+
+fn print_iso_report(report: &IsoReport) {
+    println!("## keyed_isolation");
+    println!(
+        "   {} keyed channels, capacity {}",
+        report.admitted.len(),
+        report.keyed_cap,
+    );
+    println!(
+        "   status: {}",
+        if report.timed_out {
+            "TIMED OUT — channels never all saturated (possible shared pool)"
+        } else {
+            "ok"
+        },
+    );
+    println!("   per-key admitted: {:?}", report.admitted);
+    println!(
+        "   isolation: every key admitted its full capacity = {}",
+        report.isolated(),
+    );
+    println!(
+        "   max shared depth: {} (shared-side signal; ~app_channel_capacity)",
+        report.max_shared_depth,
+    );
+    println!();
+}
+
 fn main() -> ExitCode {
     // `--smoke` runs the reduced CI profile; otherwise positional arguments
     // select full scenarios by name (other flags, e.g. cargo's `--bench`, are
@@ -1504,7 +1726,8 @@ fn main() -> ExitCode {
         .into_iter()
         .filter(|scenario| matches(scenario.base.name))
         .collect();
-    if load_to_run.is_empty() && quit_to_run.is_empty() {
+    let run_iso = matches("keyed_isolation");
+    if load_to_run.is_empty() && quit_to_run.is_empty() && !run_iso {
         let names: Vec<&str> = scenarios()
             .into_iter()
             .map(|cfg| cfg.name)
@@ -1513,6 +1736,7 @@ fn main() -> ExitCode {
                     .into_iter()
                     .map(|scenario| scenario.base.name),
             )
+            .chain(iter::once("keyed_isolation"))
             .collect();
         println!("no matching scenario; available: {}", names.join(", "));
         return ExitCode::FAILURE;
@@ -1530,11 +1754,18 @@ fn main() -> ExitCode {
         print_quit_report(&report);
         any_failed |= failed;
     }
-    // Quit-trial statistics feed RFC 0006 acceptance criteria, so a row that
-    // failed its contract, exhausted its attempt cap, or collected a partial
-    // sample must fail the run (and the CI Benchmarks check).
+    if run_iso {
+        let report = runtime.block_on(run_keyed_isolation());
+        let failed = !report.isolated();
+        print_iso_report(&report);
+        any_failed |= failed;
+    }
+    // Quit-trial statistics and the keyed_isolation regression check feed RFC
+    // 0006/0007 acceptance criteria, so a row that failed its contract,
+    // exhausted its attempt cap, collected a partial sample, or lost isolation
+    // must fail the run (and the CI Benchmarks check).
     if any_failed {
-        eprintln!("error: one or more quit scenarios failed");
+        eprintln!("error: one or more scenarios failed");
         return ExitCode::FAILURE;
     }
     ExitCode::SUCCESS

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -1,7 +1,6 @@
 # RFC 0006: Runtime Load Control
 
-- Status: Accepted (moves to Implemented when the sections 4–6
-  implementation lands)
+- Status: Implemented (section 5.1 records the bounded acceptance results)
 - Target: release-gate decision for 0.10.0 (section 3); implementation after
   0.10.0 (additive)
 - Scope: bounded memory, backpressure, and latency behavior of the runtime
@@ -17,7 +16,7 @@
 > API. Sections 4–6 fix the load-control contract. The items this RFC
 > delegated to the separate `RuntimeConfig` RFC — capacity values,
 > recommended defaults, the section 5.1 bounded-run parameters, and the CI
-> smoke-profile question — are settled there; that RFC is Accepted, so no
+> smoke-profile question — are settled there; that RFC is Implemented, so no
 > prerequisite of the implementation PR remains open (sections 3.2, 6). The
 > three contracts flagged for settling before the post-0.10.0
 > implementation — the exact scope of the memory bound (INV-L1), the quit
@@ -287,7 +286,7 @@ constructor `Runtime::with_config(flags, config)`, with `Runtime::new`
 unchanged and equivalent to the default configuration. The exact public
 shape — constructor signature, field set, naming, and
 construction/validation style — is fixed by the separate `RuntimeConfig`
-RFC (Accepted; section 6), so the load-control implementation PR can
+RFC (Implemented; section 6), so the load-control implementation PR could
 start. The verdict here needs only the additivity argument, which holds
 for any shape that keeps `Runtime::new` unchanged. Bounded behavior
 activates only through that surface:
@@ -322,7 +321,7 @@ load-control implementation (sections 4–6) lands after 0.10.0 behind
 ### 4.1 Configuration surface
 
 `RuntimeConfig` — public shape fixed by the separate `RuntimeConfig` RFC
-(Accepted; section 3.2) — carries the three controls below. That RFC
+(Implemented; section 3.2) — carries the three controls below. That RFC
 adopts these names unchanged and groups the frame rate into the same
 config, so `Runtime::with_config(flags, config)` takes the frame rate
 inside `config`; the semantics stated here are the contract.
@@ -1194,7 +1193,8 @@ bounded `RuntimeConfig`, compared cell by cell against the unbounded
 baseline below (measured on the section 2 reference machine). The
 unbounded column is fixed now so the implementation has a pinned before/after
 comparison; the bounded column states the acceptance criterion each cell
-must meet and is filled with measured values when the implementation lands.
+must meet, and the results measured against those criteria when the
+implementation landed are recorded below the matrix.
 
 Three reproducibility rules make the bounded run an acceptance
 measurement rather than an implementation-time choice:
@@ -1241,6 +1241,38 @@ measurement rather than an implementation-time choice:
 | `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), the two probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared) — the keyed probe is started only after the eight are held saturated, while the shared producer runs throughout as the saturation enabler (it cannot be idled and re-probed without letting the keyed channels drain under shared-first pull; RFC 0007 §5.3). The keyed→shared gate is the shared occupancy sampled only during the window when all nine keyed channels are concurrently saturated, which must reach `app_channel_capacity + 1` — the *simultaneous* value, not a whole-run maximum a shared pool could reach before the keyed channels start; admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency carries no bound, open question 6 resolved, section 4.7) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
+**Measured acceptance results.** The bounded column's criteria were met on the
+section 2 reference machine (Apple M1 Max, 10 cores, rustc 1.97.0) on
+2026-07-24, under the RFC 0007 section 5.1 configuration (`app_channel_capacity
+= 1024`, `keyed_channel_capacity = 16`, `batch_max_messages` unset):
+
+- **INV-L1 (`overload` / `burst_200k` depth).** Bounded max depth **1025**
+  (`capacity + 1`) versus the unbounded ~308k / ~191k that grow with the
+  overload — the cap holds. `burst_200k_bounded` drained all 200,000 messages
+  with none dropped (INV-L2), and `overload_bounded` all 500,000.
+- **INV-L3 (`overload` update latency).** Bounded p99 **28.0 ms** (p50
+  27.2 ms), flat at roughly one full queue's drain (`1024 × ~27µs`), versus the
+  unbounded 7.9 s that grows with the backlog.
+- **INV-L4 (quit→delivered p99 ≤ 1 ms, ≥ 200 valid trials).** All bounded rows
+  pass — `quit_idle_bounded` **0.61 ms**, `quit_blocked_1` **0.91 ms**,
+  `quit_blocked_64` **0.92 ms**, `quit_overload_bounded` **0.65 ms** — and p99
+  does not scale with blocked-producer count (1 → 64), the bounded analogue of
+  F6's depth-independence; the unbounded `quit_*` baselines stay ≤ 0.62 ms.
+  Observed depths matched `capacity + producers` (1025 for one producer, 1088
+  for 64). (Per-trial *max* exceeds 1 ms on the blocked rows — 1.03 / 1.17 ms —
+  but the criterion is p99, which holds.)
+- **Measurement-only rows (no criterion).** `keyed_overload` bounded keyed p50
+  **13.0 s**, and `quit_keyed_bounded` p50 **13.07 s** (≈ the full shared drain
+  the keyed quit waits behind); recorded, not gated (open questions 6/7,
+  sections 4.7 / 4.6).
+- **INV-L9 (`keyed_isolation`).** Every key admitted exactly `capacity + 1`
+  (17), no keyed message was delivered to `update`, and the shared occupancy
+  reached `app_channel_capacity + 1` (1025) while all nine keyed channels were
+  concurrently saturated — isolation held.
+
+Replacing the reference machine re-measures the unbounded baseline first and is
+recorded as a further amendment (reproducibility rules above).
+
 Queue-depth cells use the harness's depth definition, `produced -
 processed`. Raw channel occupancy is not observable through the public API,
 so two in-flight positions outside the channel had to be settled
@@ -1260,7 +1292,7 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
 
 ## 6. Open questions (all resolved)
 
-Every question below is resolved — in this RFC, or by the now-Accepted
+Every question below is resolved — in this RFC, or by the now-Implemented
 `RuntimeConfig` RFC, which fixes the public `RuntimeConfig` API (and with
 it questions 1, 5, and the default-value half of 2), the section 5.1
 bounded-run parameters (configuration under test, backlog depths, trial

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -496,45 +496,47 @@ as INV-L13 (section 5):
   observable rather than enforced (section 4.5), including the
   blocked-producer anti-pattern named there.
 
-Definition of done for the observability slice: a runtime batch-layer
-test together with an integration test, each installing a `tracing`
-subscriber (the technique the `quit_*` harness already uses, section 2).
-The runtime batch-layer test drives `process_input_batch` directly to fix
-the batch event's `Closed` differing-value case deterministically (below);
-the integration test drives a scripted load for the remaining values —
-the equal-count batch case, `shared_pending`, the capacity-wait event, and
-the producer gauges. Both verify values and firing conditions, not mere
-event presence — an implementation that emits each event once with wrong
-values must fail:
+Definition of done for the observability slice: layered tests, each
+installing a `tracing` subscriber (the technique the `quit_*` harness
+already uses, section 2) and asserting values and firing conditions, not
+mere event presence — an implementation that emits each event once with
+wrong values must fail. Each event is checked at the narrowest layer that
+makes its scripted inputs deterministic: the batch event's values at the
+runtime batch layer (driving `process_input_batch` directly), the
+capacity-wait event and the `blocked` gauge at the bounded-send layer
+(where a scripted wait and a scripted abort are deterministic), and the
+`subscriptions`/`unkeyed_commands`/`keyed_commands` gauges end-to-end over
+an integration run (where the real producers raise and lower them):
 
-- **Batch event**: `pulled` and `updated` equal the scripted input
-  counts, including a batch where the two differ. The differing case is
-  observed at the runtime batch layer rather than over the integration
-  load: a `tracing` subscriber over a `Some(1)` batch whose opening input
-  is a `ReceiverEvent::Closed` must observe `pulled = 1` and
-  `updated = 0`. This is the opening-`Closed` placement INV-L12 uses and
-  for the same reason — a queued `Closed` is not deterministically
-  constructible (section 4.7 shared-first pull; `StreamMap` order), so
-  requiring a real `Closed` mid-load would reintroduce that
-  non-determinism in the observability slice. `shared_pending` is
-  verified against a scripted leftover, not merely present: with
+- **Batch event** (runtime batch layer): `pulled` and `updated` equal the
+  scripted input counts, including a batch where the two differ — a
+  `Some(1)` batch whose opening input is a `ReceiverEvent::Closed` must
+  observe `pulled = 1` and `updated = 0`. This uses the opening-`Closed`
+  placement INV-L12 uses and for the same reason — a queued `Closed` is
+  not deterministically constructible (section 4.7 shared-first pull;
+  `StreamMap` order), which is also why the whole batch event is asserted
+  here rather than over the integration load. `shared_pending` is verified
+  against a scripted leftover, not merely present: with
   `batch_max_messages = Some(n)` and `n + k` shared messages queued under
   the paused clock, the capped batch must report `shared_pending = k`.
-- **Capacity-wait event**: an immediately accepted send fires no event;
-  a send that had to await capacity fires exactly one event, at
-  acceptance, with `channel` naming the channel that blocked it.
+- **Capacity-wait event** (bounded-send layer): an immediately accepted
+  send fires no event; a send that had to await capacity fires exactly one
+  event, at acceptance, with `channel` naming the channel that blocked it.
   `wait_us` is verified against a controlled wait: a send held blocked
   while the test advances the paused clock by a scripted duration
   before freeing capacity must report `wait_us` of at least that
   duration — which requires the wait to be measured with
   `tokio::time::Instant`, the pausable clock the batch deadline already
   uses — so an implementation that hardcodes `wait_us = 0` fails.
-- **Producer gauges**: starting a subscription, an unkeyed command, and
-  a keyed command each raise the matching field, and each completion
-  lowers it again; `blocked` rises when a producer begins awaiting
-  capacity, falls when the send is accepted, and also falls when a
-  blocked producer is aborted by cancellation (section 4.3) — the
-  decrement must not depend on the send ever completing.
+- **Producer gauges**: the `subscriptions`, `unkeyed_commands`, and
+  `keyed_commands` fields are checked end-to-end over an integration run —
+  starting a subscription, an unkeyed command, and a keyed command each
+  raises the matching field, and each falls back to zero as the run tears
+  its producers down. The `blocked` field is checked at the bounded-send
+  layer, where it rises when a producer begins awaiting capacity, falls
+  when the send is accepted, and also falls when a blocked producer is
+  aborted by cancellation (section 4.3) — the decrement must not depend on
+  the send ever completing.
 
 The bounded run of the section 5.1 matrix records capacity-wait and
 blocked-producer numbers from these same events. Per-keyed-channel occupancy gauges are
@@ -1118,14 +1120,15 @@ the check that realizes it; the implementation realizes those checks.
   shared-channel occupancy at batch end, `wait_us` the blocked send's
   admission wait. The schema is contract surface: renaming, dropping, or
   repurposing any part of it is an amendment to this RFC, not an
-  implementation detail. Behavioral check across the runtime batch layer
-  and the integration layer: the section 4.4 definition-of-done test —
-  the batch event's `Closed` differing-value case asserted at the runtime
-  batch layer, and a `tracing` subscriber over a scripted load whose value
-  assertions (scripted counts for `pulled`/`updated`, a known leftover for
-  `shared_pending`, a controlled wait for `wait_us`, and gauge transitions
-  including the cancellation-abort decrement) distinguish an
-  implementation that emits the right events with wrong values.
+  implementation detail. Behavioral check across the layered section 4.4
+  definition-of-done tests, each with a `tracing` subscriber and value
+  assertions that distinguish an implementation emitting the right events
+  with wrong values: the batch event's `pulled`/`updated` (including the
+  `Closed` differing-value case) and its `shared_pending` leftover at the
+  runtime batch layer; the capacity-wait event's `channel`/`wait_us` and
+  the `blocked` gauge's cancellation-abort decrement at the bounded-send
+  layer; and the `subscriptions`/`unkeyed_commands`/`keyed_commands`
+  gauge transitions end-to-end over an integration run.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or a
 unit, runtime-layer, or integration test. The overload scenario is the acceptance measurement for
@@ -1170,8 +1173,8 @@ review of every runtime-internal send and spawn site, not by a bench
 scenario; INV-L9 sits in both camps as described above, and so does
 INV-L10 — its routing half is structural at the keyed send site, its
 ordering half a unit-level test. INV-L11 and INV-L12 are behavioral at
-the unit layer, and INV-L13 across the runtime batch layer and the
-integration layer (the section 4.4 definition-of-done test); none of
+the unit layer, and INV-L13 across the runtime batch, bounded-send, and
+integration layers (the section 4.4 definition-of-done tests); none of
 INV-L10 through INV-L13 needs a bench scenario, and in particular the
 `quit_keyed_backlog_50k` latency numbers are not a check for either — see
 section 5.1's row for why bounded-mode keyed-quit latency cannot serve as

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -1154,13 +1154,20 @@ scenario (section 5.1), added with the implementation, is therefore a
 behavioral *regression* check, not a proof, and it is built to catch
 bounded pools rather than merely a second key: several keyed channels are
 held at capacity with their next sends pending — saturating any modest
-pool — while the two probe channels stay untouched until then. It checks
-send *admission* only, and exercises the invariant's two halves separately:
-(a) keyed→keyed — a previously idle key's first `keyed_channel_capacity`
-sends complete, and only its `capacity + 1`-th send is pending, on that
-key's own occupancy; (b) keyed→shared — the shared producer's first
-`app_channel_capacity` sends complete, with only its next send pending on
-the shared channel's own occupancy. Delivery is deliberately outside the
+pool. It checks send *admission* only, and exercises the invariant's two
+halves: (a) keyed→keyed — a previously idle probe key, started only after
+the others are held saturated, admits its own first `keyed_channel_capacity`
+sends with only its `capacity + 1`-th pending, on that key's own occupancy;
+(b) keyed→shared — the shared producer runs throughout as the saturation
+enabler (the shared channel must stay full to keep the keyed channels from
+draining under shared-first pull, so it cannot be idled and re-probed), and
+its admission is read as the shared occupancy *sampled only while every
+keyed channel is concurrently saturated*, which reaches `app_channel_capacity
++ 1` (the full channel plus its one pending send). The gate is that
+simultaneous value, not a whole-run maximum: a shared pool could reach the
+full shared occupancy before the keyed channels start and then shed capacity
+to hold them, passing a historical peak while never holding both at once.
+Delivery is deliberately outside the
 scenario: the event loop's keyed pull goes through one `StreamMap` over
 every keyed receiver and cannot drain a chosen key selectively — each poll
 returns one ready element from whichever key is picked, so waiting for the
@@ -1231,7 +1238,7 @@ measurement rather than an implementation-time choice:
 | `keyed_overload` | keyed delivery p50 / max | 9.2s / 13.0s (F4) | no latency criterion — open question 6 resolved: no fairness policy and no keyed-delivery bound under this contract (section 4.7); the bounded run is recorded as a measurement (deferral persists while shared stays ready, and admission-window deliveries are legal, section 4.6), with the unbounded baseline the regression reference for F4 |
 | `quit_idle`, `quit_backlog_50k`, `quit_backlog_300k`, `quit_overload` | quit→delivered p99 | ≤ 0.71ms at every measured depth, depth-independent (F6; section 2 table) | quit→delivered p99 ≤ 1 ms at every measured depth over ≥ 200 trials per scenario — INV-L4's resolved statistical conditions, same criterion as the unbounded default because the quit channel is never bounded (R4); named here are the unbounded rows, and the bounded rows this criterion applies to are the `RuntimeConfig` RFC's redefined ones (blocked-producer count and channel-full churn, not the `quit_backlog_*` depths — reproducibility rules above), not these names reused unchanged; the keyed control `quit_keyed_backlog_50k` is outside INV-L4 (next row) |
 | `quit_keyed_backlog_50k` | quit→delivered p50 | ≈ full shared drain, 1.30s (F7) | no latency criterion — keyed quit stays in the private channel (open question 7, section 4.6), but that contract is routing and delivery order (INV-L10/INV-L11, checked structurally and at the unit layer), not a latency number: in bounded mode a compliant implementation may deliver the keyed quit while producer backlog remains, because a pull can leave the shared channel momentarily empty while the woken producer's next send is still in flight (at `capacity = 1`, after every pull) — delivering the buffered keyed quit then outruns no *ready* input. F7's full-drain p50 therefore stays a regression check for the **unbounded default only** (re-run unbounded: p50 ≈ full shared drain); the bounded run is recorded as a statistical measurement when the implementation lands, under the capacity, depth, and trial count the `RuntimeConfig` RFC pins (reproducibility rules above) |
-| `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), two untouched probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared); admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency carries no bound, open question 6 resolved, section 4.7) (INV-L9) |
+| `keyed_isolation` (new scenario, added with the implementation) | probe-key and shared send admission while several unrelated keyed channels are held full | trivially isolated — unbounded sends never wait | with several keyed channels at capacity and their next sends pending (saturating any modest hypothetical pool), the two probes are checked separately: a previously idle key's first `keyed_channel_capacity` sends complete with only its `capacity + 1`-th pending on its own occupancy (keyed→keyed), and the shared producer's first `app_channel_capacity` sends complete with only its next send pending on shared occupancy (keyed→shared) — the keyed probe is started only after the eight are held saturated, while the shared producer runs throughout as the saturation enabler (it cannot be idled and re-probed without letting the keyed channels drain under shared-first pull; RFC 0007 §5.3). The keyed→shared gate is the shared occupancy sampled only during the window when all nine keyed channels are concurrently saturated, which must reach `app_channel_capacity + 1` — the *simultaneous* value, not a whole-run maximum a shared pool could reach before the keyed channels start; admission only, regression check — the pool-absence proof is INV-L9's structural review (section 5), and delivery is excluded (the keyed `StreamMap` cannot drain a chosen key selectively — polling for the probe may drain the saturated keys instead; delivery latency carries no bound, open question 6 resolved, section 4.7) (INV-L9) |
 | `steady_20k`, `steady_200k` | default-config code path | current unbounded path | structurally identical default path, checked by code inspection, not by diffing load numbers (INV-L6) |
 
 Queue-depth cells use the harness's depth definition, `produced -

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -496,19 +496,30 @@ as INV-L13 (section 5):
   observable rather than enforced (section 4.5), including the
   blocked-producer anti-pattern named there.
 
-Definition of done for the observability slice: an integration test
-installs a `tracing` subscriber (the technique the `quit_*` harness
-already uses, section 2), drives a scripted load, and verifies values and
-firing conditions, not mere event presence — an implementation that emits
-each event once with wrong values must fail it:
+Definition of done for the observability slice: a runtime batch-layer
+test together with an integration test, each installing a `tracing`
+subscriber (the technique the `quit_*` harness already uses, section 2).
+The runtime batch-layer test drives `process_input_batch` directly to fix
+the batch event's `Closed` differing-value case deterministically (below);
+the integration test drives a scripted load for the remaining values —
+the equal-count batch case, `shared_pending`, the capacity-wait event, and
+the producer gauges. Both verify values and firing conditions, not mere
+event presence — an implementation that emits each event once with wrong
+values must fail:
 
 - **Batch event**: `pulled` and `updated` equal the scripted input
-  counts, including a batch where the two differ — a scenario with a
-  `ReceiverEvent::Closed` among the queued inputs must observe
-  `pulled = updated + 1`. `shared_pending` is verified against a
-  scripted leftover, not merely present: with `batch_max_messages =
-  Some(n)` and `n + k` shared messages queued under the paused clock,
-  the capped batch must report `shared_pending = k`.
+  counts, including a batch where the two differ. The differing case is
+  observed at the runtime batch layer rather than over the integration
+  load: a `tracing` subscriber over a `Some(1)` batch whose opening input
+  is a `ReceiverEvent::Closed` must observe `pulled = 1` and
+  `updated = 0`. This is the opening-`Closed` placement INV-L12 uses and
+  for the same reason — a queued `Closed` is not deterministically
+  constructible (section 4.7 shared-first pull; `StreamMap` order), so
+  requiring a real `Closed` mid-load would reintroduce that
+  non-determinism in the observability slice. `shared_pending` is
+  verified against a scripted leftover, not merely present: with
+  `batch_max_messages = Some(n)` and `n + k` shared messages queued under
+  the paused clock, the capped batch must report `shared_pending = k`.
 - **Capacity-wait event**: an immediately accepted send fires no event;
   a send that had to await capacity fires exactly one event, at
   acceptance, with `channel` naming the channel that blocked it.
@@ -1081,9 +1092,23 @@ the check that realizes it; the implementation realizes those checks.
   uses `tokio::time::Instant` for exactly this) queue `n` ready inputs
   and assert one batch pulls all `n`, then queue `n + 1` and assert the
   batch pulls exactly `n` with the remaining input delivered by the next
-  batch — the off-by-one pair — plus a variant that places a
-  `ReceiverEvent::Closed` among the queued inputs and asserts it
-  consumes a slot in the count.
+  batch — the off-by-one pair — plus a `Some(1)` variant whose *opening*
+  input is a `ReceiverEvent::Closed`, asserting that a ready shared input
+  is left for the next batch. The opening `Closed` invokes no `update`,
+  so a cap that counted `update` calls instead of pulled inputs would go
+  on to pull that shared input into the same batch; the leftover
+  discriminates the two. The `Closed` is placed in the opening position,
+  not among later queued inputs, because a queued `Closed` is not
+  deterministically constructible at this layer: `AppInputs` pulls shared
+  inputs before keyed (section 4.7), and a `Closed` is surfaced only by
+  an already-empty, sender-closed keyed receiver — a closed receiver
+  still holding buffered output is removed when its *last* buffered
+  output is pulled and it becomes empty, before any `Closed` — so no real
+  input is ever pull-ordered after a `Closed` from one source, and a
+  second keyed source makes the order non-deterministic because
+  `StreamMap` randomizes the poll-start position. `Closed` surfacing
+  itself is checked at the keyed-manager layer, where a receiver yields
+  `Closed` once its sender closes on an empty buffer.
 - **INV-L13**: The runtime emits the load-observability events exactly
   as the section 4.4 schema states — target `tears::runtime::load`, the
   three event kinds with their levels, required fields, and firing
@@ -1093,16 +1118,17 @@ the check that realizes it; the implementation realizes those checks.
   shared-channel occupancy at batch end, `wait_us` the blocked send's
   admission wait. The schema is contract surface: renaming, dropping, or
   repurposing any part of it is an amendment to this RFC, not an
-  implementation detail. Behavioral check at the integration layer: the
-  section 4.4 definition-of-done test — a `tracing` subscriber over a
-  scripted load whose value assertions (scripted counts for
-  `pulled`/`updated`, a known leftover for `shared_pending`, a
-  controlled wait for `wait_us`, and gauge transitions including the
-  cancellation-abort decrement) distinguish an implementation that
-  emits the right events with wrong values.
+  implementation detail. Behavioral check across the runtime batch layer
+  and the integration layer: the section 4.4 definition-of-done test —
+  the batch event's `Closed` differing-value case asserted at the runtime
+  batch layer, and a `tracing` subscriber over a scripted load whose value
+  assertions (scripted counts for `pulled`/`updated`, a known leftover for
+  `shared_pending`, a controlled wait for `wait_us`, and gauge transitions
+  including the cancellation-abort decrement) distinguish an
+  implementation that emits the right events with wrong values.
 
-Each invariant gets a regression scenario in `benches/runtime_load.rs` or an
-integration test. The overload scenario is the acceptance measurement for
+Each invariant gets a regression scenario in `benches/runtime_load.rs` or a
+unit, runtime-layer, or integration test. The overload scenario is the acceptance measurement for
 INV-L1/L3: bounded queue depth and shared update latency must flatten where
 the unbounded baseline grows linearly. The keyed-probe scenario never
 becomes an acceptance measurement: open question 6 resolved that no
@@ -1144,9 +1170,9 @@ review of every runtime-internal send and spawn site, not by a bench
 scenario; INV-L9 sits in both camps as described above, and so does
 INV-L10 — its routing half is structural at the keyed send site, its
 ordering half a unit-level test. INV-L11 and INV-L12 are behavioral at
-the unit layer, and INV-L13 at the integration layer (the section 4.4
-definition-of-done test); none of INV-L10 through INV-L13 needs a bench
-scenario, and in particular the
+the unit layer, and INV-L13 across the runtime batch layer and the
+integration layer (the section 4.4 definition-of-done test); none of
+INV-L10 through INV-L13 needs a bench scenario, and in particular the
 `quit_keyed_backlog_50k` latency numbers are not a check for either — see
 section 5.1's row for why bounded-mode keyed-quit latency cannot serve as
 a reroute detector.

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -1,10 +1,8 @@
 # RFC 0007: RuntimeConfig public API and load-control acceptance parameters
 
-- Status: Accepted (moves to Implemented when the RFC 0006 load-control
-  implementation lands)
+- Status: Implemented
 - Target: the prerequisite RFC 0006 delegated to a separate document
-  (RFC 0006 sections 3.2, 6); with this RFC Accepted, the load-control
-  implementation PR may start
+  (RFC 0006 sections 3.2, 6)
 - Scope: the public `RuntimeConfig` surface (type, construction, constructor
   integration), the recommended-defaults documentation, the restart-rate
   interaction position, the RFC 0006 section 5.1 bounded-run parameters,

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -632,7 +632,28 @@ channel occupancy, per the note on that distinction below the table:
   16 messages with its next send pending — 128 buffered messages plus 8
   pending sends, exceeding any modest hypothetical pool), with the two
   probes exactly as RFC 0006 §5.1's row defines them (a previously idle
-  key's first 16 sends, and the shared producer's first 1024 sends). Eight
+  key's first 16 sends, and the shared producer's first 1024 sends). The
+  keyed probe is a ninth key started only *after* the eight are saturated,
+  so it is genuinely previously idle when probed; the shared producer,
+  however, runs throughout as the saturation enabler and cannot be staged
+  the same way — the shared channel must stay full to keep the keyed
+  channels from draining under shared-first pull, so it cannot be idled and
+  re-probed later. Its first `app_channel_capacity` sends are therefore
+  verified concurrently with the held keyed saturation: the gate is the
+  shared occupancy sampled *only while all nine keyed channels are
+  simultaneously saturated*, which must reach exactly `app_channel_capacity
+  + 1` (the full channel plus its one pending send). This simultaneous
+  value, not a whole-run maximum, is load-bearing — a shared pool could
+  drive the shared channel to its full occupancy *before* the keyed channels
+  start and then shed capacity to hold them, so a historical peak would pass
+  a pool that never held the full shared channel and all `9 × capacity`
+  keyed messages at once, which is exactly the violation the gate must
+  catch. The shared channel is untouched by any keyed producer, so this is
+  still the keyed→shared admission the row asks for. The measurement also
+  gates that no keyed message is ever delivered to `update` (the keyed
+  `StreamMap` never selectively drains a probe) and that every keyed
+  channel's yield count is exactly `capacity + 1`, so a drain would fail
+  rather than pass as extra admission. Eight
   saturated keys is the scale chosen to defeat a pooled implementation
   sized near per-channel capacity while keeping the row cheap to execute
   in the full acceptance and regression runs it belongs to.

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -685,10 +685,13 @@ invocation is unchanged.
   under the default (load-control-unset) configuration, shortened to 0.5s —
   the same default-path role it has in §5.3, so the smoke run never forks
   its config from its acceptance meaning — a 20k-message bounded burst under
-  the §5.1 configuration, `quit_idle` and `quit_blocked_1` at 5 *valid*
-  trials each
-  — `quit_idle`'s predicate is `none` (§5.2's table), so every attempt
-  counts toward its 5; `quit_blocked_1` counts only attempts whose §5.2
+  the §5.1 configuration, `quit_idle_bounded` and `quit_blocked_1` at 5
+  *valid* trials each
+  — `quit_idle_bounded`'s predicate is `none` (§5.2's `quit_idle` row —
+  the bounded-run table names its baseline row `quit_idle`, which the
+  harness emits as `quit_idle_bounded` to disambiguate it from the
+  default-mode `quit_idle`), so every attempt counts toward its 5;
+  `quit_blocked_1` counts only attempts whose §5.2
   predicate (`blocked == 1` at the quit instant) held, under §5.2's
   attempt cap scaled to this row's 5-trial count (a 50-attempt cap,
   `10 × 5`), which fails the smoke run outright rather than retrying past
@@ -730,8 +733,8 @@ invocation is unchanged.
   anything — the profile carries no latency assertion. One wall-clock
   condition remains: every smoke scenario carries the harness's
   per-scenario completion guard (`max_wall` in `benches/runtime_load.rs`)
-  at 30 s — the existing `steady_20k` and `quit_idle` keep their current
-  value, and the new bounded burst and `quit_blocked_1` (§5.2) take the
+  at 30 s — the existing `steady_20k` and `quit_idle_bounded` keep their
+  current value, and the new bounded burst and `quit_blocked_1` (§5.2) take the
   same — and the smoke run fails when any scenario times out. That
   timeout-failure rule is part of the profile's definition, not
   something the harness fully provides today: quit trials already fail

--- a/justfile
+++ b/justfile
@@ -48,6 +48,12 @@ test-loom:
 bench:
     cargo bench
 
+# Run the runtime-load harness smoke profile (RFC 0007 §6; the CI Benchmarks
+# profile). Latency-assertion-free: proves the harness builds and the reduced
+# scenarios terminate with their exact scripted sequences.
+bench-smoke:
+    cargo bench --bench runtime_load -- --smoke
+
 # Build the library
 build:
     cargo build

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,10 @@ pub use command::core::Command;
 pub use futures::stream::BoxStream;
 pub use panic::install_panic_hook;
 pub use runtime::Runtime;
+// `RuntimeConfig` is `Runtime::with_config`'s companion type; re-exported at the
+// crate root but deliberately *not* in the prelude, since a minimal skeleton app
+// calling `Runtime::new` never names it (RFC 0007 §2.3, INV-C4).
+pub use runtime::config::RuntimeConfig;
 // `FrameRate` lives under `runtime` (it is a scheduling input); re-exported here
 // as `tears::FrameRate` so it keeps a single canonical public path. See
 // docs/api-guidelines.md for the module visibility / root promotion rules

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -92,6 +92,10 @@ use tokio::time::{Duration, Instant};
 use crate::{application::Application, command::Command};
 
 mod app_input;
+// `pub` for the same reason as `frame_rate` below: `runtime` is already
+// `pub(crate)`, so `pub` only lets `lib.rs` re-export `RuntimeConfig` at the
+// crate root; it does not widen effective reachability.
+pub mod config;
 mod core;
 // `FrameRate` is a scheduling input, so it lives with the runtime. `pub`
 // (not `pub(crate)`) because `runtime` itself is already `pub(crate)`,
@@ -103,6 +107,7 @@ mod keyed_commands;
 mod pending_work;
 
 use app_input::AppInput;
+use config::RuntimeConfig;
 use frame_rate::FrameRate;
 use frame_scheduler::FrameScheduler;
 use keyed_commands::{CommandOutput, ReceiverEvent};
@@ -194,12 +199,59 @@ impl<App: Application> Runtime<App> {
     /// ```
     #[must_use]
     pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self {
-        let core = RuntimeCore::new(flags);
+        // Literal delegation to `with_config` (RFC 0007 INV-C1): exactly one
+        // construction path exists, and the load-control-unset configuration
+        // selects RFC 0006's unchanged unbounded path within it.
+        Self::with_config(flags, RuntimeConfig::new(frame_rate))
+    }
 
-        Self {
-            core,
-            scheduler: FrameScheduler::new(frame_rate),
-        }
+    /// Creates a new runtime from a [`RuntimeConfig`], which carries the frame
+    /// rate together with the opt-in load controls (RFC 0006).
+    ///
+    /// [`new`](Self::new) is equivalent to `with_config(flags,
+    /// RuntimeConfig::new(frame_rate))`: a default (load-control-unset)
+    /// configuration reproduces the unbounded delivery mode exactly. Use
+    /// `with_config` to opt into bounded delivery by setting one or more of the
+    /// [`RuntimeConfig`] capacities.
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - Configuration data passed to [`Application::new`]
+    /// * `config` - Frame rate and opt-in load controls
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use std::num::{NonZeroU32, NonZeroUsize};
+    /// # use tears::{FrameRate, Runtime, RuntimeConfig};
+    /// # use tears::prelude::*;
+    /// # use ratatui::Frame;
+    /// #
+    /// # struct MyApp;
+    /// # enum Message {}
+    /// # impl Application for MyApp {
+    /// #     type Message = Message;
+    /// #     type Flags = ();
+    /// #     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+    /// #     fn update(&mut self, _: Message) -> Command<Message> { Command::none() }
+    /// #     fn view(&self, _: &mut Frame<'_>) {}
+    /// #     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+    /// # }
+    /// let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))
+    ///     .expect("valid frame rate");
+    /// let config = RuntimeConfig::new(frame_rate)
+    ///     .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
+    ///     .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"));
+    /// let runtime = Runtime::<MyApp>::with_config((), config);
+    /// ```
+    #[must_use]
+    pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self {
+        let core = RuntimeCore::new(flags);
+        // INV-C5: the scheduler is paced by the frame rate the caller supplied
+        // to `RuntimeConfig::new`, never a hardcoded one.
+        let scheduler = FrameScheduler::new(config.frame_rate);
+
+        Self { core, scheduler }
     }
 
     #[cfg(test)]
@@ -531,6 +583,39 @@ mod tests {
         assert!(
             period >= Duration::from_micros(6_900) && period <= Duration::from_micros(6_950),
             "144 FPS period should be ~6.944ms, got {period:?}",
+        );
+    }
+
+    // INV-C5: `with_config` builds the frame scheduler from `config.frame_rate`
+    // — the value the caller supplied to `RuntimeConfig::new` — never a
+    // hardcoded one. A direct, deterministic value comparison (no elapsed-time
+    // observation) that fails an implementation which ignores `config.frame_rate`
+    // in exactly the way INV-C1/INV-C2 cannot.
+    #[tokio::test]
+    async fn test_with_config_scheduler_uses_config_frame_rate() {
+        for rate in [30, 144] {
+            let config = RuntimeConfig::new(frame_rate(rate));
+            let runtime = Runtime::<TestApp>::with_config(0, config);
+            assert_eq!(
+                runtime.scheduler.frame_period(),
+                frame_rate(rate).frame_duration(),
+                "with_config at {rate} FPS must pace the scheduler at that rate",
+            );
+        }
+    }
+
+    // INV-C1: `Runtime::new` is a literal delegation to `with_config` with a
+    // load-control-unset configuration, so the two construct an equivalently
+    // paced runtime. The behavioral witness of the single construction path.
+    #[tokio::test]
+    async fn test_new_delegates_to_with_config() {
+        let via_new = Runtime::<TestApp>::new(0, frame_rate(60));
+        let via_config = Runtime::<TestApp>::with_config(0, RuntimeConfig::new(frame_rate(60)));
+
+        assert_eq!(
+            via_new.scheduler.frame_period(),
+            via_config.scheduler.frame_period(),
+            "new(flags, fr) must construct the same runtime as with_config(flags, RuntimeConfig::new(fr))",
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -84,6 +84,8 @@
 //! }
 //! ```
 
+use std::num::NonZeroUsize;
+
 use color_eyre::eyre::Result;
 use futures::stream::StreamExt;
 use ratatui::prelude::Backend;
@@ -92,6 +94,12 @@ use tokio::time::{Duration, Instant};
 use crate::{application::Application, command::Command};
 
 mod app_input;
+// `pub` (not `pub(crate)`) so `subscription`'s forwarding task can name the
+// shared-channel `Sender` it feeds: `runtime` is already `pub(crate)`, so `pub`
+// caps this submodule's effective reachability at the crate the same way, while
+// avoiding the redundant-`pub(crate)` lint (see `frame_rate` below). The type
+// carries no public API.
+pub mod channel;
 // `pub` for the same reason as `frame_rate` below: `runtime` is already
 // `pub(crate)`, so `pub` only lets `lib.rs` re-export `RuntimeConfig` at the
 // crate root; it does not widen effective reachability.
@@ -142,6 +150,9 @@ pub struct Runtime<App: Application> {
     core: RuntimeCore<App>,
     /// Schedules frame work and gates idle wake-ups
     scheduler: FrameScheduler,
+    /// Count cap for one micro-batch window; `None` leaves the batch capped
+    /// only by the 100µs time window (RFC 0006 INV-L12).
+    batch_max_messages: Option<NonZeroUsize>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -246,12 +257,23 @@ impl<App: Application> Runtime<App> {
     /// ```
     #[must_use]
     pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self {
-        let core = RuntimeCore::new(flags);
+        // The single channel-construction path (RFC 0006 INV-L6): unset
+        // capacities build the unchanged unbounded channels, `Some(n)` bound
+        // them.
+        let core = RuntimeCore::with_capacities(
+            flags,
+            config.app_channel_capacity,
+            config.keyed_channel_capacity,
+        );
         // INV-C5: the scheduler is paced by the frame rate the caller supplied
         // to `RuntimeConfig::new`, never a hardcoded one.
         let scheduler = FrameScheduler::new(config.frame_rate);
 
-        Self { core, scheduler }
+        Self {
+            core,
+            scheduler,
+            batch_max_messages: config.batch_max_messages,
+        }
     }
 
     #[cfg(test)]
@@ -275,22 +297,41 @@ impl<App: Application> Runtime<App> {
             InputOutcome::Quit => return BatchOutcome::Quit,
         };
 
+        // INV-L12: the opening input is the batch's first pulled input, so a
+        // configured `batch_max_messages` of `Some(n)` admits at most `n - 1`
+        // more. Every input the batch pulls counts — including inputs that do
+        // not invoke `update` (a keyed `Closed`) — so this counter is distinct
+        // from `processed`, which counts only `update` calls.
+        let mut pulled = 1usize;
+
         // Micro-batching: process additional messages that arrived during a short window.
         // Uses tokio::time::Instant (not std) so tests can pause the clock and avoid
         // flaking under CI scheduling jitter around this tight deadline.
         let batch_deadline = Instant::now() + Duration::from_micros(100);
         while Instant::now() < batch_deadline {
+            // Stop once the batch has pulled its configured maximum number of
+            // inputs (INV-L12). Checked before the pull so `Some(1)` confines
+            // the batch to just the opening input.
+            if self
+                .batch_max_messages
+                .is_some_and(|max| pulled >= max.get())
+            {
+                break;
+            }
             match self.core.app_inputs.try_next_ready() {
-                Some(input) => match self.process_app_input(input) {
-                    InputOutcome::Updated => processed += 1,
-                    InputOutcome::NoUpdate => {}
-                    InputOutcome::Quit => {
-                        if processed > 0 {
-                            self.scheduler.mark_subscriptions_dirty();
+                Some(input) => {
+                    pulled += 1;
+                    match self.process_app_input(input) {
+                        InputOutcome::Updated => processed += 1,
+                        InputOutcome::NoUpdate => {}
+                        InputOutcome::Quit => {
+                            if processed > 0 {
+                                self.scheduler.mark_subscriptions_dirty();
+                            }
+                            return BatchOutcome::Quit;
                         }
-                        return BatchOutcome::Quit;
                     }
-                },
+                }
                 None => break, // No more inputs available
             }
         }
@@ -655,7 +696,7 @@ mod tests {
         runtime.scheduler.pending.needs_redraw = false;
         runtime.scheduler.pending.subscriptions_dirty = false;
 
-        let _ = runtime.core.msg_tx.send(RedrawControlMessage::Redraw);
+        let _ = runtime.core.msg_tx.try_send(RedrawControlMessage::Redraw);
         runtime.process_message_batch(RedrawControlMessage::Skip);
 
         assert!(runtime.scheduler.pending.needs_redraw);
@@ -696,9 +737,9 @@ mod tests {
         let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
 
         // Send multiple messages to the queue
-        let _ = runtime.core.msg_tx.send(TestMessage::Increment);
-        let _ = runtime.core.msg_tx.send(TestMessage::Increment);
-        let _ = runtime.core.msg_tx.send(TestMessage::Increment);
+        let _ = runtime.core.msg_tx.try_send(TestMessage::Increment);
+        let _ = runtime.core.msg_tx.try_send(TestMessage::Increment);
+        let _ = runtime.core.msg_tx.try_send(TestMessage::Increment);
 
         // Process first message (should batch the others within the deadline)
         runtime.process_message_batch(TestMessage::Increment);
@@ -744,18 +785,173 @@ mod tests {
         runtime
             .core
             .msg_tx
-            .send(2)
+            .try_send(2)
             .expect("receiver should be open");
         runtime
             .core
             .msg_tx
-            .send(3)
+            .try_send(3)
             .expect("receiver should be open");
 
         runtime.process_input_batch(AppInput::Shared(1));
 
         assert_eq!(runtime.core.app.messages, vec![1, 2, 3]);
         assert!(runtime.scheduler.pending.subscriptions_dirty);
+    }
+
+    // App that records every message `update` receives, in order.
+    struct RecordingApp {
+        messages: Vec<i32>,
+    }
+
+    impl Application for RecordingApp {
+        type Message = i32;
+        type Flags = ();
+
+        fn new((): ()) -> (Self, Command<Self::Message>) {
+            (
+                Self {
+                    messages: Vec::new(),
+                },
+                Command::none(),
+            )
+        }
+
+        fn update(&mut self, msg: Self::Message) -> Command<Self::Message> {
+            self.messages.push(msg);
+            Command::none()
+        }
+
+        fn view(&self, _frame: &mut Frame<'_>) {}
+
+        fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+            vec![]
+        }
+    }
+
+    // INV-L12 (exact-n, the lower half of the off-by-one pair): with exactly `n`
+    // inputs ready and `batch_max_messages = Some(n)`, one batch pulls all `n` —
+    // the opening input plus `n - 1` more — and nothing is left over. The clock
+    // is paused so the 100µs time cap never fires; the count cap alone bounds the
+    // batch (with the clock frozen the loop would otherwise drain everything
+    // ready). The opener is pulled from `app_inputs` exactly as `run()` does, so
+    // it is a genuine first pulled input, not a synthesized one.
+    #[tokio::test(start_paused = true)]
+    async fn batch_pulls_all_inputs_when_exactly_the_cap_are_ready() {
+        let config = RuntimeConfig::new(frame_rate(60))
+            .batch_max_messages(NonZeroUsize::new(2).expect("non-zero"));
+        let mut runtime = Runtime::<RecordingApp>::with_config((), config);
+
+        // Exactly n = 2 ready inputs.
+        for msg in [1, 2] {
+            runtime
+                .core
+                .msg_tx
+                .try_send(msg)
+                .expect("receiver should be open");
+        }
+        let opener = runtime
+            .core
+            .app_inputs
+            .next()
+            .await
+            .expect("the first input is ready");
+
+        assert_eq!(runtime.process_input_batch(opener), BatchOutcome::Continue);
+
+        // All n pulled in one batch; nothing left over.
+        assert_eq!(runtime.core.app.messages, vec![1, 2]);
+        assert_eq!(runtime.core.app_inputs.try_next_ready(), None);
+    }
+
+    // INV-L12 (exact-n+1, the upper half of the off-by-one pair): with `n + 1`
+    // inputs ready and `batch_max_messages = Some(n)`, one batch pulls exactly
+    // `n` and the single remaining input is delivered by the *next* batch. This
+    // is the boundary that a cap of `n + 1` (or a missing cap) would fail by
+    // draining the remainder into the first batch.
+    #[tokio::test(start_paused = true)]
+    async fn batch_pulls_exactly_the_cap_and_defers_the_remainder_to_the_next_batch() {
+        let config = RuntimeConfig::new(frame_rate(60))
+            .batch_max_messages(NonZeroUsize::new(2).expect("non-zero"));
+        let mut runtime = Runtime::<RecordingApp>::with_config((), config);
+
+        // n + 1 = 3 ready inputs.
+        for msg in [1, 2, 3] {
+            runtime
+                .core
+                .msg_tx
+                .try_send(msg)
+                .expect("receiver should be open");
+        }
+
+        let opener = runtime
+            .core
+            .app_inputs
+            .next()
+            .await
+            .expect("the first input is ready");
+        assert_eq!(runtime.process_input_batch(opener), BatchOutcome::Continue);
+
+        // The first batch pulls exactly n; the remainder waits.
+        assert_eq!(runtime.core.app.messages, vec![1, 2]);
+
+        // The next batch delivers the leftover, in FIFO order.
+        let next_opener = runtime
+            .core
+            .app_inputs
+            .next()
+            .await
+            .expect("the leftover input is ready for the next batch");
+        assert_eq!(
+            runtime.process_input_batch(next_opener),
+            BatchOutcome::Continue
+        );
+        assert_eq!(runtime.core.app.messages, vec![1, 2, 3]);
+        assert_eq!(runtime.core.app_inputs.try_next_ready(), None);
+    }
+
+    // INV-L12 (the `Closed`-counts case): the count is over *pulled inputs*, not
+    // over `update` calls — a keyed `Closed` is pulled but does not invoke
+    // `update`, yet it still consumes a slot. Under `Some(1)` an opening `Closed`
+    // ends the batch immediately, leaving a queued shared input untouched; if the
+    // cap counted only `update` calls, `pulled` would stay 0 across the `Closed`
+    // and the queued increment would be pulled into this batch (counter == 1).
+    //
+    // This uses `Closed` in the opening position deliberately. A `Closed` can
+    // only ever be pulled at the *tail* of a batch: `AppInputs` pulls shared
+    // inputs before keyed (shared-first, RFC §4.7), and a `Closed` is surfaced
+    // only by an already-empty, sender-closed keyed receiver (a receiver that
+    // still holds a buffered message is removed the moment that message is
+    // pulled, before any `Closed`). So no real input is ever pull-ordered after a
+    // `Closed` from a single source, and a second keyed source would make the
+    // order non-deterministic (`StreamMap` fairness). The opening position is
+    // therefore the only placement that deterministically distinguishes "counts
+    // pulled inputs" from "counts `update` calls"; `Closed` surfacing itself is
+    // locked separately in `keyed_commands` (`pending_keyed_poll_wakes_after_sender_closure`).
+    #[tokio::test(start_paused = true)]
+    async fn batch_max_of_one_stops_after_a_non_update_opening_closed() {
+        let config = RuntimeConfig::new(frame_rate(60))
+            .batch_max_messages(NonZeroUsize::new(1).expect("non-zero"));
+        let mut runtime = Runtime::<TestApp>::with_config(0, config);
+
+        // A shared input the batch must NOT pull under a cap of 1.
+        runtime
+            .core
+            .msg_tx
+            .try_send(TestMessage::Increment)
+            .expect("receiver should be open");
+
+        // Open the batch with a keyed `Closed` (a pulled input that does not
+        // invoke `update`). With a cap of 1 it is the sole pulled input.
+        let outcome = runtime.process_input_batch(AppInput::Keyed(ReceiverEvent::Closed));
+        assert_eq!(outcome, BatchOutcome::Continue);
+
+        // The queued increment was left for the next batch, not consumed.
+        assert_eq!(runtime.core.app.counter, 0);
+        assert!(matches!(
+            runtime.core.app_inputs.try_next_ready(),
+            Some(AppInput::Shared(TestMessage::Increment))
+        ));
     }
 
     #[tokio::test]
@@ -805,7 +1001,7 @@ mod tests {
 
         // A `Quit` message routes to `Action::Quit`, which the loop's dedicated
         // quit branch receives.
-        let _ = runtime.core.msg_tx.send(TestMessage::Quit);
+        let _ = runtime.core.msg_tx.try_send(TestMessage::Quit);
 
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend)?;
@@ -875,7 +1071,7 @@ mod tests {
         runtime
             .core
             .msg_tx
-            .send(Message::Leave)
+            .try_send(Message::Leave)
             .expect("message receiver should be open");
 
         let first = runtime

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -112,6 +112,10 @@ mod core;
 pub mod frame_rate;
 mod frame_scheduler;
 mod keyed_commands;
+// `pub` for the same crate-capping reason as `channel` above: crate-internal
+// load-observability types (`tears::runtime::load` schema, RFC 0006 §4.4) that
+// `subscription` and the channel/keyed producers share.
+pub mod load;
 mod pending_work;
 
 use app_input::AppInput;
@@ -336,7 +340,11 @@ impl<App: Application> Runtime<App> {
             }
         }
 
-        tracing::trace!(target: "tears::runtime", messages = processed, "processed message batch");
+        // Batch event (RFC 0006 §4.4): `pulled` counts every input this batch
+        // took (INV-L12's counted unit), `processed` those that invoked
+        // `update`, and `shared_pending` the shared-channel occupancy now. A
+        // quit-terminated batch returns above and never reaches here.
+        load::batch(pulled, processed, self.core.app_inputs.shared_pending());
 
         // Mark that subscriptions may have changed even when redraw is suppressed.
         if processed > 0 {
@@ -718,17 +726,152 @@ mod tests {
         assert!(runtime.scheduler.pending.subscriptions_dirty);
     }
 
-    #[tokio::test]
-    async fn test_process_message_batch_emits_tracing_event() {
-        let recorder = TraceRecorder::new().with_target("tears::runtime");
+    // Batch event (RFC 0006 §4.4, INV-L13) at the runtime batch layer: a batch
+    // that pulls the opening input plus one queued input reports `pulled = 2`,
+    // `updated = 2` (both invoked `update`), and `shared_pending = 0` (the
+    // shared channel drained). `pulled` is unique to the batch event, so the
+    // value assertions are unaffected by any gauge events on the same target.
+    #[tokio::test(start_paused = true)]
+    async fn batch_event_reports_pulled_updated_and_shared_pending() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
         let _guard = recorder.set_default();
 
         let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        runtime
+            .core
+            .msg_tx
+            .try_send(TestMessage::Increment)
+            .expect("receiver should be open");
         runtime.process_message_batch(TestMessage::Increment);
 
+        assert_eq!(
+            recorder.u64_values("pulled"),
+            vec![2],
+            "the opening input plus one batched input"
+        );
+        assert_eq!(
+            recorder.u64_values("updated"),
+            vec![2],
+            "both pulled inputs invoked update"
+        );
+        assert_eq!(
+            recorder.u64_values("shared_pending"),
+            vec![0],
+            "the shared channel drained by batch end"
+        );
+    }
+
+    // Batch event differing-value case (RFC 0006 §4.4 DoD): a batch whose
+    // opening input is a keyed `Closed` reports `pulled = 1`, `updated = 0` —
+    // the pulled input did not invoke `update`. This is the deterministic
+    // differ-value case the DoD places at the runtime batch layer; a queued
+    // `Closed` is not deterministically constructible (see INV-L12).
+    #[tokio::test]
+    async fn batch_event_reports_pulled_without_updated_for_a_closed_input() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        runtime.process_input_batch(AppInput::Keyed(ReceiverEvent::Closed));
+
+        assert_eq!(
+            recorder.u64_values("pulled"),
+            vec![1],
+            "the Closed input was pulled"
+        );
+        assert_eq!(
+            recorder.u64_values("updated"),
+            vec![0],
+            "a Closed input does not invoke update"
+        );
+        assert_eq!(recorder.u64_values("shared_pending"), vec![0]);
+    }
+
+    // Batch event `shared_pending` against a scripted leftover (RFC 0006 §4.4
+    // DoD): with `batch_max_messages = Some(n)` and `n + k` shared messages
+    // queued under the paused clock, the capped batch reports
+    // `shared_pending = k` — the inputs it left in the shared channel.
+    #[tokio::test(start_paused = true)]
+    async fn batch_event_reports_shared_pending_leftover_under_cap() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        // n = 2, k = 1: three queued shared inputs, capped at two per batch.
+        let config = RuntimeConfig::new(frame_rate(60))
+            .batch_max_messages(NonZeroUsize::new(2).expect("non-zero"));
+        let mut runtime = Runtime::<TestApp>::with_config(0, config);
+        for _ in 0..3 {
+            runtime
+                .core
+                .msg_tx
+                .try_send(TestMessage::Increment)
+                .expect("receiver should be open");
+        }
+
+        let opener = runtime
+            .core
+            .app_inputs
+            .next()
+            .await
+            .expect("the first input is ready");
+        runtime.process_input_batch(opener);
+
+        assert_eq!(recorder.u64_values("pulled"), vec![2], "the cap of two");
+        assert_eq!(
+            recorder.u64_values("shared_pending"),
+            vec![1],
+            "one input left queued after the capped batch"
+        );
+    }
+
+    // INV-L13: a quit-terminated batch emits no batch event — the loop exits
+    // instead (RFC 0006 §4.4). Opening `process_input_batch` on a keyed quit
+    // returns `Quit` before the batch event would fire, so no `pulled` is
+    // emitted.
+    #[tokio::test]
+    async fn quit_terminated_batch_emits_no_batch_event() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+        let outcome = runtime
+            .process_input_batch(AppInput::Keyed(ReceiverEvent::Output(CommandOutput::Quit)));
+
+        assert_eq!(outcome, BatchOutcome::Quit);
         assert!(
-            recorder.event_count() >= 1,
-            "processing a message batch should emit a tracing event"
+            recorder.u64_values("pulled").is_empty(),
+            "a quit-terminated batch must emit no batch event"
+        );
+    }
+
+    // The `keyed_commands` gauge is count-based, not guard-based, so a runtime
+    // dropped without a clean `shutdown()` — e.g. a render error propagating out
+    // of `run()` via `?` — must still reset it. `KeyedCommands`'s `Drop`
+    // publishes zero on that path.
+    #[tokio::test]
+    async fn dropping_a_runtime_with_a_pending_keyed_command_resets_the_keyed_gauge() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        {
+            let mut runtime = Runtime::<TestApp>::new(0, frame_rate(60));
+            runtime.core.enqueue_command(
+                Command::future(pending::<TestMessage>())
+                    .cancellable(CommandId::new("keyed"))
+                    .into_runtime_parts(),
+            );
+            assert_eq!(
+                recorder.u64_values("keyed_commands").last(),
+                Some(&1),
+                "spawning a keyed command raises the gauge"
+            );
+            // `runtime` is dropped here — no `run()`, no `shutdown()`.
+        }
+
+        assert_eq!(
+            recorder.u64_values("keyed_commands").last(),
+            Some(&0),
+            "dropping the runtime resets the keyed_commands gauge"
         );
     }
 

--- a/src/runtime/app_input.rs
+++ b/src/runtime/app_input.rs
@@ -1,11 +1,12 @@
+use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::stream::BoxStream;
-use tokio::sync::mpsc;
 
 use crate::command::{Action, CancelPolicy, CommandId};
 
+use super::channel;
 use super::keyed_commands::{KeyedCommands, KeyedPoll, ReceiverEvent};
 
 /// Input events consumed by the runtime's application loop.
@@ -19,16 +20,20 @@ pub(super) enum AppInput<Msg> {
 
 /// Stream of application inputs backed by runtime message channels.
 pub(super) struct AppInputs<Msg: Send + 'static> {
-    shared: mpsc::UnboundedReceiver<Msg>,
+    shared: channel::Receiver<Msg>,
     keyed: KeyedCommands<Msg>,
 }
 
 impl<Msg: Send + 'static> AppInputs<Msg> {
-    /// Creates an input stream from the shared message receiver.
-    pub(super) fn new(shared: mpsc::UnboundedReceiver<Msg>) -> Self {
+    /// Creates an input stream from the shared message receiver and the keyed
+    /// commands' per-command channel capacity.
+    pub(super) fn new(
+        shared: channel::Receiver<Msg>,
+        keyed_capacity: Option<NonZeroUsize>,
+    ) -> Self {
         Self {
             shared,
-            keyed: KeyedCommands::new(),
+            keyed: KeyedCommands::new(keyed_capacity),
         }
     }
 
@@ -99,29 +104,29 @@ mod tests {
 
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_shared_after_send() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
 
-        tx.send(42).expect("receiver should be open");
+        tx.try_send(42).expect("receiver should be open");
 
         assert_eq!(inputs.next().await, Some(AppInput::Shared(42)));
     }
 
     #[test]
     fn test_app_inputs_try_next_ready_empty_returns_none() {
-        let (_tx, rx) = mpsc::unbounded_channel::<i32>();
-        let mut inputs = AppInputs::new(rx);
+        let (_tx, rx) = channel::channel::<i32>(None);
+        let mut inputs = AppInputs::new(rx, None);
 
         assert_eq!(inputs.try_next_ready(), None);
     }
 
     #[test]
     fn test_app_inputs_try_next_ready_returns_queued_messages() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
 
-        tx.send(1).expect("receiver should be open");
-        tx.send(2).expect("receiver should be open");
+        tx.try_send(1).expect("receiver should be open");
+        tx.try_send(2).expect("receiver should be open");
 
         assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(1)));
         assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(2)));
@@ -130,11 +135,11 @@ mod tests {
 
     #[test]
     fn test_app_inputs_try_next_ready_preserves_fifo_order() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
 
         for msg in [1, 2, 3] {
-            tx.send(msg).expect("receiver should be open");
+            tx.try_send(msg).expect("receiver should be open");
         }
 
         assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(1)));
@@ -144,8 +149,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_none_after_sender_closes() {
-        let (tx, rx) = mpsc::unbounded_channel::<i32>();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel::<i32>(None);
+        let mut inputs = AppInputs::new(rx, None);
 
         drop(tx);
 
@@ -154,8 +159,8 @@ mod tests {
 
     #[tokio::test]
     async fn shared_input_wins_when_keyed_output_is_also_ready() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
         let id = CommandId::new("search");
         inputs.spawn_keyed(
             id.clone(),
@@ -163,7 +168,7 @@ mod tests {
             stream::iter([Action::Message(2)]).boxed(),
         );
         yield_now().await;
-        tx.send(1).expect("receiver should be open");
+        tx.try_send(1).expect("receiver should be open");
 
         assert_eq!(inputs.next().await, Some(AppInput::Shared(1)));
         inputs
@@ -179,8 +184,8 @@ mod tests {
 
     #[tokio::test]
     async fn shared_input_wins_the_nonwaiting_pull_when_keyed_output_is_also_ready() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
         let id = CommandId::new("search");
         inputs.spawn_keyed(
             id.clone(),
@@ -192,7 +197,7 @@ mod tests {
             "keyed output should be buffered before the pull",
         )
         .await;
-        tx.send(1).expect("receiver should be open");
+        tx.try_send(1).expect("receiver should be open");
 
         assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(1)));
         assert_eq!(
@@ -205,8 +210,8 @@ mod tests {
 
     #[tokio::test]
     async fn shared_input_wins_when_keyed_quit_is_also_ready() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
         let id = CommandId::new("quit");
         inputs.spawn_keyed(
             id.clone(),
@@ -218,7 +223,7 @@ mod tests {
             "keyed quit should be buffered before the pull",
         )
         .await;
-        tx.send(1).expect("receiver should be open");
+        tx.try_send(1).expect("receiver should be open");
 
         assert_eq!(inputs.try_next_ready(), Some(AppInput::Shared(1)));
         assert_eq!(
@@ -229,8 +234,8 @@ mod tests {
 
     #[tokio::test]
     async fn shared_input_wins_the_blocking_pull_when_keyed_quit_is_also_ready() {
-        let (tx, rx) = mpsc::unbounded_channel();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel(None);
+        let mut inputs = AppInputs::new(rx, None);
         let id = CommandId::new("quit");
         inputs.spawn_keyed(
             id.clone(),
@@ -242,7 +247,7 @@ mod tests {
             "keyed quit should be buffered before the pull",
         )
         .await;
-        tx.send(1).expect("receiver should be open");
+        tx.try_send(1).expect("receiver should be open");
 
         assert_eq!(inputs.next().await, Some(AppInput::Shared(1)));
         assert_eq!(
@@ -253,8 +258,8 @@ mod tests {
 
     #[tokio::test]
     async fn closed_shared_channel_and_same_poll_keyed_reconciliation_terminate_the_stream() {
-        let (tx, rx) = mpsc::unbounded_channel::<i32>();
-        let mut inputs = AppInputs::new(rx);
+        let (tx, rx) = channel::channel::<i32>(None);
+        let mut inputs = AppInputs::new(rx, None);
         inputs.spawn_keyed(
             CommandId::new("empty"),
             CancelPolicy::CancelInFlight,
@@ -272,8 +277,8 @@ mod tests {
 
     #[tokio::test]
     async fn try_next_ready_does_not_wait_for_pending_keyed_streams() {
-        let (_tx, rx) = mpsc::unbounded_channel::<i32>();
-        let mut inputs = AppInputs::new(rx);
+        let (_tx, rx) = channel::channel::<i32>(None);
+        let mut inputs = AppInputs::new(rx, None);
         inputs.spawn_keyed(
             CommandId::new("pending"),
             CancelPolicy::CancelInFlight,

--- a/src/runtime/app_input.rs
+++ b/src/runtime/app_input.rs
@@ -8,6 +8,7 @@ use crate::command::{Action, CancelPolicy, CommandId};
 
 use super::channel;
 use super::keyed_commands::{KeyedCommands, KeyedPoll, ReceiverEvent};
+use super::load::LoadObserver;
 
 /// Input events consumed by the runtime's application loop.
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -25,16 +26,23 @@ pub(super) struct AppInputs<Msg: Send + 'static> {
 }
 
 impl<Msg: Send + 'static> AppInputs<Msg> {
-    /// Creates an input stream from the shared message receiver and the keyed
-    /// commands' per-command channel capacity.
+    /// Creates an input stream from the shared message receiver, the keyed
+    /// commands' per-command channel capacity, and the shared load observer.
     pub(super) fn new(
         shared: channel::Receiver<Msg>,
         keyed_capacity: Option<NonZeroUsize>,
+        observer: LoadObserver,
     ) -> Self {
         Self {
             shared,
-            keyed: KeyedCommands::new(keyed_capacity),
+            keyed: KeyedCommands::new(keyed_capacity, observer),
         }
+    }
+
+    /// Number of messages buffered in the shared channel — the batch event's
+    /// `shared_pending` field (RFC 0006 §4.4).
+    pub(super) fn shared_pending(&self) -> usize {
+        self.shared.len()
     }
 
     /// Returns the next queued input without waiting for new messages.
@@ -105,7 +113,7 @@ mod tests {
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_shared_after_send() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
 
         tx.try_send(42).expect("receiver should be open");
 
@@ -115,7 +123,7 @@ mod tests {
     #[test]
     fn test_app_inputs_try_next_ready_empty_returns_none() {
         let (_tx, rx) = channel::channel::<i32>(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
 
         assert_eq!(inputs.try_next_ready(), None);
     }
@@ -123,7 +131,7 @@ mod tests {
     #[test]
     fn test_app_inputs_try_next_ready_returns_queued_messages() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
 
         tx.try_send(1).expect("receiver should be open");
         tx.try_send(2).expect("receiver should be open");
@@ -136,7 +144,7 @@ mod tests {
     #[test]
     fn test_app_inputs_try_next_ready_preserves_fifo_order() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
 
         for msg in [1, 2, 3] {
             tx.try_send(msg).expect("receiver should be open");
@@ -150,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn test_app_inputs_poll_next_returns_none_after_sender_closes() {
         let (tx, rx) = channel::channel::<i32>(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
 
         drop(tx);
 
@@ -160,7 +168,7 @@ mod tests {
     #[tokio::test]
     async fn shared_input_wins_when_keyed_output_is_also_ready() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         let id = CommandId::new("search");
         inputs.spawn_keyed(
             id.clone(),
@@ -185,7 +193,7 @@ mod tests {
     #[tokio::test]
     async fn shared_input_wins_the_nonwaiting_pull_when_keyed_output_is_also_ready() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         let id = CommandId::new("search");
         inputs.spawn_keyed(
             id.clone(),
@@ -211,7 +219,7 @@ mod tests {
     #[tokio::test]
     async fn shared_input_wins_when_keyed_quit_is_also_ready() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         let id = CommandId::new("quit");
         inputs.spawn_keyed(
             id.clone(),
@@ -235,7 +243,7 @@ mod tests {
     #[tokio::test]
     async fn shared_input_wins_the_blocking_pull_when_keyed_quit_is_also_ready() {
         let (tx, rx) = channel::channel(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         let id = CommandId::new("quit");
         inputs.spawn_keyed(
             id.clone(),
@@ -259,7 +267,7 @@ mod tests {
     #[tokio::test]
     async fn closed_shared_channel_and_same_poll_keyed_reconciliation_terminate_the_stream() {
         let (tx, rx) = channel::channel::<i32>(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         inputs.spawn_keyed(
             CommandId::new("empty"),
             CancelPolicy::CancelInFlight,
@@ -278,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn try_next_ready_does_not_wait_for_pending_keyed_streams() {
         let (_tx, rx) = channel::channel::<i32>(None);
-        let mut inputs = AppInputs::new(rx, None);
+        let mut inputs = AppInputs::new(rx, None, LoadObserver::default());
         inputs.spawn_keyed(
             CommandId::new("pending"),
             CancelPolicy::CancelInFlight,

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -1,0 +1,240 @@
+//! A runtime-owned mpsc channel that is either unbounded (the default delivery
+//! mode) or bounded to a configured capacity (RFC 0006 bounded mode).
+//!
+//! tokio's unbounded and bounded mpsc halves are distinct types with no shared
+//! trait, so this module wraps them in one enum pair reused for both the shared
+//! application-message channel and each keyed command's private channel. The
+//! producer path is uniform — [`Sender::send`] awaits capacity in bounded mode
+//! (INV-L2: never drops; the producer waits) and completes without suspending
+//! in unbounded mode (INV-L6: senders never wait).
+
+use std::num::NonZeroUsize;
+use std::task::{Context, Poll};
+
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::{SendError, TryRecvError};
+
+/// Sending half of a runtime-owned channel.
+///
+/// `pub` rather than `pub(crate)` only to satisfy `clippy::redundant_pub_crate`:
+/// the enclosing `runtime` module is `pub(crate)`, so this type's effective
+/// reachability is capped at the crate regardless (see `frame_rate`).
+pub enum Sender<T> {
+    Unbounded(mpsc::UnboundedSender<T>),
+    Bounded(mpsc::Sender<T>),
+}
+
+/// Receiving half of a runtime-owned channel.
+///
+/// `pub` for the same crate-capped reason as [`Sender`].
+pub enum Receiver<T> {
+    Unbounded(mpsc::UnboundedReceiver<T>),
+    Bounded(mpsc::Receiver<T>),
+}
+
+/// Builds a channel pair from an optional capacity.
+///
+/// `None` constructs the same `mpsc::unbounded_channel` as before, so the
+/// default delivery mode is structurally unchanged (INV-L6). `Some(n)`
+/// constructs a bounded channel of exactly `n` slots (INV-L1).
+pub fn channel<T>(capacity: Option<NonZeroUsize>) -> (Sender<T>, Receiver<T>) {
+    capacity.map_or_else(
+        || {
+            let (tx, rx) = mpsc::unbounded_channel();
+            (Sender::Unbounded(tx), Receiver::Unbounded(rx))
+        },
+        |capacity| {
+            let (tx, rx) = mpsc::channel(capacity.get());
+            (Sender::Bounded(tx), Receiver::Bounded(rx))
+        },
+    )
+}
+
+impl<T> Clone for Sender<T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Unbounded(tx) => Self::Unbounded(tx.clone()),
+            Self::Bounded(tx) => Self::Bounded(tx.clone()),
+        }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Sends `value`, awaiting capacity in bounded mode and completing without
+    /// suspending in unbounded mode.
+    ///
+    /// The unbounded arm has no `.await`: `UnboundedSender::send` returns
+    /// immediately, so the caller's `.await` resolves on the first poll and the
+    /// producer task is never suspended (INV-L6). The bounded arm awaits a
+    /// permit, so an overloaded producer waits rather than dropping (INV-L2).
+    pub async fn send(&self, value: T) -> Result<(), SendError<T>> {
+        match self {
+            Self::Unbounded(tx) => tx.send(value),
+            Self::Bounded(tx) => tx.send(value).await,
+        }
+    }
+
+    /// Non-awaiting send used only by tests to inject into the (default,
+    /// unbounded) shared channel synchronously. The runtime's own producer path
+    /// always uses [`send`](Self::send) so its backpressure and no-drop
+    /// behavior is exercised as in production.
+    #[cfg(test)]
+    pub fn try_send(&self, value: T) -> Result<(), mpsc::error::TrySendError<T>> {
+        match self {
+            Self::Unbounded(tx) => tx
+                .send(value)
+                .map_err(|SendError(value)| mpsc::error::TrySendError::Closed(value)),
+            Self::Bounded(tx) => tx.try_send(value),
+        }
+    }
+
+    /// Wraps an existing unbounded sender.
+    ///
+    /// Used by the `bench-internals` `BenchSubscriptionManager` wrapper (RFC
+    /// 0007 §2.3: bench-internals gains no config-related items, and the
+    /// subscription bench keeps measuring the unbounded path) and by
+    /// `SubscriptionManager`'s own tests, which drive the unbounded forwarding
+    /// path. Excluded from normal library builds, where nothing constructs a
+    /// `Sender` this way.
+    #[cfg(any(test, feature = "bench-internals"))]
+    pub const fn from_unbounded(tx: mpsc::UnboundedSender<T>) -> Self {
+        Self::Unbounded(tx)
+    }
+}
+
+impl<T> Receiver<T> {
+    /// Polls for the next value, delegating to the underlying receiver.
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        match self {
+            Self::Unbounded(rx) => rx.poll_recv(cx),
+            Self::Bounded(rx) => rx.poll_recv(cx),
+        }
+    }
+
+    /// Attempts to receive without waiting.
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        match self {
+            Self::Unbounded(rx) => rx.try_recv(),
+            Self::Bounded(rx) => rx.try_recv(),
+        }
+    }
+
+    /// Number of messages currently buffered in the channel.
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Unbounded(rx) => rx.len(),
+            Self::Bounded(rx) => rx.len(),
+        }
+    }
+
+    /// Whether every sender has been dropped.
+    pub fn is_closed(&self) -> bool {
+        match self {
+            Self::Unbounded(rx) => rx.is_closed(),
+            Self::Bounded(rx) => rx.is_closed(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::Future;
+    use std::num::NonZeroUsize;
+
+    use futures::task::noop_waker_ref;
+
+    use super::*;
+
+    fn cap(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("capacity must be non-zero")
+    }
+
+    fn noop_context() -> Context<'static> {
+        Context::from_waker(noop_waker_ref())
+    }
+
+    /// Polls a fresh `send` future exactly once and asserts it resolved without
+    /// suspending, returning the send result.
+    #[allow(
+        clippy::panic,
+        reason = "a suspended send is the failure this helper reports"
+    )]
+    fn send_now<T>(sender: &Sender<T>, value: T) -> Result<(), SendError<T>> {
+        let fut = sender.send(value);
+        futures::pin_mut!(fut);
+        match fut.poll(&mut noop_context()) {
+            Poll::Ready(result) => result,
+            Poll::Pending => panic!("send should complete without suspending"),
+        }
+    }
+
+    // INV-L6: the default (unbounded) path never waits — a send resolves on the
+    // first poll no matter how many messages are already queued undrained. This
+    // is the behavioral complement to the structural review of `send`'s
+    // unbounded arm (which contains no `.await`).
+    #[test]
+    fn unbounded_send_never_suspends() {
+        let (tx, _rx) = channel::<i32>(None);
+
+        // Far past any bounded capacity would allow: still never suspends.
+        for value in 0..10_000 {
+            send_now(&tx, value).expect("unbounded receiver is open");
+        }
+    }
+
+    // INV-L1/INV-L2/INV-L3: a bounded channel buffers at most its capacity, a
+    // send past capacity waits (rather than dropping) until a slot frees, and
+    // the full scripted sequence drains back in FIFO order with nothing lost.
+    #[test]
+    fn bounded_send_waits_at_capacity_and_drops_nothing() {
+        let (tx, mut rx) = channel::<i32>(Some(cap(2)));
+
+        // Two sends fill the two slots without suspending.
+        send_now(&tx, 1).expect("slot available");
+        send_now(&tx, 2).expect("slot available");
+
+        // The third send has no slot: it must wait, not drop.
+        let third = tx.send(3);
+        futures::pin_mut!(third);
+        assert!(
+            third.as_mut().poll(&mut noop_context()).is_pending(),
+            "a send past capacity must wait, not complete or drop"
+        );
+
+        // Freeing one slot lets exactly the waiting send through.
+        assert_eq!(rx.try_recv(), Ok(1));
+        assert!(
+            third.as_mut().poll(&mut noop_context()).is_ready(),
+            "the waiting send completes once a slot frees"
+        );
+
+        // The whole scripted sequence drained back, in order, nothing lost:
+        // this is the bounded-FIFO (INV-L3) and no-drop (INV-L2) regression.
+        assert_eq!(rx.try_recv(), Ok(2));
+        assert_eq!(rx.try_recv(), Ok(3));
+        assert_eq!(rx.try_recv(), Err(TryRecvError::Empty));
+    }
+
+    // Smoke/regression only, NOT the INV-L9 proof: two independently bounded
+    // channels do not share capacity — filling one leaves the other free. The
+    // pool-absence proof is the structural review of the channel-construction
+    // site (no shared permit/semaphore); the behavioral gate is the
+    // `keyed_isolation` harness scenario added later. A shared pool larger than
+    // `2 × capacity` would still pass this test, which is why it cannot prove
+    // isolation on its own.
+    #[test]
+    fn independent_bounded_channels_do_not_share_capacity() {
+        let (tx_a, _rx_a) = channel::<i32>(Some(cap(1)));
+        let (tx_b, mut rx_b) = channel::<i32>(Some(cap(1)));
+
+        // Saturate A and leave its next send pending.
+        send_now(&tx_a, 1).expect("A slot available");
+        let a_next = tx_a.send(2);
+        futures::pin_mut!(a_next);
+        assert!(a_next.as_mut().poll(&mut noop_context()).is_pending());
+
+        // B is unaffected by A's saturation.
+        send_now(&tx_b, 10).expect("B has its own slot");
+        assert_eq!(rx_b.try_recv(), Ok(10));
+    }
+}

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -26,10 +26,12 @@ pub enum Sender<T> {
     Unbounded(mpsc::UnboundedSender<T>),
     Bounded {
         tx: mpsc::Sender<T>,
-        /// Observability context, present only on runtime-owned bounded
-        /// channels: the capacity-wait event and the `blocked` gauge (RFC 0006
-        /// §4.4). Absent on test/bench senders.
-        obs: Option<SendObs>,
+        /// Observability context every bounded sender carries: the
+        /// capacity-wait event and the `blocked` gauge (RFC 0006 §4.4). Test
+        /// senders built via [`channel`] carry an inert [`LoadObserver`]
+        /// (no subscriber), so the type never expresses a "bounded but
+        /// unobserved" state that INV-L13 forbids.
+        obs: SendObs,
     },
 }
 
@@ -50,16 +52,23 @@ pub enum Receiver<T> {
     Bounded(mpsc::Receiver<T>),
 }
 
-/// Builds an unobserved channel pair from an optional capacity.
+/// Builds a channel pair with an inert observer from an optional capacity.
 ///
 /// `None` constructs the same `mpsc::unbounded_channel` as before, so the
 /// default delivery mode is structurally unchanged (INV-L6). `Some(n)`
-/// constructs a bounded channel of exactly `n` slots (INV-L1). The sender emits
-/// no load-observability events, so this is test-only; every runtime-owned
-/// channel is built through [`channel_observed`].
+/// constructs a bounded channel of exactly `n` slots (INV-L1). The bounded
+/// sender carries a default [`LoadObserver`], which — absent a subscriber —
+/// emits nothing, so this is test-only; every runtime-owned channel is built
+/// through [`channel_observed`] with the real observer.
 #[cfg(test)]
 pub fn channel<T>(capacity: Option<NonZeroUsize>) -> (Sender<T>, Receiver<T>) {
-    build(capacity, None)
+    build(
+        capacity,
+        SendObs {
+            channel: Channel::Shared,
+            observer: LoadObserver::default(),
+        },
+    )
 }
 
 /// Builds a channel pair whose bounded sender emits the capacity-wait event and
@@ -71,10 +80,10 @@ pub fn channel_observed<T>(
     channel: Channel,
     observer: LoadObserver,
 ) -> (Sender<T>, Receiver<T>) {
-    build(capacity, Some(SendObs { channel, observer }))
+    build(capacity, SendObs { channel, observer })
 }
 
-fn build<T>(capacity: Option<NonZeroUsize>, obs: Option<SendObs>) -> (Sender<T>, Receiver<T>) {
+fn build<T>(capacity: Option<NonZeroUsize>, obs: SendObs) -> (Sender<T>, Receiver<T>) {
     capacity.map_or_else(
         || {
             let (tx, rx) = mpsc::unbounded_channel();
@@ -122,11 +131,11 @@ impl<T> Sender<T> {
                 Err(mpsc::error::TrySendError::Closed(value)) => Err(SendError(value)),
                 Err(mpsc::error::TrySendError::Full(value)) => {
                     let started = Instant::now();
-                    let _blocked = obs.as_ref().map(|obs| obs.observer.track_blocked());
+                    let _blocked = obs.observer.track_blocked();
                     let accepted = tx.send(value).await;
                     // Emit the capacity-wait event only on acceptance; a send
                     // that failed (channel closed) was never accepted.
-                    if let (Ok(()), Some(obs)) = (accepted.as_ref(), obs) {
+                    if accepted.is_ok() {
                         load::capacity_wait(obs.channel, started.elapsed());
                     }
                     accepted

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -28,8 +28,8 @@ pub enum Sender<T> {
         tx: mpsc::Sender<T>,
         /// Observability context every bounded sender carries: the
         /// capacity-wait event and the `blocked` gauge (RFC 0006 §4.4). Test
-        /// senders built via [`channel`] carry an inert [`LoadObserver`]
-        /// (no subscriber), so the type never expresses a "bounded but
+        /// senders built via [`channel`] carry a throwaway [`LoadObserver`]
+        /// shared with no runtime, so the type never expresses a "bounded but
         /// unobserved" state that INV-L13 forbids.
         obs: SendObs,
     },
@@ -52,14 +52,20 @@ pub enum Receiver<T> {
     Bounded(mpsc::Receiver<T>),
 }
 
-/// Builds a channel pair with an inert observer from an optional capacity.
+/// Builds a channel pair from an optional capacity, for tests.
 ///
 /// `None` constructs the same `mpsc::unbounded_channel` as before, so the
 /// default delivery mode is structurally unchanged (INV-L6). `Some(n)`
 /// constructs a bounded channel of exactly `n` slots (INV-L1). The bounded
-/// sender carries a default [`LoadObserver`], which — absent a subscriber —
-/// emits nothing, so this is test-only; every runtime-owned channel is built
-/// through [`channel_observed`] with the real observer.
+/// sender carries a throwaway [`LoadObserver`] shared with no runtime, so its
+/// `blocked` gauge and capacity-wait events reach no aggregate — but they still
+/// fire to an installed `tracing` subscriber (emission is gated by the
+/// subscriber, not the observer). Every runtime-owned channel is built through
+/// [`channel_observed`] with the real observer.
+///
+/// The bounded label is fixed to [`Channel::Shared`]; a test that asserts on
+/// the capacity-wait event's `channel` field (e.g. a keyed case) must use
+/// [`channel_observed`] with the intended label instead.
 #[cfg(test)]
 pub fn channel<T>(capacity: Option<NonZeroUsize>) -> (Sender<T>, Receiver<T>) {
     build(

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -13,6 +13,9 @@ use std::task::{Context, Poll};
 
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::{SendError, TryRecvError};
+use tokio::time::Instant;
+
+use super::load::{self, Channel, LoadObserver};
 
 /// Sending half of a runtime-owned channel.
 ///
@@ -21,7 +24,22 @@ use tokio::sync::mpsc::error::{SendError, TryRecvError};
 /// reachability is capped at the crate regardless (see `frame_rate`).
 pub enum Sender<T> {
     Unbounded(mpsc::UnboundedSender<T>),
-    Bounded(mpsc::Sender<T>),
+    Bounded {
+        tx: mpsc::Sender<T>,
+        /// Observability context, present only on runtime-owned bounded
+        /// channels: the capacity-wait event and the `blocked` gauge (RFC 0006
+        /// §4.4). Absent on test/bench senders.
+        obs: Option<SendObs>,
+    },
+}
+
+/// The channel label and shared observer a bounded sender carries so it can
+/// emit the capacity-wait event and maintain the `blocked` gauge (RFC 0006
+/// §4.4).
+#[derive(Clone)]
+pub struct SendObs {
+    channel: Channel,
+    observer: LoadObserver,
 }
 
 /// Receiving half of a runtime-owned channel.
@@ -32,12 +50,31 @@ pub enum Receiver<T> {
     Bounded(mpsc::Receiver<T>),
 }
 
-/// Builds a channel pair from an optional capacity.
+/// Builds an unobserved channel pair from an optional capacity.
 ///
 /// `None` constructs the same `mpsc::unbounded_channel` as before, so the
 /// default delivery mode is structurally unchanged (INV-L6). `Some(n)`
-/// constructs a bounded channel of exactly `n` slots (INV-L1).
+/// constructs a bounded channel of exactly `n` slots (INV-L1). The sender emits
+/// no load-observability events, so this is test-only; every runtime-owned
+/// channel is built through [`channel_observed`].
+#[cfg(test)]
 pub fn channel<T>(capacity: Option<NonZeroUsize>) -> (Sender<T>, Receiver<T>) {
+    build(capacity, None)
+}
+
+/// Builds a channel pair whose bounded sender emits the capacity-wait event and
+/// maintains the `blocked` gauge under the given `channel` label (RFC 0006
+/// §4.4). An unbounded channel (`None` capacity) never blocks, so the observer
+/// is inert and dropped.
+pub fn channel_observed<T>(
+    capacity: Option<NonZeroUsize>,
+    channel: Channel,
+    observer: LoadObserver,
+) -> (Sender<T>, Receiver<T>) {
+    build(capacity, Some(SendObs { channel, observer }))
+}
+
+fn build<T>(capacity: Option<NonZeroUsize>, obs: Option<SendObs>) -> (Sender<T>, Receiver<T>) {
     capacity.map_or_else(
         || {
             let (tx, rx) = mpsc::unbounded_channel();
@@ -45,7 +82,7 @@ pub fn channel<T>(capacity: Option<NonZeroUsize>) -> (Sender<T>, Receiver<T>) {
         },
         |capacity| {
             let (tx, rx) = mpsc::channel(capacity.get());
-            (Sender::Bounded(tx), Receiver::Bounded(rx))
+            (Sender::Bounded { tx, obs }, Receiver::Bounded(rx))
         },
     )
 }
@@ -54,7 +91,10 @@ impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
         match self {
             Self::Unbounded(tx) => Self::Unbounded(tx.clone()),
-            Self::Bounded(tx) => Self::Bounded(tx.clone()),
+            Self::Bounded { tx, obs } => Self::Bounded {
+                tx: tx.clone(),
+                obs: obs.clone(),
+            },
         }
     }
 }
@@ -67,10 +107,31 @@ impl<T> Sender<T> {
     /// immediately, so the caller's `.await` resolves on the first poll and the
     /// producer task is never suspended (INV-L6). The bounded arm awaits a
     /// permit, so an overloaded producer waits rather than dropping (INV-L2).
+    ///
+    /// The bounded arm first attempts a non-blocking send; only when that finds
+    /// the channel full — the first unready attempt — does it wait, and it is
+    /// exactly that path that raises the `blocked` gauge for the wait's duration
+    /// and emits the capacity-wait event on acceptance (RFC 0006 §4.4). An
+    /// immediately accepted send stays silent. The `blocked` gauge is held by a
+    /// guard, so a send aborted mid-wait (cancellation) still lowers it.
     pub async fn send(&self, value: T) -> Result<(), SendError<T>> {
         match self {
             Self::Unbounded(tx) => tx.send(value),
-            Self::Bounded(tx) => tx.send(value).await,
+            Self::Bounded { tx, obs } => match tx.try_send(value) {
+                Ok(()) => Ok(()),
+                Err(mpsc::error::TrySendError::Closed(value)) => Err(SendError(value)),
+                Err(mpsc::error::TrySendError::Full(value)) => {
+                    let started = Instant::now();
+                    let _blocked = obs.as_ref().map(|obs| obs.observer.track_blocked());
+                    let accepted = tx.send(value).await;
+                    // Emit the capacity-wait event only on acceptance; a send
+                    // that failed (channel closed) was never accepted.
+                    if let (Ok(()), Some(obs)) = (accepted.as_ref(), obs) {
+                        load::capacity_wait(obs.channel, started.elapsed());
+                    }
+                    accepted
+                }
+            },
         }
     }
 
@@ -84,7 +145,7 @@ impl<T> Sender<T> {
             Self::Unbounded(tx) => tx
                 .send(value)
                 .map_err(|SendError(value)| mpsc::error::TrySendError::Closed(value)),
-            Self::Bounded(tx) => tx.try_send(value),
+            Self::Bounded { tx, .. } => tx.try_send(value),
         }
     }
 
@@ -236,5 +297,135 @@ mod tests {
         // B is unaffected by A's saturation.
         send_now(&tx_b, 10).expect("B has its own slot");
         assert_eq!(rx_b.try_recv(), Ok(10));
+    }
+
+    // Capacity-wait event (RFC 0006 §4.4, INV-L13): a bounded send that finds
+    // the channel full waits, and on acceptance emits exactly one capacity-wait
+    // event naming the blocking `channel` and a `wait_us` measured against the
+    // pausable clock. An immediately accepted send emits nothing. The clock is
+    // paused so the reported wait equals the scripted 5ms exactly.
+    #[tokio::test(start_paused = true)]
+    async fn bounded_send_emits_capacity_wait_on_acceptance() {
+        use tokio::task::yield_now;
+        use tokio::time::{Duration, advance};
+
+        use crate::test_support::TraceRecorder;
+
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let (tx, mut rx) =
+            channel_observed::<i32>(Some(cap(1)), Channel::Shared, LoadObserver::default());
+
+        // Fills the only slot; accepted immediately, so it fires no event.
+        tx.send(1).await.expect("first send fits the empty slot");
+
+        // The second send has no slot: it blocks. Let it reach the await, hold
+        // it blocked across a scripted 5ms, then free a slot so it is accepted.
+        let sender = tx.clone();
+        let blocked = tokio::spawn(async move { sender.send(2).await });
+        yield_now().await;
+        advance(Duration::from_millis(5)).await;
+        assert_eq!(rx.try_recv(), Ok(1), "freeing a slot unblocks the send");
+        blocked
+            .await
+            .expect("blocked send task joins")
+            .expect("the send is accepted once a slot frees");
+
+        assert_eq!(
+            recorder.str_values("channel"),
+            vec!["shared".to_owned()],
+            "exactly one capacity-wait event, naming the shared channel"
+        );
+        let waits = recorder.u64_values("wait_us");
+        assert_eq!(waits.len(), 1, "the immediate first send fired no event");
+        assert!(
+            waits[0] >= 5_000,
+            "wait_us reflects the ~5ms blocked interval, got {}",
+            waits[0]
+        );
+
+        // The `blocked` gauge rose while the send waited and fell once it was
+        // accepted (RFC 0006 §4.4) — the accepted-send counterpart to the
+        // abort-decrement below.
+        let blocked = recorder.u64_values("blocked");
+        assert!(
+            blocked.contains(&1),
+            "blocked rose while the send waited: {blocked:?}"
+        );
+        assert_eq!(
+            blocked.last(),
+            Some(&0),
+            "blocked fell once the send was accepted: {blocked:?}"
+        );
+    }
+
+    // INV-L13 (unbounded mode is silent): an unbounded channel never waits, so
+    // its observed sender emits no capacity-wait event and never touches the
+    // `blocked` gauge — `blocked` stays 0 in unbounded mode by construction (the
+    // observer is not even attached to an unbounded sender).
+    #[tokio::test]
+    async fn unbounded_observed_channel_emits_no_load_events() {
+        use crate::test_support::TraceRecorder;
+
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let (tx, _rx) = channel_observed::<i32>(None, Channel::Shared, LoadObserver::default());
+        for value in 0..1_000 {
+            tx.send(value)
+                .await
+                .expect("the unbounded receiver is open");
+        }
+
+        assert_eq!(
+            recorder.event_count(),
+            0,
+            "unbounded mode fires no capacity-wait and no blocked-gauge events"
+        );
+        assert!(recorder.str_values("channel").is_empty());
+        assert!(recorder.u64_values("blocked").is_empty());
+    }
+
+    // `blocked` gauge (RFC 0006 §4.4): a producer that begins awaiting capacity
+    // raises `blocked`, and aborting that producer mid-wait lowers it again —
+    // the decrement does not depend on the send ever being accepted, so no
+    // capacity-wait event fires. This is the cancellation-abort decrement the
+    // DoD requires.
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocked_gauge_falls_when_a_blocked_send_is_aborted() {
+        use tokio::task::yield_now;
+
+        use crate::test_support::TraceRecorder;
+
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let (tx, _rx) =
+            channel_observed::<i32>(Some(cap(1)), Channel::Keyed, LoadObserver::default());
+        tx.send(1).await.expect("first send fills the only slot");
+
+        // The second send blocks (no slot). Abort its task before any slot frees.
+        let sender = tx.clone();
+        let blocked = tokio::spawn(async move { sender.send(2).await });
+        yield_now().await;
+        blocked.abort();
+        let _ = blocked.await;
+        yield_now().await;
+
+        let blocked_values = recorder.u64_values("blocked");
+        assert!(
+            blocked_values.contains(&1),
+            "blocked rose while the send waited: {blocked_values:?}"
+        );
+        assert_eq!(
+            blocked_values.last(),
+            Some(&0),
+            "aborting the blocked send lowered blocked: {blocked_values:?}"
+        );
+        assert!(
+            recorder.str_values("channel").is_empty(),
+            "no capacity-wait event fires: the send was never accepted"
+        );
     }
 }

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -58,21 +58,14 @@ use super::frame_rate::FrameRate;
 pub struct RuntimeConfig {
     /// Target frame rate for the runtime's frame scheduler.
     pub(crate) frame_rate: FrameRate,
-    // The three load-control capacities are carried by the public surface here
-    // but not yet consumed by the channels: bounded delivery wires them into the
-    // channel-construction seam in a follow-up commit, which removes these
-    // `allow`s. Until then they are read only by this module's tests.
     /// Capacity of the shared application-message channel; `None` keeps it
     /// unbounded (RFC 0006 §4.1).
-    #[allow(dead_code)]
     pub(crate) app_channel_capacity: Option<NonZeroUsize>,
     /// Capacity of each keyed command's private channel; `None` keeps it
     /// unbounded (RFC 0006 §4.1).
-    #[allow(dead_code)]
     pub(crate) keyed_channel_capacity: Option<NonZeroUsize>,
     /// Count cap for one micro-batch window; `None` keeps the time-capped-only
     /// loop (RFC 0006 §4.1, INV-L12).
-    #[allow(dead_code)]
     pub(crate) batch_max_messages: Option<NonZeroUsize>,
 }
 

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -1,0 +1,253 @@
+//! Construction-time configuration for the [`Runtime`](crate::Runtime).
+//!
+//! [`RuntimeConfig`] carries the frame rate together with the opt-in
+//! load-control knobs (RFC 0006). With the load controls unset — the state
+//! [`RuntimeConfig::new`] produces — the configuration reproduces the
+//! unbounded delivery mode exactly (RFC 0006 INV-L6), so it is equivalent to
+//! [`Runtime::new`](crate::Runtime::new).
+
+use std::num::NonZeroUsize;
+
+use super::frame_rate::FrameRate;
+
+/// Construction-time configuration for the runtime: the frame rate and the
+/// opt-in load controls (RFC 0006).
+///
+/// `RuntimeConfig` is the runtime's construction-time configuration, not a
+/// load-control namespace — the frame rate is a runtime setting like any
+/// other, and future runtime knobs accrete here rather than growing
+/// [`Runtime`](crate::Runtime)'s constructor signatures.
+///
+/// With the load controls unset, the configuration reproduces the unbounded
+/// delivery mode exactly (RFC 0006 INV-L6): the shared and keyed channels are
+/// unbounded and senders never wait. This is the mode
+/// [`Runtime::new`](crate::Runtime::new) uses.
+///
+/// # Construction
+///
+/// [`RuntimeConfig::new`] is the sole constructor — it takes the one setting
+/// that has no meaningful default (the frame rate) and leaves the three load
+/// controls unset. The consuming setters
+/// ([`app_channel_capacity`](Self::app_channel_capacity),
+/// [`keyed_channel_capacity`](Self::keyed_channel_capacity),
+/// [`batch_max_messages`](Self::batch_max_messages)) opt into bounded delivery
+/// and follow the crate's combinator convention (like
+/// [`Command::timeout`](crate::Command::timeout)); each returns a modified
+/// copy and does not mutate in place.
+///
+/// There is deliberately no [`Default`] impl: the crate has no default frame
+/// rate, so a value would have to be invented inside the derive.
+///
+/// # Examples
+///
+/// ```
+/// # use std::num::{NonZeroU32, NonZeroUsize};
+/// # use tears::{FrameRate, RuntimeConfig};
+/// let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))
+///     .expect("valid frame rate");
+///
+/// // Default (unbounded) delivery, equivalent to `Runtime::new`.
+/// let config = RuntimeConfig::new(frame_rate);
+///
+/// // Opt into bounded delivery with the documented starting capacities.
+/// let bounded = RuntimeConfig::new(frame_rate)
+///     .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
+///     .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"));
+/// ```
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RuntimeConfig {
+    /// Target frame rate for the runtime's frame scheduler.
+    pub(crate) frame_rate: FrameRate,
+    // The three load-control capacities are carried by the public surface here
+    // but not yet consumed by the channels: bounded delivery wires them into the
+    // channel-construction seam in a follow-up commit, which removes these
+    // `allow`s. Until then they are read only by this module's tests.
+    /// Capacity of the shared application-message channel; `None` keeps it
+    /// unbounded (RFC 0006 §4.1).
+    #[allow(dead_code)]
+    pub(crate) app_channel_capacity: Option<NonZeroUsize>,
+    /// Capacity of each keyed command's private channel; `None` keeps it
+    /// unbounded (RFC 0006 §4.1).
+    #[allow(dead_code)]
+    pub(crate) keyed_channel_capacity: Option<NonZeroUsize>,
+    /// Count cap for one micro-batch window; `None` keeps the time-capped-only
+    /// loop (RFC 0006 §4.1, INV-L12).
+    #[allow(dead_code)]
+    pub(crate) batch_max_messages: Option<NonZeroUsize>,
+}
+
+impl RuntimeConfig {
+    /// Creates a configuration with the given frame rate and the three load
+    /// controls unset.
+    ///
+    /// The unset load controls reproduce the unbounded delivery mode (RFC 0006
+    /// INV-L6): this configuration is equivalent to
+    /// [`Runtime::new`](crate::Runtime::new) with the same frame rate.
+    #[must_use]
+    pub const fn new(frame_rate: FrameRate) -> Self {
+        Self {
+            frame_rate,
+            app_channel_capacity: None,
+            keyed_channel_capacity: None,
+            batch_max_messages: None,
+        }
+    }
+
+    /// Bounds the shared application-message channel to `capacity` messages,
+    /// opting into bounded delivery for it (RFC 0006 §4.1).
+    ///
+    /// # Sizing — the latency/burst trade
+    ///
+    /// A bounded shared channel's capacity buys burst absorption and costs
+    /// queueing latency: once the queue is full, a newly accepted message
+    /// waits behind at most one full queue before reaching
+    /// [`update`](crate::Application::update), so its wait is roughly
+    /// `capacity × per-message drain cost`, where the drain cost is the
+    /// application's own observed average loop service time (RFC 0006 §2). The
+    /// product is an estimate on the measured workload, not a worst-case bound;
+    /// an application that needs a hard bound derives it from its own measured
+    /// tail service time.
+    ///
+    /// The **documented starting value is `1024`** — a measurement-informed
+    /// margin choice (RFC 0007 §3.1), not a value the measurements pin
+    /// uniquely; `512` or `2048` are defensible on the same data. Applications
+    /// with larger expected bursts scale up by the same rule; the cost of
+    /// undersizing is producer wait, never message loss (RFC 0006 INV-L2).
+    #[must_use = "app_channel_capacity returns a modified config and does not mutate in place"]
+    pub const fn app_channel_capacity(mut self, capacity: NonZeroUsize) -> Self {
+        self.app_channel_capacity = Some(capacity);
+        self
+    }
+
+    /// Bounds each keyed command's private channel to `capacity` messages,
+    /// opting into bounded delivery for keyed output (RFC 0006 §4.1).
+    ///
+    /// # Sizing — burst absorption and memory, not a latency guarantee
+    ///
+    /// The `capacity × drain cost` estimate does **not** transfer to the keyed
+    /// channel: while any shared input stays ready the keyed channel is not
+    /// drained at all (shared-first pull, RFC 0006 §4.7), so keyed-delivery
+    /// latency stays unbounded independent of the configured capacity. A larger
+    /// keyed capacity bounds no delivery latency and restores no keyed
+    /// liveness; what it buys in a finite execution is reduced producer-side
+    /// admission wait — a burst of up to the channel's free capacity completes
+    /// without the command blocking — at a memory cost (the per-command share
+    /// of the `m × capacity` buffer total, RFC 0006 R1). Size it for that
+    /// absorption-versus-memory trade, never for a delivery-latency guarantee.
+    ///
+    /// The **documented starting value is `16`** — a margin choice, not
+    /// measurement-derived (RFC 0007 §3.1).
+    ///
+    /// Keying a command buys cancellation at the cost of deferral behind ready
+    /// shared inputs; liveness-critical output belongs in an unkeyed command,
+    /// and keyed liveness under load comes from pacing hot sources, not from
+    /// bounded mode (RFC 0006 §4.7).
+    #[must_use = "keyed_channel_capacity returns a modified config and does not mutate in place"]
+    pub const fn keyed_channel_capacity(mut self, capacity: NonZeroUsize) -> Self {
+        self.keyed_channel_capacity = Some(capacity);
+        self
+    }
+
+    /// Caps the number of inputs one micro-batch window may pull, complementing
+    /// the 100µs time cap (RFC 0006 §4.1, INV-L12).
+    ///
+    /// The counted unit is a *pulled input*: every input the batch takes counts
+    /// toward the cap — including the one that opened the batch and inputs that
+    /// do not invoke [`update`](crate::Application::update) — so `Some(n)` lets
+    /// the batch drain at most `n - 1` inputs after the first. A batch ends at
+    /// whichever cap is reached first (count or the 100µs window), or earlier
+    /// when no input is ready or a quit is pulled.
+    ///
+    /// The **documented recommendation is to leave this unset**: the 100µs time
+    /// cap alone holds the frame branch stable under overload (RFC 0006 F5), so
+    /// the count cap is a diagnostic knob, not a default (RFC 0007 §3.1).
+    #[must_use = "batch_max_messages returns a modified config and does not mutate in place"]
+    pub const fn batch_max_messages(mut self, max: NonZeroUsize) -> Self {
+        self.batch_max_messages = Some(max);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::{NonZeroU32, NonZeroUsize};
+
+    use super::*;
+
+    fn frame_rate(value: u32) -> FrameRate {
+        FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+            .expect("frame rate must be valid")
+    }
+
+    fn cap(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("capacity must be non-zero")
+    }
+
+    // INV-C2: `new` carries the given frame rate and leaves all three load
+    // controls unset.
+    #[test]
+    fn new_carries_frame_rate_and_leaves_controls_unset() {
+        let config = RuntimeConfig::new(frame_rate(60));
+
+        assert_eq!(config.frame_rate, frame_rate(60));
+        assert_eq!(config.app_channel_capacity, None);
+        assert_eq!(config.keyed_channel_capacity, None);
+        assert_eq!(config.batch_max_messages, None);
+    }
+
+    // INV-C2: each setter sets exactly its own field and no other.
+    #[test]
+    fn app_channel_capacity_sets_only_its_field() {
+        let config = RuntimeConfig::new(frame_rate(60)).app_channel_capacity(cap(1024));
+
+        assert_eq!(config.app_channel_capacity, Some(cap(1024)));
+        assert_eq!(config.frame_rate, frame_rate(60));
+        assert_eq!(config.keyed_channel_capacity, None);
+        assert_eq!(config.batch_max_messages, None);
+    }
+
+    #[test]
+    fn keyed_channel_capacity_sets_only_its_field() {
+        let config = RuntimeConfig::new(frame_rate(60)).keyed_channel_capacity(cap(16));
+
+        assert_eq!(config.keyed_channel_capacity, Some(cap(16)));
+        assert_eq!(config.frame_rate, frame_rate(60));
+        assert_eq!(config.app_channel_capacity, None);
+        assert_eq!(config.batch_max_messages, None);
+    }
+
+    #[test]
+    fn batch_max_messages_sets_only_its_field() {
+        let config = RuntimeConfig::new(frame_rate(60)).batch_max_messages(cap(8));
+
+        assert_eq!(config.batch_max_messages, Some(cap(8)));
+        assert_eq!(config.frame_rate, frame_rate(60));
+        assert_eq!(config.app_channel_capacity, None);
+        assert_eq!(config.keyed_channel_capacity, None);
+    }
+
+    // INV-C2/INV-C6: the setters chain, each independently, and every setter
+    // returns a modified copy (`#[must_use]`) rather than mutating in place.
+    #[test]
+    fn setters_chain_independently() {
+        let config = RuntimeConfig::new(frame_rate(30))
+            .app_channel_capacity(cap(1024))
+            .keyed_channel_capacity(cap(16))
+            .batch_max_messages(cap(4));
+
+        assert_eq!(config.frame_rate, frame_rate(30));
+        assert_eq!(config.app_channel_capacity, Some(cap(1024)));
+        assert_eq!(config.keyed_channel_capacity, Some(cap(16)));
+        assert_eq!(config.batch_max_messages, Some(cap(4)));
+    }
+
+    // INV-C3: a discarded setter call leaves the original value untouched
+    // (the consuming-call misuse guard the `#[must_use]` messages warn about).
+    #[test]
+    fn discarded_setter_leaves_original_unmodified() {
+        let config = RuntimeConfig::new(frame_rate(60));
+        let _ = config.app_channel_capacity(cap(1024));
+
+        assert_eq!(config.app_channel_capacity, None);
+    }
+}

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -6,6 +6,7 @@
 //! owns their lifecycle operations (construction, command spawning,
 //! subscription initialization, rendering, and shutdown).
 
+use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 
 use color_eyre::eyre::Result;
@@ -20,6 +21,7 @@ use crate::command::{Action, RuntimeCommandParts};
 use crate::subscription::SubscriptionManager;
 
 use super::app_input::AppInputs;
+use super::channel;
 
 /// The runtime's owned execution state for a single [`Application`] run.
 ///
@@ -44,8 +46,9 @@ use super::app_input::AppInputs;
 pub(super) struct RuntimeCore<App: Application> {
     /// The application instance
     pub(super) app: App,
-    /// Sender for application messages
-    pub(super) msg_tx: mpsc::UnboundedSender<App::Message>,
+    /// Sender for application messages (shared channel; bounded or unbounded per
+    /// `RuntimeConfig`)
+    pub(super) msg_tx: channel::Sender<App::Message>,
     /// Runtime-owned receiver for application inputs
     pub(super) app_inputs: AppInputs<App::Message>,
     /// Sender for quit signals
@@ -72,10 +75,38 @@ impl<App: Application> RuntimeCore<App> {
     /// # Arguments
     ///
     /// * `flags` - Configuration data passed to [`Application::new`]
+    ///
+    /// Constructs the default (unbounded) channels. Used only by this module's
+    /// tests; production construction goes through
+    /// [`with_capacities`](Self::with_capacities), which
+    /// [`Runtime::with_config`](super::Runtime::with_config) reaches.
+    #[cfg(test)]
     #[must_use]
     pub(super) fn new(flags: App::Flags) -> Self {
-        let (msg_tx, msg_rx) = mpsc::unbounded_channel();
-        let app_inputs = AppInputs::new(msg_rx);
+        Self::with_capacities(flags, None, None)
+    }
+
+    /// Creates the runtime core with the given channel capacities.
+    ///
+    /// This is the single channel-construction site (RFC 0006 INV-L6): `None`
+    /// capacities build the same unbounded channels as before, `Some(n)` build
+    /// bounded ones. The shared channel takes `app_channel_capacity`; each keyed
+    /// command's private channel takes `keyed_channel_capacity` independently
+    /// (INV-L9). The dedicated quit channel is never bounded (R4).
+    ///
+    /// # Arguments
+    ///
+    /// * `flags` - Configuration data passed to [`Application::new`]
+    /// * `app_channel_capacity` - Shared message channel capacity, or `None`
+    /// * `keyed_channel_capacity` - Per-keyed-command channel capacity, or `None`
+    #[must_use]
+    pub(super) fn with_capacities(
+        flags: App::Flags,
+        app_channel_capacity: Option<NonZeroUsize>,
+        keyed_channel_capacity: Option<NonZeroUsize>,
+    ) -> Self {
+        let (msg_tx, msg_rx) = channel::channel(app_channel_capacity);
+        let app_inputs = AppInputs::new(msg_rx, keyed_channel_capacity);
         let (quit_tx, quit_rx) = mpsc::unbounded_channel();
         let subscription_manager = SubscriptionManager::new(msg_tx.clone());
 
@@ -141,11 +172,16 @@ impl<App: Application> RuntimeCore<App> {
                     while let Some(action) = stream.next().await {
                         match action {
                             Action::Message(msg) => {
+                                // Awaiting applies backpressure in bounded mode (the
+                                // command task waits for shared-channel capacity;
+                                // INV-L2) and completes immediately in unbounded mode
+                                // (INV-L6).
+                                //
                                 // NOTE: Send errors are silently ignored. The channel is closed only
                                 // when the RuntimeCore is dropped, which means the application is shutting
                                 // down. In this case, dropping messages is the expected behavior.
                                 // This follows the same approach as iced and other Elm-like frameworks.
-                                let _ = msg_tx.send(msg);
+                                let _ = msg_tx.send(msg).await;
                             }
                             Action::Quit => {
                                 // NOTE: Same reasoning as above. If the quit channel is closed,

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -22,6 +22,7 @@ use crate::subscription::SubscriptionManager;
 
 use super::app_input::AppInputs;
 use super::channel;
+use super::load::{Channel, LoadObserver};
 
 /// The runtime's owned execution state for a single [`Application`] run.
 ///
@@ -57,6 +58,10 @@ pub(super) struct RuntimeCore<App: Application> {
     pub(super) quit_rx: mpsc::UnboundedReceiver<()>,
     /// Manages subscription lifecycle
     pub(super) subscription_manager: SubscriptionManager<App::Message>,
+    /// Shared producer-count gauges and event emitters (RFC 0006 §4.4). Cloned
+    /// into every producer (senders, subscriptions, keyed commands) so their
+    /// gauge updates aggregate; the batch event is emitted from here.
+    pub(super) observer: LoadObserver,
     /// Running command tasks.
     ///
     /// Kept so command tasks can be aborted on shutdown, and — because a
@@ -105,10 +110,12 @@ impl<App: Application> RuntimeCore<App> {
         app_channel_capacity: Option<NonZeroUsize>,
         keyed_channel_capacity: Option<NonZeroUsize>,
     ) -> Self {
-        let (msg_tx, msg_rx) = channel::channel(app_channel_capacity);
-        let app_inputs = AppInputs::new(msg_rx, keyed_channel_capacity);
+        let observer = LoadObserver::default();
+        let (msg_tx, msg_rx) =
+            channel::channel_observed(app_channel_capacity, Channel::Shared, observer.clone());
+        let app_inputs = AppInputs::new(msg_rx, keyed_channel_capacity, observer.clone());
         let (quit_tx, quit_rx) = mpsc::unbounded_channel();
-        let subscription_manager = SubscriptionManager::new(msg_tx.clone());
+        let subscription_manager = SubscriptionManager::new(msg_tx.clone(), observer.clone());
 
         // Initialize the application with flags
         let (app, init_cmd) = App::new(flags);
@@ -120,6 +127,7 @@ impl<App: Application> RuntimeCore<App> {
             quit_tx,
             quit_rx,
             subscription_manager,
+            observer,
             command_tasks: JoinSet::new(),
         };
 
@@ -157,6 +165,9 @@ impl<App: Application> RuntimeCore<App> {
 
             let msg_tx = self.msg_tx.clone();
             let quit_tx = self.quit_tx.clone();
+            // Raise the `unkeyed_commands` gauge for the task's lifetime; the
+            // guard lowers it on completion or abort (RFC 0006 §4.4).
+            let command_guard = self.observer.track_unkeyed_command();
 
             // Reap finished command tasks so the set stays bounded to the
             // commands that are actually still running.
@@ -165,6 +176,7 @@ impl<App: Application> RuntimeCore<App> {
             tracing::trace!(target: "tears::runtime", "command spawned");
 
             self.command_tasks.spawn(async move {
+                let _command_guard = command_guard;
                 // Catch panics in the command's stream so a bug in a fetcher or
                 // effect is logged instead of vanishing into a detached task.
                 let result = AssertUnwindSafe(async move {

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -12,6 +12,7 @@ use tokio_stream::StreamMap;
 use crate::command::{Action, CancelPolicy, CommandId};
 
 use super::channel;
+use super::load::{Channel, LoadObserver};
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub(super) enum CommandOutput<Msg> {
@@ -245,15 +246,20 @@ pub(super) struct KeyedCommands<Msg: Send + 'static> {
     /// unbounded, `Some(n)` bounds each one to `n` independently — never a
     /// shared pool (INV-L9).
     keyed_capacity: Option<NonZeroUsize>,
+    /// Shared load observer: keyed producers' channels emit through it, and the
+    /// `keyed_commands` gauge is set to the active-entry count after each
+    /// transition (RFC 0006 §4.4).
+    observer: LoadObserver,
 }
 
 impl<Msg: Send + 'static> KeyedCommands<Msg> {
-    pub(super) fn new(keyed_capacity: Option<NonZeroUsize>) -> Self {
+    pub(super) fn new(keyed_capacity: Option<NonZeroUsize>, observer: LoadObserver) -> Self {
         Self {
             entries: StreamMap::new(),
             tasks: JoinSet::new(),
             next_token: 0,
             keyed_capacity,
+            observer,
         }
     }
 
@@ -292,7 +298,8 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
         stream: BoxStream<'static, Action<Msg>>,
     ) {
         self.next_token = self.next_token.wrapping_add(1);
-        let (output_tx, output_rx) = channel::channel(self.keyed_capacity);
+        let (output_tx, output_rx) =
+            channel::channel_observed(self.keyed_capacity, Channel::Keyed, self.observer.clone());
         let task_id = id.clone();
 
         let abort = self.tasks.spawn(async move {
@@ -435,6 +442,11 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
             LifecycleDecision::Remove => self.remove_entry(&id),
             LifecycleDecision::MarkDraining { token } => self.mark_draining(id, token),
         }
+        // Every entry insert/remove funnels through here; publish the resulting
+        // active-entry count to the `keyed_commands` gauge (RFC 0006 §4.4). A
+        // `MarkDraining` (remove-then-reinsert) or a no-op transition leaves the
+        // count unchanged, so the observer emits nothing.
+        self.observer.set_keyed_entries(self.entries.len());
     }
 
     fn abort_running_entry(&mut self, id: &CommandId) {
@@ -511,6 +523,7 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
     pub(super) fn shutdown(&mut self) {
         self.tasks.abort_all();
         self.entries.clear();
+        self.observer.set_keyed_entries(self.entries.len());
     }
 
     #[cfg(test)]
@@ -526,6 +539,20 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
                 facts.sender_closed && facts.buffered > 0
             }
         })
+    }
+}
+
+impl<Msg: Send + 'static> Drop for KeyedCommands<Msg> {
+    fn drop(&mut self) {
+        // Dropping abandons every entry and aborts every task (the `StreamMap`
+        // and `JoinSet` do that themselves), so publish the `keyed_commands`
+        // gauge returning to zero here. `shutdown()` already did this on the
+        // clean path; the gauge is count-based rather than guard-based, so a
+        // path that drops the runtime without `shutdown()` — a render error
+        // propagating out of `run()` — would otherwise leave it stuck above
+        // zero. `set_keyed_entries` re-emits only on a change, so a
+        // shutdown-then-drop pair emits once.
+        self.observer.set_keyed_entries(0);
     }
 }
 
@@ -620,7 +647,7 @@ mod tests {
     #[tokio::test]
     async fn pending_keyed_poll_wakes_after_output() {
         let id = CommandId::new("output-wake");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         let output_tx = insert_pending_receiver(&mut manager, id.clone());
         let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
         let waker = waker_ref(&wake_counter);
@@ -648,7 +675,7 @@ mod tests {
     #[tokio::test]
     async fn pending_keyed_poll_wakes_after_sender_closure() {
         let id = CommandId::new("closure-wake");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         let output_tx = insert_pending_receiver(&mut manager, id.clone());
         let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
         let waker = waker_ref(&wake_counter);
@@ -675,7 +702,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_in_flight_drops_finished_buffered_output() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -697,7 +724,7 @@ mod tests {
     #[tokio::test]
     async fn explicit_cancel_is_strict_and_idempotent() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -726,7 +753,7 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let guard = AbortGuard(Arc::clone(&dropped));
         let (started_tx, started_rx) = oneshot::channel();
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -755,7 +782,7 @@ mod tests {
     #[tokio::test]
     async fn keep_in_flight_preserves_finished_buffered_output() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -777,7 +804,7 @@ mod tests {
     async fn keep_in_flight_rechecks_a_closed_empty_receiver_before_task_exit() {
         let id = CommandId::new("submit");
         let token = RunToken(0);
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         // Model the panic-reporting window: the task still has no published
         // TaskExit, but unwinding has already dropped its output sender.
         let (output_tx, output_rx) = channel::channel(None);
@@ -810,7 +837,7 @@ mod tests {
     #[tokio::test]
     async fn delivering_the_closed_senders_last_item_releases_the_id_for_retry() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -833,7 +860,7 @@ mod tests {
     #[tokio::test]
     async fn keep_in_flight_does_not_spawn_while_sender_is_open() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -854,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn keyed_quit_is_delivered_after_the_same_runs_earlier_output() {
         let id = CommandId::new("save-then-quit");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -873,7 +900,7 @@ mod tests {
     #[tokio::test]
     async fn cancelling_buffered_quit_suppresses_it() {
         let id = CommandId::new("quit");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -889,7 +916,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn cancelling_suppresses_a_pending_timeout_message() {
         let id = CommandId::new("timeout");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         let command = Command::future(pending())
             .timeout(Duration::from_secs(5), || 99)
             .cancellable(id.clone());
@@ -919,7 +946,7 @@ mod tests {
             },
             |_| 1,
         );
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -959,7 +986,7 @@ mod tests {
             },
             |result| result.expect("second retry would succeed"),
         );
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -979,7 +1006,7 @@ mod tests {
     #[tokio::test]
     async fn stale_completion_cannot_remove_or_mutate_a_successor() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -1014,7 +1041,7 @@ mod tests {
             .with_level(Level::ERROR);
         let _guard = recorder.set_default();
         let id = CommandId::new("panic");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         let (event_count, contains_id) = with_silent_panic_hook(async {
             manager.spawn(
                 id.clone(),
@@ -1052,7 +1079,7 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let guard = AbortGuard(Arc::clone(&dropped));
         let id = CommandId::new("running");
-        let mut manager = KeyedCommands::new(None);
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
         manager.spawn(
             id,
             CancelPolicy::CancelInFlight,
@@ -1088,7 +1115,10 @@ mod tests {
         let id = CommandId::new("search");
         let dropped = Arc::new(AtomicBool::new(false));
         let guard = AbortGuard(Arc::clone(&dropped));
-        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+        let mut manager = KeyedCommands::new(
+            Some(NonZeroUsize::new(1).expect("non-zero")),
+            LoadObserver::default(),
+        );
 
         // The guard rides the stream's state so its drop witnesses the parked
         // task being aborted (the second send never completes).
@@ -1133,7 +1163,10 @@ mod tests {
     #[tokio::test]
     async fn bounded_cancel_in_flight_replacement_isolates_the_old_runs_blocked_send() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+        let mut manager = KeyedCommands::new(
+            Some(NonZeroUsize::new(1).expect("non-zero")),
+            LoadObserver::default(),
+        );
 
         manager.spawn(
             id.clone(),
@@ -1173,7 +1206,10 @@ mod tests {
     #[tokio::test]
     async fn keyed_quit_follows_earlier_output_under_capacity_one() {
         let id = CommandId::new("save-then-quit");
-        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+        let mut manager = KeyedCommands::new(
+            Some(NonZeroUsize::new(1).expect("non-zero")),
+            LoadObserver::default(),
+        );
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::panic::AssertUnwindSafe;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -5,11 +6,12 @@ use std::task::{Context, Poll};
 use futures::FutureExt;
 use futures::stream::{BoxStream, Stream, StreamExt};
 use futures::task::noop_waker_ref;
-use tokio::sync::mpsc;
 use tokio::task::{AbortHandle, JoinSet};
 use tokio_stream::StreamMap;
 
 use crate::command::{Action, CancelPolicy, CommandId};
+
+use super::channel;
 
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
 pub(super) enum CommandOutput<Msg> {
@@ -30,12 +32,12 @@ struct ReceiverFacts {
 }
 
 struct CommandReceiver<Msg> {
-    receiver: mpsc::UnboundedReceiver<CommandOutput<Msg>>,
+    receiver: channel::Receiver<CommandOutput<Msg>>,
     reported_closed: bool,
 }
 
 impl<Msg> CommandReceiver<Msg> {
-    const fn new(receiver: mpsc::UnboundedReceiver<CommandOutput<Msg>>) -> Self {
+    const fn new(receiver: channel::Receiver<CommandOutput<Msg>>) -> Self {
         Self {
             receiver,
             reported_closed: false,
@@ -239,14 +241,19 @@ pub(super) struct KeyedCommands<Msg: Send + 'static> {
     entries: StreamMap<CommandId, KeyedEntry<Msg>>,
     tasks: JoinSet<TaskExit>,
     next_token: u64,
+    /// Per-command private-channel capacity: `None` keeps each keyed channel
+    /// unbounded, `Some(n)` bounds each one to `n` independently — never a
+    /// shared pool (INV-L9).
+    keyed_capacity: Option<NonZeroUsize>,
 }
 
 impl<Msg: Send + 'static> KeyedCommands<Msg> {
-    pub(super) fn new() -> Self {
+    pub(super) fn new(keyed_capacity: Option<NonZeroUsize>) -> Self {
         Self {
             entries: StreamMap::new(),
             tasks: JoinSet::new(),
             next_token: 0,
+            keyed_capacity,
         }
     }
 
@@ -285,7 +292,7 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
         stream: BoxStream<'static, Action<Msg>>,
     ) {
         self.next_token = self.next_token.wrapping_add(1);
-        let (output_tx, output_rx) = mpsc::unbounded_channel();
+        let (output_tx, output_rx) = channel::channel(self.keyed_capacity);
         let task_id = id.clone();
 
         let abort = self.tasks.spawn(async move {
@@ -294,12 +301,24 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
                 while let Some(action) = stream.next().await {
                     match action {
                         Action::Message(message) => {
-                            if output_tx.send(CommandOutput::Message(message)).is_err() {
+                            // Awaiting the send applies backpressure in bounded
+                            // mode (the producer waits for capacity; INV-L2) and
+                            // completes immediately in unbounded mode (INV-L6).
+                            // An abort during this await drops the in-flight
+                            // output exactly like aborting a running task.
+                            if output_tx
+                                .send(CommandOutput::Message(message))
+                                .await
+                                .is_err()
+                            {
                                 break;
                             }
                         }
                         Action::Quit => {
-                            let _ = output_tx.send(CommandOutput::Quit);
+                            // A keyed quit travels this private channel like any
+                            // other keyed output (INV-L10), so in bounded mode it
+                            // waits on `keyed_channel_capacity` too (RFC 0006 §4.2).
+                            let _ = output_tx.send(CommandOutput::Quit).await;
                             break;
                         }
                     }
@@ -555,8 +574,8 @@ mod tests {
     fn insert_pending_receiver(
         manager: &mut KeyedCommands<i32>,
         id: CommandId,
-    ) -> mpsc::UnboundedSender<CommandOutput<i32>> {
-        let (output_tx, output_rx) = mpsc::unbounded_channel();
+    ) -> channel::Sender<CommandOutput<i32>> {
+        let (output_tx, output_rx) = channel::channel(None);
         let token = RunToken(manager.next_token);
         manager.next_token = manager.next_token.wrapping_add(1);
         let abort = manager.tasks.spawn(pending::<TaskExit>());
@@ -601,7 +620,7 @@ mod tests {
     #[tokio::test]
     async fn pending_keyed_poll_wakes_after_output() {
         let id = CommandId::new("output-wake");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         let output_tx = insert_pending_receiver(&mut manager, id.clone());
         let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
         let waker = waker_ref(&wake_counter);
@@ -612,7 +631,7 @@ mod tests {
             KeyedPoll::PendingWithWakeSource
         ));
         output_tx
-            .send(CommandOutput::Message(42))
+            .try_send(CommandOutput::Message(42))
             .expect("receiver should remain open");
         assert!(wake_counter.0.load(Ordering::SeqCst) > 0);
         assert!(matches!(
@@ -629,7 +648,7 @@ mod tests {
     #[tokio::test]
     async fn pending_keyed_poll_wakes_after_sender_closure() {
         let id = CommandId::new("closure-wake");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         let output_tx = insert_pending_receiver(&mut manager, id.clone());
         let wake_counter = Arc::new(WakeCounter(AtomicUsize::new(0)));
         let waker = waker_ref(&wake_counter);
@@ -656,7 +675,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_in_flight_drops_finished_buffered_output() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -678,7 +697,7 @@ mod tests {
     #[tokio::test]
     async fn explicit_cancel_is_strict_and_idempotent() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -707,7 +726,7 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let guard = AbortGuard(Arc::clone(&dropped));
         let (started_tx, started_rx) = oneshot::channel();
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -736,7 +755,7 @@ mod tests {
     #[tokio::test]
     async fn keep_in_flight_preserves_finished_buffered_output() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -758,10 +777,10 @@ mod tests {
     async fn keep_in_flight_rechecks_a_closed_empty_receiver_before_task_exit() {
         let id = CommandId::new("submit");
         let token = RunToken(0);
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         // Model the panic-reporting window: the task still has no published
         // TaskExit, but unwinding has already dropped its output sender.
-        let (output_tx, output_rx) = mpsc::unbounded_channel();
+        let (output_tx, output_rx) = channel::channel(None);
         drop(output_tx);
         let abort = manager.tasks.spawn(pending::<TaskExit>());
         manager.entries.insert(
@@ -791,7 +810,7 @@ mod tests {
     #[tokio::test]
     async fn delivering_the_closed_senders_last_item_releases_the_id_for_retry() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -814,7 +833,7 @@ mod tests {
     #[tokio::test]
     async fn keep_in_flight_does_not_spawn_while_sender_is_open() {
         let id = CommandId::new("submit");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -835,7 +854,7 @@ mod tests {
     #[tokio::test]
     async fn keyed_quit_is_delivered_after_the_same_runs_earlier_output() {
         let id = CommandId::new("save-then-quit");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -854,7 +873,7 @@ mod tests {
     #[tokio::test]
     async fn cancelling_buffered_quit_suppresses_it() {
         let id = CommandId::new("quit");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -870,7 +889,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn cancelling_suppresses_a_pending_timeout_message() {
         let id = CommandId::new("timeout");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         let command = Command::future(pending())
             .timeout(Duration::from_secs(5), || 99)
             .cancellable(id.clone());
@@ -900,7 +919,7 @@ mod tests {
             },
             |_| 1,
         );
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -940,7 +959,7 @@ mod tests {
             },
             |result| result.expect("second retry would succeed"),
         );
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -960,7 +979,7 @@ mod tests {
     #[tokio::test]
     async fn stale_completion_cannot_remove_or_mutate_a_successor() {
         let id = CommandId::new("search");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id.clone(),
             CancelPolicy::CancelInFlight,
@@ -995,7 +1014,7 @@ mod tests {
             .with_level(Level::ERROR);
         let _guard = recorder.set_default();
         let id = CommandId::new("panic");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         let (event_count, contains_id) = with_silent_panic_hook(async {
             manager.spawn(
                 id.clone(),
@@ -1033,7 +1052,7 @@ mod tests {
         let dropped = Arc::new(AtomicBool::new(false));
         let guard = AbortGuard(Arc::clone(&dropped));
         let id = CommandId::new("running");
-        let mut manager = KeyedCommands::new();
+        let mut manager = KeyedCommands::new(None);
         manager.spawn(
             id,
             CancelPolicy::CancelInFlight,
@@ -1050,6 +1069,136 @@ mod tests {
             "shutdown should drop the running keyed future",
         )
         .await;
+    }
+
+    // INV-L5 under bounded keyed delivery: a keyed command whose task is parked
+    // awaiting capacity on a full channel is still cancelled cleanly. With
+    // capacity 1 the task buffers its first output (filling the only slot) and
+    // blocks on the second send; an explicit cancel removes the entry, drops the
+    // buffered-but-undelivered output with it, and aborts the parked task.
+    #[tokio::test]
+    async fn bounded_keyed_cancel_drops_buffered_output_and_aborts_the_blocked_send() {
+        struct AbortGuard(Arc<AtomicBool>);
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let id = CommandId::new("search");
+        let dropped = Arc::new(AtomicBool::new(false));
+        let guard = AbortGuard(Arc::clone(&dropped));
+        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+
+        // The guard rides the stream's state so its drop witnesses the parked
+        // task being aborted (the second send never completes).
+        let stream = stream::unfold((guard, 0_u8), |(guard, n)| async move {
+            match n {
+                0 => Some((Action::Message(1), (guard, 1_u8))),
+                1 => Some((Action::Message(2), (guard, 2_u8))),
+                _ => None,
+            }
+        })
+        .boxed();
+        manager.spawn(id.clone(), CancelPolicy::CancelInFlight, stream);
+
+        wait_until(
+            || {
+                manager.entries.iter().any(|(entry_id, entry)| {
+                    entry_id == &id && {
+                        let facts = entry.receiver.facts();
+                        !facts.sender_closed && facts.buffered == 1
+                    }
+                })
+            },
+            "the task should buffer its first output and block on the second send",
+        )
+        .await;
+
+        manager.cancel(&id);
+
+        assert!(!manager.contains(&id));
+        assert!(manager.try_next_ready().is_none());
+        wait_until(
+            || dropped.load(Ordering::SeqCst),
+            "cancelling the bounded keyed command should abort its parked send",
+        )
+        .await;
+    }
+
+    // INV-L9 under bounded keyed delivery: a `CancelInFlight` replacement gives
+    // the successor a fresh private channel, so the old run's buffered and
+    // blocked outputs cannot leak into it. Run A buffers 10 and parks on sending
+    // 11 (capacity 1); run B replaces it and only B's output is ever delivered.
+    #[tokio::test]
+    async fn bounded_cancel_in_flight_replacement_isolates_the_old_runs_blocked_send() {
+        let id = CommandId::new("search");
+        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(10), Action::Message(11)]),
+        );
+        wait_until(
+            || {
+                manager.entries.iter().any(|(entry_id, entry)| {
+                    entry_id == &id && {
+                        let facts = entry.receiver.facts();
+                        !facts.sender_closed && facts.buffered == 1
+                    }
+                })
+            },
+            "run A should buffer its first output and block on the second send",
+        )
+        .await;
+
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(20)]),
+        );
+
+        wait_for_closed_buffered(&mut manager, &id).await;
+        assert_eq!(take_message(&mut manager, &id), 20);
+        assert!(manager.try_next_ready().is_none());
+    }
+
+    // INV-L10 under bounded keyed delivery: a keyed quit travels the private
+    // channel in FIFO behind the same run's earlier output even when capacity 1
+    // forces the quit send to park behind that output. This repeats the
+    // unbounded ordering guarantee (`keyed_quit_is_delivered_after_the_same_runs_earlier_output`)
+    // under `Some(1)`, where the ordering is enforced by backpressure rather
+    // than by buffering.
+    #[tokio::test]
+    async fn keyed_quit_follows_earlier_output_under_capacity_one() {
+        let id = CommandId::new("save-then-quit");
+        let mut manager = KeyedCommands::new(Some(NonZeroUsize::new(1).expect("non-zero")));
+        manager.spawn(
+            id.clone(),
+            CancelPolicy::CancelInFlight,
+            actions([Action::Message(1), Action::Quit]),
+        );
+
+        wait_until(
+            || {
+                manager.entries.iter().any(|(entry_id, entry)| {
+                    entry_id == &id && entry.receiver.facts().buffered == 1
+                })
+            },
+            "the first message should buffer before the blocked quit",
+        )
+        .await;
+        assert_eq!(take_message(&mut manager, &id), 1);
+
+        // Freeing the slot lets the parked quit send complete; the task then
+        // exits and closes the channel, leaving the quit as the last item.
+        wait_for_closed_buffered(&mut manager, &id).await;
+        let (event_id, event) = manager
+            .try_next_ready()
+            .expect("keyed quit should be ready after the earlier message");
+        assert_eq!(event_id, id);
+        assert_eq!(event, ReceiverEvent::Output(CommandOutput::Quit));
     }
 }
 

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -1,0 +1,330 @@
+//! Load observability: the `tears::runtime::load` event schema (RFC 0006 §4.4).
+//!
+//! Three event kinds share the `tears::runtime::load` target. The batch event
+//! and the capacity-wait event are stateless emissions from the batch loop and
+//! the bounded send path; the producer gauges are backed by [`LoadObserver`], a
+//! cheap cloneable handle over four shared counters that every producer updates,
+//! so a single subscriber sees the aggregate. The schema (targets, levels,
+//! fields, firing conditions) is pinned as RFC 0006 INV-L13; changing it is a
+//! contract change.
+//!
+//! The gauge counters live behind one mutex, and each change updates a field,
+//! snapshots all four, and emits under the same lock. That serialization is the
+//! contract's "event per change" guarantee: were the update and the read
+//! separate (e.g. lone atomics), a value could be reached and superseded before
+//! its own emit re-read the counters, so a subscriber's high-water mark could
+//! miss it.
+//!
+//! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
+//! already `pub(crate)`, so effective reachability is capped at the crate
+//! (see `channel`/`frame_rate`), while `pub` avoids the redundant-`pub(crate)`
+//! lint.
+
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+/// The runtime channel a bounded send blocked on — the capacity-wait event's
+/// `channel` field (`"shared"` or `"keyed"`).
+#[derive(Clone, Copy)]
+pub enum Channel {
+    Shared,
+    Keyed,
+}
+
+impl Channel {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Shared => "shared",
+            Self::Keyed => "keyed",
+        }
+    }
+}
+
+/// Emits the batch event (RFC 0006 §4.4): `pulled` inputs taken this batch
+/// (opening input included, INV-L12's counted unit), `updated` of them that
+/// invoked `update`, and `shared_pending` shared-channel occupancy at batch
+/// end. A quit-terminated batch does not call this — the loop exits instead.
+///
+/// A free function, not a [`LoadObserver`] method: the batch event carries no
+/// gauge state.
+pub fn batch(pulled: usize, updated: usize, shared_pending: usize) {
+    tracing::trace!(
+        target: "tears::runtime::load",
+        pulled,
+        updated,
+        shared_pending,
+        "processed message batch",
+    );
+}
+
+/// Emits the capacity-wait event (RFC 0006 §4.4, bounded mode only): fired once
+/// per send that had to await capacity, at acceptance, with the blocking
+/// `channel` and the `wait_us` measured from the first unready attempt to
+/// acceptance. Like [`batch`], it carries no gauge state.
+pub fn capacity_wait(channel: Channel, waited: Duration) {
+    tracing::debug!(
+        target: "tears::runtime::load",
+        channel = channel.as_str(),
+        wait_us = u64::try_from(waited.as_micros()).unwrap_or(u64::MAX),
+        "capacity wait",
+    );
+}
+
+/// Shared handle over the runtime's producer-count gauges (RFC 0006 §4.4).
+///
+/// Cloning shares the same counters; every producer holds a clone and updates
+/// its own field, so a single subscriber sees the aggregate. All four counts
+/// are emitted together under `tears::runtime::load` whenever any one changes.
+#[derive(Clone, Default)]
+pub struct LoadObserver {
+    gauges: Arc<Mutex<Gauges>>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct Gauges {
+    subscriptions: usize,
+    unkeyed_commands: usize,
+    keyed_commands: usize,
+    blocked: usize,
+}
+
+impl Gauges {
+    /// Emits the four-field producer-gauge event from this snapshot. Taking
+    /// `self` by value fixes the values at the caller's serialization point, so
+    /// the event reports the state that was reached rather than a later re-read.
+    fn emit(self) {
+        tracing::debug!(
+            target: "tears::runtime::load",
+            subscriptions = self.subscriptions,
+            unkeyed_commands = self.unkeyed_commands,
+            keyed_commands = self.keyed_commands,
+            blocked = self.blocked,
+            "producer gauges",
+        );
+    }
+}
+
+/// Which gauge a [`GaugeGuard`] owns.
+#[derive(Clone, Copy)]
+enum Field {
+    Subscriptions,
+    UnkeyedCommands,
+    Blocked,
+}
+
+impl Field {
+    const fn counter_mut(self, gauges: &mut Gauges) -> &mut usize {
+        match self {
+            Self::Subscriptions => &mut gauges.subscriptions,
+            Self::UnkeyedCommands => &mut gauges.unkeyed_commands,
+            Self::Blocked => &mut gauges.blocked,
+        }
+    }
+}
+
+impl LoadObserver {
+    /// Tracks one active subscription forwarding task: the returned guard raises
+    /// the `subscriptions` gauge now and lowers it when dropped (task end or
+    /// abort).
+    #[must_use]
+    pub fn track_subscription(&self) -> GaugeGuard {
+        self.enter(Field::Subscriptions)
+    }
+
+    /// Tracks one running unkeyed command task via the `unkeyed_commands` gauge.
+    #[must_use]
+    pub fn track_unkeyed_command(&self) -> GaugeGuard {
+        self.enter(Field::UnkeyedCommands)
+    }
+
+    /// Tracks one producer currently awaiting bounded-channel capacity via the
+    /// `blocked` gauge. Dropping the guard — on acceptance or on abort of the
+    /// blocked send — lowers it, so the decrement never depends on the send
+    /// completing (RFC 0006 §4.4).
+    #[must_use]
+    pub fn track_blocked(&self) -> GaugeGuard {
+        self.enter(Field::Blocked)
+    }
+
+    /// Sets the `keyed_commands` gauge to the current active-entry count,
+    /// emitting only when it changed. Keyed entries are counted directly (not
+    /// via a guard) because an entry's lifetime is the runtime's, not a task's:
+    /// a draining entry outlives its task.
+    pub fn set_keyed_entries(&self, count: usize) {
+        let mut gauges = self.lock();
+        if gauges.keyed_commands != count {
+            gauges.keyed_commands = count;
+            gauges.emit();
+        }
+    }
+
+    fn enter(&self, field: Field) -> GaugeGuard {
+        self.step(field, 1);
+        GaugeGuard {
+            observer: self.clone(),
+            field,
+        }
+    }
+
+    /// Adds `delta` (`+1`/`-1`) to `field` and emits the resulting snapshot,
+    /// all under one lock so the update and its event cannot interleave with
+    /// another producer's (RFC 0006 §4.4 "event per change").
+    fn step(&self, field: Field, delta: isize) {
+        let mut gauges = self.lock();
+        let counter = field.counter_mut(&mut gauges);
+        *counter = counter.wrapping_add_signed(delta);
+        gauges.emit();
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Gauges> {
+        self.gauges
+            .lock()
+            .expect("load gauges mutex should not be poisoned")
+    }
+}
+
+/// RAII guard that lowers its gauge on drop.
+///
+/// Held for the lifetime of the producer it tracks (a subscription or unkeyed
+/// command task, or a blocked send), so completion and abort both lower the
+/// gauge — the drop runs whether the tracked future finishes or is cancelled.
+pub struct GaugeGuard {
+    observer: LoadObserver,
+    field: Field,
+}
+
+impl Drop for GaugeGuard {
+    fn drop(&mut self) {
+        self.observer.step(self.field, -1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tracing::Level;
+
+    use super::*;
+    use crate::test_support::TraceRecorder;
+
+    // INV-L13: every producer-gauge event carries all four fields together, so
+    // a subscriber reads a complete snapshot from any one event. The per-field
+    // recorder views flatten across events and cannot see this; the field-set
+    // view can.
+    #[test]
+    fn gauge_event_carries_all_four_fields() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let observer = LoadObserver::default();
+        let subscription = observer.track_subscription();
+        observer.set_keyed_entries(2);
+        drop(subscription);
+
+        let gauge_events: Vec<_> = recorder
+            .field_name_sets()
+            .into_iter()
+            .filter(|fields| fields.iter().any(|name| name == "subscriptions"))
+            .collect();
+        assert!(!gauge_events.is_empty(), "gauge events should have fired");
+        for fields in gauge_events {
+            for required in [
+                "subscriptions",
+                "unkeyed_commands",
+                "keyed_commands",
+                "blocked",
+            ] {
+                assert!(
+                    fields.iter().any(|name| name == required),
+                    "a gauge event is missing `{required}`: {fields:?}"
+                );
+            }
+        }
+    }
+
+    // INV-L13 (serialization, the value-loss guard): each change emits the value
+    // it reached, not a later re-read of the counter — so a peak is never
+    // skipped. Driven single-threaded here, the emitted sequence is exact; the
+    // production guarantee under concurrency is the shared lock that brackets
+    // update-and-emit (a lone atomic would let a peak be superseded before its
+    // emit re-read it).
+    #[test]
+    fn each_gauge_change_emits_the_value_it_reached() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let observer = LoadObserver::default();
+        let first = observer.track_subscription();
+        let second = observer.track_subscription();
+        drop(second);
+        drop(first);
+
+        assert_eq!(
+            recorder.u64_values("subscriptions"),
+            vec![1, 2, 1, 0],
+            "every reached value, including the peak of 2, is emitted in order"
+        );
+    }
+
+    // INV-L13 levels: the batch event is TRACE, the gauge and capacity-wait
+    // events are DEBUG. A level-exact recorder captures an event only at its own
+    // level, so each field is present at the schema's level and absent at the
+    // other.
+    #[test]
+    fn schema_events_fire_at_their_declared_levels() {
+        // Batch event: TRACE, not DEBUG.
+        let at_trace = TraceRecorder::new()
+            .with_target("tears::runtime::load")
+            .with_level(Level::TRACE);
+        {
+            let _guard = at_trace.set_default();
+            batch(1, 1, 0);
+        }
+        assert_eq!(
+            at_trace.u64_values("pulled"),
+            vec![1],
+            "batch event is TRACE"
+        );
+
+        let at_debug = TraceRecorder::new()
+            .with_target("tears::runtime::load")
+            .with_level(Level::DEBUG);
+        {
+            let _guard = at_debug.set_default();
+            batch(1, 1, 0);
+        }
+        assert!(
+            at_debug.u64_values("pulled").is_empty(),
+            "batch event is not DEBUG"
+        );
+
+        // Capacity-wait event: DEBUG, not TRACE.
+        {
+            let _guard = at_debug.set_default();
+            capacity_wait(Channel::Shared, Duration::from_micros(1));
+        }
+        assert_eq!(
+            at_debug.str_values("channel"),
+            vec!["shared".to_owned()],
+            "capacity-wait event is DEBUG"
+        );
+
+        // Gauge event: DEBUG, not TRACE.
+        {
+            let _guard = at_debug.set_default();
+            LoadObserver::default().set_keyed_entries(1);
+        }
+        assert_eq!(
+            at_debug.u64_values("keyed_commands"),
+            vec![1],
+            "gauge event is DEBUG"
+        );
+        {
+            let _guard = at_trace.set_default();
+            LoadObserver::default().set_keyed_entries(1);
+        }
+        assert!(
+            at_trace.u64_values("keyed_commands").is_empty(),
+            "gauge event is not TRACE"
+        );
+    }
+}

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -20,7 +20,7 @@
 //! (see `channel`/`frame_rate`), while `pub` avoids the redundant-`pub(crate)`
 //! lint.
 
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
 
 /// The runtime channel a bounded send blocked on — the capacity-wait event's
@@ -177,9 +177,14 @@ impl LoadObserver {
     }
 
     fn lock(&self) -> MutexGuard<'_, Gauges> {
-        self.gauges
-            .lock()
-            .expect("load gauges mutex should not be poisoned")
+        // Recover rather than propagate a poisoned lock. The gauges are plain
+        // counters with no cross-field invariant, so a producer that panicked
+        // mid-update leaves them merely off-by-one, not corrupt. Recovering
+        // matters most in `GaugeGuard::drop`, which runs during unwinding: an
+        // `expect` there would panic-during-unwind and abort the process (e.g.
+        // a subscriber panicking under the lock poisons it, then every
+        // unwinding producer's guard drop would double-panic).
+        self.gauges.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -158,6 +158,7 @@ use tokio::sync::mpsc;
 pub(crate) use core::{Subscription, SubscriptionId, SubscriptionSource};
 
 use crate::runtime::channel;
+use crate::runtime::load::LoadObserver;
 
 struct RunningSubscription {
     handle: JoinHandle<()>,
@@ -169,15 +170,17 @@ struct RunningSubscription {
 pub(crate) struct SubscriptionManager<Msg> {
     running: HashMap<SubscriptionId, RunningSubscription>,
     msg_sender: channel::Sender<Msg>,
+    observer: LoadObserver,
 }
 
 impl<Msg: Send + 'static> SubscriptionManager<Msg> {
-    /// Create a new subscription manager.
+    /// Create a new subscription manager sharing the runtime's load observer.
     #[must_use]
-    pub(crate) fn new(msg_sender: channel::Sender<Msg>) -> Self {
+    pub(crate) fn new(msg_sender: channel::Sender<Msg>, observer: LoadObserver) -> Self {
         Self {
             running: HashMap::new(),
             msg_sender,
+            observer,
         }
     }
 
@@ -247,8 +250,12 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
 
     fn spawn_subscription(&self, mut stream: BoxStream<'static, Msg>) -> JoinHandle<()> {
         let sender = self.msg_sender.clone();
+        // Raise the `subscriptions` gauge for the forwarding task's lifetime;
+        // the guard lowers it on completion or abort (RFC 0006 §4.4).
+        let subscription_guard = self.observer.track_subscription();
 
         tokio::spawn(async move {
+            let _subscription_guard = subscription_guard;
             // Catch panics in the subscription's stream so a bug in a source is
             // logged instead of vanishing into a detached task.
             let result = AssertUnwindSafe(async move {
@@ -324,9 +331,12 @@ impl<Msg: Send + 'static> BenchSubscriptionManager<Msg> {
     pub fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
         // The bench keeps measuring the unbounded reconciliation path; wrap the
         // caller's unbounded sender so the public bench signature is unchanged.
-        Self(SubscriptionManager::new(channel::Sender::from_unbounded(
-            msg_sender,
-        )))
+        // The bench does not assert gauges, so a fresh, unshared observer is
+        // sufficient.
+        Self(SubscriptionManager::new(
+            channel::Sender::from_unbounded(msg_sender),
+            LoadObserver::default(),
+        ))
     }
 
     pub fn update<I>(&mut self, subscriptions: I)
@@ -465,7 +475,8 @@ mod tests {
 
     async fn assert_completed_oneshot_subscription_restarts() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         // Start the first one-shot subscription.
         manager.update(vec![Subscription::new(OneshotSource { value: 1 })]);
@@ -623,7 +634,8 @@ mod tests {
     async fn test_subscription_manager_basic_update() -> Result<()> {
         // Test basic subscription update functionality
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock = MockSource::new();
         let sub = Subscription::new(mock.clone());
@@ -665,7 +677,8 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let sub = Subscription::new(InfiniteSub);
         manager.update(vec![sub]);
@@ -720,7 +733,10 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
 
         {
-            let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+            let mut manager = SubscriptionManager::new(
+                channel::Sender::from_unbounded(tx),
+                LoadObserver::default(),
+            );
             manager.update(vec![Subscription::new(ParkedSource {
                 started: started.clone(),
                 aborted: aborted.clone(),
@@ -748,7 +764,8 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_multiple_subscriptions() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock1 = MockSource::new();
         let mock2 = MockSource::new();
@@ -785,7 +802,8 @@ mod tests {
         let _guard = recorder.set_default();
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let first = MockSource::<i32>::new();
         let duplicate = first.clone();
 
@@ -848,7 +866,8 @@ mod tests {
             .with_level(tracing::Level::WARN);
         let _guard = recorder.set_default();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         manager.update(vec![
             Subscription::new(CollidingSource {
@@ -881,7 +900,8 @@ mod tests {
     #[tokio::test]
     async fn removing_one_hash_colliding_subscription_aborts_only_its_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let first = ProbedCollidingSource::pending(1);
         let second = ProbedCollidingSource::pending(2);
 
@@ -907,7 +927,8 @@ mod tests {
     async fn completed_hash_colliding_subscription_restarts_without_replacing_the_other()
     -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let completed = ProbedCollidingSource::once(1, 10);
         let continuing = ProbedCollidingSource::pending(2);
         let completed_subscription = Subscription::new(completed.clone());
@@ -954,7 +975,8 @@ mod tests {
     #[tokio::test]
     async fn same_local_id_in_two_scopes_starts_two_independent_streams() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         manager.update(vec![
             Subscription::new(ProbedCollidingSource::once(1, 10)).scoped("pane-a"),
@@ -974,7 +996,8 @@ mod tests {
     #[tokio::test]
     async fn removing_one_pane_stops_only_its_scoped_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let source = ProbedCollidingSource::pending(1);
 
         manager.update(vec![
@@ -1006,7 +1029,8 @@ mod tests {
     async fn same_local_id_with_hash_colliding_scopes_starts_two_independent_streams() -> Result<()>
     {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         manager.update(vec![
             Subscription::new(ProbedCollidingSource::once(1, 10)).scoped(ManagerCollisionKey(1)),
@@ -1026,7 +1050,8 @@ mod tests {
     #[tokio::test]
     async fn removing_one_hash_colliding_scope_stops_only_its_own_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let source = ProbedCollidingSource::pending(1);
 
         manager.update(vec![
@@ -1077,7 +1102,8 @@ mod tests {
         }
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
         let started = Arc::new(Mutex::new(Vec::new()));
 
         manager.update(vec![
@@ -1098,7 +1124,8 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_starts_when_enabled() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock = MockSource::new();
 
@@ -1122,7 +1149,8 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_stops_when_disabled() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock = MockSource::new();
 
@@ -1151,7 +1179,8 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_changes_based_on_state() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock1 = MockSource::new();
         let mock2 = MockSource::new();
@@ -1219,7 +1248,8 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         // Start and let the task finish.
         manager.update(vec![Subscription::new(OneshotSource)]);
@@ -1250,7 +1280,8 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_multiple_changes() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
 
         let mock = MockSource::new();
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -147,12 +147,17 @@ use std::{
 };
 
 use futures::{FutureExt, StreamExt, stream::BoxStream};
-use tokio::{
-    sync::mpsc::{self},
-    task::JoinHandle,
-};
+use tokio::task::JoinHandle;
+
+// `mpsc` is no longer used on the production message path (that is now
+// `channel::Sender`); it survives only in the `bench-internals` wrapper's
+// unbounded-sender signature and in this module's tests.
+#[cfg(any(test, feature = "bench-internals"))]
+use tokio::sync::mpsc;
 
 pub(crate) use core::{Subscription, SubscriptionId, SubscriptionSource};
+
+use crate::runtime::channel;
 
 struct RunningSubscription {
     handle: JoinHandle<()>,
@@ -163,13 +168,13 @@ struct RunningSubscription {
 /// Internal to the runtime; not part of the public API.
 pub(crate) struct SubscriptionManager<Msg> {
     running: HashMap<SubscriptionId, RunningSubscription>,
-    msg_sender: mpsc::UnboundedSender<Msg>,
+    msg_sender: channel::Sender<Msg>,
 }
 
 impl<Msg: Send + 'static> SubscriptionManager<Msg> {
     /// Create a new subscription manager.
     #[must_use]
-    pub(crate) fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
+    pub(crate) fn new(msg_sender: channel::Sender<Msg>) -> Self {
         Self {
             running: HashMap::new(),
             msg_sender,
@@ -248,7 +253,11 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
             // logged instead of vanishing into a detached task.
             let result = AssertUnwindSafe(async move {
                 while let Some(msg) = stream.next().await {
-                    if sender.send(msg).is_err() {
+                    // Awaiting the send applies backpressure in bounded mode: the
+                    // forwarding task stops polling the source stream until the
+                    // consumer catches up (INV-L2), and completes immediately in
+                    // unbounded mode (INV-L6).
+                    if sender.send(msg).await.is_err() {
                         break;
                     }
                 }
@@ -313,7 +322,11 @@ pub struct BenchSubscriptionManager<Msg>(SubscriptionManager<Msg>);
 impl<Msg: Send + 'static> BenchSubscriptionManager<Msg> {
     #[must_use]
     pub fn new(msg_sender: mpsc::UnboundedSender<Msg>) -> Self {
-        Self(SubscriptionManager::new(msg_sender))
+        // The bench keeps measuring the unbounded reconciliation path; wrap the
+        // caller's unbounded sender so the public bench signature is unchanged.
+        Self(SubscriptionManager::new(channel::Sender::from_unbounded(
+            msg_sender,
+        )))
     }
 
     pub fn update<I>(&mut self, subscriptions: I)
@@ -452,7 +465,7 @@ mod tests {
 
     async fn assert_completed_oneshot_subscription_restarts() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         // Start the first one-shot subscription.
         manager.update(vec![Subscription::new(OneshotSource { value: 1 })]);
@@ -610,7 +623,7 @@ mod tests {
     async fn test_subscription_manager_basic_update() -> Result<()> {
         // Test basic subscription update functionality
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock = MockSource::new();
         let sub = Subscription::new(mock.clone());
@@ -652,7 +665,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let sub = Subscription::new(InfiniteSub);
         manager.update(vec![sub]);
@@ -707,7 +720,7 @@ mod tests {
         let (tx, _rx) = mpsc::unbounded_channel();
 
         {
-            let mut manager = SubscriptionManager::new(tx);
+            let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
             manager.update(vec![Subscription::new(ParkedSource {
                 started: started.clone(),
                 aborted: aborted.clone(),
@@ -735,7 +748,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_multiple_subscriptions() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock1 = MockSource::new();
         let mock2 = MockSource::new();
@@ -772,7 +785,7 @@ mod tests {
         let _guard = recorder.set_default();
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let first = MockSource::<i32>::new();
         let duplicate = first.clone();
 
@@ -835,7 +848,7 @@ mod tests {
             .with_level(tracing::Level::WARN);
         let _guard = recorder.set_default();
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         manager.update(vec![
             Subscription::new(CollidingSource {
@@ -868,7 +881,7 @@ mod tests {
     #[tokio::test]
     async fn removing_one_hash_colliding_subscription_aborts_only_its_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let first = ProbedCollidingSource::pending(1);
         let second = ProbedCollidingSource::pending(2);
 
@@ -894,7 +907,7 @@ mod tests {
     async fn completed_hash_colliding_subscription_restarts_without_replacing_the_other()
     -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let completed = ProbedCollidingSource::once(1, 10);
         let continuing = ProbedCollidingSource::pending(2);
         let completed_subscription = Subscription::new(completed.clone());
@@ -941,7 +954,7 @@ mod tests {
     #[tokio::test]
     async fn same_local_id_in_two_scopes_starts_two_independent_streams() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         manager.update(vec![
             Subscription::new(ProbedCollidingSource::once(1, 10)).scoped("pane-a"),
@@ -961,7 +974,7 @@ mod tests {
     #[tokio::test]
     async fn removing_one_pane_stops_only_its_scoped_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let source = ProbedCollidingSource::pending(1);
 
         manager.update(vec![
@@ -993,7 +1006,7 @@ mod tests {
     async fn same_local_id_with_hash_colliding_scopes_starts_two_independent_streams() -> Result<()>
     {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         manager.update(vec![
             Subscription::new(ProbedCollidingSource::once(1, 10)).scoped(ManagerCollisionKey(1)),
@@ -1013,7 +1026,7 @@ mod tests {
     #[tokio::test]
     async fn removing_one_hash_colliding_scope_stops_only_its_own_stream() {
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let source = ProbedCollidingSource::pending(1);
 
         manager.update(vec![
@@ -1064,7 +1077,7 @@ mod tests {
         }
 
         let (tx, _rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
         let started = Arc::new(Mutex::new(Vec::new()));
 
         manager.update(vec![
@@ -1085,7 +1098,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_starts_when_enabled() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock = MockSource::new();
 
@@ -1109,7 +1122,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_stops_when_disabled() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock = MockSource::new();
 
@@ -1138,7 +1151,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_changes_based_on_state() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock1 = MockSource::new();
         let mock2 = MockSource::new();
@@ -1206,7 +1219,7 @@ mod tests {
         }
 
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         // Start and let the task finish.
         manager.update(vec![Subscription::new(OneshotSource)]);
@@ -1237,7 +1250,7 @@ mod tests {
     #[tokio::test]
     async fn test_subscription_manager_subscription_multiple_changes() -> Result<()> {
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let mut manager = SubscriptionManager::new(tx);
+        let mut manager = SubscriptionManager::new(channel::Sender::from_unbounded(tx));
 
         let mock = MockSource::new();
 

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -36,6 +36,12 @@ pub struct TraceRecorder {
 struct TraceRecorderState {
     events: AtomicUsize,
     bool_fields: Mutex<HashMap<String, Vec<bool>>>,
+    u64_fields: Mutex<HashMap<String, Vec<u64>>>,
+    str_fields: Mutex<HashMap<String, Vec<String>>>,
+    // The sorted field-name set of each matching event, in arrival order, so a
+    // test can assert which fields co-occur on a single event (the per-field
+    // maps above flatten across events and cannot).
+    field_sets: Mutex<Vec<Vec<String>>>,
 }
 
 #[derive(Clone, Default)]
@@ -99,6 +105,42 @@ impl TraceRecorder {
             .get(field)
             .cloned()
             .unwrap_or_default()
+    }
+
+    /// Returns all unsigned-integer values recorded for the named event field
+    /// (covers `u64` and `usize` fields).
+    #[must_use]
+    pub fn u64_values(&self, field: &str) -> Vec<u64> {
+        self.state
+            .u64_fields
+            .lock()
+            .expect("trace recorder u64 field log mutex should not be poisoned")
+            .get(field)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns all string values recorded for the named event field.
+    #[must_use]
+    pub fn str_values(&self, field: &str) -> Vec<String> {
+        self.state
+            .str_fields
+            .lock()
+            .expect("trace recorder str field log mutex should not be poisoned")
+            .get(field)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns the sorted field-name set of every matching event, in arrival
+    /// order — for asserting which fields appear together on one event.
+    #[must_use]
+    pub fn field_name_sets(&self) -> Vec<Vec<String>> {
+        self.state
+            .field_sets
+            .lock()
+            .expect("trace recorder field-set log mutex should not be poisoned")
+            .clone()
     }
 }
 
@@ -179,19 +221,46 @@ impl Subscriber for TraceRecorder {
 
         self.state.events.fetch_add(1, Ordering::SeqCst);
 
-        let mut visitor = BoolFieldVisitor::default();
+        let mut visitor = FieldVisitor::default();
         event.record(&mut visitor);
-        if visitor.values.is_empty() {
-            return;
-        }
 
-        let mut fields = self
-            .state
-            .bool_fields
+        let mut names = visitor.names.clone();
+        names.sort();
+        self.state
+            .field_sets
             .lock()
-            .expect("trace recorder bool field log mutex should not be poisoned");
-        for (field, value) in visitor.values {
-            fields.entry(field).or_default().push(value);
+            .expect("trace recorder field-set log mutex should not be poisoned")
+            .push(names);
+
+        if !visitor.bools.is_empty() {
+            let mut fields = self
+                .state
+                .bool_fields
+                .lock()
+                .expect("trace recorder bool field log mutex should not be poisoned");
+            for (field, value) in visitor.bools {
+                fields.entry(field).or_default().push(value);
+            }
+        }
+        if !visitor.u64s.is_empty() {
+            let mut fields = self
+                .state
+                .u64_fields
+                .lock()
+                .expect("trace recorder u64 field log mutex should not be poisoned");
+            for (field, value) in visitor.u64s {
+                fields.entry(field).or_default().push(value);
+            }
+        }
+        if !visitor.strs.is_empty() {
+            let mut fields = self
+                .state
+                .str_fields
+                .lock()
+                .expect("trace recorder str field log mutex should not be poisoned");
+            for (field, value) in visitor.strs {
+                fields.entry(field).or_default().push(value);
+            }
         }
     }
 
@@ -201,16 +270,39 @@ impl Subscriber for TraceRecorder {
 }
 
 #[derive(Default)]
-struct BoolFieldVisitor {
-    values: Vec<(String, bool)>,
+struct FieldVisitor {
+    bools: Vec<(String, bool)>,
+    u64s: Vec<(String, u64)>,
+    strs: Vec<(String, String)>,
+    names: Vec<String>,
 }
 
-impl Visit for BoolFieldVisitor {
+impl Visit for FieldVisitor {
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.values.push((field.name().to_owned(), value));
+        self.names.push(field.name().to_owned());
+        self.bools.push((field.name().to_owned(), value));
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.names.push(field.name().to_owned());
+        self.u64s.push((field.name().to_owned(), value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.names.push(field.name().to_owned());
+        if let Ok(value) = u64::try_from(value) {
+            self.u64s.push((field.name().to_owned(), value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.names.push(field.name().to_owned());
+        self.strs.push((field.name().to_owned(), value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, _value: &dyn Debug) {
+        self.names.push(field.name().to_owned());
+    }
 }
 
 #[cfg(test)]

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -36,6 +36,12 @@ pub struct TraceRecorder {
 struct TraceRecorderState {
     events: AtomicUsize,
     bool_fields: Mutex<HashMap<String, Vec<bool>>>,
+    u64_fields: Mutex<HashMap<String, Vec<u64>>>,
+    str_fields: Mutex<HashMap<String, Vec<String>>>,
+    // The sorted field-name set of each matching event, in arrival order, so a
+    // test can assert which fields co-occur on a single event (the per-field
+    // maps above flatten across events and cannot).
+    field_sets: Mutex<Vec<Vec<String>>>,
 }
 
 #[derive(Clone, Default)]
@@ -88,6 +94,7 @@ impl TraceRecorder {
     }
 
     /// Returns the number of events that matched this recorder's filter.
+    #[allow(dead_code)]
     #[must_use]
     pub fn event_count(&self) -> usize {
         self.state.events.load(Ordering::SeqCst)
@@ -104,6 +111,45 @@ impl TraceRecorder {
             .get(field)
             .cloned()
             .unwrap_or_default()
+    }
+
+    /// Returns all unsigned-integer values recorded for the named event field
+    /// (covers `u64` and `usize` fields).
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn u64_values(&self, field: &str) -> Vec<u64> {
+        self.state
+            .u64_fields
+            .lock()
+            .expect("trace recorder u64 field log mutex should not be poisoned")
+            .get(field)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns all string values recorded for the named event field.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn str_values(&self, field: &str) -> Vec<String> {
+        self.state
+            .str_fields
+            .lock()
+            .expect("trace recorder str field log mutex should not be poisoned")
+            .get(field)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Returns the sorted field-name set of every matching event, in arrival
+    /// order — for asserting which fields appear together on one event.
+    #[allow(dead_code)]
+    #[must_use]
+    pub fn field_name_sets(&self) -> Vec<Vec<String>> {
+        self.state
+            .field_sets
+            .lock()
+            .expect("trace recorder field-set log mutex should not be poisoned")
+            .clone()
     }
 }
 
@@ -184,19 +230,46 @@ impl Subscriber for TraceRecorder {
 
         self.state.events.fetch_add(1, Ordering::SeqCst);
 
-        let mut visitor = BoolFieldVisitor::default();
+        let mut visitor = FieldVisitor::default();
         event.record(&mut visitor);
-        if visitor.values.is_empty() {
-            return;
-        }
 
-        let mut fields = self
-            .state
-            .bool_fields
+        let mut names = visitor.names.clone();
+        names.sort();
+        self.state
+            .field_sets
             .lock()
-            .expect("trace recorder bool field log mutex should not be poisoned");
-        for (field, value) in visitor.values {
-            fields.entry(field).or_default().push(value);
+            .expect("trace recorder field-set log mutex should not be poisoned")
+            .push(names);
+
+        if !visitor.bools.is_empty() {
+            let mut fields = self
+                .state
+                .bool_fields
+                .lock()
+                .expect("trace recorder bool field log mutex should not be poisoned");
+            for (field, value) in visitor.bools {
+                fields.entry(field).or_default().push(value);
+            }
+        }
+        if !visitor.u64s.is_empty() {
+            let mut fields = self
+                .state
+                .u64_fields
+                .lock()
+                .expect("trace recorder u64 field log mutex should not be poisoned");
+            for (field, value) in visitor.u64s {
+                fields.entry(field).or_default().push(value);
+            }
+        }
+        if !visitor.strs.is_empty() {
+            let mut fields = self
+                .state
+                .str_fields
+                .lock()
+                .expect("trace recorder str field log mutex should not be poisoned");
+            for (field, value) in visitor.strs {
+                fields.entry(field).or_default().push(value);
+            }
         }
     }
 
@@ -206,14 +279,37 @@ impl Subscriber for TraceRecorder {
 }
 
 #[derive(Default)]
-struct BoolFieldVisitor {
-    values: Vec<(String, bool)>,
+struct FieldVisitor {
+    bools: Vec<(String, bool)>,
+    u64s: Vec<(String, u64)>,
+    strs: Vec<(String, String)>,
+    names: Vec<String>,
 }
 
-impl Visit for BoolFieldVisitor {
+impl Visit for FieldVisitor {
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.values.push((field.name().to_owned(), value));
+        self.names.push(field.name().to_owned());
+        self.bools.push((field.name().to_owned(), value));
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.names.push(field.name().to_owned());
+        self.u64s.push((field.name().to_owned(), value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.names.push(field.name().to_owned());
+        if let Ok(value) = u64::try_from(value) {
+            self.u64s.push((field.name().to_owned(), value));
+        }
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.names.push(field.name().to_owned());
+        self.strs.push((field.name().to_owned(), value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, _value: &dyn Debug) {
+        self.names.push(field.name().to_owned());
+    }
 }

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -83,8 +83,18 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
         .await
         .expect("the timer tick should quit the run before the timeout")?;
 
-    // Let the aborted subscription task's future drop so its gauge guard lowers.
-    for _ in 0..4 {
+    // The aborted subscription task drops its gauge guard on a later scheduler
+    // pass. Poll for the gauges to settle to zero rather than assuming a fixed
+    // number of passes — that count is a tokio cooperative-budget detail, so a
+    // fixed wait would make this assertion flake on a scheduler change. The cap
+    // only bounds a pathological hang; the loop exits the moment they settle.
+    for _ in 0..1_000 {
+        let settled = recorder.u64_values("subscriptions").last() == Some(&0)
+            && recorder.u64_values("unkeyed_commands").last() == Some(&0)
+            && recorder.u64_values("keyed_commands").last() == Some(&0);
+        if settled {
+            break;
+        }
         yield_now().await;
     }
 

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -1,0 +1,125 @@
+//! Integration test for the load-observability producer gauges (RFC 0006 §4.4,
+//! INV-L13). These verify end-to-end that starting a subscription, an unkeyed
+//! command, and a keyed command each raise the matching `tears::runtime::load`
+//! gauge, and that every gauge falls back to zero once the run tears down. The
+//! batch event, capacity-wait event, and the gauge/abort mechanics are covered
+//! at their narrower deterministic layers in `src/runtime`.
+
+mod common;
+#[path = "common/trace_recorder.rs"]
+mod trace_recorder;
+
+use std::future::pending;
+use std::num::{NonZeroU32, NonZeroU64};
+
+use color_eyre::eyre::Result;
+use ratatui::Frame;
+use tears::command::CommandId;
+use tears::prelude::*;
+use tears::subscription::time::Timer;
+use tokio::task::yield_now;
+use tokio::time::{Duration, timeout};
+use trace_recorder::TraceRecorder;
+
+fn frame_rate(value: u32) -> FrameRate {
+    FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+        .expect("frame rate must be valid")
+}
+
+#[derive(Clone)]
+enum Msg {
+    Tick,
+    Quit,
+}
+
+// The app keeps all three producer kinds active at once. `new` starts a
+// top-level *keyed* parked command (raising `keyed_commands`; a batch would
+// discard the key, so it must not be batched). Its subscription is a `Timer`
+// (raising `subscriptions`). The timer's first tick spawns a short *unkeyed*
+// command that emits `Quit` (raising `unkeyed_commands`, then lowering it on
+// completion), which ends the run.
+struct GaugeApp;
+
+impl Application for GaugeApp {
+    type Message = Msg;
+    type Flags = ();
+
+    fn new((): ()) -> (Self, Command<Self::Message>) {
+        (
+            Self,
+            Command::future(pending::<Msg>()).cancellable(CommandId::new("keyed")),
+        )
+    }
+
+    fn update(&mut self, msg: Self::Message) -> Command<Self::Message> {
+        match msg {
+            Msg::Tick => Command::future(async { Msg::Quit }),
+            Msg::Quit => Command::quit(),
+        }
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {}
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        vec![
+            Subscription::new(Timer::new(NonZeroU64::new(10).expect("non-zero")))
+                .map(|_| Msg::Tick),
+        ]
+    }
+}
+
+// Producer gauges over a real run: each producer kind raises its field, and
+// every field returns to zero once the run tears its producers down. Under a
+// current-thread runtime the producers' gauge emissions land on the recorder's
+// thread; paused time jumps straight to the timer tick.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<GaugeApp>::new((), frame_rate(60));
+    timeout(Duration::from_secs(5), runtime.run(&mut terminal))
+        .await
+        .expect("the timer tick should quit the run before the timeout")?;
+
+    // Let the aborted subscription task's future drop so its gauge guard lowers.
+    for _ in 0..4 {
+        yield_now().await;
+    }
+
+    let subscriptions = recorder.u64_values("subscriptions");
+    let unkeyed = recorder.u64_values("unkeyed_commands");
+    let keyed = recorder.u64_values("keyed_commands");
+
+    assert!(
+        subscriptions.contains(&1),
+        "starting a subscription must raise the subscriptions gauge: {subscriptions:?}"
+    );
+    assert!(
+        unkeyed.contains(&1),
+        "starting an unkeyed command must raise the unkeyed_commands gauge: {unkeyed:?}"
+    );
+    assert!(
+        keyed.contains(&1),
+        "starting a keyed command must raise the keyed_commands gauge: {keyed:?}"
+    );
+
+    assert_eq!(
+        subscriptions.last(),
+        Some(&0),
+        "the subscriptions gauge must fall back to zero: {subscriptions:?}"
+    );
+    assert_eq!(
+        unkeyed.last(),
+        Some(&0),
+        "the unkeyed_commands gauge must fall back to zero: {unkeyed:?}"
+    );
+    assert_eq!(
+        keyed.last(),
+        Some(&0),
+        "the keyed_commands gauge must fall back to zero: {keyed:?}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Implements RFC 0006 (Runtime Load Control) and RFC 0007 (RuntimeConfig public API and load-control acceptance parameters). Opt-in, additive, and non-breaking: `Runtime::new` is unchanged, and a load-control-unset `RuntimeConfig` reproduces the previous unbounded delivery path exactly (RFC 0006 INV-L6).

## What lands

- **Public API** — `RuntimeConfig` (re-exported at the crate root, not the prelude) carries the frame rate plus three opt-in load controls, and `Runtime::with_config(flags, config)`; `Runtime::new` delegates to it literally, so exactly one construction path exists.
- **Bounded delivery + backpressure** — one channel abstraction that is unbounded by default or bounded per `app_channel_capacity` (shared channel) and `keyed_channel_capacity` (each keyed command's private channel, no shared pool). A producer waits for capacity rather than dropping (INV-L2); the dedicated quit channel is never bounded. Plus a micro-batch count cap (`batch_max_messages`, INV-L12).
- **Load observability** — the `tears::runtime::load` tracing schema (INV-L13): a per-micro-batch event (`pulled`/`updated`/`shared_pending`), a bounded-mode capacity-wait event (`channel`/`wait_us`), and producer-count gauges (`subscriptions`/`unkeyed_commands`/`keyed_commands`/`blocked`), serialized so every reached gauge value is emitted.
- **Bench + CI** — bounded re-runs and bounded quit scenarios (with gauge-observed valid-trial predicates and attempt caps), the `keyed_isolation` regression scenario (INV-L9), and a `--smoke` profile (`just bench-smoke`) that replaces the full harness run in CI's Benchmarks job; the `subscription` bench is unchanged.

## Contract tests & acceptance

- INV-C1..C6 and INV-L1..L13 are gated by unit / runtime-layer / integration tests.
- The RFC 0006 §5.1 bounded acceptance run passed on the §2 reference machine (Apple M1 Max, rustc 1.97.0): bounded queue depth caps at `capacity + 1` where unbounded grows to ~308k (INV-L1); overload update p99 flattens to ~28 ms vs ~7.9 s (INV-L3); no message dropped (INV-L2); every quit→delivered p99 ≤ 1 ms over 200 valid trials in both modes, independent of blocked-producer count (INV-L4); `keyed_isolation` holds — every key admits exactly `capacity + 1`, zero keyed delivery, concurrent shared depth `app_channel_capacity + 1` (INV-L9). Measured results are recorded in RFC 0006 §5.1, and both RFCs are marked Implemented.

## Notes

- `CHANGELOG.md` gains an `Added` entry under `[Unreleased]`.
- Commits are organized into reviewable units (public API, backpressure/batching, observability, bench/CI), with review-fix and RFC-sync commits interleaved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
