### PR TITLE
refactor(poll): unify the poll-once-with-noop-waker pattern

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@
 pub(crate) mod application;
 pub mod command;
 pub(crate) mod panic;
+pub(crate) mod poll_util;
 pub mod prelude;
 pub(crate) mod runtime;
 mod structural_key;

--- a/src/poll_util.rs
+++ b/src/poll_util.rs
@@ -1,0 +1,17 @@
+//! Shared poll-once-with-noop-waker support.
+//!
+//! Several call sites need to poll a future or stream exactly once, without an
+//! executor, to check whether it is ready right now: a wake-up scheduled
+//! during that single poll is deliberately not honored, since nothing is
+//! listening for it.
+
+use std::task::Context;
+
+use futures::task::noop_waker_ref;
+
+/// A [`Context`] whose waker discards every wake-up. Building one costs
+/// nothing (the waker is a static no-op vtable), so callers construct a fresh
+/// one per poll rather than holding it across calls.
+pub fn noop_context() -> Context<'static> {
+    Context::from_waker(noop_waker_ref())
+}

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -217,16 +217,11 @@ mod tests {
     use std::future::Future;
     use std::num::NonZeroUsize;
 
-    use futures::task::noop_waker_ref;
-
     use super::*;
+    use crate::poll_util::noop_context;
 
     fn cap(value: usize) -> NonZeroUsize {
         NonZeroUsize::new(value).expect("capacity must be non-zero")
-    }
-
-    fn noop_context() -> Context<'static> {
-        Context::from_waker(noop_waker_ref())
     }
 
     /// Polls a fresh `send` future exactly once and asserts it resolved without

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -5,11 +5,11 @@ use std::task::{Context, Poll};
 
 use futures::FutureExt;
 use futures::stream::{BoxStream, Stream, StreamExt};
-use futures::task::noop_waker_ref;
 use tokio::task::{AbortHandle, JoinSet};
 use tokio_stream::StreamMap;
 
 use crate::command::{Action, CancelPolicy, CommandId};
+use crate::poll_util::noop_context;
 
 use super::channel;
 use super::load::{Channel, LoadObserver};
@@ -513,7 +513,7 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
     }
 
     pub(super) fn try_next_ready(&mut self) -> Option<(CommandId, ReceiverEvent<Msg>)> {
-        let mut context = Context::from_waker(noop_waker_ref());
+        let mut context = noop_context();
         match self.poll_event(&mut context) {
             KeyedPoll::Item(id, event) => Some((id, event)),
             KeyedPoll::PendingWithWakeSource | KeyedPoll::Quiescent => None,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -46,15 +46,15 @@
 //! [`Command::timeout`]: crate::Command::timeout
 
 use std::fmt::Debug;
-use std::task::{Context, Poll};
+use std::task::Poll;
 use std::thread;
 
 use futures::stream::BoxStream;
-use futures::task::noop_waker_ref;
 use tokio::runtime::Handle;
 
 use crate::application::Application;
 use crate::command::{Action, CancelPolicy, CommandId, RuntimeCommandParts};
+use crate::poll_util::noop_context;
 use crate::subscription::core::SubscriptionId;
 
 /// One undelivered effect leaf, held at its enqueue position.
@@ -82,7 +82,7 @@ impl<Msg: Send + 'static> PendingLeaf<Msg> {
         let Some(stream) = self.stream.as_mut() else {
             return Poll::Ready(None);
         };
-        let mut context = Context::from_waker(noop_waker_ref());
+        let mut context = noop_context();
         let poll = stream.as_mut().poll_next(&mut context);
         if matches!(poll, Poll::Ready(None)) {
             self.stream = None;


### PR DESCRIPTION
## Summary
- `testing.rs`'s `PendingLeaf::poll_once`, `runtime/keyed_commands.rs`'s `try_next_ready`, and `runtime/channel.rs`'s test-only `noop_context()` each independently spelled `Context::from_waker(noop_waker_ref())` to poll a future/stream exactly once without an executor.
- Extracted the single canonical `noop_context()` into a new crate-internal `poll_util` module (`pub(crate)`, not `cfg(test)`-gated, since two of the three call sites are production code) and updated all three call sites to use it.

## Test plan
- [x] `cargo build --all-features`
- [x] `cargo test --all-features` (415 lib tests + integration/doc tests, all passing)
- [x] `cargo clippy --all-features --all-targets -- -D warnings` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)