### PR TITLE
fix(time): make Timer non-catch-up directly instead of leaning on Skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Short-interval `Timer` subscriptions no longer replay a catch-up burst of
+  missed ticks after a delay: however many interval boundaries elapse while a
+  tick goes untaken, exactly one tick becomes deliverable, and the cadence
+  resumes on the timer's original phase (first anchor-phase boundary strictly
+  after the late tick). The timer's anchor is fixed when its stream is built;
+  the first tick still arrives one full interval later (RFC 0009 §4.2)
+
 ### Added
 
 - `tears::testing::TestStore`, a deterministic, executor-free test harness

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   missed ticks after a delay: however many interval boundaries elapse while a
   tick goes untaken, exactly one tick becomes deliverable, and the cadence
   resumes on the timer's original phase (first anchor-phase boundary strictly
-  after the late tick). The timer's anchor is fixed when its stream is built;
-  the first tick still arrives one full interval later (RFC 0009 §4.2)
+  after the late tick). The timer's anchor is fixed at its stream's first
+  poll — read from the clock of the runtime that polls it — and the first
+  tick arrives one full interval after that anchor (RFC 0009 §4.2)
 
 ### Added
 

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,6 +1,10 @@
 # RFC 0009: Clock DI — deterministic time via the virtual clock
 
 - Status: Accepted
+- Amended: 2026-07-25 — §4.2/INV-C3: `Timer`'s anchor moved from stream
+  construction to the stream's first poll (review finding: a stream
+  built outside the polling runtime's clock context anchored against
+  the wrong clock and ticked immediately or never)
 - Target: a crate-wide determinism contract for time-dependent behavior,
   with no new public API
 - Scope: the no-clock-abstraction decision, the single-time-source rule,
@@ -111,7 +115,7 @@ Rationale:
 - **An injected clock cannot reach the sites that need it without
   breaking the API.** `Command::timeout`, `Command::retry`'s backoff,
   and `Timer` (constructed via `Timer::new` in `subscriptions`, its time
-  anchored when its stream is built, §4.2) declare time-gated behavior
+  anchored at its stream's first poll, §4.2) declare time-gated behavior
   inside `update` and `subscriptions`, which receive no environment.
   Serving them with an
   injected clock requires either a clock parameter on every such
@@ -298,7 +302,7 @@ controlled context, the contract a consumer may cite:
   timeout semantics (deadline anchored at the leaf's first poll, one
   timeout message per modifier) and retry-backoff semantics, and
   `Timer`'s semantics, stated over a running `next_deadline` that starts
-  one full interval after the timer's stream-construction anchor: while
+  one full interval after the timer's first-poll anchor: while
   virtual now `<` `next_deadline` no tick is deliverable; once now `>=`
   `next_deadline` exactly one tick becomes deliverable, never a burst,
   however many deadlines have elapsed, and after it is taken nothing more
@@ -389,18 +393,27 @@ behavior-preserving.
   tick per missed interval. This is a user-visible behavior change for
   short-interval timers under load, so it lands with a `CHANGELOG: Fixed`
   entry, not as a mere rustdoc adjustment.
-- **Anchor.** The time anchor is fixed at **stream construction** — the
-  moment `Timer::stream()` is called (`interval()` in
-  `src/subscription/time.rs`), not `Timer::new`, which only stores the
-  interval value. Time that passes between `Timer::new` and `stream()`
-  does not count against the timer; the first `next_deadline` is one
-  full interval after the `stream()` call.
+- **Anchor** (amended 2026-07-25; originally "stream construction").
+  The time anchor is fixed at the stream's **first poll** — not
+  `Timer::new`, which only stores the interval value, and not the
+  `stream()` call, which only builds the stream. `stream()` may legally
+  run outside the runtime that will poll the stream (on another thread,
+  or in setup code outside a paused test runtime), and an anchor read
+  there comes from the ambient clock, which can disagree with the
+  virtualizable clock the timer's sleeping measures against — a
+  construction-time anchor then delivers a tick at the first poll or
+  never becomes ready at all. The first poll, by definition, happens on
+  the polling runtime's clock, so the mismatch is structurally
+  impossible. Time that passes before the first poll counts against
+  nothing; the first `next_deadline` is one full interval after the
+  first poll.
 - **Pinned observable properties**, stated over a running `next_deadline`
   (independent of the implementation mechanism, so a from-scratch
   reimplementation that drops `.skip(1)` or `interval` altogether still
   conforms):
-  - `next_deadline` starts one full interval after the stream-construction
-    anchor. The construction-instant tick is never delivered.
+  - `next_deadline` starts one full interval after the first-poll
+    anchor. No tick is ever deliverable at or before the anchor
+    instant.
   - While virtual now `<` `next_deadline`, no tick is deliverable. Once
     now `>=` `next_deadline`, **exactly one** tick becomes deliverable —
     however many interval boundaries lie between the old `next_deadline`
@@ -420,7 +433,7 @@ behavior-preserving.
     rustdoc describes.
 - **rustdoc.** `Timer` gains a first-tick, non-catch-up, and post-miss
   cadence sentence citing this RFC as the semantics of record, and names
-  the stream-construction anchor.
+  the first-poll anchor.
 - **Tests.** INV-C3's paused-clock tests at 1 ms and 2 ms intervals are
   the proof; a Skip-margin-dependent implementation fails them.
 
@@ -458,7 +471,7 @@ Three design inputs recorded for that amendment:
   leaf's *first poll*, and the store's scans decide when that first
   poll happens; the amendment's advance semantics must account for
   scan-order-dependent anchoring rather than assuming
-  construction-time anchoring. (`Timer`'s stream-construction anchor
+  construction-time anchoring. (`Timer`'s first-poll anchor
   (§4.2) is not a stage-2 concern: stage 2 delivers command time leaves
   only, never `Timer`.)
 - **Advance semantics and executor context.** Tokio's `advance` does
@@ -585,7 +598,7 @@ Enforcement classes follow the pre-review checklist's definitions.
   Tokio's lateness margin so a Skip-dependent implementation fails them),
   covering the §4.2 observable properties:
   (a) no tick ready while now is before the first `next_deadline` (one
-  interval after the stream-construction anchor);
+  interval after the first-poll anchor);
   (b) the first tick becoming ready once now reaches that deadline;
   (c) a single advance past several interval boundaries making exactly
   one tick ready, not a burst, followed by Pending until the new
@@ -598,11 +611,17 @@ Enforcement classes follow the pre-review checklist's definitions.
   4.5 ms; a Delay-style "now + interval" reset fails this, and a
   gap-length rule that suppressed the sub-interval boundary would too;
   and
-  (e) **anchor** — advancing virtual time before `stream()` is called
-  does not consume the first interval: the first deadline is
-  `stream_time + interval` (later in absolute time for a later `stream()`
-  call), because the anchor is the `stream()` call, not `Timer::new`,
-  which stores only the interval. The
+  (e) **anchor** — virtual time advanced before the stream's first
+  poll, whether before or after `Timer::new` and `stream()`, does not
+  consume the first interval: the first deadline is
+  `first_poll_time + interval`, because the anchor is the first poll —
+  an implementation anchoring at `Timer::new` or at the `stream()` call
+  already has a tick ready at that first poll and fails; and, the
+  cross-context half, a stream built outside the polling runtime's
+  clock context (constructed on a plain thread, polled under a paused
+  runtime) still delivers its first tick exactly one interval after its
+  first poll — a construction-time anchor reads the ambient clock there
+  and, against the virtual clock, fires immediately or never. The
   existing wide-margin real-time `Timer` tests remain as non-normative
   smoke checks; the paused tests are the contract's proof.
 - **INV-C4**: production neutrality — the crate exposes no time-control

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -407,7 +407,16 @@ ambiguous between `Timer::new` (which only stores the interval) and
 `Timer::stream()` (which builds the `interval()`); advancing time between
 them changes the first deadline, so the text was fixed to
 "stream-construction anchor" and given a test that advances time across
-the gap.
+the gap. Pinning the site is not yet pinning its execution context: a
+read anchored at a site that need not run under the facility the
+contract measures against reads the wrong instrument, so check which
+ambient facility (clock, reactor) each candidate site provably runs
+under, not only which site it is. *From PR #252:* the
+stream-construction anchor PR #246 had just pinned was itself the
+defect — `stream()` can legally run outside the polling runtime's
+clock context, anchoring against the wrong clock — and the anchor
+moved to the stream's first poll, the one moment guaranteed to run on
+the measuring clock.
 
 "Behavior-preserving", "no-op", or "internal only" is an operational
 absolute about the whole change: one observable difference refutes it,

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -519,8 +519,12 @@ impl<App: Application> Runtime<App> {
                 // scheduler parks while idle, so the loop does not wake at the
                 // frame rate just to do nothing. When a message re-enables frame
                 // work, the elapsed timer is ready on the next poll and adds no
-                // render latency; `MissedTickBehavior::Skip` only controls where
-                // the following tick lands (no catch-up burst).
+                // render latency; `MissedTickBehavior::Skip` controls where the
+                // following tick lands, but its skip engages only once a tick
+                // is late past tokio's fixed lateness margin, so sub-margin
+                // frame periods (above roughly 200 FPS) can still replay a
+                // catch-up burst of frame ticks after a stall — the defect
+                // RFC 0009 §4.2 removed from `Timer`.
                 () = self.scheduler.next_work_frame() => {
                     self.process_frame_tick(terminal)?;
                 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -524,7 +524,8 @@ impl<App: Application> Runtime<App> {
                 // is late past tokio's fixed lateness margin, so sub-margin
                 // frame periods (above roughly 200 FPS) can still replay a
                 // catch-up burst of frame ticks after a stall — the defect
-                // RFC 0009 §4.2 removed from `Timer`.
+                // RFC 0009 §4.2 removed from `Timer`, tracked for the frame
+                // scheduler in https://github.com/akiomik/tears/issues/256.
                 () = self.scheduler.next_work_frame() => {
                     self.process_frame_tick(terminal)?;
                 }

--- a/src/runtime/frame_rate.rs
+++ b/src/runtime/frame_rate.rs
@@ -11,6 +11,12 @@ use std::time::Duration;
 /// The value must be non-zero and small enough to produce a non-zero frame
 /// duration. This prevents divide-by-zero panics and invalid zero-duration
 /// Tokio intervals.
+///
+/// Known limitation: at frame rates above roughly 200 FPS — periods inside
+/// tokio's missed-tick lateness margin — the frame scheduler can replay a
+/// short catch-up burst of frames after a stall, instead of dropping the
+/// missed frames as it does at lower rates
+/// (<https://github.com/akiomik/tears/issues/256>).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FrameRate {
     frames_per_second: NonZeroU32,

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -144,12 +144,18 @@ impl SubscriptionSource for Timer {
 /// §4.2 post-miss cadence).
 fn next_anchor_phase_deadline(anchor: Instant, interval: Duration, now: Instant) -> Instant {
     let elapsed_intervals = now.duration_since(anchor).as_nanos() / interval.as_nanos();
-    let offset_nanos = interval
-        .as_nanos()
-        .saturating_mul(elapsed_intervals + 1)
-        .try_into()
-        .unwrap_or(u64::MAX);
-    anchor + Duration::from_nanos(offset_nanos)
+    let offset_nanos = interval.as_nanos().saturating_mul(elapsed_intervals + 1);
+    // Assemble the offset as seconds + sub-second nanos rather than through
+    // `Duration::from_nanos`, whose u64 argument caps the offset at ~584
+    // years of nanoseconds — a saturated deadline would sit permanently in
+    // the past and turn every poll into an immediate tick, the forbidden
+    // burst. `Duration`'s seconds field is u64, so this stays exact (and the
+    // anchor phase preserved) far beyond any reachable horizon.
+    let offset = Duration::new(
+        u64::try_from(offset_nanos / 1_000_000_000).unwrap_or(u64::MAX),
+        u32::try_from(offset_nanos % 1_000_000_000).expect("sub-second nanos fit u32"),
+    );
+    anchor + offset
 }
 
 #[cfg(test)]
@@ -202,6 +208,30 @@ mod tests {
 
         // Different intervals should produce different IDs
         assert_ne!(timer1.key(), timer2.key());
+    }
+
+    #[test]
+    fn next_anchor_phase_deadline_stays_exact_past_u64_nanoseconds() {
+        // ~600 years past the anchor the offset no longer fits u64
+        // nanoseconds: a `Duration::from_nanos`-based implementation
+        // saturates the deadline permanently into the past, turning every
+        // poll into an immediate tick — a forever catch-up burst.
+        let anchor = Instant::now();
+        let interval = Duration::from_millis(1);
+        let now = anchor + Duration::from_secs(600 * 365 * 24 * 60 * 60);
+
+        let next = next_anchor_phase_deadline(anchor, interval, now);
+
+        assert!(next > now, "the deadline must stay strictly after now");
+        assert!(
+            next - now <= interval,
+            "the deadline is the first boundary after now, at most one interval away"
+        );
+        assert_eq!(
+            (next - anchor).as_nanos() % interval.as_nanos(),
+            0,
+            "the deadline stays on the anchor's phase"
+        );
     }
 
     // Paused-clock contract tests (RFC 0009 §4.2, INV-C3). The 1 ms and 2 ms

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -7,10 +7,8 @@ use std::num::NonZeroU64;
 use std::time::Duration;
 
 use futures::StreamExt;
-use futures::stream::BoxStream;
-use tokio::time::MissedTickBehavior;
-use tokio::time::interval;
-use tokio_stream::wrappers::IntervalStream;
+use futures::stream::{self, BoxStream};
+use tokio::time::{Instant, sleep_until};
 
 use super::SubscriptionSource;
 
@@ -26,17 +24,28 @@ pub enum TimerEvent {
 /// This is useful for creating animations, periodic updates, or any time-based
 /// behavior in your application.
 ///
-/// ## Implementation Details
+/// ## Timing semantics
 ///
-/// Uses `tokio::time::interval` with `MissedTickBehavior::Skip` to provide
-/// accurate timing without catching up on missed ticks. This is appropriate
-/// for UI applications where maintaining a consistent tick rate is more
-/// important than processing every tick.
+/// The semantics of record are RFC 0009 §4.2
+/// (`docs/rfcs/0009-clock-di.md`):
 ///
-/// ## Performance
+/// - **Anchor.** The timer's time anchor is fixed when its stream is built
+///   ([`SubscriptionSource::stream`]); [`Timer::new`] only stores the
+///   interval. The first tick becomes deliverable one full interval after
+///   that anchor — there is no tick at the construction instant.
+/// - **No catch-up.** However many interval boundaries elapse while a tick
+///   goes untaken (a busy runtime, a long delay), exactly one tick becomes
+///   deliverable — never a burst of missed ticks.
+/// - **Post-miss cadence.** Taking a tick sets the next deadline to the
+///   first anchor-phase boundary strictly after that moment: the cadence is
+///   drift-corrected against the anchor, not reset to "now + interval", so
+///   after a late tick the next one can arrive less than one interval
+///   later.
 ///
-/// The timer uses Tokio's efficient interval mechanism with drift correction,
-/// making it suitable for high frame rates (e.g., 60 FPS or higher).
+/// Dropping missed ticks instead of replaying them is appropriate for UI
+/// applications, where holding a consistent tick rate matters more than
+/// processing every scheduled tick; the drift-corrected cadence keeps the
+/// timer suitable for high frame rates (e.g. 60 FPS or higher).
 ///
 /// # Example
 ///
@@ -92,22 +101,24 @@ impl SubscriptionSource for Timer {
     type Key = NonZeroU64;
 
     fn stream(&self) -> BoxStream<'static, TimerEvent> {
-        // NOTE: Using Skip behavior to drop missed ticks rather than trying to catch up.
-        // This is appropriate for UI applications where we want
-        // to maintain a consistent tick rate rather than processing old ticks.
-        let duration = Duration::from_millis(self.interval_ms.get());
+        let interval = Duration::from_millis(self.interval_ms.get());
         tracing::trace!(
             target: "tears::subscription::time",
             interval_ms = self.interval_ms.get(),
             "timer stream created"
         );
-        let mut interval = interval(duration);
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-        IntervalStream::new(interval)
-            .skip(1) // Skip the first immediate tick
-            .map(|_| TimerEvent::Tick)
-            .boxed()
+        // The anchor is fixed here, at stream construction (RFC 0009 §4.2);
+        // every deadline is an anchor-phase boundary. `tokio::time::interval`
+        // is deliberately not used: its `MissedTickBehavior::Skip` engages
+        // only once a tick is late by more than a fixed margin, so at
+        // sub-margin intervals it replays a catch-up burst the RFC forbids.
+        let anchor = Instant::now();
+        stream::unfold(anchor + interval, move |deadline| async move {
+            sleep_until(deadline).await;
+            let next = next_anchor_phase_deadline(anchor, interval, Instant::now());
+            Some((TimerEvent::Tick, next))
+        })
+        .boxed()
     }
 
     fn key(&self) -> Self::Key {
@@ -115,14 +126,35 @@ impl SubscriptionSource for Timer {
     }
 }
 
+/// The first anchor-phase boundary strictly after `now`: the smallest
+/// `anchor + k * interval` with `k >= 1` that lies after `now` (RFC 0009
+/// §4.2 post-miss cadence).
+fn next_anchor_phase_deadline(anchor: Instant, interval: Duration, now: Instant) -> Instant {
+    let elapsed_intervals = now.duration_since(anchor).as_nanos() / interval.as_nanos();
+    let offset_nanos = interval
+        .as_nanos()
+        .saturating_mul(elapsed_intervals + 1)
+        .try_into()
+        .unwrap_or(u64::MAX);
+    anchor + Duration::from_nanos(offset_nanos)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use tokio::time::{Duration, Instant, timeout};
+    use futures::FutureExt;
+    use tokio::time::{Duration, Instant, advance, timeout};
 
     fn timer(interval_ms: u64) -> Timer {
         Timer::new(NonZeroU64::new(interval_ms).expect("timer interval must be non-zero"))
+    }
+
+    /// Polls the stream exactly once without idling the executor, so the
+    /// paused clock never auto-advances (RFC 0009 §3.2's non-idling
+    /// controller).
+    fn poll_once(stream: &mut BoxStream<'static, TimerEvent>) -> Option<TimerEvent> {
+        stream.next().now_or_never().flatten()
     }
 
     #[test]
@@ -148,6 +180,115 @@ mod tests {
 
         // Different intervals should produce different IDs
         assert_ne!(timer1.key(), timer2.key());
+    }
+
+    // Paused-clock contract tests (RFC 0009 §4.2, INV-C3). The 1 ms and 2 ms
+    // intervals fall inside Tokio's `MissedTickBehavior::Skip` lateness
+    // margin, so an implementation leaning on Skip replays a catch-up burst
+    // and fails them. The real-time tests further down remain non-normative
+    // smoke checks.
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timer_paused_first_tick_one_interval_after_anchor() {
+        // INV-C3 (a) and (b): no tick before `anchor + interval`, first tick
+        // ready once virtual now reaches it.
+        let mut stream = timer(2).stream();
+
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "no tick at the construction instant"
+        );
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "no tick before the first deadline"
+        );
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "first tick ready one interval after the anchor"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timer_paused_no_catch_up_burst() {
+        // INV-C3 (c): one advance spanning several interval boundaries makes
+        // exactly one tick ready, followed by pending until the next
+        // anchor-phase deadline.
+        let mut stream = timer(1).stream();
+
+        advance(Duration::from_micros(5500)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "one tick ready after the multi-interval advance"
+        );
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "a second tick would be a catch-up burst"
+        );
+
+        // The next anchor-phase boundary (6 ms) is only 0.5 ms away.
+        advance(Duration::from_micros(500)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "cadence resumes at the next anchor-phase boundary"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timer_paused_post_miss_cadence_preserves_phase() {
+        // INV-C3 (d): after a tick delivered late at 3.5 ms on a 1 ms timer,
+        // the next tick fires at the 4 ms anchor-phase boundary, not at
+        // "now + interval" (4.5 ms).
+        let mut stream = timer(1).stream();
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "on-time first tick"
+        );
+
+        advance(Duration::from_micros(2500)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "late tick at 3.5 ms"
+        );
+
+        advance(Duration::from_micros(400)).await;
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "no tick before the 4 ms boundary"
+        );
+
+        advance(Duration::from_micros(100)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "tick at the preserved 4 ms anchor-phase boundary, not 4.5 ms"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timer_paused_anchor_is_stream_construction() {
+        // INV-C3 (e): time advanced before `stream()` does not consume the
+        // first interval — the anchor is the `stream()` call, not
+        // `Timer::new`.
+        let source = timer(2);
+        advance(Duration::from_millis(10)).await;
+
+        let mut stream = source.stream();
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "pre-stream() time must not count against the first interval"
+        );
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "first deadline is stream_time + interval"
+        );
     }
 
     #[tokio::test]

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -29,10 +29,13 @@ pub enum TimerEvent {
 /// The semantics of record are RFC 0009 §4.2
 /// (`docs/rfcs/0009-clock-di.md`):
 ///
-/// - **Anchor.** The timer's time anchor is fixed when its stream is built
-///   ([`SubscriptionSource::stream`]); [`Timer::new`] only stores the
-///   interval. The first tick becomes deliverable one full interval after
-///   that anchor — there is no tick at the construction instant.
+/// - **Anchor.** The timer's time anchor is fixed at its stream's first
+///   poll — read from the clock of the runtime that polls it, so a stream
+///   built outside that runtime ([`SubscriptionSource::stream`] on another
+///   thread, say) anchors correctly anyway; [`Timer::new`] and `stream()`
+///   itself store or build, never anchor. The first tick becomes
+///   deliverable one full interval after that anchor — there is no tick at
+///   or before the anchor instant.
 /// - **No catch-up.** However many interval boundaries elapse while a tick
 ///   goes untaken (a busy runtime, a long delay), exactly one tick becomes
 ///   deliverable — never a burst of missed ticks.
@@ -107,16 +110,26 @@ impl SubscriptionSource for Timer {
             interval_ms = self.interval_ms.get(),
             "timer stream created"
         );
-        // The anchor is fixed here, at stream construction (RFC 0009 §4.2);
-        // every deadline is an anchor-phase boundary. `tokio::time::interval`
-        // is deliberately not used: its `MissedTickBehavior::Skip` engages
-        // only once a tick is late by more than a fixed margin, so at
-        // sub-margin intervals it replays a catch-up burst the RFC forbids.
-        let anchor = Instant::now();
-        stream::unfold(anchor + interval, move |deadline| async move {
+        // The anchor is sampled on the stream's first poll (RFC 0009 §4.2),
+        // never here at construction: `stream()` may legally run outside the
+        // runtime that will poll the stream (for example on a plain thread
+        // while the poller is a paused test runtime), and an anchor read from
+        // that ambient clock can disagree with the clock `sleep_until`
+        // measures against — firing a construction-instant tick or never
+        // firing at all. The first poll, by definition, happens on the
+        // polling runtime's clock. Every deadline is an anchor-phase
+        // boundary; `tokio::time::interval` is deliberately not used, since
+        // its `MissedTickBehavior::Skip` engages only once a tick is late by
+        // more than a fixed margin, so at sub-margin intervals it replays a
+        // catch-up burst the RFC forbids.
+        stream::unfold(None, move |state: Option<(Instant, Instant)>| async move {
+            let (anchor, deadline) = state.unwrap_or_else(|| {
+                let anchor = Instant::now();
+                (anchor, anchor + interval)
+            });
             sleep_until(deadline).await;
             let next = next_anchor_phase_deadline(anchor, interval, Instant::now());
-            Some((TimerEvent::Tick, next))
+            Some((TimerEvent::Tick, Some((anchor, next))))
         })
         .boxed()
     }
@@ -143,18 +156,27 @@ fn next_anchor_phase_deadline(anchor: Instant, interval: Duration, now: Instant)
 mod tests {
     use super::*;
 
-    use futures::FutureExt;
+    use std::task::Poll;
+    use std::thread;
+
     use tokio::time::{Duration, Instant, advance, timeout};
+
+    use crate::poll_util::noop_context;
 
     fn timer(interval_ms: u64) -> Timer {
         Timer::new(NonZeroU64::new(interval_ms).expect("timer interval must be non-zero"))
     }
 
-    /// Polls the stream exactly once without idling the executor, so the
-    /// paused clock never auto-advances (RFC 0009 §3.2's non-idling
-    /// controller).
+    /// Polls the stream exactly once with the canonical no-op waker, so the
+    /// executor never idles and the paused clock never auto-advances
+    /// (RFC 0009 §3.2's non-idling controller). Pending and end-of-stream
+    /// both read as `None`; the timer stream never ends, so the ambiguity is
+    /// moot here.
     fn poll_once(stream: &mut BoxStream<'static, TimerEvent>) -> Option<TimerEvent> {
-        stream.next().now_or_never().flatten()
+        match stream.as_mut().poll_next(&mut noop_context()) {
+            Poll::Ready(item) => item,
+            Poll::Pending => None,
+        }
     }
 
     #[test]
@@ -196,7 +218,7 @@ mod tests {
 
         assert!(
             poll_once(&mut stream).is_none(),
-            "no tick at the construction instant"
+            "the first poll anchors and yields nothing"
         );
 
         advance(Duration::from_millis(1)).await;
@@ -218,6 +240,10 @@ mod tests {
         // exactly one tick ready, followed by pending until the next
         // anchor-phase deadline.
         let mut stream = timer(1).stream();
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "the first poll anchors and yields nothing"
+        );
 
         advance(Duration::from_micros(5500)).await;
         assert!(
@@ -243,6 +269,10 @@ mod tests {
         // the next tick fires at the 4 ms anchor-phase boundary, not at
         // "now + interval" (4.5 ms).
         let mut stream = timer(1).stream();
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "the first poll anchors and yields nothing"
+        );
 
         advance(Duration::from_millis(1)).await;
         assert!(
@@ -270,24 +300,63 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_timer_paused_anchor_is_stream_construction() {
-        // INV-C3 (e): time advanced before `stream()` does not consume the
-        // first interval — the anchor is the `stream()` call, not
-        // `Timer::new`.
+    async fn test_timer_paused_anchor_is_first_poll() {
+        // INV-C3 (e): time advanced before the stream's first poll — whether
+        // before or after `Timer::new` and `stream()` — does not consume the
+        // first interval: the anchor is the first poll, and the first
+        // deadline is one interval after it. An implementation anchoring at
+        // `Timer::new` or at the `stream()` call would already have a tick
+        // ready at the first poll below.
         let source = timer(2);
         advance(Duration::from_millis(10)).await;
 
         let mut stream = source.stream();
+        advance(Duration::from_millis(10)).await;
+
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "pre-first-poll time must not count against the first interval"
+        );
+
         advance(Duration::from_millis(1)).await;
         assert!(
             poll_once(&mut stream).is_none(),
-            "pre-stream() time must not count against the first interval"
+            "one interval has not elapsed since the anchor"
         );
 
         advance(Duration::from_millis(1)).await;
         assert!(
             matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
-            "first deadline is stream_time + interval"
+            "first deadline is first_poll_time + interval"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_timer_stream_built_outside_the_runtime_anchors_at_first_poll() {
+        // INV-C3 (e), cross-context half: a stream built outside the polling
+        // runtime's clock context (a plain thread reads the real clock)
+        // still anchors on the polling runtime's virtual clock at its first
+        // poll. A construction-time anchor reads the ambient clock instead
+        // and fires immediately or never against the virtual clock.
+        let mut stream = thread::spawn(|| timer(2).stream())
+            .join()
+            .expect("stream construction off-runtime should not panic");
+
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "no tick at the first poll"
+        );
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            poll_once(&mut stream).is_none(),
+            "no tick before one interval after the first poll"
+        );
+
+        advance(Duration::from_millis(1)).await;
+        assert!(
+            matches!(poll_once(&mut stream), Some(TimerEvent::Tick)),
+            "first tick one interval after the first poll, on the polling runtime's clock"
         );
     }
 
@@ -337,10 +406,11 @@ mod tests {
 
         let second_tick = start.elapsed();
 
-        // NOTE: The interval should be accurate within a reasonable margin.
-        // With tokio::time::interval, we expect better accuracy than sleep-based approach.
-        // First tick should be around 50ms, second around 100ms.
-        // Wide margins to account for CI environments and system load.
+        // NOTE: The interval should be accurate within a reasonable margin:
+        // deadlines are anchor-phase boundaries, so lateness on one tick does
+        // not drift the cadence. First tick should be around 50ms, second
+        // around 100ms. Wide margins to account for CI environments and
+        // system load.
         assert!(
             first_tick >= Duration::from_millis(30) && first_tick <= Duration::from_millis(100),
             "First tick was {first_tick:?}, expected between 30-100ms",


### PR DESCRIPTION
## Summary

Implements RFC 0009 §4.2 (Timer contract alignment), the second Clock DI implementation deliverable:

- `Timer::stream()` no longer uses `tokio::time::interval` + `MissedTickBehavior::Skip`: Skip's lateness margin (5 ms in tokio 1.50.0) meant short-interval timers replayed a catch-up burst of missed ticks after a delay. The stream is now an `unfold` over `sleep_until` against explicitly computed anchor-phase deadlines.
- **Anchor: the stream's first poll** (amended in RFC 0009 §4.2/INV-C3(e) in this PR, from the original "stream construction"): the anchor is sampled lazily on the first poll, which by definition happens on the polling runtime's clock. A construction-time anchor read the ambient clock around `stream()`, so a stream built outside the polling runtime (setup code on a plain thread, with a paused test runtime as the poller) anchored against the wrong clock — delivering an immediate first tick or never becoming ready. The same latent defect existed in the `interval()`-based implementation.
- Pinned observable properties (rustdoc cites RFC 0009 §4.2 as semantics of record): first-poll anchor, first tick one full interval after it, exactly one deliverable tick however many boundaries elapsed, and post-miss cadence advancing to the first anchor-phase boundary strictly after now (phase preserved, not "now + interval").
- `CHANGELOG: Fixed` entry — user-visible behavior change for short-interval timers under load, per the RFC's front matter.
- The runtime event-loop comment claiming the frame scheduler's Skip produces "no catch-up burst" is corrected (it restated the claim this PR refutes; Skip's margin leaves >~200 FPS periods exposed). Aligning `FrameScheduler` itself is follow-up work in a separate PR.

## Verification (INV-C3, timer half)

- Paused-clock tests at 1 ms and 2 ms cover §4.2's items (a)–(e): first-deadline timing, no-burst after a multi-interval advance, post-miss phase preservation (3.5 ms late tick → next at 4 ms, not 4.5 ms), first-poll anchoring (pre-first-poll advances don't consume the first interval), and the cross-context half (stream built on a plain thread, polled under a paused runtime, still ticks one interval after its first poll).
- Adversarial checks: the burst and post-miss-cadence tests fail the old Skip-based implementation; the two anchor tests fail a construction-anchored implementation (both verified by temporarily reverting).
- Test helper polls via the canonical `poll_util::noop_context()` (unified in #250) instead of a third hand-rolled variant.
- RFC 0009 amendment self-reviewed against all 8 items of `docs/rfcs/pre-review-checklist.md`; existing wide-margin real-time tests remain as non-normative smoke checks; `cargo clippy --all-targets -- -D warnings`, full suite, and `typos` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Re-review fixes

- **`next_anchor_phase_deadline` past u64 nanoseconds**: the offset is now assembled as seconds + sub-second nanos (`Duration::new`) instead of `Duration::from_nanos`, whose u64 argument saturated ~584 years past the anchor and pinned the deadline permanently in the past — a forever catch-up burst. The seconds-based form keeps the exact anchor phase far beyond any reachable horizon, preserving the full §4.2 contract (phase clause included) rather than clamping to `now + interval`. A pure-function test pins the >u64-ns regime and fails the `from_nanos` implementation (verified).
- **Frame scheduler burst**: now tracked in #256 — the event-loop comment references the issue and `FrameRate`'s rustdoc documents the high-FPS limitation until the fix lands. The mechanism fix itself is already implemented in #255 (stacked on this PR, `Closes #256`), which shares the Timer's deadline helper via a crate-internal `time_util` module.
