### PR TITLE
docs(rfcs): add RFC 0008 TestStore draft

### DIFF
--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -211,7 +211,10 @@ generic) are implementation latitude.
 - **`send`** is one synchronous `update` call plus bookkeeping. It
   spawns no task, requires no executor, and returns only after the
   command's metadata (directives, cancellation) has been applied to the
-  store. It does not poll effects; polling happens in `receive*` calls.
+  store. Its polling is limited to §4.1's checks — the exhaustiveness
+  precondition before `update` and, when the returned command is keyed,
+  the intake reconciliation poll (§5.1); it never delivers output,
+  which happens only in `receive*` calls.
 - **`receive` / `receive_matching`** select the next deliverable output
   under the canonical order (§4.2), assert it, and apply it through
   `update` — so the store advances exactly as the runtime would on that
@@ -283,11 +286,17 @@ keeping them apart. INV-T3 names this revised boundary.
 
 **Deliverability and the poll budget.** A leaf's output is
 **deliverable** at a given check when the leaf yields it on that
-check's poll. The poll contract is fixed, because INV-T4's determinism
-rests on it: polling happens only inside `receive*`,
-`send`-precondition, `finish`, and drop checks — except after an
-observed quit, when the `finish` and drop checks poll nothing (§5.3,
-§6) — and each check polls each leaf its scan reaches (§4.2) exactly
+check's poll, or when a keyed-intake reconciliation poll (§5.1) has
+already yielded it into the leaf's buffer — a buffered item is
+deliverable at every later check without a further poll. The poll
+contract is fixed, because INV-T4's determinism rests on it: polling
+happens only inside `receive*`, `send`-precondition, `finish`, and
+drop checks, plus the keyed-intake reconciliation of §5.1. The
+quit-state check precedes every one of these sites, so after an
+observed quit no store call polls at all: `send`/`receive*` fail on
+the quit state before reaching any leaf, and the `finish` and drop
+checks pass without polling (§5.3, §6). Each check polls each leaf its
+scan reaches (§4.2) exactly
 once, with a waker whose wake-ups are not honored within the call. A
 self-waking leaf is therefore re-polled no earlier than the next store
 call and cannot loop a check — if it does not yield on its one poll, it
@@ -306,8 +315,9 @@ reaches it. Between calls the store does nothing.
   leaves in `Command::batch`'s flattened declaration order. Two runs of
   the same test program therefore observe the same delivery sequence
   (INV-T4, INV-T6).
-- **Scan semantics**: a `receive*` check polls the pending leaves in
-  enqueue order and stops at the first leaf that yields; the `send`
+- **Scan semantics**: a `receive*` check walks the pending leaves in
+  enqueue order and stops at the first deliverable one (a buffered
+  head, or a yield on that leaf's one poll); the `send`
   precondition and the pre-quit `finish`/drop checks scan in the same
   order until they find a deliverable output (failing) or exhaust the
   set (establishing that nothing is deliverable). Either way, each
@@ -348,16 +358,40 @@ until it becomes deliverable, and only `finish` holds it to account
 
 ### 5.1 Cancellation parity (RFC 0003)
 
-The store applies RFC 0003's delivery semantics to its pending set, with
-occupancy defined on the store's own lifecycle: **an id is occupied
-while its current run's stream has not been driven to completion.**
+The store applies RFC 0003's delivery semantics to its pending set.
+Occupancy follows RFC 0003's own accounting (INV-6, INV-7): **an id is
+occupied while its current run may still deliver output, and is
+released once every one of the run's leaves has been observed
+exhausted.** Exhaustion is observable only by polling, so the store
+mirrors the runtime's pre-spawn reconciliation (before any
+`Spawn(policy)` decision the runtime reaps completed keyed tasks and
+samples the target receiver once — RFC 0003 §4.2) with **keyed-intake
+reconciliation**: when a keyed command arrives for an occupied id, the
+store reconciles before the admission decision. If the occupant already
+has buffered output, the id is occupied and nothing is polled;
+otherwise the store polls the occupant's remaining leaves in enqueue
+order, stopping at the first that shows the run still open — a yield
+(the item is buffered at that leaf's canonical position as its next
+deliverable output; buffered output occupies, INV-6, and §6's
+exhaustiveness counts it like any deliverable message) or a pending
+(INV-7: "a still-open stream remains occupied even after delivering
+one item"). The id is released exactly when every remaining leaf
+completes — the analogue of INV-7's sender-closed empty receiver.
 
 - A keyed command under `CancelPolicy::CancelInFlight` supersedes the
   same-id occupant: the occupant's undelivered output — buffered
   messages and quit requests alike — can no longer be delivered
   (RFC 0003 INV-3, INV-6, INV-9), and the new stream takes the id.
-- Under `CancelPolicy::KeepInFlight`, while the id is occupied the new
-  command's stream is discarded and the occupant is untouched (INV-5).
+- Under `CancelPolicy::KeepInFlight`, the admission decision reads the
+  reconciled state: while the id remains occupied the new command's
+  stream is discarded and the occupant is untouched (INV-5); when
+  reconciliation observes the occupant exhausted, the id is released
+  and the new command is admitted (INV-7). For
+  `CancelPolicy::CancelInFlight` the reconciled state changes no
+  admission outcome — superseding an exhausted occupant and spawning
+  into a released id are indistinguishable — so the reconciliation rule
+  is stated once for all keyed intake; its polls follow §4.1's budget
+  either way.
 - `Command::cancel(id)` drops the occupant's stream and undelivered
   output, and is idempotent (INV-4).
 - Unkeyed commands are unaffected by any of the above (INV-1's default
@@ -368,22 +402,24 @@ while its current run's stream has not been driven to completion.**
   INV-11).
 
 These are the deterministic core of RFC 0003 — what may still be
-delivered — restated over the store's pending set. The runtime-side
-mechanics that exist only because the runtime is concurrent (task
-reaping, stale-exit tokens, INV-7/8/13) have no TestStore counterpart
-and are deliberately not modeled.
+delivered, and when an id releases — restated over the store's pending
+set, with keyed-intake reconciliation as the store's analogue of the
+runtime's pre-spawn reap-and-sample. The mechanics that exist only
+because the runtime is concurrent (stale-exit tokens, INV-8; bounded
+bookkeeping, INV-13) have no TestStore counterpart and are deliberately
+not modeled.
 
-Negative space, matching §4.2's: occupancy *timing* is the store's
-linearization, not the runtime's. A leaf that has yielded its last item
-but has not yet been driven to completion is occupied here, while the
-runtime's occupancy for the same command ends at task reap — so a
-`KeepInFlight` command landing in that window is deterministically
-discarded by the store while in the runtime the outcome depends on reap
-timing. Like §4.2's cross-leaf order, a test exercising that window
-asserts the store's linearization and is not evidence of runtime
-behavior. The stream-lifetime definition itself stays: it is the choice
-closest to the runtime's deliverable-output accounting (a
-finished-but-buffered run is still cancellable, RFC 0003 INV-6).
+The residual negative space is the reconciliation instrument itself:
+the store's proof of exhaustion is §4.1's single poll per leaf at
+intake. A leaf that needs further polls to complete (a self-waking
+future mid-completion) reads as still open and keeps the id occupied —
+deterministically — while at the runtime's decision point the same
+run's task may or may not have exited yet, a scheduling fact the
+runtime's reconciliation resolves whichever way it finds. In that
+window the store deterministically selects one of the runtime's legal
+outcomes; a test pinning a `KeepInFlight` discard there asserts the
+store's selection, not a runtime guarantee (§4.2's citation rule
+applies).
 
 ### 5.2 Redraw directive (RFC 0002)
 
@@ -520,12 +556,17 @@ Enforcement classes follow the pre-review checklist's definitions
   declaration order; a leaf made ready late delivers after an
   earlier-enqueued ready leaf but before a later one. The negative-space
   half is documentation, checked in review of the rustdoc (structural).
-- **INV-T7**: cancellation parity — the four behaviors of §5.1
-  (supersede, keep-in-flight discard, explicit cancel, unkeyed
-  unaffected) hold over the store's pending output as RFC 0003's INV-3,
-  INV-4, INV-5, INV-6, and INV-9 state them for deliverable output.
-  Behavioral: one test per behavior, including quit suppression
-  (a superseded keyed quit is never observable via `receive_quit`).
+- **INV-T7**: cancellation parity — the five behaviors of §5.1
+  (supersede, keep-in-flight discard, reconciliation release, explicit
+  cancel, unkeyed unaffected) hold over the store's pending output as
+  RFC 0003's INV-3, INV-4, INV-5, INV-6, INV-7, and INV-9 state them
+  for deliverable output. Behavioral: one test per behavior, including
+  quit suppression (a superseded keyed quit is never observable via
+  `receive_quit`) and the two reconciliation edges: a `KeepInFlight`
+  command arriving after the occupant's leaves are exhausted is
+  admitted, and one arriving while the reconciliation poll yields a
+  buffered item is discarded with that item still deliverable at its
+  canonical position.
 - **INV-T8**: exhaustiveness — each leak class in §6 fails at its named
   call site, with a diagnostic naming the leaked values for the
   message classes and the count and enqueue position for the
@@ -537,11 +578,14 @@ Enforcement classes follow the pre-review checklist's definitions
   wrong-value adversary is exactly what the message-content assertion
   exists to fail.
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
-  `send`/`receive*` fail, and the `finish` and drop checks poll
-  nothing and pass regardless of remaining output. Behavioral: a test
-  quits with output still pending — including a reactor-dependent leaf,
-  which the post-quit no-poll rule leaves untouched and which would
-  fail the run if polled (§4.3) — and asserts both halves.
+  `send`/`receive*` fail on the quit state without polling any leaf,
+  and the `finish` and drop checks poll nothing and pass regardless of
+  remaining output. Behavioral: a test quits with output still
+  pending — including a reactor-dependent leaf, which the post-quit
+  no-poll rule leaves untouched and which would fail the run if any
+  post-quit call polled it (§4.3) — and asserts the failing `send` and
+  `receive*` (whose failure is the quit-state diagnostic, not the
+  reactor panic polling would produce) and the passing `finish`.
 
 Surface–invariant coverage: `new`/`send`/`receive*`/`finish` map to
 INV-T2/T3/T4/T8; `state` is the pure accessor through which INV-T4's
@@ -573,8 +617,9 @@ change maps to INV-T1.
 
 - RFC 0002 — redraw suppression: the directive `redraw_requested`
   observes.
-- RFC 0003 — command cancellation: INV-1, INV-3, INV-4, INV-5, INV-6,
-  INV-9, INV-10, INV-11, INV-14 (cited in §§4.2, 5.1, 5.3).
+- RFC 0003 — command cancellation: its §4.2 pre-spawn reconciliation
+  and INV-1, INV-3, INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11,
+  INV-14 (cited in §§4.1, 4.2, 5.1, 5.3 of this document).
 - RFC 0005 — structural lifecycle identity: `SubscriptionId`, the
   declared-set semantics `subscription_ids` observes.
 - RFC 0006 — runtime load control: the shutdown discard carve-out §5.3

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -5,7 +5,8 @@
   `Application` API (stage 1: pure `update` + immediately ready effects)
 - Scope: the `Message` trait-bound decision, the exhaustive-assertion
   decision, the `TestStore` public surface, its delivery-order and
-  cancellation-parity contracts, and the staging split with Clock DI
+  cancellation-parity contracts, the per-leaf `RuntimeCommandParts`
+  prerequisite (§4.1), and the staging split with Clock DI
 - Feature flag: none (precedent: `subscription::mock` ships
   unconditionally)
 - CHANGELOG: `Added` entry lands at the implementation release, not with
@@ -43,7 +44,9 @@ Three decisions, ordered by urgency:
 The harness itself: `tears::testing::TestStore<App>` wraps an
 `Application`, applies messages synchronously through `update`, consumes
 the returned `Command` through the same decomposition boundary the
-runtime uses, and lets the test assert state, delivered messages, quit,
+runtime uses (§4.1 records the named prerequisite refactor that makes
+that boundary carry per-leaf streams), and lets the test assert state,
+delivered messages, quit,
 declared subscription identity, and the redraw directive — with RFC 0003
 cancellation semantics honored on the pending output (§5).
 
@@ -102,9 +105,11 @@ cancellation semantics honored on the pending output (§5).
   change with a migration path, and cannot present it as implied by
   TestStore.
 - TestStore's bounds, in full:
-  - `App::Message: Debug` on the store itself. Every exhaustiveness and
-    mismatch failure names the offending messages; a diagnostic that
-    cannot print what leaked is not worth the harness.
+  - `App::Message: Debug` on the store itself. Exhaustiveness and
+    mismatch failures name the offending messages wherever a value
+    exists to name (§6's unfinished-leaf class has none and reports
+    count and enqueue position instead); a diagnostic that cannot print
+    what leaked is not worth the harness.
   - `App::Message: PartialEq` on the equality-asserting methods only
     (`receive`, and any future `receive_*` that compares values).
   - `Clone` nowhere. A delivered message is asserted once and then moved
@@ -179,7 +184,8 @@ where
     pub fn receive_quit(&mut self);
 
     /// Whether the command returned by the most recent `send`/`receive`
-    /// step requested a redraw (RFC 0002).
+    /// step requested a redraw (RFC 0002). `receive_quit` is not a
+    /// step (§5.2).
     pub fn redraw_requested(&self) -> bool;
 
     /// The `SubscriptionId`s the application currently declares. Pure
@@ -246,20 +252,49 @@ generic) are implementation latitude.
 
 ## 4. Determinism and delivery contract
 
-### 4.1 Deliverable output
+### 4.1 Command intake, deliverability, and the poll budget
 
 TestStore holds the effects of every command it has accepted (init
-command, then each step's command) as a pending set of leaf streams,
-consumed through `Command`'s runtime decomposition boundary — the same
-`into_runtime_parts` lowering the runtime uses — so what the store
-observes (directives, cancellation metadata, effect stream) is what the
-runtime observes (INV-T3). A leaf's output is **deliverable** when the
-leaf yields it under polling with no executor, no timer, and no external
-wake — either immediately, or because a test-controlled source (a
-oneshot the test completed, a `MockSource`-style seam) has made it ready
-since the last call. Polling happens only inside `receive*`,
-`send`-precondition, and `finish` checks; between calls the store does
-nothing.
+command, then each step's command) as a pending set of leaf streams in
+enqueue order, consumed through `Command`'s runtime decomposition
+boundary (`into_runtime_parts`) so that what the store observes —
+directives, cancellation metadata, effects — is what the runtime
+observes (INV-T3).
+
+**Named prerequisite — per-leaf parts.** Today that boundary folds a
+multi-leaf effect into one stream before the parts exist:
+`into_runtime_parts` calls `Effect::into_stream()`, which merges the
+leaves through an unordered select (`src/command/core.rs`,
+`src/command/effect.rs`). A store built on the current parts type
+therefore could not implement §4.2's per-leaf canonical order without
+re-deriving the leaves in parallel — exactly what INV-T3 forbids — and
+relying on the merged stream happening to yield in declaration order
+would rest on a coincidental property of the select combinator, not on
+any contract. Stage-1 implementation is therefore gated on a
+prerequisite refactor, owned by this RFC's implementation task:
+`RuntimeCommandParts` carries the effect's leaves unfolded, in
+`Command::batch`'s flattened declaration order, and each consumer folds
+or drives them at its own consumption site — the runtime merging them
+at its spawn site exactly as `into_stream()` merges them today (a
+behavior-preserving relocation of the existing fold; `Effect` already
+keeps its leaves apart to preserve leaf identity for future per-leaf
+consumers, per its own comment in `src/command/effect.rs`), the store
+keeping them apart. INV-T3 names this revised boundary.
+
+**Deliverability and the poll budget.** A leaf's output is
+**deliverable** at a given check when the leaf yields it on that
+check's poll. The poll contract is fixed, because INV-T4's determinism
+rests on it: polling happens only inside `receive*`,
+`send`-precondition, `finish`, and drop checks — except after an
+observed quit, when the `finish` and drop checks poll nothing (§5.3,
+§6) — and each check polls each leaf its scan reaches (§4.2) exactly
+once, with a waker whose wake-ups are not honored within the call. A
+self-waking leaf is therefore re-polled no earlier than the next store
+call and cannot loop a check — if it does not yield on its one poll, it
+is not deliverable at that check; a leaf made ready between calls by a
+test-controlled source (a oneshot the test completed, a
+`MockSource`-style seam) is observed at the next check whose scan
+reaches it. Between calls the store does nothing.
 
 ### 4.2 Ordering
 
@@ -271,6 +306,12 @@ nothing.
   leaves in `Command::batch`'s flattened declaration order. Two runs of
   the same test program therefore observe the same delivery sequence
   (INV-T4, INV-T6).
+- **Scan semantics**: a `receive*` check polls the pending leaves in
+  enqueue order and stops at the first leaf that yields; the `send`
+  precondition and the pre-quit `finish`/drop checks scan in the same
+  order until they find a deliverable output (failing) or exhaust the
+  set (establishing that nothing is deliverable). Either way, each
+  reached leaf gets exactly one poll (§4.1).
 - **Negative space, stated deliberately**: the canonical cross-leaf
   order is *TestStore's* contract, not the runtime's. The runtime folds
   a command's leaves through an unordered select and pins no cross-leaf
@@ -289,10 +330,16 @@ A leaf that requires a timer or reactor (`Command::timeout` wraps every
 leaf in a deadline; a backoff retry sleeps; `Timer` is
 `tokio::time::interval`-backed) cannot be driven without an executor.
 Stage 1's contract is honest about this rather than silently lenient:
-polling such a leaf fails the test. The failure today surfaces as the
-underlying missing-reactor panic, which is a poor diagnostic; the
-documentation on `TestStore` names the limitation and points at the
-stage-2 plan (§7). A leaf that is merely *pending* on a test-controlled
+polling such a leaf fails the test. Note what that means under §4.2's
+scan semantics: the failure fires at the *first store call whose scan
+polls the leaf* — a `send`'s exhaustiveness precondition or a
+`receive` aimed at a different message, not only a call targeting the
+leaf itself — so from its enqueue onward the store is effectively
+poisoned, unless every scan stops at an earlier-enqueued yielding leaf
+first or cancellation removes the leaf (§5.1) before a scan reaches
+it. The failure today surfaces as the underlying missing-reactor
+panic, which is a poor diagnostic; the documentation on `TestStore`
+names the limitation and points at the stage-2 plan (§7). A leaf that is merely *pending* on a test-controlled
 source does not fail anything: it is skipped by the canonical order
 until it becomes deliverable, and only `finish` holds it to account
 (§6).
@@ -326,12 +373,26 @@ mechanics that exist only because the runtime is concurrent (task
 reaping, stale-exit tokens, INV-7/8/13) have no TestStore counterpart
 and are deliberately not modeled.
 
+Negative space, matching §4.2's: occupancy *timing* is the store's
+linearization, not the runtime's. A leaf that has yielded its last item
+but has not yet been driven to completion is occupied here, while the
+runtime's occupancy for the same command ends at task reap — so a
+`KeepInFlight` command landing in that window is deterministically
+discarded by the store while in the runtime the outcome depends on reap
+timing. Like §4.2's cross-leaf order, a test exercising that window
+asserts the store's linearization and is not evidence of runtime
+behavior. The stream-lifetime definition itself stays: it is the choice
+closest to the runtime's deliverable-output accounting (a
+finished-but-buffered run is still cancellable, RFC 0003 INV-6).
+
 ### 5.2 Redraw directive (RFC 0002)
 
 `redraw_requested()` reports the folded redraw directive of the command
 returned by the most recent step (a `send`, or the `update` call inside
-a `receive*`). Before any step completes it reports the init command's
-directive. This makes `without_redraw` decisions assertable per
+a `receive` / `receive_matching`). Before any step completes it reports
+the init command's directive. `receive_quit` applies no message and is
+not a step: after it, `redraw_requested` keeps reporting the previous
+step's directive. This makes `without_redraw` decisions assertable per
 transition, which is the granularity RFC 0002 defines them at.
 
 ### 5.3 Quit
@@ -339,10 +400,10 @@ transition, which is the granularity RFC 0002 defines them at.
 Quit is a deliverable output like any message and is asserted explicitly
 via `receive_quit` (§3.2). After quit is observed the store mirrors the
 runtime's shutdown contract: remaining undelivered output is legally
-discarded — `finish` passes regardless of what remains (the analogue of
-the shutdown discard carve-out in RFC 0006's INV-L2), and further
-`send`/`receive*` calls fail because the application would no longer be
-running. A quit that is *suppressed* by cancellation (§5.1) is not
+discarded — the `finish` and drop checks poll nothing and pass
+regardless of what remains (the analogue of the shutdown discard
+carve-out in RFC 0006's INV-L2), and further `send`/`receive*` calls
+fail because the application would no longer be running. A quit that is *suppressed* by cancellation (§5.1) is not
 "observed" and triggers none of this — exactly RFC 0003 INV-9.
 
 ## 6. Exhaustiveness
@@ -362,8 +423,10 @@ Exhaustive assertion is the only stage-1 mode. The rules, by call site:
   observed and either (a) a deliverable message or quit request remains,
   or (b) any pending leaf has not been driven to completion — an
   in-flight effect the test never accounted for is a leak even if it
-  never produced a message. After an observed quit, `finish` passes
-  unconditionally (§5.3).
+  never produced a message. After an observed quit, `finish` and the
+  drop check poll nothing and pass unconditionally (§5.3) — a
+  reactor-dependent leaf legally discarded at quit cannot fail them,
+  because §4.3's failure requires a poll.
 - Every exhaustiveness failure names the leaked messages via `Debug`;
   unfinished leaves that have produced no value are reported by count
   and enqueue position (there is no value to print).
@@ -423,17 +486,30 @@ Enforcement classes follow the pre-review checklist's definitions
   but neither `PartialEq` nor `Clone`. Structural: review of every
   public TestStore signature for stray bounds.
 - **INV-T3**: TestStore consumes each command through the same
-  decomposition boundary the runtime consumes
-  (`Command::into_runtime_parts`), never a parallel re-derivation of
-  directives, cancellation, or effects. Structural: review of the
-  store's single command-intake site. This is what makes TestStore
+  decomposition boundary the runtime consumes — after the §4.1
+  prerequisite refactor, a `RuntimeCommandParts` that carries the
+  effect's leaves unfolded in declaration order, folded or driven only
+  at each consumer's own site — never a parallel re-derivation of
+  directives, cancellation, or effects. Structural, in two parts:
+  review of the store's single command-intake site (it accepts the
+  parts type and touches no `Command` or `Effect` internals), and
+  review of the runtime's spawn site for the prerequisite's
+  behavior-preservation half (the relocated fold merges the leaves
+  exactly as `into_stream()` does today). This is what makes TestStore
   results evidence about real commands rather than about a test-only
   model.
-- **INV-T4**: `send` and `receive*` are synchronous — no task spawn, no
-  executor requirement — and two executions of one test program observe
+- **INV-T4**: the store introduces no nondeterminism of its own —
+  `send` and `receive*` are synchronous (no task spawn, no executor
+  requirement) and polling follows §4.1's fixed budget — so for an
+  application whose `update` is deterministic (the store cannot
+  contract this for the application; `subscriptions` alone carries a
+  purity contract), two executions of one test program observe
   identical state transitions and delivery sequences. Behavioral: a
-  repeated-run test asserts equal delivery transcripts across runs of a
-  multi-leaf, cancellation-exercising program.
+  repeated-run test over a deterministic application asserts equal
+  delivery transcripts across runs of a multi-leaf,
+  cancellation-exercising program, and a poll-counting leaf asserts
+  §4.1's one-poll-per-reached-leaf budget (a double-polling
+  implementation fails it).
 - **INV-T5**: one leaf's messages are delivered in stream order.
   Behavioral: a multi-message `Command::stream` test.
 - **INV-T6**: across leaves, delivery follows §4.2's canonical order
@@ -461,12 +537,16 @@ Enforcement classes follow the pre-review checklist's definitions
   wrong-value adversary is exactly what the message-content assertion
   exists to fail.
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
-  `send`/`receive*` fail and `finish` passes regardless of remaining
-  output. Behavioral: a test quits with output still pending and
-  asserts both halves.
+  `send`/`receive*` fail, and the `finish` and drop checks poll
+  nothing and pass regardless of remaining output. Behavioral: a test
+  quits with output still pending — including a reactor-dependent leaf,
+  which the post-quit no-poll rule leaves untouched and which would
+  fail the run if polled (§4.3) — and asserts both halves.
 
 Surface–invariant coverage: `new`/`send`/`receive*`/`finish` map to
-INV-T2/T3/T4/T8; delivery order to INV-T5/T6; cancellation metadata to
+INV-T2/T3/T4/T8; `state` is the pure accessor through which INV-T4's
+state-transition transcript is read, covered there; delivery order maps
+to INV-T5/T6; cancellation metadata to
 INV-T7; `receive_quit` and the quit state to INV-T9;
 `redraw_requested` and `subscription_ids` are pure observations of
 contracts owned elsewhere (RFC 0002's directive; RFC 0005's declared

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -1,0 +1,510 @@
+# RFC 0008: TestStore — deterministic update and effect testing
+
+- Status: Draft
+- Target: an additive, executor-free test harness for the current
+  `Application` API (stage 1: pure `update` + immediately ready effects)
+- Scope: the `Message` trait-bound decision, the exhaustive-assertion
+  decision, the `TestStore` public surface, its delivery-order and
+  cancellation-parity contracts, and the staging split with Clock DI
+- Feature flag: none (precedent: `subscription::mock` ships
+  unconditionally)
+- CHANGELOG: `Added` entry lands at the implementation release, not with
+  this RFC
+
+> **Staging.** This RFC specifies stage 1 only: driving pure `update`
+> transitions and effects that become ready without an executor, a timer,
+> or wall-clock time. Time-dependent effects (`Command::timeout`, retry
+> backoff, `Timer`-based subscriptions) are stage 2, which waits on a
+> separate Clock DI RFC (§7) and lands as a reviewed amendment to this
+> document.
+
+## Summary
+
+Three decisions, ordered by urgency:
+
+1. **`Message` boundary** (§2): `Application::Message`'s bounds stay
+   exactly `Send + 'static`. `TestStore` carries its own bounds instead —
+   `Debug` on the store, `PartialEq` scoped to the equality-asserting
+   methods only, and `Clone` nowhere. Retrofitting a bound onto
+   `Application::Message` later would be a silent breaking change for
+   every existing application, so the placement is pinned now, before any
+   TestStore code exists, and constrains future RFCs (INV-T1, INV-T2).
+2. **Exhaustive assertions** (§6): exhaustive is the only mode in
+   stage 1. Undelivered deliverable output — a ready message never
+   received, an effect stream never driven to completion — fails the
+   test. The one carve-out mirrors the runtime's shutdown contract:
+   output remaining after an observed quit is legally discarded. A
+   non-exhaustive mode is deliberately not designed here (open
+   question 2).
+3. **Clock DI split** (§7): Clock injection is a separate RFC. This RFC
+   does not gate on it, and stage 2 of TestStore gates on that RFC, not
+   the reverse.
+
+The harness itself: `tears::testing::TestStore<App>` wraps an
+`Application`, applies messages synchronously through `update`, consumes
+the returned `Command` through the same decomposition boundary the
+runtime uses, and lets the test assert state, delivered messages, quit,
+declared subscription identity, and the redraw directive — with RFC 0003
+cancellation semantics honored on the pending output (§5).
+
+## 1. Scope
+
+### 1.1 In scope (stage 1)
+
+- Constructing the store from `Application::new(flags)`, including the
+  init command's effects.
+- `send`: apply one message through `update`, synchronously, with no
+  executor and no task spawn.
+- `receive`: assert the next deliverable message (or quit) and apply it
+  through `update`, closing the effect→message loop the runtime closes.
+- State observation (`state(&self) -> &App`) for plain-assertion access.
+- Effects that become ready without an executor: `Command::message`,
+  `Command::future`/`perform` over immediately ready futures,
+  `Command::stream`/`run`, `Command::quit`, `Command::batch`,
+  `Command::map`, and effects fed by test-controlled sources (for
+  example a channel-backed future the test completes between calls).
+- Cancellation metadata: `cancellable` / `cancellable_with` / `cancel` /
+  `scoped`, with RFC 0003's delivery semantics applied to the store's
+  pending output (§5.1).
+- The redraw directive (RFC 0002) as a per-step observation (§5.2).
+- Declared subscription identity: the `SubscriptionId` set returned by
+  `subscriptions()`, observed without starting any source (§3.2).
+
+### 1.2 Out of scope (stage 1)
+
+- **Time-dependent effects**: `Command::timeout`, `RetryPolicy` with a
+  non-zero backoff, and any effect that needs a timer or reactor. Polling
+  such a leaf inside TestStore fails the test (§4.3); making it pass
+  deterministically is exactly stage 2's job (§7).
+- **Subscription source execution**: TestStore never starts, polls, or
+  restarts a subscription source. It observes the *declared* set only.
+  Lifecycle behavior (keyed restart, RFC 0005) stays covered by the
+  runtime's own tests.
+- **Runtime integration contracts**: channel capacities, backpressure,
+  batching, and scheduling (RFC 0006/0007) are properties of the runtime
+  event loop, which TestStore replaces. A TestStore run exercises none of
+  them, and passing TestStore proves nothing about them — stated here as
+  negative space so no later document cites TestStore as evidence for a
+  runtime scheduling property.
+- **Reducer composition**: there is no reducer trait yet. TestStore
+  targets `Application` directly; when a composition API lands, its
+  `Application` adapter is expected to reuse this store rather than grow
+  a second harness, but that is that RFC's obligation, not this one's.
+
+## 2. The `Message` boundary
+
+### 2.1 Decision
+
+- `Application::Message`'s bounds remain exactly `Send + 'static`. This
+  RFC adds no bound to any `Application` associated item, and pins that
+  as an invariant (INV-T1) rather than an accident: a future RFC that
+  wants a bound on `Application::Message` must state it as a breaking
+  change with a migration path, and cannot present it as implied by
+  TestStore.
+- TestStore's bounds, in full:
+  - `App::Message: Debug` on the store itself. Every exhaustiveness and
+    mismatch failure names the offending messages; a diagnostic that
+    cannot print what leaked is not worth the harness.
+  - `App::Message: PartialEq` on the equality-asserting methods only
+    (`receive`, and any future `receive_*` that compares values).
+  - `Clone` nowhere. A delivered message is asserted once and then moved
+    into `update`; the expected value is consumed by the assertion.
+    Nothing in the store's contract needs two copies of a message.
+- `receive_matching(predicate)` is provided alongside `receive` as the
+  bound-free escape hatch: it asserts via a caller predicate and needs
+  neither `PartialEq` nor anything beyond the store's `Debug`. It exists
+  so `PartialEq` never becomes load-bearing — an application whose
+  message type cannot implement `PartialEq` (for example one carrying a
+  connection handle) still gets the full harness.
+
+### 2.2 Rejected alternatives
+
+- **Add `PartialEq` (or `Debug`) to `Application::Message`.** Breaking
+  for every existing application whose message type lacks the impl, in
+  exchange for nothing stage 1 needs: the store-scoped placement above
+  reaches the same test ergonomics. Rejected.
+- **Require `Clone` for re-delivery or replay.** No stage-1 API replays
+  a message. If a future replay/snapshot feature wants `Clone`, it can
+  carry the bound on its own method under INV-T2's placement rule; it
+  does not need it here. Rejected.
+- **Matcher-only API (no `PartialEq` anywhere).** Keeps bounds minimal
+  but makes the common case — "the effect resolved to exactly this
+  message" — a closure with a hand-written match on every call site.
+  Equality assertion is the ergonomic default in every comparable
+  harness; the matcher stays as the escape hatch, not the front door.
+  Rejected as the sole API.
+
+## 3. Public API
+
+### 3.1 Type and construction
+
+```rust
+/// Deterministic, executor-free test harness for an `Application`
+/// (RFC 0008). Drives `update` and immediately ready effects
+/// synchronously; time-dependent effects are out of scope until the
+/// Clock DI RFC lands.
+pub struct TestStore<App: Application>
+where
+    App::Message: Debug,
+{ /* private */ }
+
+impl<App: Application> TestStore<App>
+where
+    App::Message: Debug,
+{
+    /// Runs `Application::new(flags)` and enqueues the init command.
+    #[must_use]
+    pub fn new(flags: App::Flags) -> Self;
+
+    /// The application state, for plain assertions.
+    pub fn state(&self) -> &App;
+
+    /// Applies `msg` through `update` and enqueues the returned
+    /// command's effects. Fails the test if a deliverable message is
+    /// pending (§6) or quit has been observed (§5.3).
+    pub fn send(&mut self, msg: App::Message);
+
+    /// Asserts that the next deliverable output is a message equal to
+    /// `expected`, then applies it through `update`.
+    pub fn receive(&mut self, expected: App::Message)
+    where
+        App::Message: PartialEq;
+
+    /// Like `receive`, but asserts via a predicate; requires no
+    /// `PartialEq`.
+    pub fn receive_matching(&mut self, matches: impl FnOnce(&App::Message) -> bool);
+
+    /// Asserts that the next deliverable output is a quit request and
+    /// puts the store into the quit state (§5.3).
+    pub fn receive_quit(&mut self);
+
+    /// Whether the command returned by the most recent `send`/`receive`
+    /// step requested a redraw (RFC 0002).
+    pub fn redraw_requested(&self) -> bool;
+
+    /// The `SubscriptionId`s the application currently declares. Pure
+    /// observation; no source is started.
+    pub fn subscription_ids(&self) -> Vec<SubscriptionId>;
+
+    /// Consumes the store, failing the test if deliverable output or an
+    /// unfinished effect remains and quit was not observed (§6).
+    pub fn finish(self);
+}
+```
+
+The signatures above are normative for bound *placement* (which bound
+appears where — INV-T2); parameter spellings (`impl FnOnce` vs a named
+generic) are implementation latitude.
+
+### 3.2 Method semantics
+
+- **`new`** applies `Application::new` and enqueues the init command
+  exactly as a `send` enqueues an update's command. Exhaustiveness
+  applies from construction: an init command's ready message must be
+  received before the first `send`.
+- **`send`** is one synchronous `update` call plus bookkeeping. It
+  spawns no task, requires no executor, and returns only after the
+  command's metadata (directives, cancellation) has been applied to the
+  store. It does not poll effects; polling happens in `receive*` calls.
+- **`receive` / `receive_matching`** select the next deliverable output
+  under the canonical order (§4.2), assert it, and apply it through
+  `update` — so the store advances exactly as the runtime would on that
+  delivery, including enqueuing the resulting command. If the next
+  deliverable output is a quit request, both fail with a diagnostic
+  saying so (quit is asserted only via `receive_quit`). If nothing is
+  deliverable, both fail with a diagnostic that distinguishes "no
+  pending effects" from "effects pending but not ready" (§4.3).
+- **`receive_quit`** asserts the next deliverable output is a quit
+  request. After it succeeds, the store is in the quit state: `send`,
+  `receive`, `receive_matching`, and `receive_quit` all fail; `state`,
+  `redraw_requested`, `subscription_ids`, and `finish` remain callable.
+- **`subscription_ids`** calls `Application::subscriptions` and returns
+  the declared IDs in declaration order. `SubscriptionId` is already
+  `Clone + Eq + Hash + Debug`, so the test asserts on it directly. This
+  is the observation the `subscriptions`-purity contract
+  (`src/application.rs`) makes meaningful: the declared set is a pure
+  function of state, so asserting it after a `send` is deterministic.
+- **`finish` / drop**: `finish` runs the exhaustiveness check (§6).
+  Dropping an unfinished store runs the same check, except when the
+  thread is already panicking (so a failed assertion does not cascade
+  into a double panic). The drop check exists so a test that forgets
+  `finish` cannot silently leak output; `finish` remains the recommended
+  spelling because its failure points at the right line.
+
+### 3.3 Placement
+
+- Module: `src/testing.rs` (`pub mod testing`), path
+  `tears::testing::TestStore`. No crate-root re-export and no prelude
+  membership: a minimal skeleton app never names the type
+  (`docs/api-guidelines.md`, "Prelude Membership" — the same test that
+  keeps `RuntimeConfig` out of the prelude, RFC 0007 §2.3), and a single
+  path keeps `tests/api_surface.rs` invariants trivially satisfied.
+- No feature flag. Precedent: `subscription::mock` ships
+  unconditionally as public test support. A flag would put a compile
+  gate between a user and their first test for zero build-cost benefit
+  (the store is small and pulls no new dependency).
+
+## 4. Determinism and delivery contract
+
+### 4.1 Deliverable output
+
+TestStore holds the effects of every command it has accepted (init
+command, then each step's command) as a pending set of leaf streams,
+consumed through `Command`'s runtime decomposition boundary — the same
+`into_runtime_parts` lowering the runtime uses — so what the store
+observes (directives, cancellation metadata, effect stream) is what the
+runtime observes (INV-T3). A leaf's output is **deliverable** when the
+leaf yields it under polling with no executor, no timer, and no external
+wake — either immediately, or because a test-controlled source (a
+oneshot the test completed, a `MockSource`-style seam) has made it ready
+since the last call. Polling happens only inside `receive*`,
+`send`-precondition, and `finish` checks; between calls the store does
+nothing.
+
+### 4.2 Ordering
+
+- **Within one leaf**: messages are delivered in stream order. This is
+  the leaf's own contract and the store preserves it.
+- **Across leaves**: the store delivers from the *earliest-enqueued*
+  leaf that is currently deliverable. Enqueue order is: init command
+  first, then each step's command in step order; within one command,
+  leaves in `Command::batch`'s flattened declaration order. Two runs of
+  the same test program therefore observe the same delivery sequence
+  (INV-T4, INV-T6).
+- **Negative space, stated deliberately**: the canonical cross-leaf
+  order is *TestStore's* contract, not the runtime's. The runtime folds
+  a command's leaves through an unordered select and pins no cross-leaf
+  delivery order (RFC 0003's ordering-adjacent invariants — INV-10's
+  one-item dispatch and INV-14's shared-first app-input scheduling —
+  order dispatch and pull points, not sibling leaves).
+  A test that asserts an interleaving across sibling leaves is asserting
+  TestStore's linearization and remains valid as a TestStore test, but
+  must not be cited as evidence of runtime ordering. Whether a
+  set-based `receive_unordered` helper should exist for such tests is
+  open question 1.
+
+### 4.3 Leaves that cannot become ready
+
+A leaf that requires a timer or reactor (`Command::timeout` wraps every
+leaf in a deadline; a backoff retry sleeps; `Timer` is
+`tokio::time::interval`-backed) cannot be driven without an executor.
+Stage 1's contract is honest about this rather than silently lenient:
+polling such a leaf fails the test. The failure today surfaces as the
+underlying missing-reactor panic, which is a poor diagnostic; the
+documentation on `TestStore` names the limitation and points at the
+stage-2 plan (§7). A leaf that is merely *pending* on a test-controlled
+source does not fail anything: it is skipped by the canonical order
+until it becomes deliverable, and only `finish` holds it to account
+(§6).
+
+## 5. Cancellation, directives, quit
+
+### 5.1 Cancellation parity (RFC 0003)
+
+The store applies RFC 0003's delivery semantics to its pending set, with
+occupancy defined on the store's own lifecycle: **an id is occupied
+while its current run's stream has not been driven to completion.**
+
+- A keyed command under `CancelPolicy::CancelInFlight` supersedes the
+  same-id occupant: the occupant's undelivered output — buffered
+  messages and quit requests alike — can no longer be delivered
+  (RFC 0003 INV-3, INV-6, INV-9), and the new stream takes the id.
+- Under `CancelPolicy::KeepInFlight`, while the id is occupied the new
+  command's stream is discarded and the occupant is untouched (INV-5).
+- `Command::cancel(id)` drops the occupant's stream and undelivered
+  output, and is idempotent (INV-4).
+- Unkeyed commands are unaffected by any of the above (INV-1's default
+  path).
+- `Command::batch`'s child-key folding needs no restatement: the store
+  consumes real `Command` values, so batch has already discarded child
+  keys and folded cancels before the store sees the parts (RFC 0003
+  INV-11).
+
+These are the deterministic core of RFC 0003 — what may still be
+delivered — restated over the store's pending set. The runtime-side
+mechanics that exist only because the runtime is concurrent (task
+reaping, stale-exit tokens, INV-7/8/13) have no TestStore counterpart
+and are deliberately not modeled.
+
+### 5.2 Redraw directive (RFC 0002)
+
+`redraw_requested()` reports the folded redraw directive of the command
+returned by the most recent step (a `send`, or the `update` call inside
+a `receive*`). Before any step completes it reports the init command's
+directive. This makes `without_redraw` decisions assertable per
+transition, which is the granularity RFC 0002 defines them at.
+
+### 5.3 Quit
+
+Quit is a deliverable output like any message and is asserted explicitly
+via `receive_quit` (§3.2). After quit is observed the store mirrors the
+runtime's shutdown contract: remaining undelivered output is legally
+discarded — `finish` passes regardless of what remains (the analogue of
+the shutdown discard carve-out in RFC 0006's INV-L2), and further
+`send`/`receive*` calls fail because the application would no longer be
+running. A quit that is *suppressed* by cancellation (§5.1) is not
+"observed" and triggers none of this — exactly RFC 0003 INV-9.
+
+## 6. Exhaustiveness
+
+Exhaustive assertion is the only stage-1 mode. The rules, by call site:
+
+- **`send`** fails if any deliverable message or quit request is
+  pending. Effects that are pending but not deliverable (§4.1) do not
+  block `send` — they may be waiting on a test-controlled source the
+  test will feed later.
+- **`receive` / `receive_matching` / `receive_quit`** fail on a
+  mismatch, on quit-versus-message confusion, or when nothing is
+  deliverable — each with a diagnostic that names the actual value
+  (`Debug`) and, in the nothing-deliverable case, distinguishes "no
+  pending effects" from "effects pending but not ready".
+- **`finish`** (and the drop check, §3.2) fails if quit was not
+  observed and either (a) a deliverable message or quit request remains,
+  or (b) any pending leaf has not been driven to completion — an
+  in-flight effect the test never accounted for is a leak even if it
+  never produced a message. After an observed quit, `finish` passes
+  unconditionally (§5.3).
+- Every exhaustiveness failure names the leaked messages via `Debug`;
+  unfinished leaves that have produced no value are reported by count
+  and enqueue position (there is no value to print).
+
+Rationale for exhaustive-only: the harness exists to make effect flow
+*fully* explicit — TCA's experience is that the exhaustive mode is where
+the testing value concentrates, because unasserted output is exactly
+where regressions hide. A lenient mode is a real feature with real
+semantics to design (what is skippable, what drop does, how it composes
+with quit) and no current consumer; it is deferred with a trigger, not
+smuggled in half-specified (open question 2).
+
+## 7. Clock DI split
+
+**Decision: Clock injection is its own RFC; this RFC does not contain
+it.** Stage 2 of TestStore — deterministic driving of `timeout`, retry
+backoff, debounce/throttle, and `Timer` — lands as an amendment to this
+document after that RFC is accepted.
+
+Rationale:
+
+- The `Message`-bound decision (§2) is urgent and wholly independent of
+  time: deferring it until a Clock design settles would leave the silent
+  breaking-change risk open for no gain.
+- Clock DI is a cross-cutting determinism contract — it decides what is
+  injectable for *every* time-dependent subscription and command
+  modifier, with the runtime and future debounce/throttle work as
+  consumers alongside TestStore. Folding it in here would put a
+  runtime-wide contract inside a testing RFC, inverting the dependency:
+  TestStore should consume the Clock contract, not own it.
+- Stage 1 is additive and independently shippable; bundling would gate
+  it behind the larger design.
+
+Non-normative sketch of what the amendment adds, recorded so stage-1 API
+shapes are chosen with it in mind: a store-held clock handle, an
+`advance(duration)` call that makes time-gated leaves deliverable, and
+the §4.3 limitation dissolving into ordinary `receive` flow. Nothing in
+the stage-1 surface above assumes otherwise or blocks that shape.
+
+## 8. Invariants
+
+Enforcement classes follow the pre-review checklist's definitions
+(structural / behavioral / statistical).
+
+- **INV-T1**: `Application`'s definition is unchanged by this RFC —
+  `type Message: Send + 'static` and no new bound on any associated
+  item. Structural: review of `src/application.rs` against the pre-RFC
+  definition. Behavioral: a compile test, added with the
+  implementation, instantiates `Application` with a message type that
+  implements nothing beyond `Send + 'static` (no existing test does —
+  every current test app's message type also derives comparison and
+  formatting traits, so none would catch a smuggled bound).
+- **INV-T2**: TestStore's bounds are exactly §2.1's — `Debug` on the
+  store, `PartialEq` on equality-asserting methods only, `Clone` on
+  nothing. Behavioral: a compile test drives `new` → `send` → `state` →
+  `receive_matching` → `finish` with a message type implementing `Debug`
+  but neither `PartialEq` nor `Clone`. Structural: review of every
+  public TestStore signature for stray bounds.
+- **INV-T3**: TestStore consumes each command through the same
+  decomposition boundary the runtime consumes
+  (`Command::into_runtime_parts`), never a parallel re-derivation of
+  directives, cancellation, or effects. Structural: review of the
+  store's single command-intake site. This is what makes TestStore
+  results evidence about real commands rather than about a test-only
+  model.
+- **INV-T4**: `send` and `receive*` are synchronous — no task spawn, no
+  executor requirement — and two executions of one test program observe
+  identical state transitions and delivery sequences. Behavioral: a
+  repeated-run test asserts equal delivery transcripts across runs of a
+  multi-leaf, cancellation-exercising program.
+- **INV-T5**: one leaf's messages are delivered in stream order.
+  Behavioral: a multi-message `Command::stream` test.
+- **INV-T6**: across leaves, delivery follows §4.2's canonical order
+  (earliest-enqueued deliverable leaf first), and this order is
+  TestStore's contract only — no test or document may cite it as a
+  runtime ordering guarantee, which the runtime does not make.
+  Behavioral for the order itself: a batch of ready leaves delivers in
+  declaration order; a leaf made ready late delivers after an
+  earlier-enqueued ready leaf but before a later one. The negative-space
+  half is documentation, checked in review of the rustdoc (structural).
+- **INV-T7**: cancellation parity — the four behaviors of §5.1
+  (supersede, keep-in-flight discard, explicit cancel, unkeyed
+  unaffected) hold over the store's pending output as RFC 0003's INV-3,
+  INV-4, INV-5, INV-6, and INV-9 state them for deliverable output.
+  Behavioral: one test per behavior, including quit suppression
+  (a superseded keyed quit is never observable via `receive_quit`).
+- **INV-T8**: exhaustiveness — each leak class in §6 fails at its named
+  call site, with a diagnostic naming the leaked values for the
+  message classes and the count and enqueue position for the
+  unfinished-leaf class (§6). Behavioral: one test per class (ready
+  message at `send`; ready message at `finish`; unfinished leaf at
+  `finish`; drop-without-finish), each asserting the failure fires
+  *and* its message contains the class's required content — the leaked
+  value's `Debug` rendering for the message classes — because the
+  wrong-value adversary is exactly what the message-content assertion
+  exists to fail.
+- **INV-T9**: quit terminality and carve-out — after `receive_quit`,
+  `send`/`receive*` fail and `finish` passes regardless of remaining
+  output. Behavioral: a test quits with output still pending and
+  asserts both halves.
+
+Surface–invariant coverage: `new`/`send`/`receive*`/`finish` map to
+INV-T2/T3/T4/T8; delivery order to INV-T5/T6; cancellation metadata to
+INV-T7; `receive_quit` and the quit state to INV-T9;
+`redraw_requested` and `subscription_ids` are pure observations of
+contracts owned elsewhere (RFC 0002's directive; RFC 0005's declared
+identity) and are covered by INV-T3 (they read what the runtime would
+read) plus one behavioral test each; the absence of an `Application`
+change maps to INV-T1.
+
+## 9. Open questions
+
+1. **Unordered batch receive.** Should a set-based helper (assert that
+   the next N deliverable messages equal this multiset, in any order)
+   exist for tests over sibling leaves, so they need not encode the
+   canonical linearization? Trigger: real tests that repeatedly assert
+   cross-leaf sequences where the order is incidental. Additive either
+   way; stage 1 ships without it.
+2. **Non-exhaustive mode.** A lenient mode (unasserted output tolerated,
+   or selectively skippable) is not designed here. Trigger: a concrete
+   consumer — most plausibly migrating a large existing test suite —
+   that exhaustive-only demonstrably blocks. Designing it then is a
+   reviewed amendment (skippability interacts with §5.3's quit carve-out
+   and §6's drop check).
+
+## 10. References
+
+- RFC 0002 — redraw suppression: the directive `redraw_requested`
+  observes.
+- RFC 0003 — command cancellation: INV-1, INV-3, INV-4, INV-5, INV-6,
+  INV-9, INV-10, INV-11, INV-14 (cited in §§4.2, 5.1, 5.3).
+- RFC 0005 — structural lifecycle identity: `SubscriptionId`, the
+  declared-set semantics `subscription_ids` observes.
+- RFC 0006 — runtime load control: the shutdown discard carve-out §5.3
+  mirrors (INV-L2); the runtime contracts §1.2 excludes.
+- RFC 0007 — RuntimeConfig: the prelude-membership reasoning §3.3
+  follows.
+- `src/application.rs` — the trait whose bounds §2 pins.
+- `src/command/core.rs`, `src/command/runtime_parts.rs` — the
+  decomposition boundary INV-T3 names.
+- `src/subscription/mock.rs` — the unconditional test-support precedent
+  §3.3 cites.
+- `docs/rfcs/pre-review-checklist.md` — enforcement-class definitions
+  used in §8.

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -64,3 +64,4 @@ Three corollaries:
 | [0005](0005-structural-lifecycle-identity.md) | Structural lifecycle identity and composition scope |
 | [0006](0006-runtime-load-control.md) | Runtime load control, backpressure, latency guarantees |
 | [0007](0007-runtime-config.md) | RuntimeConfig public API, load-control acceptance parameters |
+| [0008](0008-teststore.md) | TestStore: deterministic update/effect testing, `Message` boundary |

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -56,6 +56,27 @@ enough for the smoke profile's build check" while the `--smoke`
 selector's set never contained the scenario — and if the appeal was to
 compilation instead, key count never affected build cost at all.
 
+A definition by cases is an inventory too: enumerate the space the
+definition partitions and check that the named cases cover it, and
+treat an exception clause as quantified over every member of the
+inventory it exempts. *From PR #240:* "deliverable — either
+immediately, or because a test-controlled source has made it ready"
+had no case for a self-waking future (neither immediate nor
+externally completed), and a post-quit no-poll exception named only
+the finish/drop checks while send/receive were also polling sites
+that could reach a leaf on their way to failing.
+
+A universal claim about executions quantifies over the behavior other
+parties supply. A harness, runtime, or wrapper cannot promise a
+property of the whole execution when part of the execution is the
+caller's own code; scope the claim to what the mechanism itself
+contributes. *From PR #240:* a determinism invariant promised
+identical transcripts across "two executions of one test program" —
+refuted by any application whose own `update` is nondeterministic —
+and had to be re-scoped to "the store introduces no nondeterminism of
+its own", with transcript identity conditional on a deterministic
+application.
+
 ## 2. Adversarial counterexample per invariant
 
 For each requirement and invariant, deliberately construct at least one
@@ -108,6 +129,27 @@ Prompts that have already paid off:
   with lock-serialized dispatch — a coincidence the contract had never
   pinned, undetected until grepped for and named explicitly as the `seq`
   field).
+- A joint-satisfiability walk, dual to the per-invariant adversary:
+  sketch one implementation that satisfies every invariant
+  *simultaneously*, against the production seams as they exist in the
+  code today. Two invariants can each be individually checkable while
+  no implementation can honor both; and when the only satisfying
+  implementation requires changing existing code first, that change is
+  recorded as a named prerequisite under item 5's delegation rule, not
+  assumed (from PR #240: one invariant required consuming the runtime's
+  decomposition boundary while another required a per-leaf delivery
+  order that boundary had already folded away into an unordered
+  select — jointly unimplementable until a parts-type refactor was
+  named as a prerequisite in the RFC body).
+- A repeat-until check without a budget: any check that re-runs an
+  operation until a condition holds needs its budget stated, or an
+  adversarial input that never satisfies the condition (an
+  always-self-waking, never-ready stream) runs it forever — and even
+  when every real input terminates, an unstated budget lets two
+  compliant implementations disagree on observable outcomes (from PR
+  #240: the deliverability check had no poll budget until "each check
+  polls each leaf its scan reaches exactly once, with wake-ups not
+  honored within the call" was pinned).
 
 ## 3. Enforcement class, declared up front
 
@@ -184,6 +226,19 @@ states. *From PR #213:* a resolution leaned on "INV-L5 carries RFC 0003"
 for delivery-FIFO and quit precedence, but RFC 0003's INV-9 defines only
 post-dispatch suppression and INV-14 only same-pull-point ordering — the
 properties had to be pinned as new invariants with their own checks.
+
+Negative citations are code claims too. A sentence claiming another
+document *leaves a behavior open* — "RFC N does not guarantee X", "the
+outcome is scheduling-dependent", "this depends on reap timing" — is
+verified by searching that document for the passage that would pin the
+behavior, never by failing to recall one; and re-reading an invariant's
+*title* is not a fresh read of its statement. *From PR #240:*
+review-fix text described a keyed-admission window as
+reap-timing-dependent in the runtime, while RFC 0003's pre-spawn
+reconciliation and the exact wording of INV-6/INV-7 pin a deterministic
+release — the citation pass behind the patch had verified the invariant
+labels, not the release semantics the paragraph leaned on, so the
+document contradicted the contract it claimed parity with.
 
 Measurement citations are code claims too, and they prove only what they
 measured. Two classes from PR #220:
@@ -313,6 +368,13 @@ changed-claims list.
   (from PR #213: "RFC 0003's FIFO" survived in R5, §4.3, the
   open-question text, and the references after the body had already
   conceded RFC 0003 states no FIFO invariant).
+- A corrected claim's stale restatements rarely share its wording: grep
+  for the claim's *subject* vocabulary across the whole document, not
+  only for the sentence that was rewritten (from PR #240: rewriting the
+  polling-site inventory left "It does not poll effects; polling
+  happens in `receive*` calls" standing in the API-semantics section —
+  found by grepping "poll", invisible to a grep for the rewritten
+  sentence).
 - Resolving a decision is a corrected claim: grep for the decision's own
   vocabulary — its option labels ("(a)/(b)"), *pending*, *remaining
   step*, *the input for the choice* — across the findings, every open


### PR DESCRIPTION
## Summary

Adds RFC 0008 (Draft): **TestStore — deterministic update and effect testing**, plus its index row in `docs/rfcs/README.md`. This is the design-track item gating the next implementation work: the `Message` boundary must be fixed before any TestStore code exists, because retrofitting a bound onto `Application::Message` later would be a silent breaking change.

The RFC decides the three gating questions:

1. **`Message` boundary (§2)** — `Application::Message` stays exactly `Send + 'static` (pinned as INV-T1). TestStore carries its own bounds: `Debug` on the store, `PartialEq` scoped to the equality-asserting methods only, `Clone` nowhere. `receive_matching(predicate)` is the bound-free escape hatch so `PartialEq` never becomes load-bearing. Rejected alternatives (trait-level bound, `Clone`, matcher-only) are recorded in §2.2.
2. **Exhaustive assertions (§6)** — exhaustive is the only stage-1 mode; undelivered deliverable output or an unfinished effect leaf fails at `send`/`finish`/drop. The one carve-out mirrors the runtime's shutdown discard (RFC 0006 INV-L2): after an observed quit no store call polls, and the `finish`/drop checks pass. A non-exhaustive mode is deferred with a trigger (OQ2), not half-specified.
3. **Clock DI split (§7)** — Clock injection is its own RFC; TestStore stage 2 (timeout / retry backoff / `Timer`) lands as a reviewed amendment after that RFC. Stage 1 (pure `update` + immediately ready effects) is additive and independently shippable.

Other contracts pinned:

- **Production seam and named prerequisite (§4.1, INV-T3)**: TestStore consumes commands through the runtime's decomposition boundary — after a named prerequisite refactor this RFC gates on: `RuntimeCommandParts` carries the effect's leaves unfolded in declaration order, and each consumer folds or drives them at its own site (the runtime's relocated fold is behavior-preserving; the store keeps leaves apart).
- **Deliverability and poll budget (§4.1)**: output is deliverable when its leaf yields on that check's poll (or sits in the reconciliation buffer); each check polls each leaf its scan reaches exactly once, with wake-ups not honored within the call; the quit-state check precedes every polling site. Determinism (INV-T4) is scoped to applications with a deterministic `update` and rests on this fixed budget.
- **Delivery order (§4.2, INV-T5/T6)**: stream order within a leaf; a deterministic canonical order across leaves (earliest-enqueued deliverable leaf first), pinned explicitly as TestStore's own contract with the negative space stated: the runtime guarantees no cross-leaf order, and the canonical order must not be cited as a runtime guarantee.
- **Cancellation parity (§5.1, INV-T7)**: occupancy follows RFC 0003's INV-6/INV-7 accounting, with **keyed-intake reconciliation** — the store analogue of RFC 0003 §4.2's pre-spawn reap-and-sample — releasing an id whose occupant is exhausted, buffering a yielded item at its canonical position, and keeping still-open runs occupied. Residual negative space: the single-poll granularity, where the store deterministically selects one of the runtime's legal outcomes. Concurrency-only mechanics (INV-8, INV-13) deliberately unmodeled.
- **Placement (§3.3)**: `tears::testing::TestStore`, no feature flag (precedent: `subscription::mock`), no prelude / root re-export.

## Review round 1 (resolved)

- **P1**: INV-T3 (consume via `into_runtime_parts`) and INV-T6 (per-leaf canonical order) were unimplementable together — the boundary folds leaves via `select_all` before the parts exist. Resolved by re-deriving §4.1: the named per-leaf-parts prerequisite above, with INV-T3 rewritten against the revised boundary.
- **P2**: poll/waker semantics fixed; post-quit `finish`/drop pinned as no-poll; INV-T4 scoped to deterministic applications, with a poll-counting behavioral check.
- **P3**: occupancy-timing negative space; `state()` in the surface–invariant walk; `receive_quit` not a redraw step; §2.1 diagnostics claim aligned; §4.3 scan-reach poisoning consequence spelled out.

## Review round 2 (resolved)

- **P2**: the round-1 §5.1 negative-space paragraph misread RFC 0003 — INV-6 keeps an id occupied until output is *delivered or dropped* (not until reap), and §4.2's pre-spawn reconciliation plus INV-7 make the runtime release *deterministically*, so the store's stream-lifetime occupancy was a parity break (deterministic discard vs deterministic admit), not a linearization nuance. Resolved by the reviewer's option 1: §5.1 re-derived around keyed-intake reconciliation (rule above); INV-T7 now covers five behaviors including reconciliation release, with both reconciliation edges as behavioral tests. The item-6 re-check on this patch caught one further over-claim ("no observable outcome" → "no admission outcome", since reconciliation polls are themselves observable to a poll-counting leaf).
- **P3**: §3.2's stale "send does not poll effects" sentence now defers to §4.1's budget (precondition + intake reconciliation); the quit-state check is pinned as preceding *every* polling site, so post-quit `send`/`receive*` fail on the quit state without reaching a leaf (INV-T9's behavioral test asserts the diagnostic is the quit-state one, not a reactor panic).

## Review focus

- §5.1's reconciliation rule: does the buffered-head mechanism (an item yielded by the reconciliation poll staying deliverable at its leaf's canonical position) interact cleanly with §4.2's scan and §6's exhaustiveness everywhere?
- §4.1's named prerequisite: is the behavior-preservation claim for the relocated fold acceptable as a structural check, or should the prerequisite get its own behavioral gate?
- §4.2's canonical cross-leaf order: is the negative-space framing strong enough, or does OQ1 (`receive_unordered`) need resolving before accept?

Pre-review checklist: hedge scan, cross-reference pass, `typos`, and `git diff --check` clean. Round-1's RFC 0003 citation pass verified the invariant labels but misread INV-6/INV-7's release semantics; round 2 re-verified both against the RFC text (exact INV-6/INV-7 wording and the §4.2 reconciliation passage) before re-deriving §5.1. Both rounds were handled per checklist item 6: clause re-derivation from premises, then items 1–5 re-run on the changed-claims list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Checklist updates (living-document rule)

Per the checklist's own instruction ("when a review pass finds a defect class this checklist should have caught, add an item ... in the same PR"), the five new defect classes from rounds 1–2 are folded into `docs/rfcs/pre-review-checklist.md`:

- **Item 1**: a definition by cases is an inventory (round 1's deliverability either/or missed self-waking futures; the post-quit exception named only finish/drop), and universal claims must not quantify over party-supplied behavior (INV-T4's original scope).
- **Item 2**: a joint-satisfiability walk — one implementation sketch honoring every invariant simultaneously against today's seams, with unimplementable pairs resolved as named prerequisites (round 1's P1); repeat-until checks need a stated budget (the poll budget).
- **Item 4**: negative citations ("RFC N leaves this open") are verified by searching for the passage that would pin the behavior; an invariant's title is not a fresh read of its statement (round 2's P2).
- **Item 7**: grep a corrected claim's subject vocabulary, not only the rewritten sentence (the stale "does not poll effects" text).

`docs/rfcs/README.md` is deliberately unchanged: every lesson from these rounds is checklist-class (how to verify contract text), none touches the README's scope guidance (what an RFC pins or the process rules).
