### PR TITLE
feat(runtime): order producer-gauge events by an explicit seq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Load observability is emitted through `tracing` under the
     `tears::runtime::load` target: a per-micro-batch event
     (`pulled`/`updated`/`shared_pending`), a bounded-mode capacity-wait event
-    (`channel`/`wait_us`), and producer-count gauges (`subscriptions`,
-    `unkeyed_commands`, `keyed_commands`, `blocked`)
+    (`channel`/`wait_us`), and producer-count gauges (`seq`, `subscriptions`,
+    `unkeyed_commands`, `keyed_commands`, `blocked`); a gauge event's `seq` is
+    a per-runtime monotone counter that fixes the current gauge value as the
+    greatest-`seq` event's, so consumers order gauge events by `seq`, not by
+    arrival
   - Additive and non-breaking: `Runtime::new` is unchanged, and a
     load-control-unset `RuntimeConfig` reproduces the previous unbounded
     delivery path exactly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Load observability is emitted through `tracing` under the
     `tears::runtime::load` target: a per-micro-batch event
     (`pulled`/`updated`/`shared_pending`), a bounded-mode capacity-wait event
-    (`channel`/`wait_us`), and producer-count gauges (`seq`, `subscriptions`,
-    `unkeyed_commands`, `keyed_commands`, `blocked`); a gauge event's `seq` is
-    a per-runtime monotone counter that fixes the current gauge value as the
-    greatest-`seq` event's, so consumers order gauge events by `seq`, not by
-    arrival
+    (`channel`/`wait_us`), and producer-count gauges (`subscriptions`,
+    `unkeyed_commands`, `keyed_commands`, `blocked`); each gauge event also
+    carries a per-runtime monotone `seq` — not a gauge but an ordering counter
+    — that fixes the current gauge value as the greatest-`seq` event's, so
+    consumers order gauge events by `seq`, not by arrival
   - Additive and non-breaking: `Runtime::new` is unchanged, and a
     load-control-unset `RuntimeConfig` reproduces the previous unbounded
     delivery path exactly

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -507,14 +507,26 @@ fn quit_scenarios() -> Vec<QuitScenarioCfg> {
 /// ignored. Trials run sequentially, so a single slot suffices.
 static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 
-/// The most recent producer-gauge sum
+/// The current producer-gauge sum
 /// (`subscriptions + unkeyed_commands + keyed_commands + blocked`), updated by
-/// [`QuitDeliverySubscriber`] on every gauge event regardless of the trial
-/// slot. Reaches 0 only when the *current* runtime has fully torn its producers
-/// down; scenarios run one runtime at a time, so [`await_quiescence`] can wait
-/// on it as a common teardown barrier before the next runtime starts, keeping a
-/// late gauge/capacity event from one scenario out of the next scenario's slot.
+/// [`QuitDeliverySubscriber`] from the greatest-`seq` gauge event regardless of
+/// the trial slot. Reaches 0 only when the *current* runtime has fully torn its
+/// producers down; scenarios run one runtime at a time, so [`await_quiescence`]
+/// can wait on it as a common teardown barrier before the next runtime starts,
+/// keeping a late gauge/capacity event from one scenario out of the next
+/// scenario's slot.
 static LIVE_PRODUCERS: AtomicU64 = AtomicU64::new(0);
+
+/// Newest producer-gauge `seq` applied for the current runtime (RFC 0006 §4.4).
+/// A gauge event's values reach [`LIVE_PRODUCERS`] and [`Metrics::blocked_live`]
+/// only when its `seq` advances this high-water mark, so a reordered stale gauge
+/// event never supersedes the current value — the schema orders gauge events by
+/// `seq`, not by arrival. It is a `Mutex`, not an atomic, so the advance and the
+/// value stores it guards happen as one step even if a future runtime dispatches
+/// gauge events off several producer threads at once. [`await_quiescence`] resets
+/// it to 0 per runtime, since `seq` restarts at 0 with each new runtime's
+/// `LoadObserver`.
+static GAUGE_SEQ_SEEN: Mutex<u64> = Mutex::new(0);
 
 /// Waits until the current runtime's producers have fully torn down (the gauge
 /// sum returns to 0) before the caller starts the next runtime — the teardown
@@ -533,6 +545,11 @@ async fn await_quiescence() {
         "harness fault: a scenario's producers did not quiesce within 5s; \
          refusing to reuse the trial slot with a teardown still in flight",
     );
+    // The next runtime starts a fresh `LoadObserver` whose gauge `seq` restarts
+    // at 0, so clear the high-water mark; the barrier above guarantees the
+    // drained runtime emits no further gauge event that this reset could let a
+    // stale reading through.
+    *GAUGE_SEQ_SEEN.lock().expect("gauge seq high-water mark poisoned") = 0;
 }
 
 /// Records the instant the event loop's quit branch fires.
@@ -570,16 +587,42 @@ impl Subscriber for QuitDeliverySubscriber {
 
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
+    // The gauge high-water guard (`seen`) is deliberately held across the value
+    // stores below: releasing it after `*seen = seq` — the nursery lint's
+    // suggestion — would let a concurrent stale gauge event interleave its store
+    // between the check and the apply, the exact reorder the `seq` ordering
+    // exists to defeat (RFC 0006 §4.4).
+    #[allow(clippy::significant_drop_tightening)]
     fn event(&self, event: &Event<'_>) {
         let is_load = event.metadata().target() == "tears::runtime::load";
         let mut visitor = LoadVisitor::default();
         event.record(&mut visitor);
 
-        // The teardown barrier is global and slot-independent: update it on every
-        // gauge event (a gauge event always carries `blocked`), so a scenario
-        // with no active trial slot still drives its producers' quiescence.
-        if is_load && visitor.blocked.is_some() {
+        // A producer-gauge event carries `seq` (and `blocked`). Order these by
+        // `seq`, not by arrival: apply the event's values only when its `seq`
+        // advances the high-water mark, so a reordered stale gauge event never
+        // supersedes the current value (RFC 0006 §4.4). Holding the high-water
+        // lock across the value stores makes "advance and apply" one step, so
+        // concurrent dispatch cannot interleave a stale store between the check
+        // and the apply. This gates both the slot-independent teardown barrier
+        // and the per-trial `blocked` reading. The trial slot is cloned out
+        // first, before the high-water lock, so the two locks are never held at
+        // once.
+        if let Some(seq) = visitor.seq {
+            let slot = TRIAL_METRICS
+                .lock()
+                .expect("trial metrics slot poisoned")
+                .clone();
+            let mut seen = GAUGE_SEQ_SEEN.lock().expect("gauge seq high-water mark poisoned");
+            if seq <= *seen {
+                return;
+            }
+            *seen = seq;
             LIVE_PRODUCERS.store(visitor.gauge_sum(), Ordering::Relaxed);
+            if let (Some(metrics), Some(blocked)) = (slot, visitor.blocked) {
+                metrics.blocked_live.store(blocked, Ordering::Relaxed);
+            }
+            return;
         }
 
         let Some(metrics) = TRIAL_METRICS
@@ -591,12 +634,8 @@ impl Subscriber for QuitDeliverySubscriber {
         };
 
         if is_load {
-            // Per-trial recording (only while a slot is active): the live
-            // `blocked` count for the predicate, and shared capacity-wait instants
-            // for the churn window.
-            if let Some(blocked) = visitor.blocked {
-                metrics.blocked_live.store(blocked, Ordering::Relaxed);
-            }
+            // Capacity-wait event (per-occurrence, not seq-ordered): log shared
+            // capacity-wait instants for the churn window while a slot is active.
             if visitor.channel.as_deref() == Some("shared") {
                 metrics
                     .capacity_wait_shared_ns
@@ -619,6 +658,10 @@ impl Subscriber for QuitDeliverySubscriber {
 #[derive(Default)]
 struct LoadVisitor {
     matched_quit: bool,
+    /// Present only on a producer-gauge event: its monotone ordering counter
+    /// (RFC 0006 §4.4). Its presence identifies the event as a gauge event, and
+    /// its value orders it against the other gauge events.
+    seq: Option<u64>,
     subscriptions: Option<u64>,
     unkeyed_commands: Option<u64>,
     keyed_commands: Option<u64>,
@@ -640,6 +683,7 @@ impl LoadVisitor {
 impl Visit for LoadVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
         match field.name() {
+            "seq" => self.seq = Some(value),
             "subscriptions" => self.subscriptions = Some(value),
             "unkeyed_commands" => self.unkeyed_commands = Some(value),
             "keyed_commands" => self.keyed_commands = Some(value),

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -598,17 +598,20 @@ impl Subscriber for QuitDeliverySubscriber {
         let mut visitor = LoadVisitor::default();
         event.record(&mut visitor);
 
-        // A producer-gauge event carries `seq` (and `blocked`). Order these by
-        // `seq`, not by arrival: apply the event's values only when its `seq`
-        // advances the high-water mark, so a reordered stale gauge event never
-        // supersedes the current value (RFC 0006 §4.4). Holding the high-water
-        // lock across the value stores makes "advance and apply" one step, so
-        // concurrent dispatch cannot interleave a stale store between the check
-        // and the apply. This gates both the slot-independent teardown barrier
-        // and the per-trial `blocked` reading. The trial slot is cloned out
-        // first, before the high-water lock, so the two locks are never held at
-        // once.
-        if let Some(seq) = visitor.seq {
+        // A producer-gauge event is a load-target event carrying `seq` (and
+        // `blocked`). Match on the target too, not on `seq` alone: were a `seq`
+        // field ever added to a `tears::runtime` DEBUG event, matching on `seq`
+        // alone would swallow it here and skip the quit-delivery match below.
+        // Order these by `seq`, not by arrival: apply the event's values only
+        // when its `seq` advances the high-water mark, so a reordered stale
+        // gauge event never supersedes the current value (RFC 0006 §4.4).
+        // Holding the high-water lock across the value stores makes "advance and
+        // apply" one step, so concurrent dispatch cannot interleave a stale
+        // store between the check and the apply. This gates both the
+        // slot-independent teardown barrier and the per-trial `blocked` reading.
+        // The trial slot is cloned out first, before the high-water lock, so the
+        // two locks are never held at once.
+        if is_load && let Some(seq) = visitor.seq {
             let slot = TRIAL_METRICS
                 .lock()
                 .expect("trial metrics slot poisoned")

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -549,7 +549,9 @@ async fn await_quiescence() {
     // at 0, so clear the high-water mark; the barrier above guarantees the
     // drained runtime emits no further gauge event that this reset could let a
     // stale reading through.
-    *GAUGE_SEQ_SEEN.lock().expect("gauge seq high-water mark poisoned") = 0;
+    *GAUGE_SEQ_SEEN
+        .lock()
+        .expect("gauge seq high-water mark poisoned") = 0;
 }
 
 /// Records the instant the event loop's quit branch fires.
@@ -616,7 +618,9 @@ impl Subscriber for QuitDeliverySubscriber {
                 .lock()
                 .expect("trial metrics slot poisoned")
                 .clone();
-            let mut seen = GAUGE_SEQ_SEEN.lock().expect("gauge seq high-water mark poisoned");
+            let mut seen = GAUGE_SEQ_SEEN
+                .lock()
+                .expect("gauge seq high-water mark poisoned");
             if seq <= *seen {
                 return;
             }

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -487,13 +487,29 @@ as INV-L13 (section 5):
   this event's firing condition; adding a separate aggregate event
   alongside it is additive and does not require revisiting this choice.
 - **Producer gauges** — target `tears::runtime::load`, level `debug`,
-  fired whenever any counted value changes. Fields: `subscriptions`
-  (active forwarding tasks), `unkeyed_commands` (running unkeyed command
-  tasks), `keyed_commands` (active keyed entries), and `blocked`
-  (producers currently awaiting capacity; always 0 in unbounded mode).
-  These gauges are how the application-owned producer-count premise stays
-  observable rather than enforced (section 4.5), including the
-  blocked-producer anti-pattern named there.
+  fired whenever any counted value changes. Fields: `seq` (the ordering
+  counter defined below), `subscriptions` (active forwarding tasks),
+  `unkeyed_commands` (running unkeyed command tasks), `keyed_commands`
+  (active keyed entries), and `blocked` (producers currently awaiting
+  capacity; always 0 in unbounded mode). These gauges are how the
+  application-owned producer-count premise stays observable rather than
+  enforced (section 4.5), including the blocked-producer anti-pattern named
+  there. `seq` is a per-runtime counter incremented once per emitted gauge
+  event and captured with the same snapshot as the four counts, so a
+  greater `seq` always carries a gauge state reached no earlier than any
+  lesser `seq`. It fixes the *current* value of each gauge as the value on
+  the gauge event with the greatest `seq` a subscriber has observed —
+  **gauge-event arrival order is not part of this contract**, so a consumer
+  that reads "the value on the most recently *arrived* event" is relying on
+  an ordering the schema does not provide. Ordering by an explicit `seq`
+  rather than by arrival is deliberate: because the snapshot-and-`seq`
+  capture is atomic while only the emit need move, it lets a later change
+  emit gauge events without holding the runtime's gauge lock across the
+  `tracing` dispatch — so a slow or re-entrant subscriber can no longer
+  stall or deadlock producers — without breaking any `seq`-ordered
+  consumer. The initial implementation still emits under that lock, so
+  `seq` and arrival order coincide there; consumers must not depend on the
+  coincidence.
 
 Definition of done for the observability slice: layered tests, each
 installing a `tracing` subscriber (the technique the `quit_*` harness
@@ -535,7 +551,13 @@ an integration run (where the real producers raise and lower them):
   layer, where it rises when a producer begins awaiting capacity, falls
   when the send is accepted, and also falls when a blocked producer is
   aborted by cancellation (section 4.3) — the decrement must not depend on
-  the send ever completing.
+  the send ever completing. The gauge event's `seq` is checked at the
+  gauge layer where the emitted sequence is deterministic: a scripted
+  series of gauge changes emits one event per change with a strictly
+  increasing `seq`, so a subscriber ordering by `seq` recovers each
+  gauge's current value without relying on arrival order — an
+  implementation that omits `seq`, repeats it, or lets it run backward
+  fails.
 
 The bounded run of the section 5.1 matrix records capacity-wait and
 blocked-producer numbers from these same events. Per-keyed-channel occupancy gauges are
@@ -1117,17 +1139,21 @@ the check that realizes it; the implementation realizes those checks.
   capacity-wait event — and the field values carry the stated meanings:
   `pulled` is INV-L12's counted unit, `shared_pending` the
   shared-channel occupancy at batch end, `wait_us` the blocked send's
-  admission wait. The schema is contract surface: renaming, dropping, or
-  repurposing any part of it is an amendment to this RFC, not an
-  implementation detail. Behavioral check across the layered section 4.4
+  admission wait, and the producer-gauge event's `seq` a per-runtime
+  monotone counter that fixes each gauge's current value as the
+  greatest-`seq` event's, so gauge-event arrival order is not part of the
+  contract (section 4.4). The schema is contract surface: renaming,
+  dropping, or repurposing any part of it is an amendment to this RFC, not
+  an implementation detail. Behavioral check across the layered section 4.4
   definition-of-done tests, each with a `tracing` subscriber and value
   assertions that distinguish an implementation emitting the right events
   with wrong values: the batch event's `pulled`/`updated` (including the
   `Closed` differing-value case) and its `shared_pending` leftover at the
   runtime batch layer; the capacity-wait event's `channel`/`wait_us` and
   the `blocked` gauge's cancellation-abort decrement at the bounded-send
-  layer; and the `subscriptions`/`unkeyed_commands`/`keyed_commands`
-  gauge transitions end-to-end over an integration run.
+  layer; the `subscriptions`/`unkeyed_commands`/`keyed_commands`
+  gauge transitions end-to-end over an integration run; and the
+  gauge event's strictly increasing `seq` at the gauge layer.
 
 Each invariant gets a regression scenario in `benches/runtime_load.rs` or a
 unit, runtime-layer, or integration test. The overload scenario is the acceptance measurement for

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -495,20 +495,31 @@ as INV-L13 (section 5):
   application-owned producer-count premise stays observable rather than
   enforced (section 4.5), including the blocked-producer anti-pattern named
   there. `seq` is a per-runtime counter incremented once per emitted gauge
-  event and captured with the same snapshot as the four counts, so a
-  greater `seq` always carries a gauge state reached no earlier than any
-  lesser `seq`. It fixes the *current* value of each gauge as the value on
-  the gauge event with the greatest `seq` a subscriber has observed —
-  **gauge-event arrival order is not part of this contract**, so a consumer
-  that reads "the value on the most recently *arrived* event" is relying on
-  an ordering the schema does not provide. Ordering by an explicit `seq`
-  rather than by arrival is deliberate: because the snapshot-and-`seq`
-  capture is atomic while only the emit need move, it lets a later change
-  emit gauge events without holding the runtime's gauge lock across the
-  `tracing` dispatch — so a slow or re-entrant subscriber can no longer
-  stall or deadlock producers — without breaking any `seq`-ordered
-  consumer. The initial implementation still emits under that lock, so
-  `seq` and arrival order coincide there; consumers must not depend on the
+  event — a `u64`, monotone within a run; wraparound would take ~2^64
+  events and does not occur in practice — and captured with the same
+  snapshot as the four counts, so a greater `seq` always carries a gauge
+  state reached no earlier than any lesser `seq`. It fixes the *current*
+  value of each gauge as the value on the gauge event with the greatest
+  `seq` a subscriber has observed — **gauge-event arrival order is not part
+  of this contract**, so a consumer that reads "the value on the most
+  recently *arrived* event" is relying on an ordering the schema does not
+  provide. Ordering by an explicit `seq` rather than by arrival is
+  deliberate: because the snapshot-and-`seq` capture is atomic while only
+  the emit need move, it lets a later change emit gauge events without
+  holding the runtime's gauge lock across the `tracing` dispatch, so a slow
+  subscriber can no longer stall producers on that lock and a subscriber
+  that re-enters the runtime can no longer deadlock on it — without
+  breaking any `seq`-ordered consumer. That move does **not**, on its own,
+  make a subscriber that itself *causes* a gauge change safe: such a
+  subscriber re-enters the emit path, risking unbounded recursion under a
+  global `tracing` dispatcher, or — under a scoped one — a nested event
+  silently dropped by `tracing`'s re-entrancy guard, which breaks value
+  fidelity. Resolving that re-entrancy is a prerequisite of any future
+  off-lock change and is out of scope for the `seq` field, which secures
+  only the ordering; it is recorded here so the off-lock change cannot read
+  the stall/deadlock sentence as a claim that re-entrancy is already safe.
+  The initial implementation still emits under that lock, so `seq` and
+  arrival order coincide there; consumers must not depend on the
   coincidence.
 
 Definition of done for the observability slice: layered tests, each

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -527,6 +527,24 @@ channel occupancy, per the note on that distinction below the table:
   `quit_keyed_bounded`) is the whole predicate. The acceptance run
   reports each row's count as that many *valid* trials, not that many
   attempts.
+- **This section depends on RFC 0006 §4.4's gauge current-value
+  contract.** Every predicate that reads `blocked` (the `quit_blocked_*`
+  and `quit_keyed_bounded` rows) reads the *current* value of the
+  `blocked` gauge at the quit instant, and the harness's teardown barrier
+  (`await_quiescence`, `benches/runtime_load.rs`) reads the current gauge
+  sum returning to zero. "Current value" is RFC 0006 §4.4's contract term:
+  the value on the gauge event with the greatest `seq`, not the value on
+  the most recently *arrived* event — the schema does not order gauge
+  events by arrival. The harness therefore consumes these gauges by
+  greatest `seq`, discarding any event whose `seq` does not advance, so a
+  reordered stale gauge event can corrupt neither a predicate reading nor
+  the barrier. This dependency is stated explicitly because it is
+  otherwise invisible: a consumer that instead trusted arrival order would
+  read correctly today — the initial implementation emits gauge events
+  under the runtime's gauge lock, so arrival and `seq` order coincide — yet
+  would silently break the moment that emit moved out from under the lock
+  (RFC 0006 §4.4's stated reason for the `seq` field), a change this
+  section must not be allowed to obstruct unknowingly.
 - Counting only valid trials means an implementation may need more
   attempts than the row's required count whenever some attempts fail their
   predicate. To make the retry rule precise — which attempts are retried,

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -8,12 +8,25 @@
 //! fields, firing conditions) is pinned as RFC 0006 INV-L13; changing it is a
 //! contract change.
 //!
-//! The gauge counters live behind one mutex, and each change updates a field,
-//! snapshots all four, and emits under the same lock. That serialization is the
-//! contract's "event per change" guarantee: were the update and the read
-//! separate (e.g. lone atomics), a value could be reached and superseded before
-//! its own emit re-read the counters, so a subscriber's high-water mark could
-//! miss it.
+//! The gauge counters live behind one mutex. Each change updates a field, bumps
+//! a monotone `seq`, and snapshots everything under the same lock. Two separate
+//! guarantees ride on that lock, and only one of them constrains the order
+//! events *arrive* in:
+//!
+//! - **Value fidelity** (every reached value gets its own event): capturing the
+//!   update and the snapshot together under the lock prevents a value from being
+//!   reached and superseded before its own emit re-reads the counters — a lone
+//!   atomic would let a subscriber's high-water mark miss a peak. This guarantee
+//!   is about the snapshot, not about arrival order.
+//! - **Ordering** is carried by `seq`, not by arrival: the current value of each
+//!   gauge is the value on the greatest-`seq` event (RFC 0006 §4.4, INV-L13).
+//!   The lock currently also serializes the `tracing` dispatch, so today arrival
+//!   order happens to match `seq` order — but the contract does not promise it,
+//!   and consumers must order by `seq`. That is deliberate: because the
+//!   snapshot-and-`seq` capture stays under the lock while only the dispatch
+//!   would move, a later change can emit the event out from under the lock (so a
+//!   slow or re-entrant subscriber can no longer stall or deadlock producers)
+//!   without breaking any `seq`-ordered consumer.
 //!
 //! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
 //! already `pub(crate)`, so effective reachability is capped at the crate
@@ -82,6 +95,12 @@ pub struct LoadObserver {
 
 #[derive(Clone, Copy, Default)]
 struct Gauges {
+    /// Monotone per-observer counter, bumped once per emitted gauge event and
+    /// carried on it as `seq`. Captured under the same lock as the four counts,
+    /// so a greater `seq` never carries an older value; a subscriber reads the
+    /// current value of each gauge from the greatest-`seq` event, so arrival
+    /// order is not load-bearing (RFC 0006 §4.4, INV-L13).
+    seq: u64,
     subscriptions: usize,
     unkeyed_commands: usize,
     keyed_commands: usize,
@@ -89,12 +108,17 @@ struct Gauges {
 }
 
 impl Gauges {
-    /// Emits the four-field producer-gauge event from this snapshot. Taking
-    /// `self` by value fixes the values at the caller's serialization point, so
-    /// the event reports the state that was reached rather than a later re-read.
-    fn emit(self) {
+    /// Bumps `seq` and emits the four-field producer-gauge event with it. Takes
+    /// `&mut self` so the bump lands in the shared state; the caller holds the
+    /// lock, fixing the counts and `seq` together at the serialization point, so
+    /// the event reports the state that was reached (never a later re-read) and
+    /// its `seq` orders it against every other gauge event without relying on
+    /// arrival order.
+    fn emit(&mut self) {
+        self.seq = self.seq.wrapping_add(1);
         tracing::debug!(
             target: "tears::runtime::load",
+            seq = self.seq,
             subscriptions = self.subscriptions,
             unkeyed_commands = self.unkeyed_commands,
             keyed_commands = self.keyed_commands,
@@ -233,6 +257,7 @@ mod tests {
         assert!(!gauge_events.is_empty(), "gauge events should have fired");
         for fields in gauge_events {
             for required in [
+                "seq",
                 "subscriptions",
                 "unkeyed_commands",
                 "keyed_commands",
@@ -244,6 +269,27 @@ mod tests {
                 );
             }
         }
+    }
+
+    // INV-L13 (ordering): every gauge event carries a monotone `seq`, one per
+    // emission, so a subscriber orders the events by `seq` rather than by
+    // arrival — the current value of each gauge is the greatest-`seq` event's.
+    #[test]
+    fn each_gauge_change_carries_a_monotone_seq() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let observer = LoadObserver::default();
+        let first = observer.track_subscription();
+        let second = observer.track_subscription();
+        drop(second);
+        drop(first);
+
+        assert_eq!(
+            recorder.u64_values("seq"),
+            vec![1, 2, 3, 4],
+            "each of the four gauge changes emits one event with the next `seq`"
+        );
     }
 
     // INV-L13 (serialization, the value-loss guard): each change emits the value

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -244,12 +244,12 @@ mod tests {
     use super::*;
     use crate::test_support::TraceRecorder;
 
-    // INV-L13: every producer-gauge event carries all four fields together, so
-    // a subscriber reads a complete snapshot from any one event. The per-field
-    // recorder views flatten across events and cannot see this; the field-set
-    // view can.
+    // INV-L13: every producer-gauge event carries the full field set together —
+    // the four gauges plus their ordering `seq` — so a subscriber reads a
+    // complete, ordered snapshot from any one event. The per-field recorder
+    // views flatten across events and cannot see this; the field-set view can.
     #[test]
-    fn gauge_event_carries_all_four_fields() {
+    fn gauge_event_carries_the_full_field_set() {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");
         let _guard = recorder.set_default();
 

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -24,9 +24,13 @@
 //!   order happens to match `seq` order — but the contract does not promise it,
 //!   and consumers must order by `seq`. That is deliberate: because the
 //!   snapshot-and-`seq` capture stays under the lock while only the dispatch
-//!   would move, a later change can emit the event out from under the lock (so a
-//!   slow or re-entrant subscriber can no longer stall or deadlock producers)
-//!   without breaking any `seq`-ordered consumer.
+//!   would move, a later change can emit the event out from under the lock — so
+//!   a slow subscriber no longer stalls producers on that lock, and one that
+//!   re-enters the runtime no longer deadlocks on it — without breaking any
+//!   `seq`-ordered consumer. Moving the dispatch off the lock does not by itself
+//!   make a subscriber that *causes* a gauge change safe (it re-enters the emit
+//!   path); that is a separate re-entrancy hazard, out of scope here and tracked
+//!   against RFC 0006 §4.4.
 //!
 //! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
 //! already `pub(crate)`, so effective reachability is capped at the crate
@@ -93,7 +97,11 @@ pub struct LoadObserver {
     gauges: Arc<Mutex<Gauges>>,
 }
 
-#[derive(Clone, Copy, Default)]
+// Deliberately not `Copy`/`Clone`: `emit` bumps `seq` through `&mut self`, so a
+// by-value copy (`let mut g = *guard; g.emit()`) would bump and emit a throwaway
+// while the shared `seq` stalled — the exact silently-dropped update this
+// ordering exists to prevent. Without the derives that pattern fails to compile.
+#[derive(Default)]
 struct Gauges {
     /// Monotone per-observer counter, bumped once per emitted gauge event and
     /// carried on it as `seq`. Captured under the same lock as the four counts,
@@ -108,9 +116,10 @@ struct Gauges {
 }
 
 impl Gauges {
-    /// Bumps `seq` and emits the four-field producer-gauge event with it. Takes
-    /// `&mut self` so the bump lands in the shared state; the caller holds the
-    /// lock, fixing the counts and `seq` together at the serialization point, so
+    /// Bumps `seq` and emits the producer-gauge event — the four counts plus
+    /// their ordering `seq`. Takes `&mut self` so the bump lands in the shared
+    /// state; the caller holds the lock, fixing the counts and `seq` together
+    /// at the serialization point, so
     /// the event reports the state that was reached (never a later re-read) and
     /// its `seq` orders it against every other gauge event without relying on
     /// arrival order.


### PR DESCRIPTION
## Summary

The producer-gauge event's current-value semantics were implicitly load-bearing on **arrival order** — the last gauge event to arrive was read as the current value — a property provided only by emitting under the gauge lock. Two consumers depended on it, and the dependency was discoverable only by grep:

- `benches/runtime_load.rs` — the `LIVE_PRODUCERS` teardown barrier and the `blocked`-gauge quit-instant valid-trial predicate, both last-event-wins.
- RFC 0007 §5.2 — the quit-instant gauge observation.

Because the coupling was invisible, an earlier attempt to move the emit off the lock (the intended fix for a slow/re-entrant subscriber stalling or deadlocking producers) broke both without review catching it.

This PR pins the ordering **explicitly** rather than the arrival-order coincidence (option B of the two considered — see below):

- Add a per-runtime monotone **`seq`** field to the gauge event, captured under the same lock as the four-count snapshot, so a greater `seq` never carries an older value.
- Define the current value of each gauge as the **greatest-`seq`** event's value. **Arrival order is no longer part of the contract.**
- This makes a future emit-off-lock change contract-preserving (the snapshot-and-`seq` capture stays under the lock; only the tracing dispatch would move) — this PR does **not** perform that move; the initial implementation still emits under the lock.

## Why B, not A

The alternative (A) was to pin ordered current-value delivery as an invariant — but that forces handler-under-lock serialization, fixing the stall/deadlock footgun into the contract as negative space. B satisfies the observation need (§5.2, bench) and non-blocking emission simultaneously, and matches the project's correctness-first / clean-breaks-early direction.

## Changes

- **`src/runtime/load.rs`**: add `Gauges.seq`; `emit` bumps it and snapshots under the lock; module doc split into the value-fidelity guarantee (the snapshot) vs. the ordering guarantee (`seq`, not arrival); new test asserts monotone `seq`.
- **`benches/runtime_load.rs`**: consume gauges by greatest `seq` — a `GAUGE_SEQ_SEEN` mutex gates the teardown barrier and the `blocked` reading across check-and-apply so concurrent dispatch cannot apply a stale event; reset per runtime in `await_quiescence`.
- **RFC 0006 §4.4 / INV-L13**: pin the `seq` field, the max-`seq` current-value rule, and its definition-of-done check.
- **RFC 0007 §5.2**: add an explicit cross-reference to the RFC 0006 §4.4 gauge current-value contract this section depends on, so the coupling is no longer grep-only.
- **CHANGELOG**: record the `seq` field on the gauge event.

## Verification

- `cargo test --lib` — 328 pass (incl. new `each_gauge_change_carries_a_monotone_seq`).
- `cargo clippy --benches --lib` — clean (one justified `#[allow(significant_drop_tightening)]`: the lint's early-drop suggestion would reintroduce the stale-store race the held lock prevents).
- `cargo bench --bench runtime_load -- --smoke` — exit 0; `quit_blocked_1` collected 5/5 valid trials at depth 1025, confirming the seq-gated gauge read drives both the predicate and the teardown barrier correctly.
- Ran the RFC pre-review checklist (7 items) against the amendment.

## Follow-up (out of scope here)

A future PR that actually moves the emit off the lock must also handle the §4.4 "a handler may itself cause a gauge change" re-entrancy concern (global dispatcher: unbounded recursion; scoped dispatcher: tracing-core's re-entrancy guard silently drops the nested event, breaking value fidelity). This PR does not address it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)