### PR TITLE
refactor(time): migrate HTTP time reads to tokio::time and land the INV-C1 lint

### DIFF
--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -763,6 +763,10 @@ struct Metrics {
 }
 
 impl Metrics {
+    // Real wall-clock reads: RFC 0006's statistical acceptance criteria are
+    // defined on real time, the one sanctioned exception to the
+    // single-time-source rule (RFC 0009 §3.1).
+    #[allow(clippy::disallowed_methods)]
     fn new() -> Self {
         Self {
             start: Instant::now(),
@@ -800,10 +804,12 @@ impl Metrics {
         produced.saturating_sub(processed)
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn elapsed_ns(&self) -> u64 {
         u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
     }
 
+    #[allow(clippy::disallowed_methods)]
     fn push_latency(bucket: &Mutex<Vec<u64>>, sent_at: Instant) {
         let nanos = u64::try_from(sent_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
         bucket.lock().expect("latency bucket poisoned").push(nanos);
@@ -830,6 +836,7 @@ impl SubscriptionSource for FloodSource {
     type Output = Msg;
     type Key = u32;
 
+    #[allow(clippy::disallowed_methods)]
     fn stream(&self) -> BoxStream<'static, Msg> {
         let metrics = Arc::clone(&self.metrics);
         let total = self.cfg.total;
@@ -884,6 +891,7 @@ impl Application for LoadApp {
     type Message = Msg;
     type Flags = (ScenarioCfg, Arc<Metrics>);
 
+    #[allow(clippy::disallowed_methods)]
     fn new((cfg, metrics): Self::Flags) -> (Self, Command<Msg>) {
         let cmd = if cfg.keyed_probe {
             let mut ticker = interval(Duration::from_millis(25));
@@ -1002,6 +1010,7 @@ impl Application for LoadApp {
 }
 
 /// Busy-waits for `duration` to simulate CPU-bound work on the runtime task.
+#[allow(clippy::disallowed_methods)]
 fn spin(duration: Duration) {
     if duration.is_zero() {
         return;
@@ -1031,6 +1040,7 @@ struct Report {
     seq_broken: bool,
 }
 
+#[allow(clippy::disallowed_methods)]
 async fn run_scenario(cfg: ScenarioCfg) -> Report {
     let rss_before = peak_rss_bytes();
     let metrics = Arc::new(Metrics::new());

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,3 +3,41 @@
 # Valid identifiers in documentation that should not require backticks
 # The ".." appends to the default list instead of replacing it
 doc-valid-idents = ["TanStack", ".."]
+
+# Single-time-source rule (RFC 0009 §3.1, INV-C1): every time read goes
+# through the virtualizable executor clock (`tokio::time`). The entries below
+# are §3.1's banned-entry-point inventory — `std` calls that read the current
+# time, block on its passage, or configure a timed block. Pure arithmetic on
+# existing time values and untimed blocking stay allowed. The one sanctioned
+# exception is `benches/runtime_load.rs`'s wall-clock measurement sites,
+# which carry explicit `#[allow(clippy::disallowed_methods)]`.
+disallowed-methods = [
+    # Now-reads
+    { path = "std::time::Instant::now", reason = "time reads go through tokio::time (RFC 0009 §3.1)" },
+    { path = "std::time::Instant::elapsed", reason = "now-read reachable via tokio::time::Instant::into_std; use tokio::time::Instant (RFC 0009 §3.1)" },
+    { path = "std::time::SystemTime::now", reason = "time reads go through tokio::time (RFC 0009 §3.1)" },
+    { path = "std::time::SystemTime::elapsed", reason = "now-read callable on UNIX_EPOCH without a prior now() (RFC 0009 §3.1)" },
+    # Real-time waits
+    { path = "std::thread::sleep", reason = "real-time wait; use tokio::time::sleep (RFC 0009 §3.1)" },
+    { path = "std::thread::sleep_ms", reason = "real-time wait (deprecated spelling) (RFC 0009 §3.1)" },
+    { path = "std::thread::park_timeout", reason = "real-time wait (RFC 0009 §3.1)" },
+    { path = "std::thread::park_timeout_ms", reason = "real-time wait (deprecated spelling) (RFC 0009 §3.1)" },
+    { path = "std::sync::Condvar::wait_timeout", reason = "real-time wait (RFC 0009 §3.1)" },
+    { path = "std::sync::Condvar::wait_timeout_while", reason = "real-time wait (RFC 0009 §3.1)" },
+    { path = "std::sync::Condvar::wait_timeout_ms", reason = "real-time wait (deprecated spelling) (RFC 0009 §3.1)" },
+    { path = "std::sync::mpsc::Receiver::recv_timeout", reason = "real-time wait (RFC 0009 §3.1)" },
+    { path = "std::sync::mpsc::Receiver::recv_deadline", reason = "real-time wait (unstable; listed defensively, RFC 0009 §3.1)" },
+    { path = "std::net::TcpStream::connect_timeout", reason = "real-time wait (RFC 0009 §3.1)" },
+    # Timed-wait configuration (the setters close the only route to a timed
+    # socket wait; the blocking read/write sites stay unbanned)
+    { path = "std::net::TcpStream::set_read_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)" },
+    { path = "std::net::TcpStream::set_write_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)" },
+    { path = "std::net::UdpSocket::set_read_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)" },
+    { path = "std::net::UdpSocket::set_write_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)" },
+    # Platform-gated rows: unresolvable on non-unix targets; enforced by the
+    # Linux CI lint gate (RFC 0009 §3.1)
+    { path = "std::os::unix::net::UnixStream::set_read_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)", allow-invalid = true },
+    { path = "std::os::unix::net::UnixStream::set_write_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)", allow-invalid = true },
+    { path = "std::os::unix::net::UnixDatagram::set_read_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)", allow-invalid = true },
+    { path = "std::os::unix::net::UnixDatagram::set_write_timeout", reason = "timed-wait configuration (RFC 0009 §3.1)", allow-invalid = true },
+]

--- a/src/subscription/http/cell.rs
+++ b/src/subscription/http/cell.rs
@@ -3,9 +3,10 @@ use std::sync::{
     Arc, Mutex,
     atomic::{AtomicU64, Ordering},
 };
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tokio::sync::watch;
+use tokio::time::Instant;
 
 use super::config::QueryConfig;
 use super::query::QueryError;

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -65,7 +65,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
-use std::time::Instant;
+use tokio::time::Instant;
 
 use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;


### PR DESCRIPTION
## Summary

Implements RFC 0009 §4.1 (the named prerequisite of the Clock DI RFC):

- `src/subscription/http/cell.rs` and `src/subscription/http/query.rs` migrate from `std::time::Instant` to `tokio::time::Instant` — the last two library sites outside the single-time-source rule. Behavior-preserving in unpaused contexts (same platform monotonic clock); none of the migrated values appears in a public signature.
- `clippy.toml` gains RFC 0009 §3.1's banned-entry-point inventory as `disallowed-methods`, turning on INV-C1's mechanical enforcement. The platform-gated `std::os::unix` socket-timeout rows carry `allow-invalid = true` and are enforced by the Linux CI lint gate. The unstable `recv_deadline` path resolves without `allow-invalid` (confirmed locally, as §3.1's implementation task requires).
- `benches/runtime_load.rs` keeps its deliberate real wall-clock measurement (RFC 0006's statistical criteria are defined on real time) with explicit `#[allow(clippy::disallowed_methods)]` at the measurement sites.

Per RFC 0009's front matter, this deliverable is internal and behavior-preserving and carries no CHANGELOG entry.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean.
- Lint canary check: a temporary `std::time::Instant::now()` in library code is flagged by the new configuration (then removed).
- `cargo test`: all suites and doctests green (HTTP suite unchanged, per §4.1's behavior-preservation half of INV-C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)