### PR TITLE
docs(rfcs): accept RFC 0009

### DIFF
--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,6 +1,6 @@
 # RFC 0009: Clock DI — deterministic time via the virtual clock
 
-- Status: Draft
+- Status: Accepted
 - Target: a crate-wide determinism contract for time-dependent behavior,
   with no new public API
 - Scope: the no-clock-abstraction decision, the single-time-source rule,


### PR DESCRIPTION
## Summary
- Promote RFC 0009 (Clock DI) Status from Draft to Accepted.
- The contract (no injected `Clock`, single time source via `tokio::time`, controlled-context guarantees §3.2, production neutrality §3.3) is stable after three review rounds (PR #242, #243, #244).
- §7 Open Questions records none; the remaining candidates (equal-deadline ordering, real-time accuracy) are pinned as deliberate negative space (§3.4) instead.

## Test plan
- [x] `docs/rfcs/pre-review-checklist.md` items re-run: no hedge words in normative sections, §7 has no pending choices, `typos` and `git diff --check` clean.
- [x] No other doc currently references RFC 0009, so no cross-reference updates are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)