### PR TITLE
docs(rfcs): fix RFC 0008/0009 contracts flagged as No-Go for implementation

### DIFF
--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -37,7 +37,7 @@ Three decisions, ordered by urgency:
    received, an effect stream never driven to completion — fails the
    test at `receive`, `finish`, or drop; `send` does not block on
    pending output, so a scripted `send` can supersede or cancel an
-   earlier step's not-yet-received output the way the runtime's
+   earlier step's not-yet-received keyed output the way the runtime's
    shared-first schedule does (§6). The one carve-out mirrors the
    runtime's shutdown contract: output remaining after an observed quit
    is legally discarded. A non-exhaustive mode is deliberately not
@@ -225,8 +225,8 @@ generic) are implementation latitude.
   polls no pending leaf for output; pending deliverable output is left
   in place for a later `receive*` (or caught by `finish`/drop, §6),
   which lets a scripted `send` supersede or cancel an earlier step's
-  not-yet-received output exactly as the runtime's shared-first schedule
-  does (§6). Its only poll is the keyed-intake reconciliation of §5.1,
+  not-yet-received keyed output as the runtime's shared-first schedule
+  allows (§6). Its only poll is the keyed-intake reconciliation of §5.1,
   and only when the returned command is keyed under
   `CancelPolicy::KeepInFlight`; it never delivers output, which happens
   only in `receive*` calls.
@@ -415,10 +415,15 @@ completes — the analogue of INV-7's sender-closed empty receiver.
   issued only for `KeepInFlight`, whose admission outcome depends on
   whether the occupant is still open. For `CancelPolicy::CancelInFlight`
   the outcome is fixed — the occupant is superseded and its undelivered
-  output discarded regardless of its state — so no reconciliation poll
-  is issued: superseding an exhausted occupant and spawning into a
-  released id are indistinguishable, and this matches the runtime, which
-  aborts the in-flight keyed task without sampling it. Not polling also
+  output discarded regardless of its state — so the store issues no
+  reconciliation poll: superseding an exhausted occupant and spawning
+  into a released id are indistinguishable. The runtime does sample the
+  target receiver's facts before *every* `Spawn(policy)`, `CancelInFlight`
+  included (`reconcile_receiver` in `src/runtime/keyed_commands.rs`;
+  RFC 0003 §4.2), but that sample cannot change a `CancelInFlight`
+  admission outcome, and the store has no equivalent receiver snapshot to
+  reconcile — so skipping the poll preserves the delivery contract while
+  matching the runtime's outcome, not its every step. Not polling also
   lets a `CancelInFlight` command supersede a reactor-dependent occupant
   (a `timeout` or backoff leaf) without polling it, so cancellation of a
   time-dependent keyed leaf is expressible in stage 1 (§4.3). Any poll
@@ -492,14 +497,20 @@ Exhaustive assertion is the only stage-1 mode. The rules, by call site:
   output does not block a `send`, and neither do effects that are
   pending but not deliverable. Leaving deliverable output in place lets
   a test script a `send` that supersedes or cancels an earlier step's
-  not-yet-received output — the sequence `send(Start); send(Cancel)`
-  cancels a keyed effect before its output is received — which mirrors
-  the runtime's shared-first schedule, where a shared input (the next
-  message) is processed ahead of a keyed effect's already-ready output
-  (RFC 0003 §4.2; `src/runtime/app_input.rs`). Undelivered output is
-  not lost track of: it stays subject to the `receive*`, `finish`, and
-  drop checks below, which remain exhaustive. `send` still fails after
-  an observed quit (§5.3).
+  not-yet-received *keyed* output — the sequence
+  `send(Start); send(Cancel)` cancels a keyed effect before its output
+  is received — which is exactly the runtime's shared-first schedule:
+  a shared input (the next message) is processed ahead of a keyed
+  effect's already-ready output (RFC 0003 INV-14, §4.2;
+  `src/runtime/app_input.rs`). Ordering a `send` ahead of *unkeyed*
+  pending output is **not** a runtime guarantee: unkeyed command output
+  travels the shared channel in FIFO order alongside other shared
+  traffic (a `send`'s message does not jump it), so a `send` scripted
+  before unkeyed output is TestStore's own linearization, not evidence
+  of runtime scheduling (§4.2's citation rule). Undelivered output is
+  not lost track of either way: it stays subject to the `receive*`,
+  `finish`, and drop checks below, which remain exhaustive. `send` still
+  fails after an observed quit (§5.3).
 - **`receive` / `receive_matching` / `receive_quit`** fail on a
   mismatch, on quit-versus-message confusion, or when nothing is
   deliverable — each with a diagnostic that names the actual value

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -14,10 +14,12 @@
 
 > **Staging.** This RFC specifies stage 1 only: driving pure `update`
 > transitions and effects that become ready without an executor, a timer,
-> or wall-clock time. Time-dependent effects (`Command::timeout`, retry
-> backoff, `Timer`-based subscriptions) are stage 2, which waits on a
-> separate Clock DI RFC (§7) and lands as a reviewed amendment to this
-> document.
+> or wall-clock time. Time-dependent *command* effects (`Command::timeout`,
+> retry backoff) are stage 2, which waits on a separate Clock DI RFC (§7)
+> and lands as a reviewed amendment to this document. `Timer`-based
+> subscriptions are not staged here at all: TestStore never executes
+> subscription sources (§1.2), so lifting that is a separate
+> subscription-execution design, not stage 2.
 
 ## Summary
 
@@ -33,10 +35,13 @@ Three decisions, ordered by urgency:
 2. **Exhaustive assertions** (§6): exhaustive is the only mode in
    stage 1. Undelivered deliverable output — a ready message never
    received, an effect stream never driven to completion — fails the
-   test. The one carve-out mirrors the runtime's shutdown contract:
-   output remaining after an observed quit is legally discarded. A
-   non-exhaustive mode is deliberately not designed here (open
-   question 2).
+   test at `receive`, `finish`, or drop; `send` does not block on
+   pending output, so a scripted `send` can supersede or cancel an
+   earlier step's not-yet-received output the way the runtime's
+   shared-first schedule does (§6). The one carve-out mirrors the
+   runtime's shutdown contract: output remaining after an observed quit
+   is legally discarded. A non-exhaustive mode is deliberately not
+   designed here (open question 2).
 3. **Clock DI split** (§7): Clock injection is a separate RFC. This RFC
    does not gate on it, and stage 2 of TestStore gates on that RFC, not
    the reverse.
@@ -82,7 +87,11 @@ cancellation semantics honored on the pending output (§5).
 - **Subscription source execution**: TestStore never starts, polls, or
   restarts a subscription source. It observes the *declared* set only.
   Lifecycle behavior (keyed restart, RFC 0005) stays covered by the
-  runtime's own tests.
+  runtime's own tests. This covers `Timer` and every other
+  `SubscriptionSource`: subscription execution is out of scope in
+  stage 1 and stage 2 alike — lifting it would be a separate
+  subscription-execution design, not the Clock DI stage-2 amendment
+  (RFC 0009 §5.1), which delivers command time leaves only.
 - **Runtime integration contracts**: channel capacities, backpressure,
   batching, and scheduling (RFC 0006/0007) are properties of the runtime
   event loop, which TestStore replaces. A TestStore run exercises none of
@@ -165,8 +174,9 @@ where
     pub fn state(&self) -> &App;
 
     /// Applies `msg` through `update` and enqueues the returned
-    /// command's effects. Fails the test if a deliverable message is
-    /// pending (§6) or quit has been observed (§5.3).
+    /// command's effects. Does not deliver or poll pending output;
+    /// undelivered output stays caught by `receive*`/`finish`/drop (§6).
+    /// Fails the test only if quit has been observed (§5.3).
     pub fn send(&mut self, msg: App::Message);
 
     /// Asserts that the next deliverable output is a message equal to
@@ -211,10 +221,15 @@ generic) are implementation latitude.
 - **`send`** is one synchronous `update` call plus bookkeeping. It
   spawns no task, requires no executor, and returns only after the
   command's metadata (directives, cancellation) has been applied to the
-  store. Its polling is limited to §4.1's checks — the exhaustiveness
-  precondition before `update` and, when the returned command is keyed,
-  the intake reconciliation poll (§5.1); it never delivers output,
-  which happens only in `receive*` calls.
+  store. It runs no deliverable-output exhaustiveness precondition and
+  polls no pending leaf for output; pending deliverable output is left
+  in place for a later `receive*` (or caught by `finish`/drop, §6),
+  which lets a scripted `send` supersede or cancel an earlier step's
+  not-yet-received output exactly as the runtime's shared-first schedule
+  does (§6). Its only poll is the keyed-intake reconciliation of §5.1,
+  and only when the returned command is keyed under
+  `CancelPolicy::KeepInFlight`; it never delivers output, which happens
+  only in `receive*` calls.
 - **`receive` / `receive_matching`** select the next deliverable output
   under the canonical order (§4.2), assert it, and apply it through
   `update` — so the store advances exactly as the runtime would on that
@@ -290,8 +305,9 @@ check's poll, or when a keyed-intake reconciliation poll (§5.1) has
 already yielded it into the leaf's buffer — a buffered item is
 deliverable at every later check without a further poll. The poll
 contract is fixed, because INV-T4's determinism rests on it: polling
-happens only inside `receive*`, `send`-precondition, `finish`, and
-drop checks, plus the keyed-intake reconciliation of §5.1. The
+happens only inside `receive*`, `finish`, and drop checks, plus the
+keyed-intake reconciliation of §5.1 (a keyed `send`'s only poll, and
+only under `KeepInFlight`). A bare `send` polls no leaf (§6). The
 quit-state check precedes every one of these sites, so after an
 observed quit no store call polls at all: `send`/`receive*` fail on
 the quit state before reaching any leaf, and the `finish` and drop
@@ -317,10 +333,10 @@ reaches it. Between calls the store does nothing.
   (INV-T4, INV-T6).
 - **Scan semantics**: a `receive*` check walks the pending leaves in
   enqueue order and stops at the first deliverable one (a buffered
-  head, or a yield on that leaf's one poll); the `send`
-  precondition and the pre-quit `finish`/drop checks scan in the same
-  order until they find a deliverable output (failing) or exhaust the
-  set (establishing that nothing is deliverable). Either way, each
+  head, or a yield on that leaf's one poll); the pre-quit `finish`/drop
+  checks scan in the same order until they find a deliverable output or
+  an unfinished leaf (failing) or exhaust the set (establishing nothing
+  is outstanding). `send` runs no such scan (§6). Either way, each
   reached leaf gets exactly one poll (§4.1).
 - **Negative space, stated deliberately**: the canonical cross-leaf
   order is *TestStore's* contract, not the runtime's. The runtime folds
@@ -336,21 +352,27 @@ reaches it. Between calls the store does nothing.
 
 ### 4.3 Leaves that cannot become ready
 
-A leaf that requires a timer or reactor (`Command::timeout` wraps every
-leaf in a deadline; a backoff retry sleeps; `Timer` is
-`tokio::time::interval`-backed) cannot be driven without an executor.
-Stage 1's contract is honest about this rather than silently lenient:
-polling such a leaf fails the test. Note what that means under §4.2's
-scan semantics: the failure fires at the *first store call whose scan
-polls the leaf* — a `send`'s exhaustiveness precondition or a
-`receive` aimed at a different message, not only a call targeting the
-leaf itself — so from its enqueue onward the store is effectively
-poisoned, unless every scan stops at an earlier-enqueued yielding leaf
-first or cancellation removes the leaf (§5.1) before a scan reaches
-it. The failure today surfaces as the underlying missing-reactor
-panic, which is a poor diagnostic; the documentation on `TestStore`
-names the limitation and points at the stage-2 plan (§7). A leaf that is merely *pending* on a test-controlled
-source does not fail anything: it is skipped by the canonical order
+A command leaf that requires a timer or reactor (`Command::timeout`
+wraps every leaf in a deadline; a backoff retry sleeps) cannot be
+driven without an executor. (`Timer` is not in this set: it is a
+subscription source, not a command leaf, so it never enters the store's
+pending command set — §1.2.) Stage 1's contract is honest about this
+rather than silently lenient: polling such a leaf fails the test. Note
+what that means under §4.2's scan semantics: the failure fires at the
+*first store call whose scan polls the leaf* — a `receive` aimed at a
+different message, a `finish`/drop check, or a keyed-intake
+reconciliation poll (§5.1) that reaches it, not only a call targeting
+the leaf itself; a bare `send` never triggers it, because `send` polls
+no leaf (§6). So from its enqueue onward the store is effectively
+poisoned for those calls, unless every scan stops at an
+earlier-enqueued yielding leaf first, or a `send`-issued cancellation
+removes the leaf (§5.1) before a scan reaches it — the latter is now
+expressible precisely because `send` itself does not poll. The failure
+today surfaces as the underlying missing-reactor panic, which is a poor
+diagnostic; the documentation on `TestStore` names the limitation and
+points at the stage-2 plan (§7). A leaf that is merely *pending* on a
+test-controlled source does not fail anything: it is skipped by the
+canonical order
 until it becomes deliverable, and only `finish` holds it to account
 (§6).
 
@@ -366,12 +388,15 @@ exhausted.** Exhaustion is observable only by polling, so the store
 mirrors the runtime's pre-spawn reconciliation (before any
 `Spawn(policy)` decision the runtime reaps completed keyed tasks and
 samples the target receiver once — RFC 0003 §4.2) with **keyed-intake
-reconciliation**: when a keyed command arrives for an occupied id, the
-store reconciles before the admission decision. If the occupant already
-has buffered output, the id is occupied and nothing is polled;
-otherwise the store polls the occupant's remaining leaves in enqueue
-order, stopping at the first that shows the run still open — a yield
-(the item is buffered at that leaf's canonical position as its next
+reconciliation**: when a keyed command arrives for an occupied id and
+its policy's admission decision depends on the occupant's state
+(`CancelPolicy::KeepInFlight`), the store reconciles before that
+decision. (`CancelInFlight`'s outcome does not depend on the occupant's
+state, so it reconciles nothing — see the per-policy bullets below.) If
+the occupant already has buffered output, the id is occupied and nothing
+is polled; otherwise the store polls the occupant's remaining leaves in
+enqueue order, stopping at the first that shows the run still open — a
+yield (the item is buffered at that leaf's canonical position as its next
 deliverable output; buffered output occupies, INV-6, and §6's
 exhaustiveness counts it like any deliverable message) or a pending
 (INV-7: "a still-open stream remains occupied even after delivering
@@ -386,12 +411,18 @@ completes — the analogue of INV-7's sender-closed empty receiver.
   reconciled state: while the id remains occupied the new command's
   stream is discarded and the occupant is untouched (INV-5); when
   reconciliation observes the occupant exhausted, the id is released
-  and the new command is admitted (INV-7). For
-  `CancelPolicy::CancelInFlight` the reconciled state changes no
-  admission outcome — superseding an exhausted occupant and spawning
-  into a released id are indistinguishable — so the reconciliation rule
-  is stated once for all keyed intake; its polls follow §4.1's budget
-  either way.
+  and the new command is admitted (INV-7). The reconciliation poll is
+  issued only for `KeepInFlight`, whose admission outcome depends on
+  whether the occupant is still open. For `CancelPolicy::CancelInFlight`
+  the outcome is fixed — the occupant is superseded and its undelivered
+  output discarded regardless of its state — so no reconciliation poll
+  is issued: superseding an exhausted occupant and spawning into a
+  released id are indistinguishable, and this matches the runtime, which
+  aborts the in-flight keyed task without sampling it. Not polling also
+  lets a `CancelInFlight` command supersede a reactor-dependent occupant
+  (a `timeout` or backoff leaf) without polling it, so cancellation of a
+  time-dependent keyed leaf is expressible in stage 1 (§4.3). Any poll
+  that is issued follows §4.1's budget.
 - `Command::cancel(id)` drops the occupant's stream and undelivered
   output, and is idempotent (INV-4).
 - Unkeyed commands are unaffected by any of the above (INV-1's default
@@ -431,6 +462,17 @@ not a step: after it, `redraw_requested` keeps reporting the previous
 step's directive. This makes `without_redraw` decisions assertable per
 transition, which is the granularity RFC 0002 defines them at.
 
+The init-command reading is TestStore-specific introspection and does
+*not* predict the production runtime's first render. The runtime
+enqueues the init command directly and never consults its redraw
+directive; its first frame always renders regardless
+(`src/runtime/core.rs`, `src/runtime/pending_work.rs`). So
+`redraw_requested()` before the first step exposes the init command's
+folded directive as a `Command` property, not as a claim about whether
+the runtime would redraw its first frame — the only production redraw
+decisions it mirrors are the per-step ones, which are what INV-T3's
+"runtime would read" covers (§8).
+
 ### 5.3 Quit
 
 Quit is a deliverable output like any message and is asserted explicitly
@@ -446,10 +488,18 @@ fail because the application would no longer be running. A quit that is *suppres
 
 Exhaustive assertion is the only stage-1 mode. The rules, by call site:
 
-- **`send`** fails if any deliverable message or quit request is
-  pending. Effects that are pending but not deliverable (§4.1) do not
-  block `send` — they may be waiting on a test-controlled source the
-  test will feed later.
+- **`send`** performs no exhaustiveness check: pending deliverable
+  output does not block a `send`, and neither do effects that are
+  pending but not deliverable. Leaving deliverable output in place lets
+  a test script a `send` that supersedes or cancels an earlier step's
+  not-yet-received output — the sequence `send(Start); send(Cancel)`
+  cancels a keyed effect before its output is received — which mirrors
+  the runtime's shared-first schedule, where a shared input (the next
+  message) is processed ahead of a keyed effect's already-ready output
+  (RFC 0003 §4.2; `src/runtime/app_input.rs`). Undelivered output is
+  not lost track of: it stays subject to the `receive*`, `finish`, and
+  drop checks below, which remain exhaustive. `send` still fails after
+  an observed quit (§5.3).
 - **`receive` / `receive_matching` / `receive_quit`** fail on a
   mismatch, on quit-versus-message confusion, or when nothing is
   deliverable — each with a diagnostic that names the actual value
@@ -478,9 +528,12 @@ smuggled in half-specified (open question 2).
 ## 7. Clock DI split
 
 **Decision: Clock injection is its own RFC; this RFC does not contain
-it.** Stage 2 of TestStore — deterministic driving of `timeout`, retry
-backoff, debounce/throttle, and `Timer` — lands as an amendment to this
-document after that RFC is accepted.
+it.** Stage 2 of TestStore — deterministic driving of the
+time-dependent *command* effects (`timeout`, retry backoff, and future
+command-side coalescing timers such as debounce/throttle) — lands as an
+amendment to this document after that RFC is accepted. `Timer` and other
+subscription sources are not part of stage 2 (§1.2): they are not
+command leaves and TestStore never executes subscription sources.
 
 Rationale:
 
@@ -497,10 +550,14 @@ Rationale:
   it behind the larger design.
 
 Non-normative sketch of what the amendment adds, recorded so stage-1 API
-shapes are chosen with it in mind: a store-held clock handle, an
-`advance(duration)` call that makes time-gated leaves deliverable, and
-the §4.3 limitation dissolving into ordinary `receive` flow. Nothing in
-the stage-1 surface above assumes otherwise or blocks that shape.
+shapes are chosen with it in mind: a store-held controlled time context
+(RFC 0009 §3.2 supersedes the earlier "clock handle" phrasing — there
+is no clock value to hold), an `advance(duration)` call that makes
+time-gated *command* leaves (`timeout`, retry backoff) deliverable, and
+the §4.3 limitation for those leaves dissolving into ordinary `receive`
+flow. `Timer` and other subscription sources stay out of scope in
+stage 2 as in stage 1 (§1.2; RFC 0009 §5.1). Nothing in the stage-1
+surface above assumes otherwise or blocks that shape.
 
 ## 8. Invariants
 
@@ -575,13 +632,16 @@ Enforcement classes follow the pre-review checklist's definitions
 - **INV-T8**: exhaustiveness — each leak class in §6 fails at its named
   call site, with a diagnostic naming the leaked values for the
   message classes and the count and enqueue position for the
-  unfinished-leaf class (§6). Behavioral: one test per class (ready
-  message at `send`; ready message at `finish`; unfinished leaf at
-  `finish`; drop-without-finish), each asserting the failure fires
-  *and* its message contains the class's required content — the leaked
-  value's `Debug` rendering for the message classes — because the
-  wrong-value adversary is exactly what the message-content assertion
-  exists to fail.
+  unfinished-leaf class (§6). `send` is not a leak-check site: it never
+  fails on pending deliverable output (§6). Behavioral: one test per
+  leak class (ready message at `finish`; unfinished leaf at `finish`;
+  drop-without-finish), each asserting the failure fires *and* its
+  message contains the class's required content — the leaked value's
+  `Debug` rendering for the message classes — because the wrong-value
+  adversary is exactly what the message-content assertion exists to
+  fail; plus one negative test that a `send` issued while a deliverable
+  message is still pending does *not* fail and leaves that message
+  assertable by a later `receive` (the shared-first script of §6).
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
   `send`/`receive*` fail on the quit state without polling any leaf,
   and the `finish` and drop checks poll nothing and pass regardless of
@@ -600,8 +660,13 @@ INV-T7; `receive_quit` and the quit state to INV-T9;
 `redraw_requested` and `subscription_ids` are pure observations of
 contracts owned elsewhere (RFC 0002's directive; RFC 0005's declared
 identity) and are covered by INV-T3 (they read what the runtime would
-read) plus one behavioral test each; the absence of an `Application`
-change maps to INV-T1.
+read) plus one behavioral test each — with one carve-out: the
+init-command directive `redraw_requested` reports before the first step
+is TestStore-specific `Command` introspection and is *not* a prediction
+of the runtime's first render (§5.2), so it falls outside INV-T3's
+"runtime would read" umbrella; the behavioral test for it asserts the
+init command's folded directive, not a runtime first-frame outcome. The
+absence of an `Application` change maps to INV-T1.
 
 ## 9. Open questions
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -639,7 +639,15 @@ Enforcement classes follow the pre-review checklist's definitions
   command arriving after the occupant's leaves are exhausted is
   admitted, and one arriving while the reconciliation poll yields a
   buffered item is discarded with that item still deliverable at its
-  canonical position.
+  canonical position. The supersede and explicit-cancel tests use the
+  `send`-scripted form the §6 non-blocking `send` enables — a `send`
+  carrying a same-id `CancelInFlight` command or a `Command::cancel(id)`
+  over a keyed occupant whose output is still pending: the `send` does
+  not fail (§6), and the occupant's undelivered output is thereafter
+  unobservable via any `receive*` (INV-3, INV-9). This is the
+  cancel-before-receive scenario the §6 rationale motivates; INV-T8's
+  retention tests deliberately do *not* cancel, since a cancelled
+  output cannot be retained.
 - **INV-T8**: exhaustiveness — each leak class in §6 fails at its named
   call site, with a diagnostic naming the leaked values for the
   message classes and the count and enqueue position for the
@@ -653,14 +661,17 @@ Enforcement classes follow the pre-review checklist's definitions
   fail; plus two negative tests that a `send` issued while a deliverable
   message is still pending does *not* fail and leaves that message
   assertable by a later `receive` — one over a **keyed** occupant's
-  output (the `send(Start); send(Cancel)` shared-first script of §6,
-  whose ordering is runtime parity, RFC 0003 INV-14) and one over
-  **unkeyed** output (which asserts only that `send` does not block on
-  it; the ordering is TestStore's linearization, not runtime parity,
-  §6). The keyed-only test would pass an implementation that wrongly
-  fails `send` on unkeyed pending output; the unkeyed-only test would
-  miss a broken keyed cancellation/shared-first path — so both are
-  required.
+  output using a *non-cancelling* `send` (a message that does not target
+  the occupant's id, e.g. `send(Start); send(Unrelated)`) so the keyed
+  output survives: the shared-first ordering is runtime parity (RFC 0003
+  INV-14), and the output is then `receive`d — and one over **unkeyed**
+  output (which asserts only that `send` does not block on it; the
+  ordering is TestStore's linearization, not runtime parity, §6). The
+  keyed-only test would pass an implementation that wrongly fails `send`
+  on unkeyed pending output; the unkeyed-only test would miss a broken
+  keyed shared-first path — so both are required. The `send`-carried
+  supersede/cancel case (where the pending output is *removed*, not
+  retained) is INV-T7's, not a retention test.
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
   `send`/`receive*` fail on the quit state without polling any leaf,
   and the `finish` and drop checks poll nothing and pass regardless of

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -650,9 +650,17 @@ Enforcement classes follow the pre-review checklist's definitions
   message contains the class's required content — the leaked value's
   `Debug` rendering for the message classes — because the wrong-value
   adversary is exactly what the message-content assertion exists to
-  fail; plus one negative test that a `send` issued while a deliverable
+  fail; plus two negative tests that a `send` issued while a deliverable
   message is still pending does *not* fail and leaves that message
-  assertable by a later `receive` (the shared-first script of §6).
+  assertable by a later `receive` — one over a **keyed** occupant's
+  output (the `send(Start); send(Cancel)` shared-first script of §6,
+  whose ordering is runtime parity, RFC 0003 INV-14) and one over
+  **unkeyed** output (which asserts only that `send` does not block on
+  it; the ordering is TestStore's linearization, not runtime parity,
+  §6). The keyed-only test would pass an implementation that wrongly
+  fails `send` on unkeyed pending output; the unkeyed-only test would
+  miss a broken keyed cancellation/shared-first path — so both are
+  required.
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
   `send`/`receive*` fail on the quit state without polling any leaf,
   and the `finish` and drop checks poll nothing and pass regardless of

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -59,6 +59,8 @@ stage 2 consumes this contract; nothing here gates on TestStore.
 - The determinism contract a controlled time context provides to
   consumers (§3.2), and its negative space (§3.4).
 - The HTTP time-source migration, as a named prerequisite (§4.1).
+- The `Timer` non-catch-up contract-alignment fix (§4.2), a
+  behavior-changing deliverable carrying a `CHANGELOG: Fixed` entry.
 - The `tokio` `test-util` feature decision for in-crate controlled
   contexts (§5.1).
 - A deterministic-time testing recipe in `docs/testing.md` for
@@ -293,15 +295,17 @@ controlled context, the contract a consumer may cite:
   elsewhere holds identically under the virtual clock: RFC 0004's
   timeout semantics (deadline anchored at the leaf's first poll, one
   timeout message per modifier) and retry-backoff semantics, and
-  `Timer`'s semantics (no tick before one full interval after its
-  construction-time anchor; no catch-up burst — a gap spanning several
-  intervals yields exactly one tick and a gap shorter than one interval
-  yields none, whether the gap falls before or after the timer's first
-  poll; and, after that single tick, the next tick due at the first
-  interval boundary strictly after now measured from the construction
-  anchor, so the phase is preserved, not reset. These are stated as
-  observable properties of `Timer` (§4.2), not as a claim about
-  `.skip(1)` or any other mechanism). This non-catch-up property is a
+  `Timer`'s semantics, stated over a running `next_deadline` that starts
+  one full interval after the timer's stream-construction anchor: a poll
+  with virtual now `<` `next_deadline` yields no tick; a poll with now
+  `>=` `next_deadline` yields exactly one tick, never a burst, however
+  many deadlines have elapsed; and delivering a tick advances
+  `next_deadline` to the first anchor-phase boundary strictly after the
+  current now, so the phase is preserved, not reset (§4.2). This is
+  deadline-relative, not gap-relative: after a tick delivered late, the
+  very next boundary can be less than one interval away and still fires.
+  These are observable properties of `Timer`, not a claim about
+  `.skip(1)` or any other mechanism. This non-catch-up property is a
   contract the `Timer` implementation provides directly; Tokio's
   `MissedTickBehavior::Skip` does not supply it, because its skip engages
   only once a tick is late by more than a fixed margin, so for sub-margin
@@ -373,28 +377,38 @@ This deliverable changes `Timer` to provide the non-catch-up property
 directly and pins the semantics in rustdoc. Unlike §4.1, it is **not**
 behavior-preserving.
 
-- **Observable change.** After a gap spanning several intervals, `Timer`
-  yields exactly one tick — no catch-up burst — instead of one tick per
-  missed interval. This is a user-visible behavior change for
+- **Observable change.** After a delay spanning several intervals,
+  `Timer` yields exactly one tick — no catch-up burst — instead of one
+  tick per missed interval. This is a user-visible behavior change for
   short-interval timers under load, so it lands with a `CHANGELOG: Fixed`
   entry, not as a mere rustdoc adjustment.
-- **Pinned observable properties** (independent of the implementation
-  mechanism, so a from-scratch reimplementation that drops `.skip(1)` or
-  `interval` altogether still conforms):
-  - No tick is delivered before one full interval has elapsed from the
-    timer's construction-time anchor (the construction-instant tick is
-    never delivered).
-  - A gap of at least one full interval leaves exactly one deliverable
-    tick; a shorter gap leaves none — regardless of whether the gap
-    falls before or after the first poll.
-  - **Post-miss cadence.** After the single overdue tick is delivered,
-    the next tick is due at the first interval boundary strictly after
-    the current instant, measured from the construction anchor — the
-    phase is preserved (Skip-style alignment), not reset to
-    "now + interval" (Delay-style). This preserves the existing
-    drift-corrected cadence the `Timer` rustdoc describes.
+- **Anchor.** The time anchor is fixed at **stream construction** — the
+  moment `Timer::stream()` is called (`interval()` in
+  `src/subscription/time.rs`), not `Timer::new`, which only stores the
+  interval value. Time that passes between `Timer::new` and `stream()`
+  does not count against the timer; the first `next_deadline` is one
+  full interval after the `stream()` call.
+- **Pinned observable properties**, stated over a running `next_deadline`
+  (independent of the implementation mechanism, so a from-scratch
+  reimplementation that drops `.skip(1)` or `interval` altogether still
+  conforms):
+  - `next_deadline` starts one full interval after the stream-construction
+    anchor. The construction-instant tick is never delivered.
+  - A poll observing virtual now `<` `next_deadline` yields no tick. A
+    poll observing now `>=` `next_deadline` yields **exactly one** tick,
+    however many interval boundaries lie between the old `next_deadline`
+    and now — never a burst. This holds whether the poll is the first or
+    a later one.
+  - **Post-miss cadence.** Delivering a tick advances `next_deadline` to
+    the first anchor-phase boundary strictly after the current now (the
+    phase is preserved — Skip-style alignment — not reset to
+    "now + interval", Delay-style). This is deadline-relative: after a
+    late tick, the next boundary can be less than one interval away and
+    still fires. It preserves the drift-corrected cadence the `Timer`
+    rustdoc describes.
 - **rustdoc.** `Timer` gains a first-tick, non-catch-up, and post-miss
-  cadence sentence citing this RFC as the semantics of record.
+  cadence sentence citing this RFC as the semantics of record, and names
+  the stream-construction anchor.
 - **Tests.** INV-C3's paused-clock tests at 1 ms and 2 ms intervals are
   the proof; a Skip-margin-dependent implementation fails them.
 
@@ -426,14 +440,14 @@ idles the executor, so the auto-advance clause never applies) and
 INV-C3's transparency (store results are evidence about production time
 contracts, completing the INV-T3 argument on the time axis).
 
-Two design inputs recorded for that amendment:
+Three design inputs recorded for that amendment:
 
 - **Deadline anchoring.** RFC 0004 anchors a timeout's deadline at the
   leaf's *first poll*, and the store's scans decide when that first
   poll happens; the amendment's advance semantics must account for
   scan-order-dependent anchoring rather than assuming
-  construction-time anchoring. (`Timer`'s construction-time anchor
-  (§3.2) is not a stage-2 concern: stage 2 delivers command time leaves
+  construction-time anchoring. (`Timer`'s stream-construction anchor
+  (§4.2) is not a stage-2 concern: stage 2 delivers command time leaves
   only, never `Timer`.)
 - **Advance semantics and executor context.** Tokio's `advance` does
   not wait for the sleeps it moves past to complete (§3.2), so the
@@ -556,15 +570,22 @@ Enforcement classes follow the pre-review checklist's definitions.
   (`src/command/effect.rs`, `src/command/retry.rs`, `src/runtime.rs`)
   are the timeout/retry half; new paused-clock `Timer` tests pin the
   timer half at short intervals (1 ms and 2 ms, chosen to fall inside
-  Tokio's lateness margin so a Skip-dependent implementation fails
-  them) — no tick ready before an advance of one full interval; the
-  first tick ready after exactly one interval; a single advance spanning
-  several intervals yielding exactly one tick, not a burst, whether the
-  advance falls before or after the timer's first poll (a gap shorter
-  than one full interval yields no tick); and, after that single tick,
-  the next tick due at the first interval boundary strictly after now
-  measured from the construction anchor, not one interval after the poll
-  (the §4.2 post-miss cadence — a Delay-style reset fails it). The
+  Tokio's lateness margin so a Skip-dependent implementation fails them),
+  covering the §4.2 observable properties:
+  (a) no tick ready while now is before the first `next_deadline` (one
+  interval after the stream-construction anchor);
+  (b) the first tick ready once now reaches that deadline;
+  (c) a single advance past several interval boundaries yielding exactly
+  one tick, not a burst, whether it is the first poll or a later one;
+  (d) **post-miss cadence** — after a late tick delivered at, say,
+  now = 3.5 ms on a 1 ms timer, the next tick fires at 4 ms (the first
+  anchor-phase boundary strictly after now, only 0.5 ms later), *not* at
+  4.5 ms; a Delay-style "now + interval" reset fails this, and a
+  gap-length rule that suppressed the sub-interval boundary would too;
+  and
+  (e) **anchor** — advancing virtual time between `Timer::new` and
+  `stream()` shifts no deadline, since the anchor is the `stream()` call
+  (finding: `new` stores only the interval). The
   existing wide-margin real-time `Timer` tests remain as non-normative
   smoke checks; the paused tests are the contract's proof.
 - **INV-C4**: production neutrality — the crate exposes no time-control

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -6,11 +6,14 @@
 - Scope: the no-clock-abstraction decision, the single-time-source rule,
   the controlled-context determinism contract consumed by TestStore
   stage 2 / debounce–throttle / subscription restart rate control, the
-  HTTP time-source migration prerequisite, and the `test-util` feature
-  decision
+  HTTP time-source migration prerequisite (§4.1), the `Timer`
+  non-catch-up contract-alignment fix (§4.2), and the `test-util`
+  feature decision
 - Feature flag: none
-- CHANGELOG: none (the prerequisite migration and the lint are internal
-  and behavior-preserving)
+- CHANGELOG: `Fixed` — short-interval `Timer` subscriptions no longer
+  replay a catch-up burst of missed ticks after a delay (§4.2). The HTTP
+  time-source migration (§4.1) and the lint are internal and
+  behavior-preserving and carry no entry.
 
 ## Summary
 
@@ -28,7 +31,7 @@ Four decisions:
    that read the current time or wait on its passage are banned
    mechanically via clippy's `disallowed-methods`, whose entries are
    derived as an inventory in §3.1. Two HTTP-module files violate the
-   rule today; migrating them is this RFC's named prerequisite (§4).
+   rule today; migrating them is this RFC's named prerequisite (§4.1).
 3. **Controlled-context contract** (§3.2, INV-C2, INV-C3). A consumer
    that controls the clock may rely on: virtual time advances only under
    the controller's action (plus the executor's idle auto-advance, which
@@ -55,7 +58,7 @@ stage 2 consumes this contract; nothing here gates on TestStore.
   enforcement (§3.1).
 - The determinism contract a controlled time context provides to
   consumers (§3.2), and its negative space (§3.4).
-- The HTTP time-source migration, as a named prerequisite (§4).
+- The HTTP time-source migration, as a named prerequisite (§4.1).
 - The `tokio` `test-util` feature decision for in-crate controlled
   contexts (§5.1).
 - A deterministic-time testing recipe in `docs/testing.md` for
@@ -73,8 +76,8 @@ stage 2 consumes this contract; nothing here gates on TestStore.
   separate determinism axis with its own reproducibility design,
   deferred by RFC 0004 §5.2; a future backoff-policy RFC owns it.
 - **TestStore's time API.** The shape of `advance` on the store, and
-  how time-gated leaves join the §4.2 canonical order, is the RFC 0008
-  stage-2 amendment's job. This RFC provides the contract that
+  how time-gated leaves join RFC 0008's §4.2 canonical order, is the
+  RFC 0008 stage-2 amendment's job. This RFC provides the contract that
   amendment cites (§5.1).
 - **Debounce/throttle and restart-rate semantics.** Their policies and
   invariants belong to their own RFCs; they consume this contract
@@ -167,8 +170,8 @@ Inventory of production time reads at this RFC's writing:
 | `src/runtime.rs` (event loop) | `tokio::time::Instant` | micro-batch window deadline (RFC 0006 mechanism) | yes |
 | `src/runtime/frame_scheduler.rs` | `tokio::time::interval` | frame cadence | yes |
 | `src/runtime/channel.rs` (bounded send) | `tokio::time::Instant` | capacity-wait duration in load events (RFC 0006 observability) | yes |
-| `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4 migration** |
-| `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4 migration** |
+| `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4.1 migration** |
+| `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4.1 migration** |
 
 The rule's mechanical floor is an inventory of the `std` entry points
 whose call reads the current time, blocks on its passage, or configures
@@ -223,7 +226,7 @@ blocking of `close` and so falls in the timed-wait-configuration
 class — are uncallable on the crate's stable toolchain and join the
 table on stabilization; `recv_deadline`, equally unstable, is listed
 ahead of that defensively because it completes a family already
-present, and the §4 implementation task confirms the lint accepts its
+present, and the §4.1 implementation task confirms the lint accepts its
 path.
 
 Dependencies are scoped the same way: the executor clock itself
@@ -239,7 +242,7 @@ never virtual).
 Outside library code, exactly one deliberate exception exists:
 `benches/runtime_load.rs` measures real wall-clock latency because
 RFC 0006's statistical acceptance criteria are defined on real time.
-The §4 migration, which lands the lint configuration, adds an explicit
+The §4.1 migration, which lands the lint configuration, adds an explicit
 lint allow at the bench's measurement sites in the same change. Unit
 and integration tests contain no `std::time` reads today and fall under
 the same rule.
@@ -291,17 +294,19 @@ controlled context, the contract a consumer may cite:
   timeout semantics (deadline anchored at the leaf's first poll, one
   timeout message per modifier) and retry-backoff semantics, and
   `Timer`'s semantics (no tick before one full interval after its
-  construction-time anchor, and no catch-up burst: a single advance
-  spanning several intervals yields exactly one tick, and an advance
-  shorter than one full interval yields none, whether the advance falls
-  before or after the timer's first poll — `.skip(1)` absorbs only the
-  construction-instant tick, so at most one elapsed tick is ever
-  deliverable). This non-catch-up property is a contract the `Timer`
-  implementation provides directly; Tokio's `MissedTickBehavior::Skip`
-  does not supply it, because its skip engages only once a tick is late
-  by more than a fixed margin, so for sub-margin intervals it replays
-  one tick per elapsed interval (INV-C3). The contracts are
-  inequality-shaped (never
+  construction-time anchor; no catch-up burst — a gap spanning several
+  intervals yields exactly one tick and a gap shorter than one interval
+  yields none, whether the gap falls before or after the timer's first
+  poll; and, after that single tick, the next tick due at the first
+  interval boundary strictly after now measured from the construction
+  anchor, so the phase is preserved, not reset. These are stated as
+  observable properties of `Timer` (§4.2), not as a claim about
+  `.skip(1)` or any other mechanism). This non-catch-up property is a
+  contract the `Timer` implementation provides directly; Tokio's
+  `MissedTickBehavior::Skip` does not supply it, because its skip engages
+  only once a tick is late by more than a fixed margin, so for sub-margin
+  intervals it replays one tick per elapsed interval (INV-C3). The
+  contracts are inequality-shaped (never
   early; at-or-after), so the virtual clock's perfect granularity and
   the real clock's scheduler-dependent lateness both satisfy them; a
   paused-clock run is therefore evidence for the contract itself — the
@@ -333,9 +338,13 @@ Pinned deliberately as *not* guaranteed:
   to one executor; two controlled contexts do not share time. No
   contract spans contexts.
 
-## 4. Prerequisite: HTTP time-source migration
+## 4. Implementation deliverables
 
-**Named prerequisite, owned by this RFC's implementation task.**
+Both deliverables below are owned by this RFC's implementation task.
+
+### 4.1 HTTP time-source migration (prerequisite)
+
+**Named prerequisite.**
 `src/subscription/http/cell.rs` (lifecycle `inactive_since`, data
 `data_timestamp`, and the `stale_time`/`cache_time` comparisons over
 them) and `src/subscription/http/query.rs` (the `elapsed_ms` tracing
@@ -352,6 +361,42 @@ the rule. They migrate to the virtualizable clock's `Instant`.
   controlled context like every other time-dependent contract.
 - INV-C1's mechanical enforcement turns on with this migration; the
   lint cannot land first.
+
+### 4.2 Timer contract alignment
+
+`src/subscription/time.rs`'s `Timer` does not currently satisfy the
+non-catch-up contract (§3.2, INV-C3): it leans on Tokio's
+`MissedTickBehavior::Skip`, whose skip engages only once a tick is late
+by more than a fixed margin (5 ms in tokio 1.50.0's `interval.rs`), so a
+short-interval timer replays one tick per missed interval after a delay.
+This deliverable changes `Timer` to provide the non-catch-up property
+directly and pins the semantics in rustdoc. Unlike §4.1, it is **not**
+behavior-preserving.
+
+- **Observable change.** After a gap spanning several intervals, `Timer`
+  yields exactly one tick — no catch-up burst — instead of one tick per
+  missed interval. This is a user-visible behavior change for
+  short-interval timers under load, so it lands with a `CHANGELOG: Fixed`
+  entry, not as a mere rustdoc adjustment.
+- **Pinned observable properties** (independent of the implementation
+  mechanism, so a from-scratch reimplementation that drops `.skip(1)` or
+  `interval` altogether still conforms):
+  - No tick is delivered before one full interval has elapsed from the
+    timer's construction-time anchor (the construction-instant tick is
+    never delivered).
+  - A gap of at least one full interval leaves exactly one deliverable
+    tick; a shorter gap leaves none — regardless of whether the gap
+    falls before or after the first poll.
+  - **Post-miss cadence.** After the single overdue tick is delivered,
+    the next tick is due at the first interval boundary strictly after
+    the current instant, measured from the construction anchor — the
+    phase is preserved (Skip-style alignment), not reset to
+    "now + interval" (Delay-style). This preserves the existing
+    drift-corrected cadence the `Timer` rustdoc describes.
+- **rustdoc.** `Timer` gains a first-tick, non-catch-up, and post-miss
+  cadence sentence citing this RFC as the semantics of record.
+- **Tests.** INV-C3's paused-clock tests at 1 ms and 2 ms intervals are
+  the proof; a Skip-margin-dependent implementation fails them.
 
 ## 5. Consumers
 
@@ -425,7 +470,7 @@ tests (already the runtime suite's practice) extend to it unchanged.
 
 ### 5.4 HTTP interval and backoff policies (future work)
 
-Refetch intervals and failure backoff ride §4's migrated module and
+Refetch intervals and failure backoff ride §4.1's migrated module and
 this contract. Their jitter, if any, is randomness — out of scope here
 (§1.2) and owned by that policy's RFC.
 
@@ -439,10 +484,10 @@ deterministic-time section in `docs/testing.md` documenting the recipe
 (paused runtime, explicit advance, the §3.2 auto-advance caveat). The
 caveat is named concretely: awaiting real network I/O under a paused
 runtime lets the executor judge itself idle and auto-advance the clock
-to the next timer before the I/O completes, so a test exercising §4's
+to the next timer before the I/O completes, so a test exercising §4.1's
 HTTP staleness must drive time and I/O explicitly rather than awaiting a
 live socket — the auto-advance-versus-real-I/O gotcha, stated because
-§4's payoff is precisely HTTP staleness testability. Documentation, not
+§4.1's payoff is precisely HTTP staleness testability. Documentation, not
 contract surface.
 
 ## 6. Invariants
@@ -455,7 +500,7 @@ Enforcement classes follow the pre-review checklist's definitions.
   bench exception (§3.1) at its explicitly allowed measurement sites.
   Structural-mechanical: clippy `disallowed-methods` in `clippy.toml`
   carries exactly §3.1's banned-entry-point inventory (landing with the
-  §4 migration, which removes the last violations), failing the
+  §4.1 migration, which removes the last violations), failing the
   workspace lint gate on any reintroduction. The platform-gated `std::os`
   socket timeout setters are carried as `allow-invalid = true` entries
   (§3.1) and so are enforced mechanically wherever CI resolves them —
@@ -477,13 +522,16 @@ Enforcement classes follow the pre-review checklist's definitions.
 - **INV-C2**: in a controlled context, §3.2's advancement rule holds —
   under a non-idling controller, a gated behavior stays pending across
   arbitrarily many polls until an explicit advance reaches its
-  deadline, and is ready on the next poll after one that does.
+  deadline, and thereafter becomes ready with no wall-clock waiting once
+  the executor is driven to progress. This RFC does not fix which poll
+  observes readiness (§3.2's readiness guarantee); the claim is only
+  "pending until advanced, ready without wall-clock waiting after".
   Behavioral: a paused-clock test polls a pending `Command::timeout`
   leaf repeatedly without advancing and asserts it remains pending
   (this is the check a compliant implementation passes and an
   implicitly-advancing clock fails), then advances to the deadline and
   asserts the behavior becomes ready, with no wall-clock waiting, once
-  the executor is driven to progress (§3.2's readiness guarantee).
+  the executor is driven to progress.
 - **INV-C3**: the time-dependent contracts pinned by RFC 0004 and by
   `Timer`'s semantics hold identically under the virtual clock.
   `Timer`'s current rustdoc documents only the missed-tick Skip
@@ -495,27 +543,30 @@ Enforcement classes follow the pre-review checklist's definitions.
   several sub-margin intervals replays one tick per interval — a
   catch-up burst this contract forbids. `.skip(1)` supplies only the
   first-tick timing (no tick at the construction instant); it does not
-  suppress catch-up. The §4 implementation task pins the contract on
-  both ends: it makes `Timer` provide the non-catch-up property
-  directly (rather than leaning on Tokio's lateness-margin Skip) and
-  adds a first-tick and non-catch-up sentence to `Timer`'s rustdoc
+  suppress catch-up. The §4.2 implementation task pins the contract by
+  making `Timer` provide the non-catch-up property directly (rather than
+  leaning on Tokio's lateness-margin Skip) and adds a first-tick,
+  non-catch-up, and post-miss cadence sentence to `Timer`'s rustdoc
   citing this RFC as the semantics of record, so INV-C3 references a
   written contract the code actually satisfies rather than an
-  implementation accident it does not. Behavioral: the existing
-  paused-clock timeout/retry suites
+  implementation accident it does not. The contract is stated as
+  observable properties (§4.2), not as a claim about `.skip(1)` or any
+  other mechanism, so the implementation is free to drop them.
+  Behavioral: the existing paused-clock timeout/retry suites
   (`src/command/effect.rs`, `src/command/retry.rs`, `src/runtime.rs`)
   are the timeout/retry half; new paused-clock `Timer` tests pin the
   timer half at short intervals (1 ms and 2 ms, chosen to fall inside
   Tokio's lateness margin so a Skip-dependent implementation fails
-  them) — no tick ready before an advance of one full interval, the
-  first tick ready after exactly one interval, and a single advance
-  spanning several intervals yielding exactly one tick, not a burst,
-  whether the advance falls before or after the timer's first poll (an
-  advance shorter than one full interval yields no tick; `.skip(1)`
-  absorbs only the construction-instant tick, so at most one elapsed
-  tick is ever deliverable). The existing wide-margin real-time `Timer`
-  tests remain as non-normative smoke checks; the paused tests are the
-  contract's proof.
+  them) — no tick ready before an advance of one full interval; the
+  first tick ready after exactly one interval; a single advance spanning
+  several intervals yielding exactly one tick, not a burst, whether the
+  advance falls before or after the timer's first poll (a gap shorter
+  than one full interval yields no tick); and, after that single tick,
+  the next tick due at the first interval boundary strictly after now
+  measured from the construction anchor, not one interval after the poll
+  (the §4.2 post-miss cadence — a Delay-style reset fails it). The
+  existing wide-margin real-time `Timer` tests remain as non-normative
+  smoke checks; the paused tests are the contract's proof.
 - **INV-C4**: production neutrality — the crate exposes no time-control
   surface and the production runtime never pauses or configures the
   clock, before and after the §5.1 feature flip. Structural: review of
@@ -538,8 +589,10 @@ Enforcement classes follow the pre-review checklist's definitions.
 Surface–invariant coverage: this RFC adds no public API surface. Its
 contract surface is the source rule (INV-C1), the controlled-context
 guarantees (INV-C2, INV-C3), the neutrality guarantee and the §5.1
-feature flip (INV-C4), and the §4 migration (INV-C1 turn-on plus
-INV-C4's preservation check). The `docs/testing.md` recipe (§5.5) is
+feature flip (INV-C4), the §4.1 migration (INV-C1 turn-on plus
+INV-C4's preservation check), and the §4.2 `Timer` contract-alignment
+fix (INV-C3's timer half, plus the `CHANGELOG: Fixed` entry for its
+observable behavior change). The `docs/testing.md` recipe (§5.5) is
 documentation and carries no invariant.
 
 ## 7. Open questions
@@ -569,7 +622,7 @@ consumers (§5) does.
   `src/runtime/frame_scheduler.rs`, `src/runtime/channel.rs` — the
   conforming inventory rows.
 - `src/subscription/http/cell.rs`, `src/subscription/http/query.rs` —
-  the §4 migration sites.
+  the §4.1 migration sites.
 - `benches/runtime_load.rs` — the named real-time exception.
 - `clippy.toml` — INV-C1's mechanical enforcement site.
 - `docs/testing.md` — the paused-time testing conventions §5.5 extends.

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -163,7 +163,7 @@ Inventory of production time reads at this RFC's writing:
 | --- | --- | --- | --- |
 | `src/command/effect.rs` (timeout leaf) | `tokio::time::sleep` | `Command::timeout` deadline (RFC 0004; anchored at the leaf's first poll) | yes |
 | `src/command/retry.rs` (`run_retry`) | `tokio::time::sleep` | retry backoff delay (RFC 0004) | yes |
-| `src/subscription/time.rs` (`Timer`) | `tokio::time::interval` | periodic ticks, missed ticks skipped | yes |
+| `src/subscription/time.rs` (`Timer`) | `tokio::time::interval` | periodic ticks; first-tick and non-catch-up semantics (INV-C3) | yes |
 | `src/runtime.rs` (event loop) | `tokio::time::Instant` | micro-batch window deadline (RFC 0006 mechanism) | yes |
 | `src/runtime/frame_scheduler.rs` | `tokio::time::interval` | frame cadence | yes |
 | `src/runtime/channel.rs` (bounded send) | `tokio::time::Instant` | capacity-wait duration in load events (RFC 0006 observability) | yes |
@@ -275,20 +275,33 @@ controlled context, the contract a consumer may cite:
   the controller itself contributes).
 - **No early firing.** No time-gated behavior in the crate fires while
   virtual now is earlier than its deadline.
-- **Readiness without waiting.** Once an advance moves virtual now to
-  or past a deadline, the gated behavior is ready on its next poll with
-  no real-time waiting.
+- **Readiness without waiting.** Once virtual now is at or past a
+  deadline, the gated behavior becomes ready with no real-time
+  (wall-clock) waiting — the executor need only be driven to make
+  progress (process the elapsed timers), not to sleep. This RFC does
+  not pin *which* poll observes readiness, nor whether an `advance` call
+  itself carries a timer-driver barrier: Tokio's `advance` documents
+  that it does not wait for the sleeps it moves past to complete, so the
+  exact readiness point is an executor-progress question, not a
+  wall-clock one. TestStore stage 2's advance semantics fix it (§5.1);
+  the guarantee this RFC pins is only that readiness costs no wall-clock
+  time.
 - **Transparency.** Every time-dependent contract the crate pins
   elsewhere holds identically under the virtual clock: RFC 0004's
   timeout semantics (deadline anchored at the leaf's first poll, one
   timeout message per modifier) and retry-backoff semantics, and
-  `Timer`'s semantics (no tick before one full interval; missed ticks
-  skipped, so for a timer already polled once to pending a single
-  advance spanning multiple intervals yields one tick, not a replay
-  burst — a timer whose stream is advanced past several intervals
-  *before* its first poll yields zero, since `Timer::stream`'s
-  construction-time anchor plus its `.skip(1)` absorb the one elapsed
-  deadline). The contracts are inequality-shaped (never
+  `Timer`'s semantics (no tick before one full interval after its
+  construction-time anchor, and no catch-up burst: a single advance
+  spanning several intervals yields exactly one tick, and an advance
+  shorter than one full interval yields none, whether the advance falls
+  before or after the timer's first poll — `.skip(1)` absorbs only the
+  construction-instant tick, so at most one elapsed tick is ever
+  deliverable). This non-catch-up property is a contract the `Timer`
+  implementation provides directly; Tokio's `MissedTickBehavior::Skip`
+  does not supply it, because its skip engages only once a tick is late
+  by more than a fixed margin, so for sub-margin intervals it replays
+  one tick per elapsed interval (INV-C3). The contracts are
+  inequality-shaped (never
   early; at-or-after), so the virtual clock's perfect granularity and
   the real clock's scheduler-dependent lateness both satisfy them; a
   paused-clock run is therefore evidence for the contract itself — the
@@ -345,8 +358,19 @@ the rule. They migrate to the virtualizable clock's `Instant`.
 ### 5.1 TestStore stage 2 (RFC 0008 §7 amendment)
 
 The stage-2 amendment gives the store a controlled time context and an
-advance operation, making RFC 0008 §4.3-class leaves (timeout, backoff,
-timer) deliverable through ordinary `receive` flow. RFC 0008 §7's
+advance operation, making RFC 0008 §4.3-class *command* time leaves
+(`timeout`, retry backoff) deliverable through ordinary `receive` flow.
+`Timer` is deliberately excluded: it is a subscription source, not a
+command leaf, and TestStore never executes subscription sources
+(RFC 0008 §1.2), so a `Timer` leaf never enters the store's pending
+command set at all. Delivering it would require a subscription-execution
+design — source spawn, ID reconciliation, restart, and source
+cancellation, everything the runtime's `SubscriptionManager` provides —
+which is out of scope for both RFCs; if a future need arises it is a
+separate, explicitly-designed amendment, not this stage-2 one.
+`Timer`'s own determinism under the virtual clock is still pinned here
+(INV-C3), exercised directly against its stream rather than through
+TestStore. RFC 0008 §7's
 non-normative sketch pictured "a store-held clock handle"; this RFC's
 design supersedes that shape — there is no clock value to hold. The
 store holds a controlled time context (§3.2) and `advance` acts on that
@@ -363,12 +387,19 @@ Two design inputs recorded for that amendment:
   leaf's *first poll*, and the store's scans decide when that first
   poll happens; the amendment's advance semantics must account for
   scan-order-dependent anchoring rather than assuming
-  construction-time anchoring. `Timer` anchors differently — at
-  stream-construction time, not first poll (`interval()` in
-  `src/subscription/time.rs`) — so an advance issued before a timer's
-  stream is first polled counts against the construction anchor; the
-  amendment records both anchors since stage 2 delivers `Timer` leaves
-  too.
+  construction-time anchoring. (`Timer`'s construction-time anchor
+  (§3.2) is not a stage-2 concern: stage 2 delivers command time leaves
+  only, never `Timer`.)
+- **Advance semantics and executor context.** Tokio's `advance` does
+  not wait for the sleeps it moves past to complete (§3.2), so the
+  amendment must fix whether the store's advance carries a timer-driver
+  barrier or whether "ready after advance" means "ready once the
+  executor is driven to progress, with no wall-clock wait". It must also
+  fix the executor context the store owns or borrows — whether the store
+  holds its own current-thread paused runtime or runs inside the
+  caller's `#[tokio::test]` paused runtime — and how a user effect that
+  itself spawns (`tokio::spawn`) or nests a runtime is handled. Recorded
+  here as stage-2 design inputs, not resolved by this RFC.
 - **Feature availability.** The executor's pause-and-advance facilities
   sit behind the `tokio` `test-util` feature, today a dev-dependency
   only. **Decision:** when the first in-crate controlled-context
@@ -450,29 +481,41 @@ Enforcement classes follow the pre-review checklist's definitions.
   Behavioral: a paused-clock test polls a pending `Command::timeout`
   leaf repeatedly without advancing and asserts it remains pending
   (this is the check a compliant implementation passes and an
-  implicitly-advancing clock fails), then advances exactly to the
-  deadline and asserts readiness without real-time waiting.
+  implicitly-advancing clock fails), then advances to the deadline and
+  asserts the behavior becomes ready, with no wall-clock waiting, once
+  the executor is driven to progress (§3.2's readiness guarantee).
 - **INV-C3**: the time-dependent contracts pinned by RFC 0004 and by
   `Timer`'s semantics hold identically under the virtual clock.
   `Timer`'s current rustdoc documents only the missed-tick Skip
-  behavior, not the first-tick timing (no tick before one full
-  interval) — the `.skip(1)` in `Timer::stream` is the sole source of
-  that behavior today. The §4 implementation task pins it: it adds a
-  first-tick sentence to `Timer`'s rustdoc citing this RFC as the
-  semantics of record, so INV-C3 references a written contract rather
-  than an implementation accident. Behavioral: the existing paused-clock
-  timeout/retry suites
+  behavior, and the current implementation does not in fact provide the
+  non-catch-up contract at short intervals: it composes
+  `MissedTickBehavior::Skip` with `.skip(1)`, but Tokio's Skip engages
+  only once a tick is late by more than a fixed margin (5 ms in
+  tokio 1.50.0's `interval.rs`), so a paused-clock advance spanning
+  several sub-margin intervals replays one tick per interval — a
+  catch-up burst this contract forbids. `.skip(1)` supplies only the
+  first-tick timing (no tick at the construction instant); it does not
+  suppress catch-up. The §4 implementation task pins the contract on
+  both ends: it makes `Timer` provide the non-catch-up property
+  directly (rather than leaning on Tokio's lateness-margin Skip) and
+  adds a first-tick and non-catch-up sentence to `Timer`'s rustdoc
+  citing this RFC as the semantics of record, so INV-C3 references a
+  written contract the code actually satisfies rather than an
+  implementation accident it does not. Behavioral: the existing
+  paused-clock timeout/retry suites
   (`src/command/effect.rs`, `src/command/retry.rs`, `src/runtime.rs`)
   are the timeout/retry half; new paused-clock `Timer` tests pin the
-  timer half — no tick ready before an advance of one full interval,
-  the first tick ready after exactly one interval, and, for a stream
-  already polled once to pending, a single advance spanning several
-  intervals yielding exactly one tick (the skipped-not-replayed
-  contract; the poll-once precondition is the §3.2 construction-anchor
-  caveat — an advance before the first poll yields zero). The existing
-  wide-margin real-time
-  `Timer` tests remain as non-normative smoke checks; the paused tests
-  are the contract's proof.
+  timer half at short intervals (1 ms and 2 ms, chosen to fall inside
+  Tokio's lateness margin so a Skip-dependent implementation fails
+  them) — no tick ready before an advance of one full interval, the
+  first tick ready after exactly one interval, and a single advance
+  spanning several intervals yielding exactly one tick, not a burst,
+  whether the advance falls before or after the timer's first poll (an
+  advance shorter than one full interval yields no tick; `.skip(1)`
+  absorbs only the construction-instant tick, so at most one elapsed
+  tick is ever deliverable). The existing wide-margin real-time `Timer`
+  tests remain as non-normative smoke checks; the paused tests are the
+  contract's proof.
 - **INV-C4**: production neutrality — the crate exposes no time-control
   surface and the production runtime never pauses or configures the
   clock, before and after the §5.1 feature flip. Structural: review of

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -110,8 +110,10 @@ Rationale:
   injection" as a separate concern; this RFC resolves that deferral.
 - **An injected clock cannot reach the sites that need it without
   breaking the API.** `Command::timeout`, `Command::retry`'s backoff,
-  and `Timer::new` construct time-gated behavior inside `update` and
-  `subscriptions`, which receive no environment. Serving them with an
+  and `Timer` (constructed via `Timer::new` in `subscriptions`, its time
+  anchored when its stream is built, §4.2) declare time-gated behavior
+  inside `update` and `subscriptions`, which receive no environment.
+  Serving them with an
   injected clock requires either a clock parameter on every such
   constructor (breaking churn across the command and subscription
   surface) or an ambient task-local clock — a second, hand-rolled
@@ -296,16 +298,21 @@ controlled context, the contract a consumer may cite:
   timeout semantics (deadline anchored at the leaf's first poll, one
   timeout message per modifier) and retry-backoff semantics, and
   `Timer`'s semantics, stated over a running `next_deadline` that starts
-  one full interval after the timer's stream-construction anchor: a poll
-  with virtual now `<` `next_deadline` yields no tick; a poll with now
-  `>=` `next_deadline` yields exactly one tick, never a burst, however
-  many deadlines have elapsed; and delivering a tick advances
-  `next_deadline` to the first anchor-phase boundary strictly after the
-  current now, so the phase is preserved, not reset (§4.2). This is
-  deadline-relative, not gap-relative: after a tick delivered late, the
-  very next boundary can be less than one interval away and still fires.
-  These are observable properties of `Timer`, not a claim about
-  `.skip(1)` or any other mechanism. This non-catch-up property is a
+  one full interval after the timer's stream-construction anchor: while
+  virtual now `<` `next_deadline` no tick is deliverable; once now `>=`
+  `next_deadline` exactly one tick becomes deliverable, never a burst,
+  however many deadlines have elapsed, and after it is taken nothing more
+  is deliverable until now reaches the new `next_deadline`; and delivering
+  a tick advances `next_deadline` to the first anchor-phase boundary
+  strictly after the current now, so the phase is preserved, not reset
+  (§4.2). This is deadline-relative, not gap-relative: after a tick
+  delivered late, the very next boundary can be less than one interval
+  away and still fires. This fixes *how many* ticks are deliverable and
+  the cadence, not *which* poll observes them — that follows the
+  readiness guarantee above, and `Timer` claims no stronger same-poll
+  guarantee than any other gated behavior. These are observable
+  properties of `Timer`, not a claim about `.skip(1)` or any other
+  mechanism. This non-catch-up property is a
   contract the `Timer` implementation provides directly; Tokio's
   `MissedTickBehavior::Skip` does not supply it, because its skip engages
   only once a tick is late by more than a fixed margin, so for sub-margin
@@ -394,11 +401,16 @@ behavior-preserving.
   conforms):
   - `next_deadline` starts one full interval after the stream-construction
     anchor. The construction-instant tick is never delivered.
-  - A poll observing virtual now `<` `next_deadline` yields no tick. A
-    poll observing now `>=` `next_deadline` yields **exactly one** tick,
+  - While virtual now `<` `next_deadline`, no tick is deliverable. Once
+    now `>=` `next_deadline`, **exactly one** tick becomes deliverable —
     however many interval boundaries lie between the old `next_deadline`
-    and now — never a burst. This holds whether the poll is the first or
-    a later one.
+    and now, never a burst — and after it is taken, no further tick is
+    deliverable until now reaches the new `next_deadline`. This is a
+    count-and-cadence claim about *how many* ticks are deliverable, not
+    about *which* poll observes them: the readiness-poll timing follows
+    §3.2's general guarantee (no wall-clock wait once the executor
+    progresses; the observing poll is not fixed), and `Timer` claims no
+    stronger same-poll guarantee than any other gated behavior.
   - **Post-miss cadence.** Delivering a tick advances `next_deadline` to
     the first anchor-phase boundary strictly after the current now (the
     phase is preserved — Skip-style alignment — not reset to
@@ -574,18 +586,23 @@ Enforcement classes follow the pre-review checklist's definitions.
   covering the §4.2 observable properties:
   (a) no tick ready while now is before the first `next_deadline` (one
   interval after the stream-construction anchor);
-  (b) the first tick ready once now reaches that deadline;
-  (c) a single advance past several interval boundaries yielding exactly
-  one tick, not a burst, whether it is the first poll or a later one;
+  (b) the first tick becoming ready once now reaches that deadline;
+  (c) a single advance past several interval boundaries making exactly
+  one tick ready, not a burst, followed by Pending until the new
+  deadline, whether it is the first poll or a later one (the test drives
+  the executor to observe readiness — it asserts tick count and the
+  following Pending, not the specific poll index, consistent with §3.2);
   (d) **post-miss cadence** — after a late tick delivered at, say,
   now = 3.5 ms on a 1 ms timer, the next tick fires at 4 ms (the first
   anchor-phase boundary strictly after now, only 0.5 ms later), *not* at
   4.5 ms; a Delay-style "now + interval" reset fails this, and a
   gap-length rule that suppressed the sub-interval boundary would too;
   and
-  (e) **anchor** — advancing virtual time between `Timer::new` and
-  `stream()` shifts no deadline, since the anchor is the `stream()` call
-  (finding: `new` stores only the interval). The
+  (e) **anchor** — advancing virtual time before `stream()` is called
+  does not consume the first interval: the first deadline is
+  `stream_time + interval` (later in absolute time for a later `stream()`
+  call), because the anchor is the `stream()` call, not `Timer::new`,
+  which stores only the interval. The
   existing wide-margin real-time `Timer` tests remain as non-normative
   smoke checks; the paused tests are the contract's proof.
 - **INV-C4**: production neutrality — the crate exposes no time-control

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -177,6 +177,32 @@ Prompts that have already paid off:
   #240: the deliverability check had no poll budget until "each check
   polls each leaf its scan reaches exactly once, with wake-ups not
   honored within the call" was pinned).
+- A behavioral test an invariant *prescribes*, checked against the other
+  invariants and contracts — not only against the property it proves. A
+  mandated test is itself an execution; run the joint-satisfiability walk
+  on it (from PR #246: INV-T8's retention test scripted
+  `send(Start); send(Cancel)` and then asserted the message was still
+  deliverable, which INV-T7 and §5.1 make impossible — a cancelled
+  occupant's output is gone; the retention test had to use a
+  non-cancelling `send`, and the cancel case moved to INV-T7).
+- A normative contract stated as *observable properties*, not as the
+  implementation mechanism that happens to produce them. A clause phrased
+  over a specific call (`.skip(1)`, an `interval` handle) is satisfiable
+  by keeping that mechanism while breaking intent, and is falsely refuted
+  by a conforming reimplementation that drops it (from PR #246: the
+  `Timer` non-catch-up contract was reworded from "`.skip(1)` absorbs the
+  elapsed deadline" to a `next_deadline`-relative property so a
+  from-scratch timer still conforms).
+- A multi-clause contract over one stateful object, checked where its
+  clauses interact and with the *resulting* state pinned, not only the
+  immediate output. Read each clause against the boundary input the
+  others produce (from PR #246: a `Timer` contract said "a gap shorter
+  than one interval yields no tick" and, separately, "the next deadline
+  is the anchor-phase boundary after a miss" — at 3.5 ms on a 1 ms timer
+  that boundary is 4 ms, 0.5 ms later, so the clauses disagreed on
+  whether it fires; and "return one tick after a miss" left the post-miss
+  cadence unpinned. Restating the whole contract deadline-relative fixed
+  both).
 
 ## 3. Enforcement class, declared up front
 
@@ -319,6 +345,43 @@ against the tool's suppression and configuration surface, not only its
 default diagnostic, before writing any review half at all; and name the
 delegated remainder even when it is currently empty (item 1).
 
+A behavioral claim about a dependency is a code claim, verified against
+that dependency's documented semantics — thresholds, margins, and
+"best-effort" hedges included — not its assumed behavior. *From PR #246:*
+a `Timer` contract asserted no catch-up burst "because
+`MissedTickBehavior::Skip` skips missed ticks", but Tokio's Skip engages
+only once a tick is late past a fixed 5 ms margin, so sub-margin
+intervals replayed a burst; and "ready on the next poll after `advance`"
+was stronger than Tokio's `advance`, which documents that it does not
+wait for the sleeps it moves past.
+
+A "matches the runtime" or parity claim separates outcome-parity from
+mechanism-parity, and the runtime step it names is verified to exist.
+*From PR #246:* "the store skips the poll, matching the runtime, which
+aborts the keyed task without sampling it" was false — the runtime
+samples receiver facts before every `Spawn` regardless of policy; the
+store's skip was justified instead by the sample not changing the
+outcome. Separately, `redraw_requested` reading the init directive was
+described as "what the runtime would read" although the runtime never
+consults the init redraw directive at all.
+
+A term naming a code moment — "construction", "start", "first poll",
+"anchor" — is pinned to the exact site when two candidate sites differ
+observably. *From PR #246:* "the timer's construction-time anchor" was
+ambiguous between `Timer::new` (which only stores the interval) and
+`Timer::stream()` (which builds the `interval()`); advancing time between
+them changes the first deadline, so the text was fixed to
+"stream-construction anchor" and given a test that advances time across
+the gap.
+
+"Behavior-preserving", "no-op", or "internal only" is an operational
+absolute about the whole change: one observable difference refutes it,
+and once refuted the header's `CHANGELOG` and `Scope` must record the
+change (item 7). *From PR #246:* the `Timer` non-catch-up fix was an
+observable behavior change for short-interval timers, so `CHANGELOG:
+none` / "behavior-preserving" became `CHANGELOG: Fixed`, with the fix
+added to `Scope` and its own implementation section.
+
 ## 5. Normative force and readiness
 
 An RFC or amendment that gates implementation carries no soft spots in
@@ -421,6 +484,22 @@ changed-claims list.
   happens in `receive*` calls" standing in the API-semantics section —
   found by grepping "poll", invisible to a grep for the rewritten
   sentence).
+- A guarantee you deliberately *weakened or negated* is re-checked
+  across every object that could re-assert it, by the *concept* removed
+  rather than the old wording: the stale restatement is usually a
+  positive claim in a different section that shares no vocabulary with
+  the sentence you changed (from PR #246, twice: after §3.2 stopped
+  fixing "which poll observes readiness", INV-C2 still said "ready on the
+  next poll after one that does", and later the `Timer` contract
+  re-fixed it as "a poll observing now ≥ next_deadline yields a tick" —
+  neither reachable by grepping the §3.2 sentence).
+- A decision that changes observable behavior is reflected in the header
+  block: the `Scope` list, the `CHANGELOG` line, and any
+  "behavior-preserving" / "no new behavior" claim in the summary or
+  invariants. Grep the header for `CHANGELOG:` and "behavior-preserving"
+  whenever a decision's behavior changes (from PR #246: a
+  behavior-changing timer fix shipped for two review rounds with
+  `CHANGELOG: none` and the fix absent from `Scope`).
 - Resolving a decision is a corrected claim: grep for the decision's own
   vocabulary — its option labels ("(a)/(b)"), *pending*, *remaining
   step*, *the input for the choice* — across the findings, every open


### PR DESCRIPTION
## Context

A pre-implementation review judged RFC 0008 (TestStore) and RFC 0009 (Clock DI) **No-Go** for implementation: the normative text diverged from the current code and from Tokio's documented guarantees. Every finding was verified against the source, `Cargo.lock`'s tokio 1.50.0, and `docs/rfcs/pre-review-checklist.md` before the affected clauses were re-derived (checklist item 6).

## Round 1 — original findings

| # | Finding | Evidence | Resolution |
|---|---------|----------|------------|
| 1 | Timer non-catch-up contract unachievable with current impl | `interval.rs`'s `now > timeout + 5ms` — Skip only engages past a fixed lateness margin | Keep the contract; pin it as a property the `Timer` impl must provide directly, with paused tests at 1ms/2ms. Corrected the internally-inconsistent "zero tick before first poll" |
| 2 | Timer cannot reach stage-2 `receive` | Timer is a `SubscriptionSource`; RFC 0008 §1.2 excludes subscription execution | Stage 2 delivers command time leaves only; Timer determinism stays pinned via INV-C3 against its stream |
| 3 | "ready on next poll after advance" over-promises | `clock.rs`: `advance` does not wait for the sleeps it moves past | Weakened to "no wall-clock wait once the executor is driven to progress"; deferred driver-barrier/executor-context to stage 2 |
| 4 | send's exhaustiveness poll blocks cancellation tests | `app_input.rs` shared-first schedule | Dropped send's deliverable-output failure/poll; CancelInFlight intake issues no reconciliation poll |
| 5 | init redraw observation not runtime-equivalent | `core.rs`/`pending_work.rs` | Carved init-directive read out of INV-T3's "runtime would read" |

## Round 2 — re-review findings

- **INV-C2 (blocker)** — dropped the residual "ready on the next poll after one that does" that re-introduced the readiness over-promise.
- **Timer fix visibility (major)** — added it to Scope + `CHANGELOG: Fixed`; split §4 into §4.1 (HTTP, behavior-preserving) and §4.2 (Timer alignment, not behavior-preserving), owned by INV-C3.
- **Post-miss cadence (major)** — pinned next deadline after the overdue tick; restated as observable properties, not `.skip(1)` mechanism.
- **CancelInFlight sampling (major)** — corrected the false "runtime aborts without sampling it": the runtime samples receiver facts before every Spawn (`keyed_commands.rs`; RFC 0003 §4.2), but the sample can't change a CancelInFlight outcome and the store has no equivalent snapshot.
- **send shared-first scope (medium)** — narrowed runtime-parity to keyed output (INV-14); unkeyed ordering is TestStore's linearization.

## Round 3 — re-review findings

- **Timer deadline vs phase (blocker)** — "gap shorter than one interval yields no tick" contradicted phase-preservation (a late tick at 3.5ms on a 1ms timer must still fire at 4ms, 0.5ms away). Restated the contract **deadline-relative** over a running `next_deadline` (`now < next_deadline` → 0; `now >= next_deadline` → exactly 1; deliver → advance to first anchor-phase boundary strictly after now). INV-C3 now requires the sub-interval boundary-crossing test.
- **Anchor ambiguity (major)** — pinned the anchor at **stream construction** (`stream()`/`interval()`), not `Timer::new`; INV-C3 gains a test advancing time between `new()` and `stream()`.
- **INV-T8 keyed/unkeyed (medium)** — split the negative test into a keyed one (runtime parity, INV-14) and an unkeyed one (send does not block; no parity claim), so neither failure mode slips through.
- Minor sync: §4.2 added to §1.1 in-scope; "Two design inputs" → "Three".

## Verification

- `git diff --check` clean; `typos` clean; English-only.
- Re-ran the pre-review checklist on each round's changed claims, including the deadline-based Timer re-derivation (item 6) and the joint-satisfiability check on the CancelInFlight no-poll refinement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 4 — re-review findings

- **INV-T8 keyed retention vs cancellation (blocker)** — the keyed retention test scripted `send(Start); send(Cancel)` yet asserted the old message via a later `receive`, contradicting §5.1 (a superseded/cancelled occupant's output is undeliverable). Retention test now uses a non-cancelling `send(Unrelated)`; the `send`-carried supersede/cancel case moved to INV-T7 (`send` does not fail, output thereafter unobservable).
- **Timer poll-fixing (major)** — the Timer contract re-fixed which poll yields the tick ("a poll observing now >= next_deadline yields exactly one tick"), conflicting with §3.2/INV-C2 leaving the observing poll open. Restated as **deliverability** (count-and-cadence), with the observing poll deferred to §3.2's readiness guarantee; Timer claims no stronger same-poll guarantee than any other gated behavior.
- **Stale anchor restatements (medium)** — §2.1 no longer says `Timer::new` constructs time-gated behavior; INV-C3(e) reads "pre-stream time does not consume the first interval; the first deadline is stream_time + interval" instead of "shifts no deadline".

## Checklist updates

Per `pre-review-checklist.md`'s living-document rule, this PR folds the defect classes these four rounds surfaced back into the checklist (9 prompts, all cited to this PR):

- **Item 2** — a prescribed test checked against the *other* invariants; contracts stated as observable properties not mechanisms; multi-clause contracts over a stateful object checked at their interacting boundary with the resulting state pinned.
- **Item 4** — dependency behavioral claims verified against the dependency's documented semantics (margins included); "matches the runtime" separating outcome- from mechanism-parity; a code-moment term pinned to its exact site; "behavior-preserving" as an operational absolute that forces a CHANGELOG/Scope update once refuted.
- **Item 7** — a deliberately weakened/negated guarantee re-checked by concept not wording; a behavior-changing decision reflected in the header's Scope and CHANGELOG.