### PR TITLE
docs(rfcs): pin non-functional guarantees as observable thresholds

### DIFF
--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -18,7 +18,7 @@ mechanism — leave it to the code and its comments. If a from-scratch
 implementation could instead satisfy every stated word yet break something a
 dependent depends on, the missing property belongs in the RFC.
 
-Two corollaries:
+Three corollaries:
 
 - Pin a property's negative space too. When a guarantee holds only under
   conditions the current mechanism happens to cover — a value stays correct
@@ -31,6 +31,13 @@ Two corollaries:
   and structural where they are not (a concurrency-only guarantee reviewed at
   the seam that provides it); classify each part rather than the guarantee as
   a whole. See the [pre-review checklist](pre-review-checklist.md) items 2–3.
+- A non-functional guarantee is pinned as an observable threshold, never as
+  the mechanism that meets it. Latency, throughput, and memory footprint are
+  mechanism-sensitive by nature, so state the bound a dependent may rely on —
+  an acceptance criterion such as quit→delivered p99 ≤ 1 ms (RFC 0006 INV-L4)
+  — and leave the channel capacity, queue shape, or task layout that reaches
+  it to the code. The reimplementation test is unchanged: the number is the
+  contract; the structure that meets it is not.
 
 ## Process
 


### PR DESCRIPTION
## Summary

Reinforces #234. That PR established that an RFC fixes the *observable contract*, not the *mechanism*, and that the property a mechanism provides — not the structure — is what belongs in the RFC. But it leaves one class ambiguous: **non-functional guarantees** (latency, throughput, footprint) are mechanism-sensitive by nature, so "pin the property, not the mechanism" is under-specified for them — the guarantee has to be *translated* into an observable threshold before it can be pinned at all. Without naming that step, a reader could either try to pin the mechanism (a channel capacity, a queue shape) or leave the guarantee unpinned as "fast enough."

## Changes

- `docs/rfcs/README.md` — third corollary under **"What an RFC pins"**: a non-functional guarantee is pinned as an observable threshold, never as the mechanism that meets it. The RFC fixes the bound a dependent may rely on — an acceptance criterion such as quit→delivered p99 ≤ 1 ms (RFC 0006 INV-L4) — and leaves the channel capacity, queue shape, or task layout that reaches it to the code. The reimplementation test is unchanged: the number is the contract; the structure that meets it is not.

The addition is scoped to the doctrine gap only; it introduces no new checklist item and no change to existing prose beyond `Two corollaries:` → `Three corollaries:`.

## Verification

- `git diff --check` — clean
- `typos docs/rfcs/README.md` — clean
- Citation cross-checked: `INV-L4` in `docs/rfcs/0006-runtime-load-control.md:1293` is exactly "quit→delivered p99 ≤ 1 ms, ≥ 200 valid trials"
- No British spellings introduced (`dependent`, not `dependant`; avoided `-our`/`-ise` forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)