### PR TITLE
docs(rfcs): pin RFC scope boundary and add a coincidental-property checklist item

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -4,6 +4,34 @@ Design contracts, invariants, and decision records for tears. When code
 and an accepted RFC disagree, the RFC states the intended contract; fix
 one or the other explicitly.
 
+## What an RFC pins
+
+An RFC fixes the *observable contract* — the guarantees and properties a
+caller, subscriber, or composed feature can depend on — not the *mechanism*
+that implements it. A lock, a snapshot, a data structure, a task layout is
+out of scope; the property it exists to provide (a value is never lost, an
+emission cannot deadlock a handler, an order is or is not guaranteed) is in
+scope. The test for a candidate sentence: *could a conforming
+reimplementation, reading only the RFC, pick a different mechanism and still
+preserve everything a dependant relies on?* If yes, the sentence is
+mechanism — leave it to the code and its comments. If a from-scratch
+implementation could instead satisfy every stated word yet break something a
+dependant depends on, the missing property belongs in the RFC.
+
+Two corollaries:
+
+- Pin a property's negative space too. When a guarantee holds only under
+  conditions the current mechanism happens to cover — a value stays correct
+  only because a snapshot is taken under a lock — state both what is
+  guaranteed and what is not (e.g. per-event fidelity, but not cross-producer
+  ordering), so a later mechanism change is measured against the contract
+  rather than silently narrowing it.
+- A property and its mechanism can carry different enforcement classes. The
+  observable property may be behavioral where its scenarios are deterministic
+  and structural where they are not (a concurrency-only guarantee reviewed at
+  the seam that provides it); classify each part rather than the guarantee as
+  a whole. See the [pre-review checklist](pre-review-checklist.md) items 2–3.
+
 ## Process
 
 - Each RFC carries its own `Status` in its header — it is not duplicated

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -13,10 +13,10 @@ out of scope; the property it exists to provide (a value is never lost, an
 emission cannot deadlock a handler, an order is or is not guaranteed) is in
 scope. The test for a candidate sentence: *could a conforming
 reimplementation, reading only the RFC, pick a different mechanism and still
-preserve everything a dependant relies on?* If yes, the sentence is
+preserve everything a dependent relies on?* If yes, the sentence is
 mechanism — leave it to the code and its comments. If a from-scratch
 implementation could instead satisfy every stated word yet break something a
-dependant depends on, the missing property belongs in the RFC.
+dependent depends on, the missing property belongs in the RFC.
 
 Two corollaries:
 

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -94,6 +94,20 @@ Prompts that have already paid off:
   sufficiently fast machine pass it (from PR #217: the bounded
   acceptance run deferred capacity/depth/trial count to implementation
   time, and the p99 ≤ 1 ms condition named no machine).
+- A coincidental property of the current mechanism, silently depended on
+  by other components because the RFC never named it as contract: check
+  every consumer of the property under review, not only the ones the
+  invariant text already lists, by grepping for the thing a from-scratch
+  reimplementation would be free to drop. A change that satisfies every
+  stated invariant can still break such a consumer if the coincidence,
+  not the invariant, was what it actually relied on (from the RFC 0006
+  §4.4 gauge-event seq amendment: an earlier attempt to move gauge-event
+  emission off the lock satisfied the stated value-fidelity invariant but
+  broke `benches/runtime_load.rs`'s teardown barrier and RFC 0007 §5.2's
+  current-value read, both of which relied on arrival order coinciding
+  with lock-serialized dispatch — a coincidence the contract had never
+  pinned, undetected until grepped for and named explicitly as the `seq`
+  field).
 
 ## 3. Enforcement class, declared up front
 


### PR DESCRIPTION
## Summary

PR #232 (closed, not merged) proposed a no-seq emit-outside-lock design for the producer-gauge event. That design was superseded by the seq-based ordering that landed instead in PR #233 (`Gauges.seq`, max-seq current-value rule). But two review lessons produced while writing PR #232 are independent of the superseded design and worth keeping on their own.

## Changes

- `docs/rfcs/README.md` — new **"What an RFC pins"** section: an RFC fixes the *observable contract*, not the *mechanism*; the from-scratch-reimplementation test for telling the two apart; two corollaries (pin negative space; a property and its mechanism can carry different enforcement classes).
- `docs/rfcs/pre-review-checklist.md` (item 2) — a new adversary prompt: a coincidental property of the current mechanism that other components silently depend on because the RFC never named it as contract. The cited incident is not PR #232's own (unmerged, and its premise no longer holds) but the real one from the seq-ordering amendment that did land: an earlier off-lock attempt satisfied the stated value-fidelity invariant but broke `benches/runtime_load.rs`'s teardown barrier and RFC 0007 §5.2's current-value read, both of which relied on arrival order coinciding with lock-serialized dispatch — a coincidence the contract had never pinned.

## Verification

- `git diff --check` — clean
- `typos` — clean
- Manual cross-check: the README.md addition matches PR #232's version verbatim (content is mechanism-independent); the checklist item's example was rewritten to cite the actual, still-true incident instead of the superseded one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)