### PR TITLE
docs(rfcs): add a minimal-contract counterweight to the pre-review checklist

### DIFF
--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -4,13 +4,21 @@ Run this before requesting review on a new RFC or an amendment to an
 existing one. It exists because contract text fails review in predictable
 ways: the checklist internalizes the reviewer's method — *construct an
 implementation or execution that satisfies everything stated but violates
-the intent* — so those findings surface before review instead of during
-it. It distills the review of the RFC 0006 open-question-3 amendment
-(PR #211), where three of five passes were preventable in hindsight.
+the intent, and cut the claims that pin no intent at all* — so those
+findings surface before review instead of during it. It distills
+the review of the RFC 0006 open-question-3 amendment (PR #211),
+where three of five passes were preventable in hindsight.
 
-This is a living document: when a review pass finds a defect class this
-checklist should have caught, add an item (or a prompt under an existing
-item) in the same PR that fixes the finding.
+This is a living document, and it prunes as well as grows. When a review
+pass finds a defect class this checklist should have caught, add an item
+(or a prompt under an existing item) in the same PR that fixes the
+finding — but when the new prompt only restates a principle an existing
+item already carries, fold it in rather than adding a peer, and when
+several *From PR* examples have collapsed to one internalized principle,
+keep the one or two that still teach the pattern and retire the rest. An
+item earns its length by catching what its shorter form would miss;
+length that no longer does is a defect class this checklist should catch
+in its own text.
 
 ## 1. Quantifiers against the inventory
 
@@ -529,3 +537,31 @@ changed-claims list.
   §5.1 named the supersession).
 - `typos` and `git diff --check` are clean.
 - English only (repository artifact).
+
+## 8. Minimal contract
+
+Items 1–7 all pull one way — toward a more defensible contract. Each is a
+reason some claim is too weak, too broad, unproven, or inconsistent, and
+its fix is almost always to add, tighten, or correct a claim, never to
+drop one. So an RFC that runs the whole checklist converges on *airtight*
+without ever converging on *small*. This item is the counterweight, and
+it runs item 2's adversary in reverse: instead of the implementation that
+satisfies the text while violating intent, construct the *smaller
+contract* that pins the same intent, and keep a clause only against a
+stated reason it is not redundant.
+
+- For each invariant, requirement, and element of contract surface, ask
+  what an already-present claim fails to pin once it is deleted. If
+  nothing, delete it: a claim the rest of the contract already implies is
+  not a weaker claim to strengthen, it is one to remove.
+- Two claims both correct where one is a special case of the other
+  collapse to the general one. A redundant invariant is two statements a
+  later amendment can drift apart — item 7's stale-restatement defect,
+  introduced on purpose.
+- A surface element whose only justification is that some implementation
+  might want it (a configuration field, an emitted event with no
+  invariant that needs its value) is not yet a contract; defer it to the
+  RFC that needs it rather than pinning it now.
+- Record why a kept clause is *not* redundant where the clause is stated —
+  *INV-X is not implied by INV-Y because …* — so a reader re-deriving
+  under item 6 does not re-add what was deliberately left out.

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -540,18 +540,18 @@ changed-claims list.
 
 ## 8. Minimal contract
 
-Items 1–7 all pull one way — toward a more defensible contract. Each is a
-reason some claim is too weak, too broad, unproven, or inconsistent, and
-its fix is almost always to add, tighten, or correct a claim, never to
-drop one. So an RFC that runs the whole checklist converges on *airtight*
-without ever converging on *small*. This item is the counterweight, and
-it runs item 2's adversary in reverse: instead of the implementation that
-satisfies the text while violating intent, construct the *smaller
-contract* that pins the same intent, and keep a clause only against a
-stated reason it is not redundant.
+Items 1–7 all pull one way — toward a more defensible contract. Most name
+a way some claim is too weak, too broad, unproven, or inconsistent, and
+the fix adds, tightens, or corrects it; almost none asks whether a claim
+should exist at all. So an RFC that runs the whole checklist converges on
+*airtight* without ever converging on *small*. This item is the
+counterweight, and it runs item 2's adversary in reverse: instead of the
+implementation that satisfies the text while violating intent, construct
+the *smaller contract* that pins the same intent, and record the reduction
+the way item 2 records the models it excludes.
 
 - For each invariant, requirement, and element of contract surface, ask
-  what an already-present claim fails to pin once it is deleted. If
+  what the rest of the contract fails to pin once it is deleted. If
   nothing, delete it: a claim the rest of the contract already implies is
   not a weaker claim to strengthen, it is one to remove.
 - Two claims both correct where one is a special case of the other
@@ -562,6 +562,11 @@ stated reason it is not redundant.
   might want it (a configuration field, an emitted event with no
   invariant that needs its value) is not yet a contract; defer it to the
   RFC that needs it rather than pinning it now.
-- Record why a kept clause is *not* redundant where the clause is stated —
-  *INV-X is not implied by INV-Y because …* — so a reader re-deriving
-  under item 6 does not re-add what was deliberately left out.
+- Record the reduction as an *excluded claims* note (item 2's form),
+  scoped to the claims this pass acted on, not to every clause that
+  survives: each claim it drops, paired with the surviving claim that
+  implies it — *INV-Z dropped; implied by INV-Y* — and each clause it
+  suspected of redundancy but kept, with why the survivor does *not*
+  imply it. A reader re-deriving from premises under item 6 then sees the
+  dropped claim it would otherwise re-add, and sees the kept one already
+  ruled non-redundant.


### PR DESCRIPTION
## Why

An Occam's-razor pass over `docs/rfcs/pre-review-checklist.md` surfaced one structural asymmetry: the checklist only ever grows. Its living-document rule adds items, and items 1–7 mostly name a way a claim is too weak, too broad, unproven, or inconsistent — the fix adds, tightens, or corrects it; almost none asks whether a claim should exist at all. So both the checklist itself (see item 1's eight "X is an inventory too" examples) and the RFCs it guards converge on *airtight* without ever converging on *small*. Nothing asked whether a claim earns its place.

## What

- **Preamble** — the reviewer's method now includes *cut the claims that pin no intent at all*, next to the adversarial construction, so item 8 sits inside the document's stated purpose rather than beside it.
- **Living-document rule** — paired with a fold/retire counterpart: a prompt that only restates an existing item folds in rather than adding a peer, and collapsed `*From PR*` examples retire down to the one or two that still teach the pattern. Length that no longer catches a defect is itself a defect class.
- **New item 8 — Minimal contract** — runs item 2's adversary in reverse: construct the *smaller* contract that pins the same intent, delete a claim the rest already implies, collapse a special case into its general form, defer speculative surface, and record the reduction as an *excluded claims* note (item 2's form, scoped to the claims the pass acted on) — each dropped claim paired with the surviving claim that implies it — so an item-6 re-derive does not re-add a dropped claim.

## Self-review

Ran items 1–5 and 7 on the changed claims. Review round 1 (commit `aacc72b`) then fixed three findings the pass should have caught, each an instance of the defect classes item 8's own text was subject to:

- **Item 1** — `never to drop one` was an absolute beside its own hedge, and its exceptions (item 5 delegation, item 6 re-derive) lived only in prose, not the claim. Reworded to "most name a way … ; almost none asks whether a claim should exist at all", which also fixes the per-member nit (the old "each is a reason …" was refuted by item 6 and item 7's mechanical sub-items).
- **Item 1** — the unlimited `kept clause` universal (a non-redundancy note on every surviving clause, contradicting item 8's own smallness) was scoped to "the claims this pass acted on, not every clause that survives".
- **Item 2/4** — the recorded note was the kept clauses' non-redundancy, but the stated purpose (an item-6 re-derive not re-adding a deleted claim) needs the *dropped* claim recorded — invisible to a from-premises re-derive otherwise. Reworked into an item-2-symmetric excluded-claims note.

After the fixes: cross-references to items 2/6/7 verified against their exact text; new imperatives are hedge-free (*most* / *almost none* do rationale work only); grep confirms no stale copy of the old phrasings; `typos` and `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
