### PR TITLE
docs(rfcs): declare RFC 0009 unstable-surface policy for the lint walk

### DIFF
--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -172,10 +172,10 @@ Inventory of production time reads at this RFC's writing:
 
 The rule's mechanical floor is an inventory of the `std` entry points
 whose call reads the current time, blocks on its passage, or configures
-a timed block, derived by walking `std`'s time (`std::time`), thread
-and synchronization (`std::thread`, `std::sync`), and portable network
-I/O (`std::net`) surface for those three classes — not by listing the
-calls the crate happens to use today:
+a timed block, derived by walking the stable surface of `std`'s time
+(`std::time`), thread and synchronization (`std::thread`, `std::sync`),
+and portable network I/O (`std::net`) families for those three
+classes — not by listing the calls the crate happens to use today:
 
 | Banned entry point | Class |
 | --- | --- |
@@ -205,6 +205,12 @@ resolve on every compilation target, so they ride INV-C1's review half
 instead of per-target lint entries; the review half likewise covers
 what the lint does not name at all — a direct syscall, or a dependency
 other than the executor used as a time source (next paragraph).
+Unstable members of the same classes — `std::thread::sleep_until`, the
+`std::sync::mpsc`-style timed receives of `std::sync::mpmc` — are
+uncallable on the crate's stable toolchain and join the table on
+stabilization; `recv_deadline`, equally unstable, is listed ahead of
+that defensively because it completes a family already present, and
+the §4 implementation task confirms the lint accepts its path.
 
 Dependencies are scoped the same way: the executor clock itself
 (`tokio::time`) is the crate's one sanctioned time source, and no


### PR DESCRIPTION
## Summary

Follow-up to #242, addressing the final review finding there: the derivation walk's handling of unstable `std` members was implicit and inconsistent (`recv_deadline`, unstable, sat in the table while the equally unstable `thread::sleep_until` and `std::sync::mpmc` timed receives did not).

RFC 0009 §3.1 now declares the policy in one place:

- The walk covers `std`'s **stable** surface (the derivation sentence says so explicitly).
- Unstable members of the same classes — `std::thread::sleep_until`, the `std::sync::mpmc` timed receives — are uncallable on the crate's stable toolchain (channel 1.97.0, MSRV 1.88) and join the table on stabilization.
- `recv_deadline` stays listed ahead of that defensively because it completes a family already present; the §4 implementation task confirms the lint accepts its path.

#242 was merged while this fix was in flight, so it lands as its own PR. Note: the post-merge push briefly recreated `docs/rfc-0009-clock-di` on the remote; that branch is now redundant (its commits are all on `main` or here) and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)