### PR TITLE
refactor(observability): emit producer gauges outside the counter lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`pulled`/`updated`/`shared_pending`), a bounded-mode capacity-wait event
     (`channel`/`wait_us`), and producer-count gauges (`subscriptions`,
     `unkeyed_commands`, `keyed_commands`, `blocked`)
+  - The producer-gauge events carry two subscriber-facing guarantees: value
+    fidelity (each change emits the value it reached, so high-water marks and
+    other order-insensitive aggregates are exact) and non-blocking emission (a
+    subscriber's handler may run long, or re-enter the runtime, without
+    stalling or deadlocking producers); cross-producer arrival order is not
+    guaranteed
   - Additive and non-breaking: `Runtime::new` is unchanged, and a
     load-control-unset `RuntimeConfig` reproduces the previous unbounded
     delivery path exactly

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -491,9 +491,24 @@ as INV-L13 (section 5):
   (active forwarding tasks), `unkeyed_commands` (running unkeyed command
   tasks), `keyed_commands` (active keyed entries), and `blocked`
   (producers currently awaiting capacity; always 0 in unbounded mode).
-  These gauges are how the application-owned producer-count premise stays
-  observable rather than enforced (section 4.5), including the
-  blocked-producer anti-pattern named there.
+  Two delivery guarantees hold for these events, so that an implementation
+  mistake in the emission cannot silently degrade a subscriber. *Value
+  fidelity*:
+  each change emits exactly one event carrying the value the changed gauge
+  holds immediately after that change — never a later re-read — so a
+  subscriber observes every value each gauge reaches and any
+  order-insensitive aggregate over the events (a high-water mark, whether a
+  threshold was ever crossed) is exact. What is deliberately *not*
+  guaranteed is the relative arrival order of events from producers
+  updating concurrently: only per-event value fidelity holds, so a
+  subscriber must not reconstruct a cross-producer serialization from
+  arrival order. *Non-blocking emission*: emitting an event neither blocks
+  other producers' updates nor constrains the subscriber's handler — a
+  handler may run arbitrarily long, or itself cause a gauge change, without
+  stalling or deadlocking runtime producers. These gauges are how the
+  application-owned producer-count premise stays observable rather than
+  enforced (section 4.5), including the blocked-producer anti-pattern named
+  there.
 
 Definition of done for the observability slice: layered tests, each
 installing a `tracing` subscriber (the technique the `quit_*` harness
@@ -535,7 +550,21 @@ an integration run (where the real producers raise and lower them):
   layer, where it rises when a producer begins awaiting capacity, falls
   when the send is accepted, and also falls when a blocked producer is
   aborted by cancellation (section 4.3) — the decrement must not depend on
-  the send ever completing.
+  the send ever completing. Value fidelity splits by enforcement at this
+  layer. Its behavioral half is a scripted single-threaded sequence of
+  gauge changes that must emit exactly the values reached, in order
+  (deterministic only single-threaded) — refuting an implementation that
+  emits a *different* value than the change reached: the pre-change value,
+  a coalesced final value, a constant. Its concurrency half — that the
+  emitted value stays the reached value when other producers update between
+  the change and its emit — has no finite behavioral proof (a lone-atomic
+  re-read passes every single-threaded drive) and is structural, the same
+  emit-site review that establishes non-blocking emission. Non-blocking
+  emission likewise has no finite behavioral proof — a serializing or
+  deadlocking implementation hangs rather than fails a value assertion — so
+  it too is structural (section 5, INV-L13): review of the two emit sites
+  confirms each copies the four-field snapshot under the gauge lock and
+  emits the copy with no runtime lock held.
 
 The bounded run of the section 5.1 matrix records capacity-wait and
 blocked-producer numbers from these same events. Per-keyed-channel occupancy gauges are
@@ -1127,7 +1156,29 @@ the check that realizes it; the implementation realizes those checks.
   runtime batch layer; the capacity-wait event's `channel`/`wait_us` and
   the `blocked` gauge's cancellation-abort decrement at the bounded-send
   layer; and the `subscriptions`/`unkeyed_commands`/`keyed_commands`
-  gauge transitions end-to-end over an integration run.
+  gauge transitions end-to-end over an integration run. The producer-gauge
+  events additionally carry two delivery guarantees (section 4.4), each with
+  its own enforcement class. *Value fidelity* — each change emits one event
+  carrying the value that change reached, not a later re-read, so every value
+  a gauge attains is observed and order-insensitive aggregates over the events
+  are exact — is checked in two classes. Behavioral: the single-threaded
+  emitted-sequence test asserts the exact values reached, refuting an
+  implementation that emits a value other than the change reached (the
+  pre-change value, a coalesced final value, a constant). Structural: that the
+  emitted value stays the reached value under concurrent updates has no finite
+  behavioral proof — a lone-atomic re-read passes every single-threaded drive —
+  so it rests on the same emit-site review as non-blocking emission. The
+  cross-producer arrival order is deliberately outside the claim (value
+  fidelity is per event, not a serialization), so no test asserts a
+  cross-producer order. *Non-blocking emission* — emitting a gauge event holds
+  nothing a subscriber's handler could contend for, so a handler may run
+  arbitrarily long or itself trigger a gauge change without stalling or
+  deadlocking producers — is structural, because a serializing or deadlocking
+  implementation hangs rather than fails a finite test. One review of the two
+  emit sites (`LoadObserver::step` and `set_keyed_entries`) discharges both
+  structural obligations: each copies the four-field snapshot while holding the
+  gauge lock (fixing the reached value) and emits that copy after releasing it,
+  with no runtime lock held across the emission.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or a
 unit, runtime-layer, or integration test. The overload scenario is the acceptance measurement for

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -4,6 +4,34 @@ Design contracts, invariants, and decision records for tears. When code
 and an accepted RFC disagree, the RFC states the intended contract; fix
 one or the other explicitly.
 
+## What an RFC pins
+
+An RFC fixes the *observable contract* — the guarantees and properties a
+caller, subscriber, or composed feature can depend on — not the *mechanism*
+that implements it. A lock, a snapshot, a data structure, a task layout is
+out of scope; the property it exists to provide (a value is never lost, an
+emission cannot deadlock a handler, an order is or is not guaranteed) is in
+scope. The test for a candidate sentence: *could a conforming
+reimplementation, reading only the RFC, pick a different mechanism and still
+preserve everything a dependant relies on?* If yes, the sentence is
+mechanism — leave it to the code and its comments. If a from-scratch
+implementation could instead satisfy every stated word yet break something a
+dependant depends on, the missing property belongs in the RFC.
+
+Two corollaries:
+
+- Pin a property's negative space too. When a guarantee holds only under
+  conditions the current mechanism happens to cover — a value stays correct
+  only because a snapshot is taken under a lock — state both what is
+  guaranteed and what is not (e.g. per-event fidelity, but not cross-producer
+  ordering), so a later mechanism change is measured against the contract
+  rather than silently narrowing it.
+- A property and its mechanism can carry different enforcement classes. The
+  observable property may be behavioral where its scenarios are deterministic
+  and structural where they are not (a concurrency-only guarantee reviewed at
+  the seam that provides it); classify each part rather than the guarantee as
+  a whole. See the [pre-review checklist](pre-review-checklist.md) items 2–3.
+
 ## Process
 
 - Each RFC carries its own `Status` in its header — it is not duplicated

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -87,6 +87,19 @@ Prompts that have already paid off:
   happens to touch (from PR #215: an observability definition of done
   that asserted "each event fires with its required fields" — satisfied
   by emitting every event once with wrong values).
+- A concurrency-only hazard behind a guarantee whose test is deterministic
+  only single-threaded: a value-fidelity or ordering guarantee can be
+  broken solely by a concurrent interleaving (a lone-atomic counter that is
+  re-read at emit time and returns a value a later change already
+  superseded), while every single-threaded drive of the emitted-sequence
+  test passes. The behavioral test proves only the no-concurrency case; the
+  concurrency component is structural — the seam that fixes the value, e.g.
+  a snapshot taken under the lock and reviewed at each emit site — so
+  classify it that way (item 3) instead of presenting the single-threaded
+  test as proof of the whole guarantee. (From the RFC 0006 §4.4 gauge
+  delivery amendment: value fidelity was first filed as behavioral-only,
+  but the single-threaded sequence test cannot refute a re-reading
+  implementation.)
 - An acceptance criterion whose parameters the measured implementation
   itself chooses: deferring a run's configuration, load, or trial counts
   to implementation time lets the implementer pick the values their code

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -8,12 +8,18 @@
 //! fields, firing conditions) is pinned as RFC 0006 INV-L13; changing it is a
 //! contract change.
 //!
-//! The gauge counters live behind one mutex, and each change updates a field,
-//! snapshots all four, and emits under the same lock. That serialization is the
-//! contract's "event per change" guarantee: were the update and the read
-//! separate (e.g. lone atomics), a value could be reached and superseded before
-//! its own emit re-read the counters, so a subscriber's high-water mark could
-//! miss it.
+//! The gauge counters live behind one mutex. Each change locks once to update a
+//! field and copy out all four values, then emits that snapshot after releasing
+//! the lock. Snapshotting under the lock is the value-fidelity guarantee (RFC
+//! 0006 §4.4, INV-L13): the event carries the value the change reached, not a
+//! later re-read, so were the update and the read separate (e.g. lone atomics)
+//! a value could be reached and superseded before its own emit re-read the
+//! counters, and a subscriber's high-water mark could miss it. Emitting after
+//! the lock is released keeps the subscriber's handler off the counter lock, so
+//! a slow or re-entrant handler neither stalls other producers nor deadlocks
+//! against the bookkeeping (INV-L13 non-blocking emission). Arrival order across
+//! concurrently updating producers is consequently not guaranteed — only
+//! per-event value fidelity is.
 //!
 //! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
 //! already `pub(crate)`, so effective reachability is capped at the crate
@@ -151,11 +157,15 @@ impl LoadObserver {
     /// via a guard) because an entry's lifetime is the runtime's, not a task's:
     /// a draining entry outlives its task.
     pub fn set_keyed_entries(&self, count: usize) {
-        let mut gauges = self.lock();
-        if gauges.keyed_commands != count {
+        let snapshot = {
+            let mut gauges = self.lock();
+            if gauges.keyed_commands == count {
+                return;
+            }
             gauges.keyed_commands = count;
-            gauges.emit();
-        }
+            *gauges
+        };
+        snapshot.emit();
     }
 
     fn enter(&self, field: Field) -> GaugeGuard {
@@ -166,24 +176,30 @@ impl LoadObserver {
         }
     }
 
-    /// Adds `delta` (`+1`/`-1`) to `field` and emits the resulting snapshot,
-    /// all under one lock so the update and its event cannot interleave with
-    /// another producer's (RFC 0006 §4.4 "event per change").
+    /// Adds `delta` (`+1`/`-1`) to `field`, copies the resulting four-field
+    /// snapshot out under the lock, then emits it after the lock is released
+    /// (RFC 0006 §4.4, INV-L13). Snapshotting under the lock fixes the value
+    /// the change reached (value fidelity); emitting outside it keeps the
+    /// subscriber's handler off the counter lock (non-blocking emission).
     fn step(&self, field: Field, delta: isize) {
-        let mut gauges = self.lock();
-        let counter = field.counter_mut(&mut gauges);
-        *counter = counter.wrapping_add_signed(delta);
-        gauges.emit();
+        let snapshot = {
+            let mut gauges = self.lock();
+            let counter = field.counter_mut(&mut gauges);
+            *counter = counter.wrapping_add_signed(delta);
+            *gauges
+        };
+        snapshot.emit();
     }
 
     fn lock(&self) -> MutexGuard<'_, Gauges> {
         // Recover rather than propagate a poisoned lock. The gauges are plain
         // counters with no cross-field invariant, so a producer that panicked
-        // mid-update leaves them merely off-by-one, not corrupt. Recovering
-        // matters most in `GaugeGuard::drop`, which runs during unwinding: an
-        // `expect` there would panic-during-unwind and abort the process (e.g.
-        // a subscriber panicking under the lock poisons it, then every
-        // unwinding producer's guard drop would double-panic).
+        // while holding the lock would leave them merely off-by-one, not
+        // corrupt. The lock is held only for the update and the snapshot copy —
+        // emission runs after it is released — so a subscriber's handler can no
+        // longer poison it; recovery remains as defense for a panic in the
+        // update itself and keeps `GaugeGuard::drop` (which locks during
+        // unwinding) from turning a poisoned lock into a double-panic abort.
         self.gauges.lock().unwrap_or_else(PoisonError::into_inner)
     }
 }
@@ -246,12 +262,14 @@ mod tests {
         }
     }
 
-    // INV-L13 (serialization, the value-loss guard): each change emits the value
-    // it reached, not a later re-read of the counter — so a peak is never
+    // INV-L13 (value fidelity, the value-loss guard): each change emits the
+    // value it reached, not a later re-read of the counter — so a peak is never
     // skipped. Driven single-threaded here, the emitted sequence is exact; the
-    // production guarantee under concurrency is the shared lock that brackets
-    // update-and-emit (a lone atomic would let a peak be superseded before its
-    // emit re-read it).
+    // production guarantee under concurrency is the snapshot taken under the
+    // lock, which fixes the reached value before emission (a lone atomic would
+    // let a peak be superseded before its emit re-read it). Cross-producer
+    // arrival order is deliberately not guaranteed, so this asserts values, not
+    // a cross-thread order.
     #[test]
     fn each_gauge_change_emits_the_value_it_reached() {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");


### PR DESCRIPTION
## Summary

The producer-gauge path in `src/runtime/load.rs` updated a counter and emitted the `tears::runtime::load` event under the same `std::sync::Mutex`. That serialization was two footguns:

- **(a) producer stall** — a subscriber's event handler ran *under* the lock, serializing every producer and the event loop behind a slow handler.
- **(b) self-deadlock** — a handler that re-entered the runtime deadlocked on the non-reentrant `Mutex`.

This snapshots the four-field `Gauges` (`Copy`) under the lock and emits **after** releasing it. Snapshotting under the lock preserves the value-fidelity guarantee (the event carries the value the change reached, not a later re-read); emitting outside it keeps the subscriber's handler off the counter lock. No `seq` number is introduced — cross-producer arrival order is explicitly *not* guaranteed.

Caught before release: RFC 0006/0007 are Implemented but still `[Unreleased]`, so this ships in the same additive 0.10.x patch. (Was tracked as the "#\2 gauge event delivery under the lock" review-hold item.)

## Contract change (RFC 0006)

The lock/snapshot is *mechanism* and stays in code comments; the *observable guarantees* are contract, so §4.4 and INV-L13 now pin them:

- **Value fidelity** — each change emits one event carrying the value it reached, so order-insensitive aggregates (high-water marks) are exact. Enforcement split: **behavioral** for the single-threaded emitted-sequence, **structural** for the concurrency component (a single-threaded test cannot refute a lone-atomic re-read).
- **Non-blocking emission** — emitting holds nothing a handler could contend for; **structural**, reviewed at the two emit sites (`LoadObserver::step`, `set_keyed_entries`).
- Both state their **negative space**: cross-producer arrival order is not guaranteed.

## Docs (second commit)

The amendment surfaced a reusable scope distinction, recorded where future RFC authors decide what to write:

- `README.md` — new **"What an RFC pins"** section: mechanism-out / observable-property-in, the from-scratch reimplementation test, and two corollaries (pin negative space; property and mechanism can carry different enforcement classes).
- `pre-review-checklist.md` — item-2 adversary for the concrete defect this amendment's self-review caught (a concurrency-only hazard behind a single-threaded-deterministic test).

## Verification

- `cargo test --lib runtime::load` — 3 pass (existing value-fidelity / all-fields / levels tests unchanged and green)
- `cargo clippy --all-targets`, `cargo fmt --check`, `typos`, `git diff --check` — clean
- pre-review checklist run against the changed claims; the behavioral-vs-structural finding above was caught and fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)