### PR TITLE
docs(rfcs): fix RFC 0008 §3.2 init-command exhaustiveness contradiction

### DIFF
--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -248,20 +248,28 @@ generic) are implementation latitude.
   `redraw_requested`, `subscription_ids`, and `finish` remain callable.
 - **`subscription_ids`** calls `Application::subscriptions` and returns
   the declared IDs in declaration order, deduplicated by RFC 0005 §3.5's
-  first-wins rule: for equal full IDs in the declared list, only the
-  first occurrence is returned. This mirrors the set the runtime would
-  actually start — `SubscriptionManager::update` applies the same rule
-  before spawning — so asserting on `subscription_ids()` predicts which
-  subscriptions would be live, not merely which lines of `subscriptions`
-  were written. TestStore does not reproduce the warning-level tracing
-  event RFC 0005 §3.5 requires of the ignored duplicate: that event is
-  `SubscriptionManager::update`'s own side effect, and TestStore never
-  constructs or runs a `SubscriptionManager` (§1.2). `SubscriptionId` is
-  already `Clone + Eq + Hash + Debug`, so the test asserts on the
-  returned `Vec` directly. This is the observation the
-  `subscriptions`-purity contract (`src/application.rs`) makes
-  meaningful: the declared set is a pure function of state, so asserting
-  it after a `send` is deterministic.
+  first-occurrence-stable rule: for equal full IDs in the declared list,
+  only the first occurrence is kept, at its original position among the
+  survivors (`[A, B, A]` → `[A, B]`, never `[B, A]` or any other
+  reordering). This is the same *desired-set* `SubscriptionManager::update`
+  computes before reconciling — not the set it spawns: `update` leaves an
+  already-running id in that set untouched and calls a source's
+  `stream()` only for an id newly entering it (`src/subscription.rs`).
+  `subscription_ids` performs the same dedup without going anywhere near
+  that machinery — it never calls
+  `stream()` on any declared source and never constructs or runs a
+  `SubscriptionManager` (§1.2) — so its return value predicts the
+  reconciliation *input*, not which ids the runtime spawns or which are
+  currently live. For the same reason it does not reproduce the
+  warning-level tracing event RFC 0005 §3.5 requires of the ignored
+  duplicate: that event is `SubscriptionManager::update`'s own side
+  effect, never triggered by a call that runs no `SubscriptionManager`
+  at all. `SubscriptionId` is already `Clone + Eq + Hash + Debug`, so
+  the test asserts on the returned `Vec` directly. This is the
+  observation the `subscriptions`-purity contract (`src/application.rs`)
+  makes meaningful: the declared set is a pure function of state, so
+  asserting it after a `send` is deterministic. INV-T11 (§8) pins the
+  dedup rule and the no-side-effect claim as tested contract.
 - **`finish` / drop**: `finish` runs the exhaustiveness check (§6).
   Dropping an unfinished store runs the same check, except when the
   thread is already panicking (so a failed assertion does not cascade
@@ -375,17 +383,30 @@ rather than silently lenient: polling such a leaf fails the test.
 
 This guarantee holds only because stage 1 requires the reactor's
 genuine *absence*, not merely the store's own inaction, and an entered
-Tokio runtime does not reliably restore it: with the default
+Tokio runtime does not reliably restore it. With the default
 `#[tokio::test]` configuration (`enable_all`), the same leaf's first
 poll finds a real reactor and returns `Pending` instead of panicking —
-it never fails, it just never completes, which is a silent stage-1
-hang, not the documented failure — while a runtime entered with a
-narrower driver configuration can still panic on the same poll. Because
-whether polling panics or hangs depends on which drivers the entered
-runtime happens to enable, and the store has no cheap, safe way to
-inspect that from inside, stage 1 does not try to distinguish: it
-refuses to run inside any entered runtime at all. `TestStore::new`
-therefore checks
+not the documented immediate failure, but the store's ordinary
+not-yet-deliverable handling: a `receive*` reaching only this leaf
+fails with the ordinary "effects pending but not ready" diagnostic
+(§3.2, §6) rather than the one naming a reactor-requiring leaf, and a
+`Pending` poll by itself is not a failure at all — like any other
+in-flight leaf, it is caught only if `finish`/drop still finds it
+unfinished (the pending-leaf carve-out below, this section). Whether
+it stays unfinished until then is no longer stage 1's decision: because
+a real reactor is now present, the same command effect this leaf
+wraps (`tokio::time::sleep` under `timeout`, or a backoff delay) can
+keep making genuine progress against it between store calls, so a
+later poll may find it deliverable with real output — an outcome timed
+by the ambient runtime and real wall-clock elapsed time, not by the
+test program, which is exactly the nondeterminism stage 1's INV-T4
+exists to rule out. (A runtime entered with a narrower driver
+configuration — no timer, no I/O — still panics on the same poll, so
+the failure mode is not even uniform across entered runtimes.) Because
+the outcome depends on drivers and scheduling the store cannot cheaply
+or safely inspect from inside, stage 1 does not try to distinguish any
+of these cases: it refuses to run inside any entered runtime at all.
+`TestStore::new` therefore checks
 `tokio::runtime::Handle::try_current()` and panics immediately, with a
 diagnostic naming the precondition, if one is currently entered. Stage 1
 tests must run on a plain `#[test]` (or equivalent), never
@@ -768,35 +789,57 @@ Enforcement classes follow the pre-review checklist's definitions
 - **INV-T10**: reactor-absence precondition (stage 1 only, §7) —
   `TestStore::new` panics immediately, before returning a store, if
   `tokio::runtime::Handle::try_current()` succeeds, so §4.3's "polling a
-  time-dependent leaf fails the test" guarantee cannot silently degrade
-  into an unpolled hang inside a Tokio runtime context. Structural:
-  review of `TestStore::new` for the check, placed before any other
-  construction work. Behavioral: a test constructs `TestStore` from
-  inside `#[tokio::test]` and asserts the panic and that its message
-  names the precondition (not the generic missing-reactor panic §4.3
-  otherwise produces).
+  time-dependent leaf fails the test" guarantee cannot silently
+  degrade, inside a Tokio runtime context, into the leaf's ordinary
+  not-yet-deliverable handling — with the test's outcome then timed by
+  the ambient runtime and real wall-clock progress instead of guaranteed
+  fail-fast (§4.3). Structural: review of `TestStore::new` for the
+  check, placed before any other construction work. Behavioral: a test
+  constructs `TestStore` from inside `#[tokio::test]` and asserts the
+  panic and that its message names the precondition (not the generic
+  missing-reactor panic §4.3 otherwise produces).
+- **INV-T11**: subscription-declaration observation —
+  `subscription_ids` returns RFC 0005 §3.5's first-occurrence-stable
+  dedup of `Application::subscriptions()`'s declared list (duplicates
+  collapse to their first occurrence, at that occurrence's original
+  position — `[A, B, A]` → `[A, B]`, never `[B, A]`), and produces it
+  without calling `stream()` on any declared source or otherwise
+  constructing or running a `SubscriptionManager` (§1.2, §3.2). The
+  returned `Vec` is the reconciliation *input* `SubscriptionManager::update`
+  would compute, not a prediction of which ids it spawns or already has
+  running — `update` leaves an already-running id untouched and calls
+  `stream()` only for one newly entering the set
+  (`src/subscription.rs`). Structural: review of `subscription_ids`
+  for the absence of any `SubscriptionManager` construction or
+  `Subscription::spawn`/`stream()` call. Behavioral: a duplicate-ID test
+  asserting `[A, B, A]` dedups to `[A, B]`, not `[B, A]` or any other
+  order — ruling out a last-occurrence or resorted implementation; a
+  `MockSource`-style test asserting its `stream()` constructor is never
+  invoked by a `subscription_ids` call; and, since §3.2 keeps the
+  no-warning claim as contract, a `tracing` capture asserting zero
+  `target: "tears::subscription"` duplicate-ignored events fire from a
+  `subscription_ids` call over a duplicate-ID declaration.
 
 Surface–invariant coverage: `new`/`send`/`receive*`/`finish` map to
 INV-T2/T3/T4/T8, with `new` additionally covered by INV-T10; `state` is
 the pure accessor through which INV-T4's state-transition transcript is
 read, covered there; delivery order maps to INV-T5/T6; cancellation
-metadata to INV-T7; `receive_quit` and the quit state to INV-T9;
-`redraw_requested` and `subscription_ids` are pure observations of
-contracts owned elsewhere (RFC 0002's directive; RFC 0005's declared
-identity) and are covered by INV-T3 (they read what the runtime would
-read) plus one behavioral test each — with two carve-outs. First: the
-init-command directive `redraw_requested` reports before the first step
-is TestStore-specific `Command` introspection and is *not* a prediction
-of the runtime's first render (§5.2), so it falls outside INV-T3's
+metadata to INV-T7; `receive_quit` and the quit state to INV-T9.
+`redraw_requested` is a pure observation of a contract owned elsewhere
+(RFC 0002's directive) and is covered by INV-T3 (it reads what the
+runtime would read, and directives are named in INV-T3's own text)
+plus one behavioral test, with one carve-out: the init-command
+directive `redraw_requested` reports before the first step is
+TestStore-specific `Command` introspection and is *not* a prediction of
+the runtime's first render (§5.2), so it falls outside INV-T3's
 "runtime would read" umbrella; the behavioral test for it asserts the
 init command's folded directive, not a runtime first-frame outcome.
-Second: `subscription_ids`'s first-wins dedup (RFC 0005 §3.5) applies,
-but the duplicate-ignored warning event does not, since TestStore never
-runs a `SubscriptionManager` to emit it (§3.2); the behavioral test for
-`subscription_ids` therefore includes a duplicate-declared-ID case
-asserting the returned `Vec` keeps only the first occurrence, without
-asserting any tracing event. The absence of an `Application` change
-maps to INV-T1.
+`subscription_ids` is a pure observation of a contract owned elsewhere
+(RFC 0005's declared identity) but is *not* an INV-T3 case — INV-T3
+governs `Command` decomposition only, and subscriptions never pass
+through it — so it gets its own invariant, INV-T11, covering the dedup
+rule, the no-side-effect claim, and the no-warning claim together
+(§8). The absence of an `Application` change maps to INV-T1.
 
 ## 9. Open questions
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -167,6 +167,9 @@ where
     App::Message: Debug,
 {
     /// Runs `Application::new(flags)` and enqueues the init command.
+    ///
+    /// Panics if called while a Tokio runtime is already entered — for
+    /// example, from inside `#[tokio::test]` (§4.3, INV-T10).
     #[must_use]
     pub fn new(flags: App::Flags) -> Self;
 
@@ -371,13 +374,18 @@ pending command set — §1.2.) Stage 1's contract is honest about this
 rather than silently lenient: polling such a leaf fails the test.
 
 This guarantee holds only because stage 1 requires the reactor's
-genuine *absence*, not merely the store's own inaction: if `TestStore`
-is constructed while a Tokio runtime is already entered (a
-`#[tokio::test]` body, or any code running on a Tokio worker thread),
-the same leaf's first poll finds a real reactor and returns `Pending`
-instead of panicking — it never fails, it just never completes, which
-is a silent stage-1 hang, not the documented failure.
-`TestStore::new` therefore checks
+genuine *absence*, not merely the store's own inaction, and an entered
+Tokio runtime does not reliably restore it: with the default
+`#[tokio::test]` configuration (`enable_all`), the same leaf's first
+poll finds a real reactor and returns `Pending` instead of panicking —
+it never fails, it just never completes, which is a silent stage-1
+hang, not the documented failure — while a runtime entered with a
+narrower driver configuration can still panic on the same poll. Because
+whether polling panics or hangs depends on which drivers the entered
+runtime happens to enable, and the store has no cheap, safe way to
+inspect that from inside, stage 1 does not try to distinguish: it
+refuses to run inside any entered runtime at all. `TestStore::new`
+therefore checks
 `tokio::runtime::Handle::try_current()` and panics immediately, with a
 diagnostic naming the precondition, if one is currently entered. Stage 1
 tests must run on a plain `#[test]` (or equivalent), never
@@ -809,15 +817,18 @@ maps to INV-T1.
 
 - RFC 0002 — redraw suppression: the directive `redraw_requested`
   observes.
-- RFC 0003 — command cancellation: its §4.2 pre-spawn reconciliation
-  and INV-1, INV-3, INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11,
-  INV-14 (cited in §§4.1, 4.2, 5.1, 5.3 of this document).
+- RFC 0003 — command cancellation: its §4.2 pre-spawn reconciliation,
+  its §5.1 explicit-cancels-before-keyed-spawn ordering, and INV-1,
+  INV-3, INV-4, INV-5, INV-6, INV-7, INV-9, INV-10, INV-11, INV-14
+  (cited in §§4.1, 4.2, 5.1, 5.3 of this document).
 - RFC 0005 — structural lifecycle identity: `SubscriptionId`, the
   declared-set semantics `subscription_ids` observes.
 - RFC 0006 — runtime load control: the shutdown discard carve-out §5.3
   mirrors (INV-L2); the runtime contracts §1.2 excludes.
 - RFC 0007 — RuntimeConfig: the prelude-membership reasoning §3.3
   follows.
+- RFC 0009 — Clock DI: its §3.2 controlled time context, which §7's
+  stage-2 sketch and INV-T10's stage-1 scoping (§4.3, §8) both cite.
 - `src/application.rs` — the trait whose bounds §2 pins.
 - `src/command/core.rs`, `src/command/runtime_parts.rs` — the
   decomposition boundary INV-T3 names.

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -244,11 +244,21 @@ generic) are implementation latitude.
   `receive`, `receive_matching`, and `receive_quit` all fail; `state`,
   `redraw_requested`, `subscription_ids`, and `finish` remain callable.
 - **`subscription_ids`** calls `Application::subscriptions` and returns
-  the declared IDs in declaration order. `SubscriptionId` is already
-  `Clone + Eq + Hash + Debug`, so the test asserts on it directly. This
-  is the observation the `subscriptions`-purity contract
-  (`src/application.rs`) makes meaningful: the declared set is a pure
-  function of state, so asserting it after a `send` is deterministic.
+  the declared IDs in declaration order, deduplicated by RFC 0005 §3.5's
+  first-wins rule: for equal full IDs in the declared list, only the
+  first occurrence is returned. This mirrors the set the runtime would
+  actually start — `SubscriptionManager::update` applies the same rule
+  before spawning — so asserting on `subscription_ids()` predicts which
+  subscriptions would be live, not merely which lines of `subscriptions`
+  were written. TestStore does not reproduce the warning-level tracing
+  event RFC 0005 §3.5 requires of the ignored duplicate: that event is
+  `SubscriptionManager::update`'s own side effect, and TestStore never
+  constructs or runs a `SubscriptionManager` (§1.2). `SubscriptionId` is
+  already `Clone + Eq + Hash + Debug`, so the test asserts on the
+  returned `Vec` directly. This is the observation the
+  `subscriptions`-purity contract (`src/application.rs`) makes
+  meaningful: the declared set is a pure function of state, so asserting
+  it after a `send` is deterministic.
 - **`finish` / drop**: `finish` runs the exhaustiveness check (§6).
   Dropping an unfinished store runs the same check, except when the
   thread is already panicking (so a failed assertion does not cascade
@@ -358,8 +368,31 @@ wraps every leaf in a deadline; a backoff retry sleeps) cannot be
 driven without an executor. (`Timer` is not in this set: it is a
 subscription source, not a command leaf, so it never enters the store's
 pending command set — §1.2.) Stage 1's contract is honest about this
-rather than silently lenient: polling such a leaf fails the test. Note
-what that means under §4.2's scan semantics: the failure fires at the
+rather than silently lenient: polling such a leaf fails the test.
+
+This guarantee holds only because stage 1 requires the reactor's
+genuine *absence*, not merely the store's own inaction: if `TestStore`
+is constructed while a Tokio runtime is already entered (a
+`#[tokio::test]` body, or any code running on a Tokio worker thread),
+the same leaf's first poll finds a real reactor and returns `Pending`
+instead of panicking — it never fails, it just never completes, which
+is a silent stage-1 hang, not the documented failure.
+`TestStore::new` therefore checks
+`tokio::runtime::Handle::try_current()` and panics immediately, with a
+diagnostic naming the precondition, if one is currently entered. Stage 1
+tests must run on a plain `#[test]` (or equivalent), never
+`#[tokio::test]`. The check is structural and happens once, at
+construction, not per leaf: a store built outside a runtime but later
+polled from inside one (a nested `block_on`) is a misuse this RFC does
+not attempt to catch, matching stage 1's synchronous, executor-free
+design (§1, §3.2). This precondition is stage-1-only (INV-T10, §8):
+stage 2's controlled time context (§7; RFC 0009 §3.2) is itself a
+paused single-threaded executor, so the Clock DI amendment replaces this
+check with one that accepts *that specific* controlled context and
+rejects any other runtime, rather than rejecting every runtime as stage
+1 does.
+
+Note what that means under §4.2's scan semantics: the failure fires at the
 *first store call whose scan polls the leaf* — a `receive` aimed at a
 different message, a `finish`/drop check, or a keyed-intake
 reconciliation poll (§5.1) that reaches it, not only a call targeting
@@ -431,6 +464,20 @@ completes — the analogue of INV-7's sender-closed empty receiver.
   that is issued follows §4.1's budget.
 - `Command::cancel(id)` drops the occupant's stream and undelivered
   output, and is idempotent (INV-4).
+- When one command carries both explicit cancels and its own keyed
+  spawn, the store applies RFC 0003's fixed order (RFC 0003 §5.1): the
+  explicit cancels apply first, then the keyed spawn's admission
+  decision — so a command can cancel its own occupant and immediately
+  reclaim the id in one step.
+  `Command::batch([Command::cancel(id), work]).cancellable(id)` drops
+  the old occupant's undelivered output exactly as the bullet above
+  describes, then admits `work` under `id`; the old run's output is
+  gone, and only `work`'s output is thereafter deliverable at `id`. An
+  implementation that instead admitted the new spawn before applying
+  the batch's own cancel would cancel `work` itself and leave `id`
+  empty — the wrong outcome — so this ordering is load-bearing, not
+  incidental, and is asserted directly rather than left to fall out of
+  the two bullets above.
 - Unkeyed commands are unaffected by any of the above (INV-1's default
   path).
 - `Command::batch`'s child-key folding needs no restatement: the store
@@ -569,7 +616,14 @@ time-gated *command* leaves (`timeout`, retry backoff) deliverable, and
 the §4.3 limitation for those leaves dissolving into ordinary `receive`
 flow. `Timer` and other subscription sources stay out of scope in
 stage 2 as in stage 1 (§1.2; RFC 0009 §5.1). Nothing in the stage-1
-surface above assumes otherwise or blocks that shape.
+surface above assumes otherwise or blocks that shape. INV-T10's
+construction-time check (§4.3, §8) is stage-1-only for the same reason:
+it rejects *every* Tokio runtime context, while stage 2 is meant to run
+inside the specific paused single-threaded executor RFC 0009 §3.2 calls
+a controlled time context, so the amendment narrows the check rather
+than dropping it outright — it will still reject an *unpaused* or
+multi-threaded runtime, which RFC 0009 §3.2's controlled time context
+already excludes.
 
 ## 8. Invariants
 
@@ -630,11 +684,12 @@ Enforcement classes follow the pre-review checklist's definitions
   declaration order; a leaf made ready late delivers after an
   earlier-enqueued ready leaf but before a later one. The negative-space
   half is documentation, checked in review of the rustdoc (structural).
-- **INV-T7**: cancellation parity — the five behaviors of §5.1
+- **INV-T7**: cancellation parity — the six behaviors of §5.1
   (supersede, keep-in-flight discard, reconciliation release, explicit
-  cancel, unkeyed unaffected) hold over the store's pending output as
-  RFC 0003's INV-3, INV-4, INV-5, INV-6, INV-7, and INV-9 state them
-  for deliverable output. Behavioral: one test per behavior, including
+  cancel, same-command cancel-then-spawn ordering, unkeyed unaffected)
+  hold over the store's pending output as RFC 0003's INV-3, INV-4,
+  INV-5, INV-6, INV-7, and INV-9 state them for deliverable output.
+  Behavioral: one test per behavior, including
   quit suppression (a superseded keyed quit is never observable via
   `receive_quit`) and the two reconciliation edges: a `KeepInFlight`
   command arriving after the occupant's leaves are exhausted is
@@ -648,7 +703,17 @@ Enforcement classes follow the pre-review checklist's definitions
   unobservable via any `receive*` (INV-3, INV-9). This is the
   cancel-before-receive scenario the §6 rationale motivates; INV-T8's
   retention tests deliberately do *not* cancel, since a cancelled
-  output cannot be retained.
+  output cannot be retained. The same-command cancel-then-spawn test
+  (RFC 0003 §5.1) `send`s `Command::batch([Command::cancel(id),
+  work]).cancellable(id)` over an occupied id and asserts both halves
+  at once: the occupant's
+  undelivered output is unobservable via any `receive*` (as the
+  explicit-cancel test already establishes) *and* a following `receive`
+  at `id` yields `work`'s message — an implementation that admits the
+  spawn before applying the batch's own cancel fails this test even
+  though it could still pass the supersede and explicit-cancel tests in
+  isolation, since neither of those combines a cancel and a spawn in one
+  command.
 - **INV-T8**: exhaustiveness — each leak class in §6 fails at its named
   call site, with a diagnostic naming the leaked values for the
   message classes and the count and enqueue position for the
@@ -670,7 +735,17 @@ Enforcement classes follow the pre-review checklist's definitions
   ordering is TestStore's linearization, not runtime parity, §6). The
   keyed-only test would pass an implementation that wrongly fails `send`
   on unkeyed pending output; the unkeyed-only test would miss a broken
-  keyed shared-first path — so both are required. The `send`-carried
+  keyed shared-first path — so both are required. Each of these two
+  tests is duplicated with the pending output sourced from the *init*
+  command instead of a step's — an unkeyed init effect surviving a
+  first, unrelated `send`, and a keyed init effect surviving a first,
+  non-cancelling `send` — for four negative tests total. §3.2's `new`
+  rule states the init command's output is subject to the same
+  accounting as any step's output; an implementation that special-cases
+  the very first `send` to still enforce the retracted "receive init
+  output before the first send" reading of the old §3.2 text would pass
+  the two step-sourced tests but fail the two init-sourced ones, so both
+  origins are required alongside both key classes. The `send`-carried
   supersede/cancel case (where the pending output is *removed*, not
   retained) is INV-T7's, not a retention test.
 - **INV-T9**: quit terminality and carve-out — after `receive_quit`,
@@ -682,22 +757,38 @@ Enforcement classes follow the pre-review checklist's definitions
   post-quit call polled it (§4.3) — and asserts the failing `send` and
   `receive*` (whose failure is the quit-state diagnostic, not the
   reactor panic polling would produce) and the passing `finish`.
+- **INV-T10**: reactor-absence precondition (stage 1 only, §7) —
+  `TestStore::new` panics immediately, before returning a store, if
+  `tokio::runtime::Handle::try_current()` succeeds, so §4.3's "polling a
+  time-dependent leaf fails the test" guarantee cannot silently degrade
+  into an unpolled hang inside a Tokio runtime context. Structural:
+  review of `TestStore::new` for the check, placed before any other
+  construction work. Behavioral: a test constructs `TestStore` from
+  inside `#[tokio::test]` and asserts the panic and that its message
+  names the precondition (not the generic missing-reactor panic §4.3
+  otherwise produces).
 
 Surface–invariant coverage: `new`/`send`/`receive*`/`finish` map to
-INV-T2/T3/T4/T8; `state` is the pure accessor through which INV-T4's
-state-transition transcript is read, covered there; delivery order maps
-to INV-T5/T6; cancellation metadata to
-INV-T7; `receive_quit` and the quit state to INV-T9;
+INV-T2/T3/T4/T8, with `new` additionally covered by INV-T10; `state` is
+the pure accessor through which INV-T4's state-transition transcript is
+read, covered there; delivery order maps to INV-T5/T6; cancellation
+metadata to INV-T7; `receive_quit` and the quit state to INV-T9;
 `redraw_requested` and `subscription_ids` are pure observations of
 contracts owned elsewhere (RFC 0002's directive; RFC 0005's declared
 identity) and are covered by INV-T3 (they read what the runtime would
-read) plus one behavioral test each — with one carve-out: the
+read) plus one behavioral test each — with two carve-outs. First: the
 init-command directive `redraw_requested` reports before the first step
 is TestStore-specific `Command` introspection and is *not* a prediction
 of the runtime's first render (§5.2), so it falls outside INV-T3's
 "runtime would read" umbrella; the behavioral test for it asserts the
-init command's folded directive, not a runtime first-frame outcome. The
-absence of an `Application` change maps to INV-T1.
+init command's folded directive, not a runtime first-frame outcome.
+Second: `subscription_ids`'s first-wins dedup (RFC 0005 §3.5) applies,
+but the duplicate-ignored warning event does not, since TestStore never
+runs a `SubscriptionManager` to emit it (§3.2); the behavioral test for
+`subscription_ids` therefore includes a duplicate-declared-ID case
+asserting the returned `Vec` keeps only the first occurrence, without
+asserting any tracing event. The absence of an `Application` change
+maps to INV-T1.
 
 ## 9. Open questions
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -215,9 +215,10 @@ generic) are implementation latitude.
 ### 3.2 Method semantics
 
 - **`new`** applies `Application::new` and enqueues the init command
-  exactly as a `send` enqueues an update's command. Exhaustiveness
-  applies from construction: an init command's ready message must be
-  received before the first `send`.
+  exactly as a `send` enqueues an update's command. The init command's
+  deliverable output is subject to the same `receive*`/`finish`/drop
+  accounting as any step's output (§6); `send` does not require it to
+  be received first.
 - **`send`** is one synchronous `update` call plus bookkeeping. It
   spawns no task, requires no executor, and returns only after the
   command's metadata (directives, cancellation) has been applied to the

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -256,11 +256,11 @@ generic) are implementation latitude.
   already-running id in that set untouched and calls a source's
   `stream()` only for an id newly entering it (`src/subscription.rs`).
   `subscription_ids` performs the same dedup without going anywhere near
-  that machinery — it never calls
-  `stream()` on any declared source and never constructs or runs a
-  `SubscriptionManager` (§1.2) — so its return value predicts the
-  reconciliation *input*, not which ids the runtime spawns or which are
-  currently live. For the same reason it does not reproduce the
+  that machinery — it never calls `stream()` on any declared source and
+  never constructs or runs a `SubscriptionManager` (§1.2) — so its
+  return value predicts the reconciliation *input*, not which ids the
+  runtime spawns or which are currently live. For the same reason it
+  does not reproduce the
   warning-level tracing event RFC 0005 §3.5 requires of the ignored
   duplicate: that event is `SubscriptionManager::update`'s own side
   effect, never triggered by a call that runs no `SubscriptionManager`
@@ -388,21 +388,24 @@ Tokio runtime does not reliably restore it. With the default
 poll finds a real reactor and returns `Pending` instead of panicking —
 not the documented immediate failure, but the store's ordinary
 not-yet-deliverable handling: a `receive*` reaching only this leaf
-fails with the ordinary "effects pending but not ready" diagnostic
-(§3.2, §6) rather than the one naming a reactor-requiring leaf, and a
-`Pending` poll by itself is not a failure at all — like any other
-in-flight leaf, it is caught only if `finish`/drop still finds it
-unfinished (the pending-leaf carve-out below, this section). Whether
-it stays unfinished until then is no longer stage 1's decision: because
-a real reactor is now present, the same command effect this leaf
-wraps (`tokio::time::sleep` under `timeout`, or a backoff delay) can
-keep making genuine progress against it between store calls, so a
-later poll may find it deliverable with real output — an outcome timed
-by the ambient runtime and real wall-clock elapsed time, not by the
-test program, which is exactly the nondeterminism stage 1's INV-T4
-exists to rule out. (A runtime entered with a narrower driver
-configuration — no timer, no I/O — still panics on the same poll, so
-the failure mode is not even uniform across entered runtimes.) Because
+fails with the same "effects pending but not ready" diagnostic
+(§3.2, §6) any ordinary in-flight effect produces — not this leaf
+class's own diagnostic, the missing-reactor panic (poor as that
+diagnostic is, below) — and a `Pending` poll by itself is not a
+failure at all — like any other in-flight leaf, it is caught only if
+`finish`/drop still finds it unfinished (the pending-leaf carve-out
+below, this section). Whether it stays unfinished until then is no
+longer stage 1's decision: because a real reactor is now present, the
+same command effect this leaf wraps (`tokio::time::sleep` under
+`timeout`, or a backoff delay) can keep making genuine progress
+against it between store calls, so a later poll may find it
+deliverable with real output — an outcome timed by the ambient runtime
+and real wall-clock elapsed time, not by the test program, which would
+undermine the very determinism INV-T4 asserts. Ruling that out before
+it can happen, rather than living with it, is INV-T10's job. (A
+runtime entered with a narrower driver configuration — no timer, no
+I/O — still panics on the same poll, so the failure mode is not even
+uniform across entered runtimes.) Because
 the outcome depends on drivers and scheduling the store cannot cheaply
 or safely inspect from inside, stage 1 does not try to distinguish any
 of these cases: it refuses to run inside any entered runtime at all.

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -203,6 +203,20 @@ Prompts that have already paid off:
   whether it fires; and "return one tick after a miss" left the post-miss
   cadence unpinned. Restating the whole contract deadline-relative fixed
   both).
+- An ambient-facility adversary: a contract that requires some shared
+  facility's *absence* (no executor, no reactor, no ambient clock) is
+  checked against being invoked while that facility is already present
+  and running, not only against the harness's own internal state
+  machine — the facility being absent by default in a plain unit test
+  is not the same as the contract *forbidding* its presence, and
+  nothing stops a caller from providing it anyway. (From PR #247: RFC
+  0008's "polling a time-dependent leaf fails the test" assumed the
+  reactor's genuine absence without forbidding an already-entered Tokio
+  runtime; entered, the same poll returns `Pending` instead of
+  panicking, and the outcome becomes timed by the ambient runtime and
+  real wall-clock progress instead of the documented fail-fast — fixed
+  by adding a construction-time check that rejects the ambient facility
+  outright rather than assuming it away.)
 
 ## 3. Enforcement class, declared up front
 
@@ -271,6 +285,19 @@ because bounded mode "exists to exit" the overload regime, while §4.3
 had already established that bounded capacity leaves shared readiness —
 and with it keyed starvation — intact at any capacity; backpressure
 bounds memory and shared latency, not keyed liveness.
+
+A failure-mode claim about a mechanism — panics, blocks, hangs,
+silently degrades — is checked against any execution model the same
+document already pins for that mechanism, not asserted as a
+free-standing plausibility judgment. *From PR #247:* a rationale
+paragraph asserted that polling a still-pending time-dependent leaf
+inside an ambient executor "never completes" — a hang — without
+rereading the same document's own already-normative poll budget (every
+check polls each reached leaf at most once and returns immediately, so
+the store cannot block by construction); the actual defect was
+nondeterministic later-delivery (a leaf turning up genuinely
+deliverable on a later poll once real wall-clock time elapses), not
+blocking, and the fix text changed accordingly.
 
 Invariant citations are code claims too: "X is already carried by RFC
 N's INV-M" gets a fresh read of INV-M's exact statement, and an umbrella
@@ -430,7 +457,17 @@ PR #215:
   (item 3). Walk the surface list and name the invariant for each; an
   element whose semantics are defined nowhere (`batch_max_messages` had
   neither counting semantics nor a corresponding invariant) is a finding
-  you can file yourself.
+  you can file yourself. A named invariant is not yet coverage: walk the
+  mapping the other direction too, from each cited invariant back to its
+  own exact statement (item 4's invariant-citation rule applies here),
+  and confirm its stated scope actually reaches the surface element —
+  not merely that the label exists and sounds adjacent. (From PR #247:
+  `subscription_ids` was mapped to INV-T3 for coverage ("a pure
+  observation ... covered by INV-T3"), but INV-T3's own text scopes it
+  to `Command` decomposition, which subscriptions never pass through —
+  the mapping named a real invariant that did not, in fact, cover the
+  claim, and the fix added a dedicated invariant instead of stretching
+  INV-T3's label over an unrelated surface.)
 
 ## 6. Re-derive, don't patch
 


### PR DESCRIPTION
## Summary
- §3.2's `new` doc claimed an init command's ready message must be received before the first `send`, contradicting §6's "send is non-blocking on pending deliverable output" rule, §3.1's `send` doc comment ("fails only after quit observed"), and the INV-T8 negative test requirement.
- Reworded to state the init command's output is subject to the same `receive*`/`finish`/drop accounting as any step's output, with no special first-send blocking.

## Test plan
- [x] Reviewed §6, §3.1, and INV-T8 for consistency with the new wording
- [x] Confirmed no other occurrences of the retracted "before the first send" claim remain (`grep -n "before the first"`)