### PR TITLE
docs(rfcs): add RFC 0009 Clock DI draft

### DIFF
--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,0 +1,414 @@
+# RFC 0009: Clock DI — deterministic time via the virtual clock
+
+- Status: Draft
+- Target: a crate-wide determinism contract for time-dependent behavior,
+  with no new public API
+- Scope: the no-clock-abstraction decision, the single-time-source rule,
+  the controlled-context determinism contract consumed by TestStore
+  stage 2 / debounce–throttle / subscription restart rate control, the
+  HTTP time-source migration prerequisite, and the `test-util` feature
+  decision
+- Feature flag: none
+- CHANGELOG: none (the prerequisite migration and the lint are internal
+  and behavior-preserving)
+
+## Summary
+
+Four decisions:
+
+1. **No clock abstraction** (§2). tears introduces no `Clock` trait, no
+   injected clock value, and no clock parameter on any API. The crate's
+   single time axis is the async executor's clock (`tokio::time`), which
+   is already virtualizable: a single-threaded context can start it
+   paused and advance it explicitly. "Clock DI" — the working name this
+   RFC resolves — lands as a source discipline plus a citable
+   determinism contract, not as an injection surface.
+2. **Single time source** (§3.1, INV-C1). Every time read in library
+   code goes through the virtualizable clock. `std::time::Instant::now`,
+   `std::time::SystemTime::now`, and `std::thread::sleep` are banned
+   mechanically via clippy's `disallowed-methods`. Two HTTP-module files
+   violate the rule today; migrating them is this RFC's named
+   prerequisite (§4).
+3. **Controlled-context contract** (§3.2, INV-C2, INV-C3). A consumer
+   that controls the clock may rely on: virtual time advances only under
+   the controller's action (plus the executor's idle auto-advance, which
+   a non-idling controller never triggers); time-gated behavior never
+   fires before its deadline; and every time-dependent contract pinned
+   elsewhere (RFC 0004 timeout/retry, `Timer` semantics) holds
+   identically under virtual time, so a virtual-clock run is evidence
+   about production behavior.
+4. **Production neutrality** (§3.3, INV-C4). No production surface
+   changes: the runtime never pauses or configures the clock, no public
+   type or config field mentions time control, and unpaused behavior is
+   byte-for-byte the platform monotonic clock.
+
+The dependency direction fixed by RFC 0008 §7 is honored: TestStore
+stage 2 consumes this contract; nothing here gates on TestStore.
+
+## 1. Scope
+
+### 1.1 In scope
+
+- The decision that no clock abstraction exists (§2) and the rejected
+  injection designs (§2.2).
+- The single-time-source rule over all library code, with its
+  enforcement (§3.1).
+- The determinism contract a controlled time context provides to
+  consumers (§3.2), and its negative space (§3.4).
+- The HTTP time-source migration, as a named prerequisite (§4).
+- The `tokio` `test-util` feature decision for in-crate controlled
+  contexts (§5.1).
+- A deterministic-time testing recipe in `docs/testing.md` for
+  application authors (§5.5) — a documentation deliverable, not
+  contract surface.
+
+### 1.2 Out of scope
+
+- **Calendar time.** The crate reads no wall-calendar time at all — no
+  `SystemTime` read exists in the repository — and this RFC adds no
+  calendar-time contract. An application that renders dates injects its
+  own source through `Flags`, the general dependency-injection pattern,
+  which stays a docs/examples concern.
+- **Randomness.** Jitter for retry backoff or HTTP refetch is a
+  separate determinism axis with its own reproducibility design,
+  deferred by RFC 0004 §5.2; a future backoff-policy RFC owns it.
+- **TestStore's time API.** The shape of `advance` on the store, and
+  how time-gated leaves join the §4.2 canonical order, is the RFC 0008
+  stage-2 amendment's job. This RFC provides the contract that
+  amendment cites (§5.1).
+- **Debounce/throttle and restart-rate semantics.** Their policies and
+  invariants belong to their own RFCs; they consume this contract
+  (§5.2, §5.3).
+- **Real-time accuracy bounds.** No upper bound on timer lateness under
+  the real clock is pinned here or anywhere (§3.4).
+
+## 2. Decision: no clock abstraction
+
+### 2.1 The decision and its rationale
+
+tears ships no `Clock` trait and no clock handle. The crate's time axis
+is the executor's clock, reached exclusively through `tokio::time`
+(§3.1). Deterministic control — freezing time, advancing it explicitly,
+firing timers without real waiting — is exercised by running the code
+under test on a single-threaded executor with the clock started paused,
+which the executor already supports.
+
+Rationale:
+
+- **The instrument already exists and is already the crate's accepted
+  practice.** RFC 0004 §1.3 requirement 7 pins "Time-dependent tests
+  use Tokio's paused clock" for every timeout/retry contract, and the
+  runtime, command, and effect test suites already run dozens of
+  paused-clock tests. This RFC promotes that instrument from a test
+  technique into the crate-wide contract, rather than layering a second
+  clock mechanism above it. RFC 0004 §1.4 deferred "clock dependency
+  injection" as a separate concern; this RFC resolves that deferral.
+- **An injected clock cannot reach the sites that need it without
+  breaking the API.** `Command::timeout`, `Command::retry`'s backoff,
+  and `Timer::new` construct time-gated behavior inside `update` and
+  `subscriptions`, which receive no environment. Serving them with an
+  injected clock requires either a clock parameter on every such
+  constructor (breaking churn across the command and subscription
+  surface) or an ambient task-local clock — a second, hand-rolled
+  virtual clock with its own timer wheel and waker plumbing, shadowing
+  the one the executor provides.
+- **A second clock splits the time axis.** User effects run arbitrary
+  async code inside `Command::future`/`perform`/`stream`, and that code
+  is free to call `tokio::time` itself. Under an injected library-level
+  clock, library timers would follow the injected clock while user
+  timers followed the executor's — one `advance` moving one axis and
+  not the other, silently breaking exactly the deterministic tests the
+  injection exists to enable. Under the chosen design there is one
+  axis: a paused context virtualizes library and user time together.
+- **Zero cost where it matters.** No new public API, no new dependency,
+  no trait object on any hot path, and production behavior untouched
+  (§3.3). The entire user-visible delta is a documented testing recipe
+  (§5.5).
+
+### 2.2 Rejected alternatives
+
+- **`Arc<dyn Clock>` injected via `Flags`/environment.** The
+  reachability and axis-splitting failures above; additionally the
+  trait needs async sleep/interval methods with waker integration to be
+  virtualizable at all, duplicating the executor clock's machinery for
+  no capability it does not already have. Rejected.
+- **Clock resolved at drive time** (the runtime and TestStore pass a
+  clock into effect leaves through the decomposition boundary). Touches
+  the RFC 0008 INV-T3 parts type and every leaf's poll path, still
+  requires the bespoke test clock implementation, and still splits the
+  axis for user code inside futures. Rejected.
+- **Per-source injection** (`Timer` gains a clock parameter, backoff
+  gains another). Partial by construction — `Command::timeout` and
+  retry sleeps sit behind no injectable seam — so the crate would carry
+  two time regimes plus per-source API growth. Rejected.
+- **A dependency registry** (TCA-style ambient dependency system).
+  Heavyweight and macro-leaning against the crate's simplicity goals,
+  and unnecessary: non-time dependencies already have the `Flags`
+  pattern, and time needs no injection at all under the chosen design.
+  Rejected.
+
+## 3. The time contract
+
+### 3.1 Single time source
+
+Every **time read** in library code — any operation whose result or
+completion depends on the current time: now-reads (`Instant::now`,
+`elapsed`), sleeps, intervals, and deadlines — goes through the
+executor's virtualizable clock, i.e. through `tokio::time` types and
+functions. `Duration` values are plain data and are not time reads.
+
+Inventory of production time reads at this RFC's writing:
+
+| Site | Read | Purpose | Conforming |
+| --- | --- | --- | --- |
+| `src/command/effect.rs` (timeout leaf) | `tokio::time::sleep` | `Command::timeout` deadline (RFC 0004; anchored at the leaf's first poll) | yes |
+| `src/command/retry.rs` (`run_retry`) | `tokio::time::sleep` | retry backoff delay (RFC 0004) | yes |
+| `src/subscription/time.rs` (`Timer`) | `tokio::time::interval` | periodic ticks, missed ticks skipped | yes |
+| `src/runtime.rs` (event loop) | `tokio::time::Instant` | micro-batch window deadline (RFC 0006 mechanism) | yes |
+| `src/runtime/frame_scheduler.rs` | `tokio::time::interval` | frame cadence | yes |
+| `src/runtime/channel.rs` (bounded send) | `tokio::time::Instant` | capacity-wait duration in load events (RFC 0006 observability) | yes |
+| `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4 migration** |
+| `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4 migration** |
+
+Outside library code, exactly one deliberate exception exists:
+`benches/runtime_load.rs` measures real wall-clock latency because
+RFC 0006's statistical acceptance criteria are defined on real time; it
+carries an explicit lint allow at its measurement sites. Unit and
+integration tests contain no `std::time` reads today and fall under the
+same rule.
+
+Observability-only reads (tracing durations, load-event fields) follow
+the same rule as contract-bearing reads. A uniform rule keeps the
+universal claim mechanically checkable and makes observability output
+deterministic under a controlled context; there is no exempt category
+to reason about.
+
+Enforcement is INV-C1 (§6).
+
+### 3.2 Controlled contexts
+
+A **controlled time context** is a single-threaded executor whose clock
+starts paused. (The executor supports pausing only on a single-threaded
+runtime; the production multi-thread configuration cannot be paused,
+which is production neutrality working as intended, §3.3.) Within a
+controlled context, the contract a consumer may cite:
+
+- **Advancement.** Virtual time advances only through (a) the
+  controller's explicit advance and (b) the executor's auto-advance to
+  the earliest pending timer deadline when the executor is idle. A
+  controller that never lets the executor idle on a timer — one that
+  polls manually rather than awaiting, as TestStore's §4.1 poll budget
+  already requires — therefore observes advancement only from its own
+  advance calls. The (b) clause is stated because it is the executor's
+  documented behavior, not a facility this contract grants: a consumer
+  that awaits a gated future and observes it complete "by itself" is
+  seeing auto-advance, and may not cite this RFC for explicit-only
+  advancement (adversarial model: an idling test citing INV-C2 —
+  excluded by the non-idling condition, which scopes the claim to what
+  the controller itself contributes).
+- **No early firing.** No time-gated behavior in the crate fires while
+  virtual now is earlier than its deadline.
+- **Readiness without waiting.** Once an advance moves virtual now to
+  or past a deadline, the gated behavior is ready on its next poll with
+  no real-time waiting.
+- **Transparency.** Every time-dependent contract the crate pins
+  elsewhere holds identically under the virtual clock: RFC 0004's
+  timeout semantics (deadline anchored at the leaf's first poll, one
+  timeout message per modifier) and retry-backoff semantics, and
+  `Timer`'s semantics (no tick before one full interval; missed ticks
+  skipped, so a single advance spanning multiple intervals yields one
+  tick, not a replay burst). The contracts are inequality-shaped (never
+  early; at-or-after), so the virtual clock's perfect granularity and
+  the real clock's scheduler-dependent lateness both satisfy them; a
+  paused-clock run is therefore evidence for the contract itself — the
+  clock analogue of RFC 0008's INV-T3 boundary argument.
+
+### 3.3 Production neutrality
+
+The production runtime never pauses, constructs, or configures the
+clock. No public type, method, or `RuntimeConfig` field mentions time
+control. In an unpaused context every time read above is the platform
+monotonic clock, exactly as before this RFC. There is nothing to
+migrate, configure, or opt into for any existing application.
+
+### 3.4 Negative space
+
+Pinned deliberately as *not* guaranteed:
+
+- **Equal-deadline ordering.** When two gated behaviors share a virtual
+  deadline, their firing order is unspecified. A consumer needing a
+  delivery order provides its own linearization — TestStore's §4.2
+  canonical order already does — and may not cite the clock for it.
+- **Real-time accuracy.** Under the real clock, a timer fires at or
+  after its deadline with no pinned upper bound on lateness; wide-margin
+  wall-clock tests remain non-normative smoke checks (§6, INV-C3).
+- **Cross-context isolation is per-executor.** The paused clock belongs
+  to one executor; two controlled contexts do not share time. No
+  contract spans contexts.
+
+## 4. Prerequisite: HTTP time-source migration
+
+**Named prerequisite, owned by this RFC's implementation task.**
+`src/subscription/http/cell.rs` (lifecycle `inactive_since`, data
+`data_timestamp`, and the `stale_time`/`cache_time` comparisons over
+them) and `src/subscription/http/query.rs` (the `elapsed_ms` tracing
+read) read `std::time::Instant` and are the only library sites outside
+the rule. They migrate to the virtualizable clock's `Instant`.
+
+- The migration is behavior-preserving in unpaused contexts: the
+  virtualizable `Instant` reads the same platform monotonic clock when
+  time is not paused, and none of the migrated values appears in a
+  public signature (`inactive_since` is `pub(super)`; the rest are
+  module-internal), so the change is invisible outside the module.
+- The payoff is that HTTP staleness and cache-eviction behavior —
+  contract-bearing time comparisons — become testable under a
+  controlled context like every other time-dependent contract.
+- INV-C1's mechanical enforcement turns on with this migration; the
+  lint cannot land first.
+
+## 5. Consumers
+
+### 5.1 TestStore stage 2 (RFC 0008 §7 amendment)
+
+The stage-2 amendment gives the store a controlled time context and an
+advance operation, making §4.3-class leaves (timeout, backoff, timer)
+deliverable through ordinary `receive` flow. What it cites here:
+INV-C2's explicit-advance determinism (the store's poll budget never
+idles the executor, so the auto-advance clause never applies) and
+INV-C3's transparency (store results are evidence about production time
+contracts, completing the INV-T3 argument on the time axis).
+
+Two design inputs recorded for that amendment:
+
+- **Deadline anchoring.** RFC 0004 anchors a timeout's deadline at the
+  leaf's *first poll*, and the store's scans decide when that first
+  poll happens; the amendment's advance semantics must account for
+  scan-order-dependent anchoring rather than assuming
+  construction-time anchoring.
+- **Feature availability.** The executor's pause-and-advance facilities
+  sit behind the `tokio` `test-util` feature, today a dev-dependency
+  only. **Decision:** when the first in-crate controlled-context
+  consumer lands — TestStore stage 2 is the named owner — `test-util`
+  joins the crate's unconditional `tokio` dependency features. tears
+  adds no feature flag of its own, per the no-feature-flag precedent
+  for test support (RFC 0008 §3.3): pausing is opt-in at runtime
+  construction, so the unconditional feature changes no production
+  behavior (INV-C4 continues to hold and its check covers this flip).
+
+### 5.2 Debounce / throttle (future keyed-lifecycle work)
+
+Coalescing timers added to the keyed registry read the executor clock
+like every other gated behavior, so their determinism under test needs
+no design of its own — their RFC owns coalescing semantics and cites
+§3.2 for time control.
+
+### 5.3 Subscription restart rate control (future work)
+
+A minimum-restart-interval or backoff policy on the runtime's
+subscription lifecycle reads the same clock; paused-clock event-loop
+tests (already the runtime suite's practice) extend to it unchanged.
+
+### 5.4 HTTP interval and backoff policies (future work)
+
+Refetch intervals and failure backoff ride §4's migrated module and
+this contract. Their jitter, if any, is randomness — out of scope here
+(§1.2) and owned by that policy's RFC.
+
+### 5.5 Applications
+
+A downstream application enables the `tokio` `test-util` feature in its
+own dev-dependencies and runs its tests on a paused single-threaded
+runtime; feature unification makes every tears time read virtual in
+those tests with no tears-side configuration. Deliverable: a
+deterministic-time section in `docs/testing.md` documenting the recipe
+(paused runtime, explicit advance, the §3.2 auto-advance caveat).
+Documentation, not contract surface.
+
+## 6. Invariants
+
+Enforcement classes follow the pre-review checklist's definitions.
+
+- **INV-C1**: every time read in library code goes through the
+  virtualizable clock (`tokio::time`), and `std::time::Instant::now`,
+  `std::time::SystemTime::now`, and `std::thread::sleep` appear nowhere
+  in the repository's Rust targets except the named bench exception
+  (§3.1) at its explicitly allowed measurement sites.
+  Structural-mechanical: clippy `disallowed-methods` entries for the
+  three named calls in `clippy.toml`, failing the workspace lint gate
+  on any reintroduction, with the bench allow visible at its use sites.
+  Structural-review for what a lint cannot name: a time source that
+  bypasses `std` (a direct syscall, or a new dependency reading OS
+  time) is checked at dependency and code review — the crate currently
+  has no time-reading dependency, and adding one is a reviewable event.
+  (Adversarial models: virtualized sleeps combined with `std` now-reads
+  for comparisons — caught by the lint; a libc/syscall clock — caught
+  only by the review half, which is why the class is structural rather
+  than purely mechanical.)
+- **INV-C2**: in a controlled context, §3.2's advancement rule holds —
+  under a non-idling controller, a gated behavior stays pending across
+  arbitrarily many polls until an explicit advance reaches its
+  deadline, and is ready on the next poll after one that does.
+  Behavioral: a paused-clock test polls a pending `Command::timeout`
+  leaf repeatedly without advancing and asserts it remains pending
+  (this is the check a compliant implementation passes and an
+  implicitly-advancing clock fails), then advances exactly to the
+  deadline and asserts readiness without real-time waiting.
+- **INV-C3**: the time-dependent contracts pinned by RFC 0004 and by
+  `Timer`'s documented semantics hold identically under the virtual
+  clock. Behavioral: the existing paused-clock timeout/retry suites
+  (`src/command/effect.rs`, `src/command/retry.rs`, `src/runtime.rs`)
+  are the timeout/retry half; new paused-clock `Timer` tests pin the
+  timer half — no tick ready before an advance of one full interval,
+  the first tick ready after exactly one interval, and a single advance
+  spanning several intervals yielding exactly one tick (the
+  skipped-not-replayed contract). The existing wide-margin real-time
+  `Timer` tests remain as non-normative smoke checks; the paused tests
+  are the contract's proof.
+- **INV-C4**: production neutrality — the crate exposes no time-control
+  surface and the production runtime never pauses or configures the
+  clock, before and after the §5.1 feature flip. Structural: review of
+  `Runtime` construction and `RuntimeConfig` for the absence of any
+  clock field, and the public-surface check (`tests/api_surface.rs`)
+  showing no time-control item. The §4 migration's
+  behavior-preservation half is structural too: the diff is a type
+  swap with no logic change, and the existing HTTP suite stays green.
+
+Surface–invariant coverage: this RFC adds no public API surface. Its
+contract surface is the source rule (INV-C1), the controlled-context
+guarantees (INV-C2, INV-C3), the neutrality guarantee and the §5.1
+feature flip (INV-C4), and the §4 migration (INV-C1 turn-on plus
+INV-C4's preservation check). The `docs/testing.md` recipe (§5.5) is
+documentation and carries no invariant.
+
+## 7. Open questions
+
+None. The nearest candidates are recorded as negative space instead
+(§3.4): equal-deadline firing order and real-time accuracy stay
+unpinned until a consumer states a need, which none of the named
+consumers (§5) does.
+
+## 8. References
+
+- RFC 0004 — command timeout and retry: §1.3 requirement 7 (paused
+  clock as the deterministic instrument), §1.4/§5.2 (the clock-DI and
+  jitter deferrals this RFC resolves and re-scopes), and the
+  timeout/retry semantics INV-C3 carries onto the virtual clock.
+- RFC 0006 — runtime load control: the real-time statistical criteria
+  behind the bench exception (§3.1); the load-event fields under the
+  uniform observability rule.
+- RFC 0007 — RuntimeConfig: the config surface INV-C4 checks for the
+  absence of clock fields.
+- RFC 0008 — TestStore: §7 (the split this RFC completes), §4.1 (the
+  poll budget that makes stage 2 a non-idling controller), §4.2 (the
+  canonical order that supplies what §3.4 declines to), INV-T3 (the
+  evidence-transfer argument INV-C3 mirrors).
+- `src/command/effect.rs`, `src/command/retry.rs`,
+  `src/subscription/time.rs`, `src/runtime.rs`,
+  `src/runtime/frame_scheduler.rs`, `src/runtime/channel.rs` — the
+  conforming inventory rows.
+- `src/subscription/http/cell.rs`, `src/subscription/http/query.rs` —
+  the §4 migration sites.
+- `benches/runtime_load.rs` — the named real-time exception.
+- `clippy.toml` — INV-C1's mechanical enforcement site.
+- `docs/testing.md` — the paused-time testing conventions §5.5 extends.
+- `docs/rfcs/pre-review-checklist.md` — enforcement-class definitions.

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -24,11 +24,11 @@ Four decisions:
    RFC resolves — lands as a source discipline plus a citable
    determinism contract, not as an injection surface.
 2. **Single time source** (§3.1, INV-C1). Every time read in library
-   code goes through the virtualizable clock. `std::time::Instant::now`,
-   `std::time::SystemTime::now`, and `std::thread::sleep` are banned
-   mechanically via clippy's `disallowed-methods`. Two HTTP-module files
-   violate the rule today; migrating them is this RFC's named
-   prerequisite (§4).
+   code goes through the virtualizable clock. The `std` entry points
+   that read the current time or wait on its passage are banned
+   mechanically via clippy's `disallowed-methods`, whose entries are
+   derived as an inventory in §3.1. Two HTTP-module files violate the
+   rule today; migrating them is this RFC's named prerequisite (§4).
 3. **Controlled-context contract** (§3.2, INV-C2, INV-C3). A consumer
    that controls the clock may rely on: virtual time advances only under
    the controller's action (plus the executor's idle auto-advance, which
@@ -39,8 +39,8 @@ Four decisions:
    about production behavior.
 4. **Production neutrality** (§3.3, INV-C4). No production surface
    changes: the runtime never pauses or configures the clock, no public
-   type or config field mentions time control, and unpaused behavior is
-   byte-for-byte the platform monotonic clock.
+   type or config field mentions time control, and unpaused time reads
+   are observably identical to the platform monotonic clock.
 
 The dependency direction fixed by RFC 0008 §7 is honored: TestStore
 stage 2 consumes this contract; nothing here gates on TestStore.
@@ -170,12 +170,49 @@ Inventory of production time reads at this RFC's writing:
 | `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4 migration** |
 | `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4 migration** |
 
+The rule's mechanical floor is an inventory of the `std` entry points
+whose call reads the current time or blocks on its passage, derived by
+walking `std`'s surface for both classes rather than by listing the
+calls the crate happens to use today:
+
+| Banned entry point | Class |
+| --- | --- |
+| `std::time::Instant::now` | now-read |
+| `std::time::Instant::elapsed` | now-read; reachable on a value converted out of the virtual clock (`tokio::time::Instant::into_std`), so banning `now` alone does not close the type |
+| `std::time::SystemTime::now` | now-read |
+| `std::time::SystemTime::elapsed` | now-read; callable on the `UNIX_EPOCH` constant without any prior `now` |
+| `std::thread::sleep` | real-time wait |
+| `std::thread::park_timeout` | real-time wait |
+| `std::sync::Condvar::wait_timeout` | real-time wait |
+| `std::sync::Condvar::wait_timeout_while` | real-time wait |
+| `std::sync::mpsc::Receiver::recv_timeout` | real-time wait |
+| `std::sync::mpsc::Receiver::recv_deadline` | real-time wait |
+
+The deprecated `_ms` spellings (`std::thread::sleep_ms`,
+`std::thread::park_timeout_ms`, `std::sync::Condvar::wait_timeout_ms`)
+carry their own lint entries. Pure arithmetic between existing time
+values (`duration_since`, `checked_add`, comparisons) reads nothing and
+stays allowed; untimed blocking (`std::thread::park`, `Condvar::wait`)
+waits on events, not on time, and stays allowed. What the lint cannot
+name — a timed wait routed through an API outside the table (an
+OS-level I/O timeout on a socket), a direct syscall, or a dependency
+used as a time source — falls to INV-C1's review half.
+
+Dependencies are scoped the same way: no dependency serves *library
+code* as a time source, and adding one is a reviewable event. Time
+spent inside dependencies on the crate's behalf — the bench harness
+measuring elapsed time (`criterion`), the terminal backend's internal
+event polling — is measurement or external-input timing, not a time
+read issued by the crate's code, and sits outside the axis this rule
+governs (like network latency, it was never virtual).
+
 Outside library code, exactly one deliberate exception exists:
 `benches/runtime_load.rs` measures real wall-clock latency because
-RFC 0006's statistical acceptance criteria are defined on real time; it
-carries an explicit lint allow at its measurement sites. Unit and
-integration tests contain no `std::time` reads today and fall under the
-same rule.
+RFC 0006's statistical acceptance criteria are defined on real time.
+The §4 migration, which lands the lint configuration, adds an explicit
+lint allow at the bench's measurement sites in the same change. Unit
+and integration tests contain no `std::time` reads today and fall under
+the same rule.
 
 Observability-only reads (tracing durations, load-event fields) follow
 the same rule as contract-bearing reads. A uniform rule keeps the
@@ -227,9 +264,12 @@ controlled context, the contract a consumer may cite:
 
 The production runtime never pauses, constructs, or configures the
 clock. No public type, method, or `RuntimeConfig` field mentions time
-control. In an unpaused context every time read above is the platform
-monotonic clock, exactly as before this RFC. There is nothing to
-migrate, configure, or opt into for any existing application.
+control. In an unpaused context every time read above returns what the
+platform monotonic clock returns — observably unchanged from before
+this RFC, and still observably unchanged after the §5.1 feature flip,
+which adds a clock-context check on the read path but no observable
+difference. There is nothing to migrate, configure, or opt into for
+any existing application.
 
 ### 3.4 Negative space
 
@@ -272,7 +312,12 @@ the rule. They migrate to the virtualizable clock's `Instant`.
 
 The stage-2 amendment gives the store a controlled time context and an
 advance operation, making §4.3-class leaves (timeout, backoff, timer)
-deliverable through ordinary `receive` flow. What it cites here:
+deliverable through ordinary `receive` flow. RFC 0008 §7's
+non-normative sketch pictured "a store-held clock handle"; this RFC's
+design supersedes that shape — there is no clock value to hold. The
+store holds a controlled time context (§3.2) and `advance` acts on that
+context's clock; the amendment specifies its API against this RFC, not
+against the sketch. What it cites here:
 INV-C2's explicit-advance determinism (the store's poll budget never
 idles the executor, so the auto-advance clause never applies) and
 INV-C3's transparency (store results are evidence about production time
@@ -329,21 +374,25 @@ Documentation, not contract surface.
 Enforcement classes follow the pre-review checklist's definitions.
 
 - **INV-C1**: every time read in library code goes through the
-  virtualizable clock (`tokio::time`), and `std::time::Instant::now`,
-  `std::time::SystemTime::now`, and `std::thread::sleep` appear nowhere
-  in the repository's Rust targets except the named bench exception
-  (§3.1) at its explicitly allowed measurement sites.
-  Structural-mechanical: clippy `disallowed-methods` entries for the
-  three named calls in `clippy.toml`, failing the workspace lint gate
-  on any reintroduction, with the bench allow visible at its use sites.
-  Structural-review for what a lint cannot name: a time source that
-  bypasses `std` (a direct syscall, or a new dependency reading OS
-  time) is checked at dependency and code review — the crate currently
-  has no time-reading dependency, and adding one is a reviewable event.
-  (Adversarial models: virtualized sleeps combined with `std` now-reads
-  for comparisons — caught by the lint; a libc/syscall clock — caught
-  only by the review half, which is why the class is structural rather
-  than purely mechanical.)
+  virtualizable clock (`tokio::time`), and none of §3.1's banned entry
+  points appears in the repository's Rust targets except the named
+  bench exception (§3.1) at its explicitly allowed measurement sites.
+  Structural-mechanical: clippy `disallowed-methods` in `clippy.toml`
+  carries exactly §3.1's banned-entry-point inventory (landing with the
+  §4 migration, which removes the last violations), failing the
+  workspace lint gate on any reintroduction. Structural-review for time
+  reads the lint does not name — inside `std` (a timed wait routed
+  through an API outside the table, such as an OS-level I/O timeout) as
+  well as outside it (a direct syscall, or a dependency used by library
+  code as a time source, §3.1's dependency scoping) — checked at code
+  and dependency review. (Adversarial models: virtual sleeps combined
+  with `std` now-reads for comparisons — the table's now-read rows;
+  wall-clock time reached without `SystemTime::now` via
+  `UNIX_EPOCH.elapsed()` — the `SystemTime::elapsed` row exists for it;
+  a `std` `Instant` smuggled out of the virtual clock via `into_std`
+  and then read — the `Instant::elapsed` row; a libc/syscall clock or a
+  time-source dependency — the review half, which is why the class is
+  structural rather than purely mechanical.)
 - **INV-C2**: in a controlled context, §3.2's advancement rule holds —
   under a non-idling controller, a gated behavior stays pending across
   arbitrarily many polls until an explicit advance reaches its

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -171,8 +171,10 @@ Inventory of production time reads at this RFC's writing:
 | `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4 migration** |
 
 The rule's mechanical floor is an inventory of the `std` entry points
-whose call reads the current time or blocks on its passage, derived by
-walking `std`'s surface for both classes rather than by listing the
+whose call reads the current time, blocks on its passage, or configures
+a timed block, derived by walking `std`'s time (`std::time`), thread
+and synchronization (`std::thread`, `std::sync`), and portable network
+I/O (`std::net`) surface for those three classes — not by listing the
 calls the crate happens to use today:
 
 | Banned entry point | Class |
@@ -187,24 +189,32 @@ calls the crate happens to use today:
 | `std::sync::Condvar::wait_timeout_while` | real-time wait |
 | `std::sync::mpsc::Receiver::recv_timeout` | real-time wait |
 | `std::sync::mpsc::Receiver::recv_deadline` | real-time wait |
+| `std::net::TcpStream::connect_timeout` | real-time wait |
+| `std::net::TcpStream::set_read_timeout`, `set_write_timeout` | timed-wait configuration; banning the setters closes the only route to a timed socket wait while the blocking `read`/`write` sites stay unbanned |
+| `std::net::UdpSocket::set_read_timeout`, `set_write_timeout` | timed-wait configuration |
 
 The deprecated `_ms` spellings (`std::thread::sleep_ms`,
 `std::thread::park_timeout_ms`, `std::sync::Condvar::wait_timeout_ms`)
 carry their own lint entries. Pure arithmetic between existing time
 values (`duration_since`, `checked_add`, comparisons) reads nothing and
 stays allowed; untimed blocking (`std::thread::park`, `Condvar::wait`)
-waits on events, not on time, and stays allowed. What the lint cannot
-name — a timed wait routed through an API outside the table (an
-OS-level I/O timeout on a socket), a direct syscall, or a dependency
-used as a time source — falls to INV-C1's review half.
+waits on events, not on time, and stays allowed. Platform-gated
+siblings of the table's rows — the `std::os` socket types' timeout
+setters (`std::os::unix::net::UnixStream`, `UnixDatagram`) — do not
+resolve on every compilation target, so they ride INV-C1's review half
+instead of per-target lint entries; the review half likewise covers
+what the lint does not name at all — a direct syscall, or a dependency
+other than the executor used as a time source (next paragraph).
 
-Dependencies are scoped the same way: no dependency serves *library
-code* as a time source, and adding one is a reviewable event. Time
-spent inside dependencies on the crate's behalf — the bench harness
-measuring elapsed time (`criterion`), the terminal backend's internal
-event polling — is measurement or external-input timing, not a time
-read issued by the crate's code, and sits outside the axis this rule
-governs (like network latency, it was never virtual).
+Dependencies are scoped the same way: the executor clock itself
+(`tokio::time`) is the crate's one sanctioned time source, and no
+*other* dependency serves library code as a time source — adding one
+is a reviewable event. Time spent inside dependencies on the crate's
+behalf — the bench harness measuring elapsed time (`criterion`), the
+terminal backend's internal event polling — is measurement or
+external-input timing, not a time read issued by the crate's code, and
+sits outside the axis this rule governs (like network latency, it was
+never virtual).
 
 Outside library code, exactly one deliberate exception exists:
 `benches/runtime_load.rs` measures real wall-clock latency because
@@ -381,18 +391,19 @@ Enforcement classes follow the pre-review checklist's definitions.
   carries exactly §3.1's banned-entry-point inventory (landing with the
   §4 migration, which removes the last violations), failing the
   workspace lint gate on any reintroduction. Structural-review for time
-  reads the lint does not name — inside `std` (a timed wait routed
-  through an API outside the table, such as an OS-level I/O timeout) as
-  well as outside it (a direct syscall, or a dependency used by library
-  code as a time source, §3.1's dependency scoping) — checked at code
-  and dependency review. (Adversarial models: virtual sleeps combined
+  reads the lint does not name — inside `std` (the platform-gated
+  `std::os` socket timeout setters, which do not resolve on every
+  target) as well as outside it (a direct syscall, or a dependency
+  other than the executor used by library code as a time source, §3.1's
+  dependency scoping) — checked at code and dependency review.
+  (Adversarial models: virtual sleeps combined
   with `std` now-reads for comparisons — the table's now-read rows;
   wall-clock time reached without `SystemTime::now` via
   `UNIX_EPOCH.elapsed()` — the `SystemTime::elapsed` row exists for it;
   a `std` `Instant` smuggled out of the virtual clock via `into_std`
   and then read — the `Instant::elapsed` row; a libc/syscall clock or a
-  time-source dependency — the review half, which is why the class is
-  structural rather than purely mechanical.)
+  time-source dependency beyond the executor — the review half, which
+  is why the class is structural rather than purely mechanical.)
 - **INV-C2**: in a controlled context, §3.2's advancement rule holds —
   under a non-idling controller, a gated behavior stays pending across
   arbitrarily many polls until an explicit advance reaches its

--- a/docs/rfcs/README.md
+++ b/docs/rfcs/README.md
@@ -65,3 +65,4 @@ Three corollaries:
 | [0006](0006-runtime-load-control.md) | Runtime load control, backpressure, latency guarantees |
 | [0007](0007-runtime-config.md) | RuntimeConfig public API, load-control acceptance parameters |
 | [0008](0008-teststore.md) | TestStore: deterministic update/effect testing, `Message` boundary |
+| [0009](0009-clock-di.md) | Clock DI: single-time-source rule, virtual-clock determinism contract |

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -77,6 +77,33 @@ and had to be re-scoped to "the store introduces no nondeterminism of
 its own", with transcript identity conditional on a deterministic
 application.
 
+An enforcement instrument's member list is an inventory too. A
+deny-list (a lint configuration, a grep pattern, a CI selector) that
+claims to close a definition is derived by walking the surface the
+definition quantifies over, never by listing the members the codebase
+happens to use today; scope the derivation claim to the sub-surfaces
+actually walked and name the delegated remainder. Closure is checked
+per obtainment route: banning a type's constructor does not close the
+type while a constant or a conversion still yields values whose reads
+bypass the list. *From PR #242:* a three-method disallowed list
+presented as enforcing "every time read" missed `UNIX_EPOCH.elapsed()`
+(a wall-clock now-read with no `now` call), the `std` timed waits
+(`park_timeout`, `Condvar::wait_timeout`, `recv_timeout`), and `std`
+`Instant`s obtained through the virtual clock's `into_std` conversion;
+the fix text then claimed the list was "derived by walking `std`'s
+surface" while `std::net`'s nameable timed I/O was still absent from
+it.
+
+A universal negative over a set that contains the rule's own
+instrument is checked against that member first. A contract that
+elevates one sanctioned channel and then states "no member of the set
+does X" quantifies over the sanctioned channel too, and either carves
+it out explicitly or is refuted by it. *From PR #242:* "the crate has
+no time-reading dependency" was refuted by the bench harness in
+dev-dependencies, and its replacement "no dependency serves library
+code as a time source" by the executor clock itself — the very
+dependency the RFC pins as the single time source.
+
 ## 2. Adversarial counterexample per invariant
 
 For each requirement and invariant, deliberately construct at least one
@@ -273,6 +300,14 @@ scenarios run only on the reference machine" narrowed RFC 0006's
 scoping, which admits full runs on any machine and reserves only
 acceptance force to the reference machine.
 
+A capability absolute about the enforcement tooling itself is the same
+class: *the lint cannot name X* is verified against the tool's actual
+expressiveness before X is delegated to a weaker check. *From
+PR #242:* socket timeout methods described as something "the lint
+cannot name" are ordinary `disallowed-methods` paths; only the
+platform-gated `std::os` siblings, whose paths do not resolve on every
+target, genuinely needed the review half.
+
 ## 5. Normative force and readiness
 
 An RFC or amendment that gates implementation carries no soft spots in
@@ -387,5 +422,20 @@ changed-claims list.
   fixes removed from the RFC do not survive in the body. Re-read the
   description at the end of each review round, not only when opening
   the PR.
+- A present-tense claim about repository state — a lint entry, an
+  allow attribute, a CI job — is checked against the repository as it
+  exists; an artifact a named prerequisite will create is stated as
+  landing with that prerequisite (from PR #242: "it carries an
+  explicit lint allow at its measurement sites" described an allow the
+  RFC's own migration prerequisite had yet to add, inside an inventory
+  framed as "at this RFC's writing").
+- Superseding another document's recorded expectation is a corrected
+  claim even when the expectation was non-normative: when a decision
+  replaces a sketch or shape another RFC recorded, name the
+  supersession where the decision lands, so the later amendment
+  reconciles against the decision rather than against two silently
+  divergent texts (from PR #242: the no-clock-handle design
+  contradicted RFC 0008 §7's "store-held clock handle" sketch until
+  §5.1 named the supersession).
 - `typos` and `git diff --check` are clean.
 - English only (repository artifact).


### PR DESCRIPTION
## Summary

Adds RFC 0009 (Draft): Clock DI — deterministic time via the virtual clock, resolving the split decided in RFC 0008 §7. TestStore stage 2, debounce/throttle (P5), and subscription restart rate control consume this contract.

Four decisions:

1. **No clock abstraction.** No `Clock` trait, no injected clock value, no clock parameter on any API. The crate's single time axis is the executor's virtualizable clock (`tokio::time`); "Clock DI" lands as a source discipline plus a citable determinism contract. This promotes RFC 0004 §1.3 requirement 7 (paused clock as the deterministic instrument) from test technique to crate-wide contract, and resolves RFC 0004 §1.4's clock-DI deferral.
2. **Single time source (INV-C1).** Every time read in library code goes through `tokio::time`. The mechanical floor is a banned-entry-point inventory derived by walking `std`'s time, thread/synchronization, and portable network I/O surface for now-reads, real-time waits, and timed-wait configuration (`Instant::now`/`elapsed`, `SystemTime::now`/`elapsed`, `thread::sleep`/`park_timeout`, `Condvar::wait_timeout(_while)`, `mpsc::recv_timeout`/`recv_deadline`, `TcpStream::connect_timeout`, the `TcpStream`/`UdpSocket` timeout setters, plus the deprecated `_ms` spellings), enforced via clippy `disallowed-methods`; what the lint does not name — platform-gated `std::os` socket setters, syscalls, or a dependency other than the executor used as a time source — falls to the review half. `benches/runtime_load.rs` is the one named real-time exception. Backed by a full inventory of the eight production time-read sites.
3. **Controlled-context contract (INV-C2/C3).** Explicit-advance determinism scoped to a non-idling controller (the auto-advance clause is stated, not granted), no early firing, readiness without real-time waiting, and clock transparency of the RFC 0004 / `Timer` contracts — the time-axis analogue of RFC 0008's INV-T3 evidence-transfer argument.
4. **Production neutrality (INV-C4).** No public surface change; unpaused time reads are observably unchanged, including after the `test-util` feature flip.

Also pinned:

- **Named prerequisite**: migrate the HTTP module's `std::time::Instant` reads (`cell.rs` staleness/gc decisions, `query.rs` tracing) to the virtual clock — behavior-preserving, no public signature involved. The migration lands the lint configuration and the bench's explicit allow in the same change; the lint cannot land first.
- **`test-util` feature decision**: joins the unconditional `tokio` dependency features with the first in-crate controlled-context consumer (TestStore stage 2 owns the flip); no tears-level feature flag, per RFC 0008 §3.3's precedent. §5.1 also records that this design supersedes RFC 0008 §7's non-normative "store-held clock handle" sketch shape.
- Open questions: none — equal-deadline ordering and real-time accuracy are recorded as negative space (§3.4) instead.

## Rejected alternatives (in the RFC body)

`Arc<dyn Clock>` via `Flags`/environment, drive-time clock parameters on the parts boundary, per-source injection, and a TCA-style dependency registry — the decisive failures are reachability (`Command::timeout`/retry/`Timer::new` construct time-gated behavior with no environment access) and time-axis splitting (user `tokio::time` calls inside effects would not follow an injected clock).

## Review notes

- The pre-review checklist was run on the draft and re-run on the review-fix commit's changed-claims list: universal claims are backed by the §3.1 inventories (grep-verified, including the absence of any `SystemTime` read in the repository), adversarial models are recorded inline (idling controller citing INV-C2; `UNIX_EPOCH.elapsed()`; a `std` `Instant` smuggled out via `into_std`; lint-bypassing time sources), every invariant declares its enforcement class, and cited code/RFC passages were re-read this session.
- INV-C3's Timer half (paused-clock tests: no tick before one full interval; a single advance spanning several intervals yields exactly one tick) is stated from `MissedTickBehavior::Skip`'s documented semantics; the implementation task verifies it.

## Checklist additions

Per the checklist's living-document rule, the review lessons are folded into `docs/rfcs/pre-review-checklist.md` in this PR: an enforcement deny-list is an inventory derived by walking the surface its definition quantifies over, with per-obtainment-route closure (item 1); a universal negative over a set containing the rule's own instrument is checked against that member first (item 1); a capability absolute about the tooling ("the lint cannot name X") is verified against the tool's actual expressiveness (item 4); present-tense repository-state claims are checked against the repository as it exists, and superseding another document's recorded sketch is a corrected claim named where the decision lands (item 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

