### PR TITLE
docs(rfcs): fix INV-T1 rationale and accept RFC 0008

### DIFF
--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -1,6 +1,6 @@
 # RFC 0008: TestStore — deterministic update and effect testing
 
-- Status: Draft
+- Status: Accepted
 - Target: an additive, executor-free test harness for the current
   `Application` API (stage 1: pure `update` + immediately ready effects)
 - Scope: the `Message` trait-bound decision, the exhaustive-assertion
@@ -512,9 +512,14 @@ Enforcement classes follow the pre-review checklist's definitions
   item. Structural: review of `src/application.rs` against the pre-RFC
   definition. Behavioral: a compile test, added with the
   implementation, instantiates `Application` with a message type that
-  implements nothing beyond `Send + 'static` (no existing test does —
-  every current test app's message type also derives comparison and
-  formatting traits, so none would catch a smuggled bound).
+  implements nothing beyond `Send + 'static`. Two `src/application.rs`
+  doctests already do this incidentally — `new`'s `enum Message { Init
+  }` and `update`'s `enum Message { Save, Quit }` carry no derives at
+  all, so a smuggled bound would already break them — but neither is
+  written as a bound-check, and either could grow a derive for
+  unrelated doc-readability reasons without anyone noticing the
+  coverage had disappeared. The compile test above names the case
+  explicitly and does not depend on those two examples' current shape.
 - **INV-T2**: TestStore's bounds are exactly §2.1's — `Debug` on the
   store, `PartialEq` on equality-asserting methods only, `Clone` on
   nothing. Behavioral: a compile test drives `new` → `send` → `state` →


### PR DESCRIPTION
## Summary
- Fix a false claim in RFC 0008's INV-T1: the rationale said no existing test instantiates `Application` with a message type implementing nothing beyond `Send + 'static`, but two `src/application.rs` doctests (`new`'s `enum Message { Init }`, `update`'s `enum Message { Save, Quit }`) already do. Rewrite the parenthetical to name that incidental coverage and explain why a dedicated compile test is still needed instead of relying on it.
- Promote RFC 0008's Status from Draft to Accepted — the contract (Message boundary, exhaustive-only stage 1, Clock DI split) has been stable across two review rounds (82364e2, 37ba211) and this fix is the only outstanding finding.

## Test plan
- [x] `pre-review-checklist.md`'s 7 items re-run against the changed clause and the document as a whole (quantifier scoping, adversarial check, enforcement class, code claim verified against `src/application.rs`, hedge scan, re-derive not patch, mechanical pass)
- [x] `git diff --check` clean
- [x] `typos` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)