### PR TITLE
refactor(runtime): dispatch gauge events off the lock behind a re-entrancy funnel

### DIFF
--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -504,23 +504,23 @@ as INV-L13 (section 5):
   of this contract**, so a consumer that reads "the value on the most
   recently *arrived* event" is relying on an ordering the schema does not
   provide. Ordering by an explicit `seq` rather than by arrival is
-  deliberate: because the snapshot-and-`seq` capture is atomic while only
-  the emit need move, it lets a later change emit gauge events without
-  holding the runtime's gauge lock across the `tracing` dispatch, so a slow
-  subscriber can no longer stall producers on that lock and a subscriber
-  that re-enters the runtime can no longer deadlock on it — without
-  breaking any `seq`-ordered consumer. That move does **not**, on its own,
-  make a subscriber that itself *causes* a gauge change safe: such a
-  subscriber re-enters the emit path, risking unbounded recursion under a
-  global `tracing` dispatcher, or — under a scoped one — a nested event
-  silently dropped by `tracing`'s re-entrancy guard, which breaks value
-  fidelity. Resolving that re-entrancy is a prerequisite of any future
-  off-lock change and is out of scope for the `seq` field, which secures
-  only the ordering; it is recorded here so the off-lock change cannot read
-  the stall/deadlock sentence as a claim that re-entrancy is already safe.
-  The initial implementation still emits under that lock, so `seq` and
-  arrival order coincide there; consumers must not depend on the
-  coincidence.
+  deliberate: it lets the runtime dispatch a gauge event without holding
+  the gauge lock across the `tracing` dispatch — the snapshot-and-`seq`
+  capture stays atomic under the lock while only the dispatch moves off
+  it — so a slow subscriber no longer stalls producers on that lock and a
+  subscriber that re-enters the runtime no longer deadlocks on it, without
+  breaking any `seq`-ordered consumer. Off-lock dispatch is
+  re-entrancy-safe by construction: a subscriber that itself *causes* a
+  gauge change re-enters the emit path, and dispatched inline that would
+  recurse without bound under a global `tracing` dispatcher, or have its
+  nested event silently dropped by a scoped dispatcher's re-entrancy guard
+  (breaking value fidelity); the runtime instead delivers a nested change
+  as its own `seq`-carrying event, never nested inside a `tracing`
+  dispatch, so value fidelity and `seq` ordering both hold across
+  re-entrancy. How that delivery is arranged is an implementation concern,
+  not part of this schema. Because dispatch is off the lock, `seq` and
+  arrival order do not coincide under concurrency — consumers must order
+  gauge events by `seq`, never by arrival.
 
 Definition of done for the observability slice: layered tests, each
 installing a `tracing` subscriber (the technique the `quit_*` harness

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -518,9 +518,10 @@ as INV-L13 (section 5):
   as its own `seq`-carrying event, never nested inside a `tracing`
   dispatch, so value fidelity and `seq` ordering both hold across
   re-entrancy. How that delivery is arranged is an implementation concern,
-  not part of this schema. Because dispatch is off the lock, `seq` and
-  arrival order do not coincide under concurrency — consumers must order
-  gauge events by `seq`, never by arrival.
+  not part of this schema. Because dispatch is off the lock, the schema
+  does not guarantee arrival order matches `seq` order — a current-value
+  read must order gauge events by `seq`, never by arrival, even where an
+  implementation happens to deliver them in `seq` order.
 
 Definition of done for the observability slice: layered tests, each
 installing a `tracing` subscriber (the technique the `quit_*` harness

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -539,12 +539,11 @@ channel occupancy, per the note on that distinction below the table:
   greatest `seq`, discarding any event whose `seq` does not advance, so a
   reordered stale gauge event can corrupt neither a predicate reading nor
   the barrier. This dependency is stated explicitly because it is
-  otherwise invisible: a consumer that instead trusted arrival order would
-  read correctly today — the initial implementation emits gauge events
-  under the runtime's gauge lock, so arrival and `seq` order coincide — yet
-  would silently break the moment that emit moved out from under the lock
-  (RFC 0006 §4.4's stated reason for the `seq` field), a change this
-  section must not be allowed to obstruct unknowingly.
+  otherwise easy to miss: gauge events are dispatched off the runtime's
+  gauge lock (RFC 0006 §4.4), so under concurrent producers their arrival
+  order does not coincide with `seq` order, and a consumer that trusted
+  arrival order could read a stale gauge value. Reading by greatest `seq`
+  is what keeps this section correct regardless of dispatch order.
 - Counting only valid trials means an implementation may need more
   attempts than the row's required count whenever some attempts fail their
   predicate. To make the retry rule precise — which attempts are retried,

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -540,10 +540,11 @@ channel occupancy, per the note on that distinction below the table:
   reordered stale gauge event can corrupt neither a predicate reading nor
   the barrier. This dependency is stated explicitly because it is
   otherwise easy to miss: gauge events are dispatched off the runtime's
-  gauge lock (RFC 0006 §4.4), so under concurrent producers their arrival
-  order does not coincide with `seq` order, and a consumer that trusted
-  arrival order could read a stale gauge value. Reading by greatest `seq`
-  is what keeps this section correct regardless of dispatch order.
+  gauge lock (RFC 0006 §4.4), so the schema does not guarantee their
+  arrival order matches `seq` order, and a consumer that trusted arrival
+  order could read a stale gauge value even if the current implementation
+  happens to deliver them in `seq` order. Reading by greatest `seq` is what
+  keeps this section correct regardless of dispatch order.
 - Counting only valid trials means an implementation may need more
   attempts than the row's required count whenever some attempts fail their
   predicate. To make the retry rule precise — which attempts are retried,

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -24,12 +24,12 @@
 //!   Dispatch happens off the lock, so the contract does not promise arrival
 //!   order matches `seq` order — consumers must order by `seq`. The single-
 //!   drainer funnel below does in fact serialize dispatch in `seq` order today,
-//!   but that is an implementation coincidence, not a guarantee (as the old
-//!   under-lock dispatch was), so no consumer may rely on it. Keeping the
-//!   snapshot-and-`seq` capture under the lock while moving only the dispatch off
-//!   it is what lets a slow subscriber no longer stall producers on the lock, and
-//!   one that re-enters the runtime no longer deadlock on it, without breaking
-//!   any `seq`-ordered consumer.
+//!   but that is an implementation coincidence, not a guarantee — just as it was
+//!   under the old under-lock dispatch — so no consumer may rely on it. Keeping
+//!   the snapshot-and-`seq` capture under the lock while moving only the dispatch
+//!   off it is what lets a slow subscriber no longer stall producers on the lock,
+//!   and one that re-enters the runtime no longer deadlock on it, without
+//!   breaking any `seq`-ordered consumer.
 //!
 //! Moving dispatch off the lock is only safe alongside a re-entrancy funnel. A
 //! subscriber can, while handling a gauge event, cause another gauge change

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -21,12 +21,15 @@
 //!   guarantee is about the snapshot, not about arrival order.
 //! - **Ordering** is carried by `seq`, not by arrival: the current value of each
 //!   gauge is the value on the greatest-`seq` event (RFC 0006 §4.4, INV-L13).
-//!   Dispatch happens off the lock, so under concurrency arrival order no longer
-//!   matches `seq` order — the contract never promised it did, and consumers
-//!   must order by `seq`. Keeping the snapshot-and-`seq` capture under the lock
-//!   while moving only the dispatch off it is what lets a slow subscriber no
-//!   longer stall producers on the lock, and one that re-enters the runtime no
-//!   longer deadlock on it, without breaking any `seq`-ordered consumer.
+//!   Dispatch happens off the lock, so the contract does not promise arrival
+//!   order matches `seq` order — consumers must order by `seq`. The single-
+//!   drainer funnel below does in fact serialize dispatch in `seq` order today,
+//!   but that is an implementation coincidence, not a guarantee (as the old
+//!   under-lock dispatch was), so no consumer may rely on it. Keeping the
+//!   snapshot-and-`seq` capture under the lock while moving only the dispatch off
+//!   it is what lets a slow subscriber no longer stall producers on the lock, and
+//!   one that re-enters the runtime no longer deadlock on it, without breaking
+//!   any `seq`-ordered consumer.
 //!
 //! Moving dispatch off the lock is only safe alongside a re-entrancy funnel. A
 //! subscriber can, while handling a gauge event, cause another gauge change
@@ -41,6 +44,13 @@
 //! Delivery is therefore iterative and never nested inside a `tracing` dispatch,
 //! so neither hazard can arise (`LoadObserver::emit`, RFC 0006 §4.4).
 //!
+//! One consequence of the funnel: a snapshot is dispatched by whichever thread
+//! is draining, which need not be the thread whose change produced it, so the
+//! event fires under that drainer's thread and current span context. A global
+//! subscriber sees only a schema-preserving change of span/thread attribution
+//! (INV-L13 is unaffected); a thread-scoped dispatcher can see another thread's
+//! gauge change delivered to it, or its own delivered on a different thread.
+//!
 //! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
 //! already `pub(crate)`, so effective reachability is capped at the crate
 //! (see `channel`/`frame_rate`), while `pub` avoids the redundant-`pub(crate)`
@@ -48,7 +58,6 @@
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
-use std::thread;
 use std::time::Duration;
 
 /// The runtime channel a bounded send blocked on — the capacity-wait event's
@@ -297,11 +306,17 @@ impl LoadObserver {
             snapshot
         };
 
-        // Release the drainer role even if a subscriber panics mid-dispatch, so
-        // a panic cannot wedge the funnel shut and silence every later gauge
-        // event (the off-lock analogue of the poisoned-lock recovery in
-        // `lock`).
-        let _release = DrainGuard { observer: self };
+        // Release the drainer role if a subscriber panics mid-dispatch, so a
+        // panic cannot wedge the funnel shut and silence every later gauge event
+        // (the off-lock analogue of the poisoned-lock recovery in `lock`). The
+        // guard stays armed until the loop relinquishes the role normally, so a
+        // still-armed drop means and only means an unwinding `dispatch` — unlike
+        // `thread::panicking()`, this stays correct when `emit` itself runs
+        // during an unrelated unwind (`GaugeGuard::drop`).
+        let mut release = DrainGuard {
+            observer: self,
+            armed: true,
+        };
         let mut next = first;
         loop {
             next.dispatch();
@@ -315,10 +330,11 @@ impl LoadObserver {
                 }
                 snapshot
             };
-            match popped {
-                Some(snapshot) => next = snapshot,
-                None => return,
-            }
+            let Some(snapshot) = popped else {
+                release.armed = false;
+                return;
+            };
+            next = snapshot;
         }
     }
 
@@ -351,18 +367,21 @@ impl Drop for GaugeGuard {
 }
 
 /// Releases the gauge drainer role if a subscriber panics while
-/// `LoadObserver::emit` is dispatching. On a normal drain the loop clears
-/// `draining` under the lock and this guard's drop is a no-op; on an unwinding
-/// panic it clears `draining` (and abandons any queued snapshots) so later gauge
-/// changes can dispatch again instead of enqueuing forever behind a drainer that
-/// will never return.
+/// `LoadObserver::emit` is dispatching. The drain loop disarms this guard the
+/// instant it relinquishes the role normally, so a drop while still armed means
+/// `dispatch` unwound: it clears `draining` (and abandons any queued snapshots)
+/// so later gauge changes can dispatch again instead of enqueuing forever behind
+/// a drainer that will never return. Arming rather than reading
+/// `thread::panicking()` is deliberate — `emit` also runs during unrelated
+/// unwinds (`GaugeGuard::drop`), where a normal drain must not trigger recovery.
 struct DrainGuard<'a> {
     observer: &'a LoadObserver,
+    armed: bool,
 }
 
 impl Drop for DrainGuard<'_> {
     fn drop(&mut self) {
-        if thread::panicking() {
+        if self.armed {
             let mut gauges = self.observer.lock();
             gauges.draining = false;
             gauges.pending.clear();
@@ -373,6 +392,7 @@ impl Drop for DrainGuard<'_> {
 #[cfg(test)]
 mod tests {
     use std::fmt::Debug;
+    use std::panic::{self, AssertUnwindSafe};
     use std::sync::atomic::{AtomicBool, Ordering};
 
     use tracing::field::{Field, Visit};
@@ -380,7 +400,7 @@ mod tests {
     use tracing::{Event, Level, Metadata, Subscriber};
 
     use super::*;
-    use crate::test_support::{TraceRecorder, set_default_subscriber};
+    use crate::test_support::{TraceRecorder, set_default_subscriber, with_silent_panic_hook};
 
     // INV-L13: every producer-gauge event carries the full field set together —
     // the four gauges plus their ordering `seq` — so a subscriber reads a
@@ -626,5 +646,95 @@ mod tests {
         }
 
         fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+    }
+
+    // A subscriber that panics while dispatching the first gauge event leaves the
+    // drainer loop unwinding before it can relinquish the role. The `DrainGuard`,
+    // still armed, must clear `draining` so the funnel is not wedged shut — every
+    // later gauge change would otherwise enqueue behind a drainer that never
+    // returns and never dispatch. This pins the recovery path that the arm/disarm
+    // `DrainGuard` (rather than `thread::panicking()`) exists to make correct.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_subscriber_panic_mid_dispatch_does_not_wedge_the_funnel() {
+        let observer = LoadObserver::default();
+        let seen_after = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = PanicOnceGaugeSubscriber {
+            panicked: Arc::new(AtomicBool::new(false)),
+            seen_after: Arc::clone(&seen_after),
+        };
+        let _guard = set_default_subscriber(subscriber);
+
+        let seen_after = with_silent_panic_hook(async {
+            // First change: the subscriber panics mid-dispatch. Caught here so
+            // the panic does not fail the test; the recovery is what is under
+            // test.
+            let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
+                observer.set_keyed_entries(1);
+            }));
+            assert!(outcome.is_err(), "the subscriber panic must propagate");
+
+            // The funnel must have recovered: this change dispatches again
+            // instead of enqueuing forever behind the unwound drainer.
+            observer.set_keyed_entries(2);
+
+            seen_after
+                .lock()
+                .expect("panic-recovery seen log mutex should not be poisoned")
+                .clone()
+        })
+        .await;
+
+        assert_eq!(
+            seen_after,
+            vec![2],
+            "after a subscriber panics mid-dispatch, later gauge events must \
+             dispatch again rather than pile up behind a wedged drainer"
+        );
+    }
+
+    /// Panics the first time it sees a producer-gauge event — mid-dispatch,
+    /// inside the drainer loop — and records the `seq` of every one after.
+    struct PanicOnceGaugeSubscriber {
+        panicked: Arc<AtomicBool>,
+        seen_after: Arc<Mutex<Vec<u64>>>,
+    }
+
+    impl Subscriber for PanicOnceGaugeSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        #[allow(
+            clippy::panic,
+            clippy::manual_assert,
+            reason = "the subscriber intentionally panics on its first event"
+        )]
+        fn event(&self, event: &Event<'_>) {
+            if event.metadata().target() != "tears::runtime::load" {
+                return;
+            }
+            let mut visitor = GaugeVisitor::default();
+            event.record(&mut visitor);
+            let Some(seq) = visitor.seq else { return };
+            if !self.panicked.swap(true, Ordering::SeqCst) {
+                panic!("subscriber panic mid-dispatch");
+            }
+            self.seen_after
+                .lock()
+                .expect("panic-recovery seen log mutex should not be poisoned")
+                .push(seq);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
     }
 }

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -9,35 +9,46 @@
 //! contract change.
 //!
 //! The gauge counters live behind one mutex. Each change updates a field, bumps
-//! a monotone `seq`, and snapshots everything under the same lock. Two separate
-//! guarantees ride on that lock, and only one of them constrains the order
-//! events *arrive* in:
+//! a monotone `seq`, and snapshots the field set together under that lock, then
+//! releases the lock before dispatching the snapshot to `tracing`. Two separate
+//! guarantees ride on the lock, and only one of them constrains the order events
+//! *arrive* in:
 //!
 //! - **Value fidelity** (every reached value gets its own event): capturing the
 //!   update and the snapshot together under the lock prevents a value from being
-//!   reached and superseded before its own emit re-reads the counters — a lone
-//!   atomic would let a subscriber's high-water mark miss a peak. This guarantee
-//!   is about the snapshot, not about arrival order.
+//!   reached and superseded before its own snapshot re-reads the counters — a
+//!   lone atomic would let a subscriber's high-water mark miss a peak. This
+//!   guarantee is about the snapshot, not about arrival order.
 //! - **Ordering** is carried by `seq`, not by arrival: the current value of each
 //!   gauge is the value on the greatest-`seq` event (RFC 0006 §4.4, INV-L13).
-//!   The lock currently also serializes the `tracing` dispatch, so today arrival
-//!   order happens to match `seq` order — but the contract does not promise it,
-//!   and consumers must order by `seq`. That is deliberate: because the
-//!   snapshot-and-`seq` capture stays under the lock while only the dispatch
-//!   would move, a later change can emit the event out from under the lock — so
-//!   a slow subscriber no longer stalls producers on that lock, and one that
-//!   re-enters the runtime no longer deadlocks on it — without breaking any
-//!   `seq`-ordered consumer. Moving the dispatch off the lock does not by itself
-//!   make a subscriber that *causes* a gauge change safe (it re-enters the emit
-//!   path); that is a separate re-entrancy hazard, out of scope here and tracked
-//!   against RFC 0006 §4.4.
+//!   Dispatch happens off the lock, so under concurrency arrival order no longer
+//!   matches `seq` order — the contract never promised it did, and consumers
+//!   must order by `seq`. Keeping the snapshot-and-`seq` capture under the lock
+//!   while moving only the dispatch off it is what lets a slow subscriber no
+//!   longer stall producers on the lock, and one that re-enters the runtime no
+//!   longer deadlock on it, without breaking any `seq`-ordered consumer.
+//!
+//! Moving dispatch off the lock is only safe alongside a re-entrancy funnel. A
+//! subscriber can, while handling a gauge event, cause another gauge change
+//! (e.g. by spawning a subscription) — re-entering the emit path on the same
+//! thread. Dispatched inline that would recurse without bound under a global
+//! `tracing` dispatcher, or have the nested event silently dropped by a scoped
+//! dispatcher's re-entrancy guard (breaking value fidelity). So dispatch is
+//! funneled through a single drainer: the first producer to find no drainer
+//! running claims the role and dispatches snapshots in a loop, while every other
+//! producer — concurrent or re-entrant — only enqueues its snapshot (in `seq`
+//! order) under the lock and returns, leaving the running drainer to deliver it.
+//! Delivery is therefore iterative and never nested inside a `tracing` dispatch,
+//! so neither hazard can arise (`LoadObserver::emit`, RFC 0006 §4.4).
 //!
 //! `pub` items rather than `pub(crate)`: the enclosing `runtime` module is
 //! already `pub(crate)`, so effective reachability is capped at the crate
 //! (see `channel`/`frame_rate`), while `pub` avoids the redundant-`pub(crate)`
 //! lint.
 
+use std::collections::VecDeque;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::thread;
 use std::time::Duration;
 
 /// The runtime channel a bounded send blocked on — the capacity-wait event's
@@ -97,13 +108,14 @@ pub struct LoadObserver {
     gauges: Arc<Mutex<Gauges>>,
 }
 
-// Deliberately not `Copy`/`Clone`: `emit` bumps `seq` through `&mut self`, so a
-// by-value copy (`let mut g = *guard; g.emit()`) would bump and emit a throwaway
+// Deliberately not `Copy`/`Clone`: `capture` bumps `seq` through `&mut self`, so
+// a by-value copy (`let mut g = *guard; g.capture()`) would bump a throwaway
 // while the shared `seq` stalled — the exact silently-dropped update this
-// ordering exists to prevent. Without the derives that pattern fails to compile.
+// ordering exists to prevent. The `pending` queue makes `Copy` impossible on its
+// own, but the rule is stated for `capture` regardless.
 #[derive(Default)]
 struct Gauges {
-    /// Monotone per-observer counter, bumped once per emitted gauge event and
+    /// Monotone per-observer counter, bumped once per captured gauge event and
     /// carried on it as `seq`. Captured under the same lock as the four counts,
     /// so a greater `seq` never carries an older value; a subscriber reads the
     /// current value of each gauge from the greatest-`seq` event, so arrival
@@ -113,18 +125,55 @@ struct Gauges {
     unkeyed_commands: usize,
     keyed_commands: usize,
     blocked: usize,
+    /// Snapshots captured but not yet dispatched, in `seq` order. Populated only
+    /// while a drainer is already running — a concurrent producer or a
+    /// re-entrant emit from within a subscriber; empty and unallocated on the
+    /// common path (`LoadObserver::emit`).
+    pending: VecDeque<GaugeSnapshot>,
+    /// Whether some thread is currently draining `pending` and dispatching
+    /// snapshots to `tracing` outside the lock. At most one drainer runs at a
+    /// time, so dispatch is serialized in `seq` order without the lock being
+    /// held across it (`LoadObserver::emit`).
+    draining: bool,
 }
 
 impl Gauges {
-    /// Bumps `seq` and emits the producer-gauge event — the four counts plus
-    /// their ordering `seq`. Takes `&mut self` so the bump lands in the shared
-    /// state; the caller holds the lock, fixing the counts and `seq` together
-    /// at the serialization point, so
-    /// the event reports the state that was reached (never a later re-read) and
-    /// its `seq` orders it against every other gauge event without relying on
-    /// arrival order.
-    fn emit(&mut self) {
+    /// Bumps `seq` and captures the four counts plus that `seq` as one snapshot.
+    /// Takes `&mut self` so the bump lands in the shared state; the caller holds
+    /// the lock, fixing the counts and `seq` together at the serialization
+    /// point, so the snapshot reports the state that was reached (never a later
+    /// re-read) and its `seq` orders it against every other gauge event without
+    /// relying on arrival order. Dispatch to `tracing` happens later, off the
+    /// lock (`GaugeSnapshot::dispatch`).
+    const fn capture(&mut self) -> GaugeSnapshot {
         self.seq = self.seq.wrapping_add(1);
+        GaugeSnapshot {
+            seq: self.seq,
+            subscriptions: self.subscriptions,
+            unkeyed_commands: self.unkeyed_commands,
+            keyed_commands: self.keyed_commands,
+            blocked: self.blocked,
+        }
+    }
+}
+
+/// One producer-gauge event's payload — the four counts and their ordering
+/// `seq` — captured under the lock and dispatched to `tracing` after the lock is
+/// released (RFC 0006 §4.4).
+#[derive(Clone, Copy)]
+struct GaugeSnapshot {
+    seq: u64,
+    subscriptions: usize,
+    unkeyed_commands: usize,
+    keyed_commands: usize,
+    blocked: usize,
+}
+
+impl GaugeSnapshot {
+    /// Emits the producer-gauge event for this snapshot. Called off the lock, so
+    /// a slow or re-entrant subscriber cannot stall or deadlock a producer on
+    /// the gauge lock.
+    fn dispatch(self) {
         tracing::debug!(
             target: "tears::runtime::load",
             seq = self.seq,
@@ -184,11 +233,13 @@ impl LoadObserver {
     /// via a guard) because an entry's lifetime is the runtime's, not a task's:
     /// a draining entry outlives its task.
     pub fn set_keyed_entries(&self, count: usize) {
-        let mut gauges = self.lock();
-        if gauges.keyed_commands != count {
+        self.emit(|gauges| {
+            if gauges.keyed_commands == count {
+                return false;
+            }
             gauges.keyed_commands = count;
-            gauges.emit();
-        }
+            true
+        });
     }
 
     fn enter(&self, field: Field) -> GaugeGuard {
@@ -199,14 +250,76 @@ impl LoadObserver {
         }
     }
 
-    /// Adds `delta` (`+1`/`-1`) to `field` and emits the resulting snapshot,
-    /// all under one lock so the update and its event cannot interleave with
-    /// another producer's (RFC 0006 §4.4 "event per change").
+    /// Adds `delta` (`+1`/`-1`) to `field` and dispatches the resulting
+    /// snapshot. The update and its `seq`/snapshot capture happen under one lock
+    /// so they cannot interleave with another producer's (RFC 0006 §4.4 "event
+    /// per change"); the dispatch itself runs off the lock (`emit`).
     fn step(&self, field: Field, delta: isize) {
-        let mut gauges = self.lock();
-        let counter = field.counter_mut(&mut gauges);
-        *counter = counter.wrapping_add_signed(delta);
-        gauges.emit();
+        self.emit(|gauges| {
+            let counter = field.counter_mut(gauges);
+            *counter = counter.wrapping_add_signed(delta);
+            true
+        });
+    }
+
+    /// Applies a gauge change and dispatches every resulting snapshot off the
+    /// lock.
+    ///
+    /// `mutate` runs under the lock and returns whether it changed a gauge; on
+    /// `false` nothing is emitted (e.g. `set_keyed_entries` with an unchanged
+    /// count). On `true` the new `seq`/snapshot is captured under the same lock,
+    /// then dispatched to `tracing` *after* the lock is released, so a slow
+    /// subscriber never stalls producers on the lock and one that re-enters the
+    /// runtime never deadlocks on it (RFC 0006 §4.4).
+    ///
+    /// Dispatch is funneled through a single drainer to stay safe under
+    /// re-entrancy. A subscriber can, while handling a gauge event, cause
+    /// another gauge change and re-enter here on the same thread; dispatched
+    /// inline that would recurse without bound under a global `tracing`
+    /// dispatcher, or have the nested event dropped by a scoped dispatcher's
+    /// re-entrancy guard. Instead, the first caller to find no drainer running
+    /// claims the role and dispatches in a loop, while every other caller —
+    /// concurrent or re-entrant — only enqueues its snapshot in `seq` order and
+    /// returns. Delivery is thus iterative and never nested inside a `tracing`
+    /// dispatch.
+    fn emit(&self, mutate: impl FnOnce(&mut Gauges) -> bool) {
+        let first = {
+            let mut gauges = self.lock();
+            if !mutate(&mut gauges) {
+                return;
+            }
+            let snapshot = gauges.capture();
+            if gauges.draining {
+                gauges.pending.push_back(snapshot);
+                return;
+            }
+            gauges.draining = true;
+            snapshot
+        };
+
+        // Release the drainer role even if a subscriber panics mid-dispatch, so
+        // a panic cannot wedge the funnel shut and silence every later gauge
+        // event (the off-lock analogue of the poisoned-lock recovery in
+        // `lock`).
+        let _release = DrainGuard { observer: self };
+        let mut next = first;
+        loop {
+            next.dispatch();
+            // Take the next snapshot, or relinquish the drainer role, under a
+            // brief lock — never held across `dispatch`.
+            let popped = {
+                let mut gauges = self.lock();
+                let snapshot = gauges.pending.pop_front();
+                if snapshot.is_none() {
+                    gauges.draining = false;
+                }
+                snapshot
+            };
+            match popped {
+                Some(snapshot) => next = snapshot,
+                None => return,
+            }
+        }
     }
 
     fn lock(&self) -> MutexGuard<'_, Gauges> {
@@ -237,12 +350,37 @@ impl Drop for GaugeGuard {
     }
 }
 
+/// Releases the gauge drainer role if a subscriber panics while
+/// `LoadObserver::emit` is dispatching. On a normal drain the loop clears
+/// `draining` under the lock and this guard's drop is a no-op; on an unwinding
+/// panic it clears `draining` (and abandons any queued snapshots) so later gauge
+/// changes can dispatch again instead of enqueuing forever behind a drainer that
+/// will never return.
+struct DrainGuard<'a> {
+    observer: &'a LoadObserver,
+}
+
+impl Drop for DrainGuard<'_> {
+    fn drop(&mut self) {
+        if thread::panicking() {
+            let mut gauges = self.observer.lock();
+            gauges.draining = false;
+            gauges.pending.clear();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use tracing::Level;
+    use std::fmt::Debug;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Level, Metadata, Subscriber};
 
     use super::*;
-    use crate::test_support::TraceRecorder;
+    use crate::test_support::{TraceRecorder, set_default_subscriber};
 
     // INV-L13: every producer-gauge event carries the full field set together —
     // the four gauges plus their ordering `seq` — so a subscriber reads a
@@ -386,5 +524,107 @@ mod tests {
             at_trace.u64_values("keyed_commands").is_empty(),
             "gauge event is not TRACE"
         );
+    }
+
+    // RFC 0006 §4.4 re-entrancy: a subscriber that causes a gauge change while
+    // handling a gauge event re-enters the emit path on the same thread. The
+    // dispatch funnel makes that safe — the nested change is enqueued and
+    // delivered iteratively by the running drainer. This is what the off-lock
+    // dispatch requires: under the old under-lock dispatch the re-entrant
+    // `set_keyed_entries` would deadlock re-locking the gauge mutex, and under a
+    // naive off-lock dispatch the nested event would be dropped by `tracing`'s
+    // re-entrancy guard (breaking value fidelity). Here the re-entrant event
+    // must be delivered as its own event, with a distinct `seq` and the value it
+    // reached.
+    #[test]
+    fn reentrant_gauge_change_from_a_subscriber_is_delivered_not_dropped() {
+        let observer = LoadObserver::default();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = ReentrantGaugeSubscriber {
+            observer: observer.clone(),
+            reentered: Arc::new(AtomicBool::new(false)),
+            seen: Arc::clone(&seen),
+        };
+        let _guard = set_default_subscriber(subscriber);
+
+        // Emits seq 1 (subscriptions=1); the subscriber re-enters on that first
+        // event and emits seq 2 (keyed_commands=1). Held so it does not drop and
+        // emit a third event before the assertion reads `seen`.
+        let _subscription = observer.track_subscription();
+
+        let seen = seen
+            .lock()
+            .expect("reentrancy seen log mutex should not be poisoned")
+            .clone();
+        assert_eq!(
+            seen,
+            vec![(1, 0), (2, 1)],
+            "the re-entrant gauge change must be delivered as its own event with \
+             a distinct seq and its reached value, neither dropped nor deadlocked"
+        );
+    }
+
+    /// Records every producer-gauge event's `(seq, keyed_commands)` and, the
+    /// first time it sees one, causes exactly one more gauge change on the same
+    /// observer — re-entering `LoadObserver::emit` from inside `event()`.
+    struct ReentrantGaugeSubscriber {
+        observer: LoadObserver,
+        reentered: Arc<AtomicBool>,
+        seen: Arc<Mutex<Vec<(u64, u64)>>>,
+    }
+
+    impl Subscriber for ReentrantGaugeSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            if event.metadata().target() != "tears::runtime::load" {
+                return;
+            }
+            let mut visitor = GaugeVisitor::default();
+            event.record(&mut visitor);
+            let Some(seq) = visitor.seq else { return };
+            self.seen
+                .lock()
+                .expect("reentrancy seen log mutex should not be poisoned")
+                .push((seq, visitor.keyed_commands.unwrap_or_default()));
+
+            // Re-enter exactly once, from within the dispatch of the first gauge
+            // event, to exercise the funnel.
+            if !self.reentered.swap(true, Ordering::SeqCst) {
+                self.observer.set_keyed_entries(1);
+            }
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    #[derive(Default)]
+    struct GaugeVisitor {
+        seq: Option<u64>,
+        keyed_commands: Option<u64>,
+    }
+
+    impl Visit for GaugeVisitor {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            match field.name() {
+                "seq" => self.seq = Some(value),
+                "keyed_commands" => self.keyed_commands = Some(value),
+                _ => {}
+            }
+        }
+
+        fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
     }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -13,7 +13,7 @@ use crate::subscription::Subscription;
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
 pub use panic_hook::{PANIC_HOOK_GUARD, with_silent_panic_hook};
-pub use trace_recorder::TraceRecorder;
+pub use trace_recorder::{TraceRecorder, set_default_subscriber};
 
 mod async_utils;
 mod panic_hook;

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -80,13 +80,7 @@ impl TraceRecorder {
     /// Installs this recorder as the default subscriber for the current thread.
     #[must_use]
     pub fn set_default(&self) -> TraceRecorderGuard {
-        let _registry = REGISTRY_LOCK
-            .lock()
-            .expect("trace recorder registry mutex should not be poisoned");
-        ensure_interest_keeper();
-        let guard = set_default(self.clone());
-        rebuild_interest_cache();
-        TraceRecorderGuard { guard: Some(guard) }
+        set_default_subscriber(self.clone())
     }
 
     /// Returns the number of events that matched this recorder's filter.
@@ -142,6 +136,26 @@ impl TraceRecorder {
             .expect("trace recorder field-set log mutex should not be poisoned")
             .clone()
     }
+}
+
+/// Installs an arbitrary subscriber as the current thread's default,
+/// cache-safely — the same process-wide callsite-interest handling
+/// [`TraceRecorder::set_default`] uses. For tests that need a bespoke subscriber
+/// rather than a [`TraceRecorder`], e.g. one that re-enters the code under test
+/// from inside `event()`. Returns a guard that restores the previous default on
+/// drop.
+#[must_use]
+pub fn set_default_subscriber<S>(subscriber: S) -> TraceRecorderGuard
+where
+    S: Subscriber + Send + Sync + 'static,
+{
+    let _registry = REGISTRY_LOCK
+        .lock()
+        .expect("trace recorder registry mutex should not be poisoned");
+    ensure_interest_keeper();
+    let guard = set_default(subscriber);
+    rebuild_interest_cache();
+    TraceRecorderGuard { guard: Some(guard) }
 }
 
 fn ensure_interest_keeper() {


### PR DESCRIPTION
## Summary

Moves the producer-gauge `tracing` dispatch out from under the runtime's gauge mutex and makes that move re-entrancy-safe, completing what RFC 0006 §4.4 anticipated when it introduced the gauge-event `seq` ordering field.

Previously the gauge event was captured **and** dispatched while holding the gauge lock, so a slow subscriber stalled every producer on that lock and a subscriber that re-entered the runtime deadlocked on it. RFC 0006 §4.4 had flagged two re-entrancy hazards as prerequisites to moving the dispatch off the lock:

- **Unbounded recursion** under a global `tracing` dispatcher, when a subscriber that itself causes a gauge change re-enters the emit path.
- **Nested-event drop** under a scoped dispatcher's re-entrancy guard, which breaks value fidelity (a reached value gets no event).

## Approach

- Split the emit path into a **snapshot-under-lock** (`Gauges::capture`, which bumps `seq`) and an **off-lock** `GaugeSnapshot::dispatch`. The `seq`/snapshot capture stays atomic under the lock; only the dispatch moves off it.
- Funnel all dispatch through a **single drainer**: the first producer to find no drainer running claims the role and dispatches in a loop, while every concurrent or re-entrant producer only enqueues its snapshot in `seq` order and returns. Delivery is thus iterative and never nested inside a `tracing` dispatch, so neither hazard can arise.
- A `DrainGuard` releases the drainer role if a subscriber panics mid-dispatch, so a panic cannot wedge the funnel shut — the off-lock analogue of the existing poisoned-lock recovery in `lock`.

## Contract & docs

The observable schema is unchanged: every gauge change is still delivered as its own `seq`-ordered event, and consumers still order by `seq`, never by arrival. The `[Unreleased]` CHANGELOG entry already states that, so **no CHANGELOG change** is needed.

The now-stale prose in RFC 0006 §4.4 and RFC 0007 §5.2 — which described gauge emission as happening under the lock, with arrival order coinciding with `seq` — is updated to present tense, keeping the delivery mechanism as an implementation concern and stating only the observable guarantee. Per the pre-review checklist's coincidental-property item, the two consumers that read gauges by greatest `seq` (`benches/runtime_load.rs` teardown barrier, RFC 0007 §5.2 predicates) were confirmed already migrated off arrival order.

## Tests

- New gauge-layer test: a subscriber causes a gauge change while handling one; the re-entrant event must be delivered with a distinct `seq` and its reached value — which the old under-lock dispatch would deadlock on and a naive off-lock dispatch would drop.
- `set_default_subscriber` added to the crate test support so a bespoke subscriber installs cache-safely (the same callsite-interest handling `TraceRecorder::set_default` uses).

## Verification

`cargo fmt --check`, `cargo clippy --all-targets --features bench-internals` (0 warnings), full `cargo test` (0 failed), `cargo doc` (public + CI mode), `git diff --check`, and `typos` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)