### PR TITLE
fix(runtime): make the frame scheduler non-catch-up like Timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after the late tick). The timer's anchor is fixed at its stream's first
   poll — read from the clock of the runtime that polls it — and the first
   tick arrives one full interval after that anchor (RFC 0009 §4.2)
+- The runtime's frame scheduler no longer replays missed frame deadlines at
+  sub-margin frame rates (above roughly 200 FPS): after a stall, at most one
+  frame fires immediately and the cadence resumes on the frame anchor's
+  phase — the same non-catch-up rule `Timer` now follows. At 60 FPS and other
+  common rates the behavior is unchanged, since tokio's `Skip` already
+  suppressed the burst outside its lateness margin
 
 ### Added
 

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -168,15 +168,16 @@ completion depends on the current time: now-reads (`Instant::now`,
 executor's virtualizable clock, i.e. through `tokio::time` types and
 functions. `Duration` values are plain data and are not time reads.
 
-Inventory of production time reads at this RFC's writing:
+Inventory of production time reads (refreshed 2026-07-25, after the
+§4.2 `Timer` fix and the frame-scheduler alignment):
 
 | Site | Read | Purpose | Conforming |
 | --- | --- | --- | --- |
 | `src/command/effect.rs` (timeout leaf) | `tokio::time::sleep` | `Command::timeout` deadline (RFC 0004; anchored at the leaf's first poll) | yes |
 | `src/command/retry.rs` (`run_retry`) | `tokio::time::sleep` | retry backoff delay (RFC 0004) | yes |
-| `src/subscription/time.rs` (`Timer`) | `tokio::time::interval` | periodic ticks; first-tick and non-catch-up semantics (INV-C3) | yes |
+| `src/subscription/time.rs` (`Timer`) | `tokio::time::sleep_until`, `tokio::time::Instant` | periodic ticks; first-tick and non-catch-up semantics (INV-C3) | yes |
 | `src/runtime.rs` (event loop) | `tokio::time::Instant` | micro-batch window deadline (RFC 0006 mechanism) | yes |
-| `src/runtime/frame_scheduler.rs` | `tokio::time::interval` | frame cadence | yes |
+| `src/runtime/frame_scheduler.rs` | `tokio::time::sleep_until`, `tokio::time::Instant` | frame cadence | yes |
 | `src/runtime/channel.rs` (bounded send) | `tokio::time::Instant` | capacity-wait duration in load events (RFC 0006 observability) | yes |
 | `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4.1 migration** |
 | `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4.1 migration** |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,6 @@ pub(crate) mod application;
 pub mod command;
 pub(crate) mod panic;
 pub(crate) mod poll_util;
-pub(crate) mod time_util;
 pub mod prelude;
 pub(crate) mod runtime;
 mod structural_key;
@@ -105,6 +104,7 @@ pub mod subscription;
 // app never names the type (RFC 0008 §3.3; docs/api-guidelines.md "Prelude
 // Membership").
 pub mod testing;
+pub(crate) mod time_util;
 
 // Re-export commonly used types
 pub use application::Application;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub(crate) mod application;
 pub mod command;
 pub(crate) mod panic;
 pub(crate) mod poll_util;
+pub(crate) mod time_util;
 pub mod prelude;
 pub(crate) mod runtime;
 mod structural_key;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -518,14 +518,11 @@ impl<App: Application> Runtime<App> {
                 // Frame tick: render if needed and update subscriptions. The
                 // scheduler parks while idle, so the loop does not wake at the
                 // frame rate just to do nothing. When a message re-enables frame
-                // work, the elapsed timer is ready on the next poll and adds no
-                // render latency; `MissedTickBehavior::Skip` controls where the
-                // following tick lands, but its skip engages only once a tick
-                // is late past tokio's fixed lateness margin, so sub-margin
-                // frame periods (above roughly 200 FPS) can still replay a
-                // catch-up burst of frame ticks after a stall — the defect
-                // RFC 0009 §4.2 removed from `Timer`, tracked for the frame
-                // scheduler in https://github.com/akiomik/tears/issues/256.
+                // work, the elapsed deadline is ready on the next poll and adds
+                // no render latency; missed frame deadlines are never replayed —
+                // at most one immediate frame fires after a stall, and the
+                // cadence resumes on the anchor's phase (the same non-catch-up
+                // rule as `Timer`, RFC 0009 §4.2).
                 () = self.scheduler.next_work_frame() => {
                     self.process_frame_tick(terminal)?;
                 }

--- a/src/runtime/frame_rate.rs
+++ b/src/runtime/frame_rate.rs
@@ -11,12 +11,6 @@ use std::time::Duration;
 /// The value must be non-zero and small enough to produce a non-zero frame
 /// duration. This prevents divide-by-zero panics and invalid zero-duration
 /// Tokio intervals.
-///
-/// Known limitation: at frame rates above roughly 200 FPS — periods inside
-/// tokio's missed-tick lateness margin — the frame scheduler can replay a
-/// short catch-up burst of frames after a stall, instead of dropping the
-/// missed frames as it does at lower rates
-/// (<https://github.com/akiomik/tears/issues/256>).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct FrameRate {
     frames_per_second: NonZeroU32,

--- a/src/runtime/frame_scheduler.rs
+++ b/src/runtime/frame_scheduler.rs
@@ -6,10 +6,11 @@
 //! rendering, and re-evaluating subscriptions.
 
 use std::future::pending;
-#[cfg(test)]
 use std::time::Duration;
 
-use tokio::time::{Interval, MissedTickBehavior, interval};
+use tokio::time::{Instant, sleep_until};
+
+use crate::time_util::next_anchor_phase_deadline;
 
 use super::frame_rate::FrameRate;
 use super::pending_work::PendingWork;
@@ -20,30 +21,32 @@ use super::pending_work::PendingWork;
 /// loop remains event-driven while idle instead of waking at the frame rate to
 /// do nothing.
 pub(super) struct FrameScheduler {
-    interval: Interval,
+    period: Duration,
+    /// The frame cadence's anchor and next deadline, sampled on the first
+    /// [`next_work_frame`](Self::next_work_frame) await — the polling
+    /// runtime's clock — never at construction, which may run outside that
+    /// runtime (`Runtime` construction precedes `block_on`).
+    schedule: Option<(Instant, Instant)>,
     pub(super) pending: PendingWork,
 }
 
 impl FrameScheduler {
     /// Creates a frame scheduler with the given target frame rate.
     pub(super) fn new(frame_rate: FrameRate) -> Self {
-        // Divide a one-second `Duration` directly so the period is exact (e.g.
-        // 60 FPS -> 16.667ms) instead of truncating to whole milliseconds.
-        let frame_duration = frame_rate.frame_duration();
-        let mut interval = interval(frame_duration);
-        // Skip missed frames rather than trying to catch up.
-        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
         Self {
-            interval,
+            // `frame_duration` divides a one-second `Duration` directly so
+            // the period is exact (e.g. 60 FPS -> 16.667ms) instead of
+            // truncating to whole milliseconds.
+            period: frame_rate.frame_duration(),
+            schedule: None,
             pending: PendingWork::new(),
         }
     }
 
     /// Returns the scheduler's frame period.
     #[cfg(test)]
-    pub(super) fn frame_period(&self) -> Duration {
-        self.interval.period()
+    pub(super) const fn frame_period(&self) -> Duration {
+        self.period
     }
 
     /// Records whether a processed command requested a redraw.
@@ -89,7 +92,27 @@ impl FrameScheduler {
             pending::<()>().await;
         }
 
-        self.interval.tick().await;
+        // Frame deadlines are anchor-phase boundaries (`time_util`), not
+        // `tokio::time::interval` ticks: `MissedTickBehavior::Skip` engages
+        // only once a tick is late past a fixed margin, so at sub-margin
+        // frame periods (above roughly 200 FPS) a stall whose missed
+        // deadlines sit within that margin replayed them one frame tick per
+        // missed period — the defect RFC 0009 §4.2 removed from `Timer`. A
+        // deadline already in the past resolves immediately (a re-enabled
+        // frame adds no render latency), and completing a frame then
+        // advances to the first anchor-phase boundary strictly after now:
+        // at most one immediate frame per stall, cadence preserved.
+        let (anchor, deadline) = *self.schedule.get_or_insert_with(|| {
+            let anchor = Instant::now();
+            // The first frame is due immediately, as `interval`'s first
+            // tick was.
+            (anchor, anchor)
+        });
+        sleep_until(deadline).await;
+        self.schedule = Some((
+            anchor,
+            next_anchor_phase_deadline(anchor, self.period, Instant::now()),
+        ));
     }
 }
 
@@ -97,7 +120,7 @@ impl FrameScheduler {
 mod tests {
     use std::num::NonZeroU32;
 
-    use tokio::time::{Duration, Instant, timeout};
+    use tokio::time::{Duration, Instant, advance, timeout};
 
     use super::*;
 
@@ -141,6 +164,72 @@ mod tests {
             Instant::now(),
             before,
             "re-arming after idle should not wait an extra frame period"
+        );
+    }
+
+    // The sub-margin non-catch-up check: at 500 FPS (2 ms) a 5 ms stall
+    // leaves every missed deadline inside tokio's `MissedTickBehavior::Skip`
+    // lateness margin, exactly where the old interval-based scheduler
+    // replayed one tick per missed period (RFC 0009 §4.2's forbidden
+    // catch-up burst; a longer stall pushes the lateness past the margin,
+    // where Skip works and either implementation passes).
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn stalled_frames_do_not_replay_a_catch_up_burst() {
+        let mut scheduler = FrameScheduler::new(frame_rate(500));
+
+        // First frame: due immediately; anchors the cadence.
+        scheduler.record_redraw(true);
+        scheduler.next_work_frame().await;
+        let anchor = Instant::now();
+
+        // Stall past the 2 ms and 4 ms deadlines with work still pending.
+        scheduler.record_redraw(true);
+        advance(Duration::from_millis(5)).await;
+
+        // Exactly one immediate late frame ...
+        scheduler.next_work_frame().await;
+        assert_eq!(
+            Instant::now(),
+            anchor + Duration::from_millis(5),
+            "one frame fires immediately after a stall"
+        );
+
+        // ... and the next frame waits for the 6 ms anchor-phase boundary:
+        // a Skip-based scheduler replays the missed 4 ms deadline
+        // immediately instead.
+        scheduler.record_redraw(true);
+        scheduler.next_work_frame().await;
+        assert_eq!(
+            Instant::now(),
+            anchor + Duration::from_millis(6),
+            "missed frame deadlines must not replay as a catch-up burst"
+        );
+    }
+
+    // Post-stall cadence resumes on the anchor's phase: after the late frame
+    // the next boundary can be less than one period away and still fires.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn post_stall_cadence_resumes_on_the_anchor_phase() {
+        let mut scheduler = FrameScheduler::new(frame_rate(250));
+
+        scheduler.record_redraw(true);
+        scheduler.next_work_frame().await;
+        let anchor = Instant::now();
+
+        // Stall to 18 ms past the anchor (between the 16 ms and 20 ms
+        // boundaries), then take the one late frame.
+        scheduler.record_redraw(true);
+        advance(Duration::from_millis(18)).await;
+        scheduler.next_work_frame().await;
+
+        // The next frame is due at the 20 ms anchor-phase boundary — 2 ms
+        // later — not a full 4 ms period after the late frame.
+        scheduler.record_redraw(true);
+        scheduler.next_work_frame().await;
+        assert_eq!(
+            Instant::now(),
+            anchor + Duration::from_millis(20),
+            "cadence resumes on the anchor's phase, not reset to now + period"
         );
     }
 }

--- a/src/runtime/frame_scheduler.rs
+++ b/src/runtime/frame_scheduler.rs
@@ -22,12 +22,19 @@ use super::pending_work::PendingWork;
 /// do nothing.
 pub(super) struct FrameScheduler {
     period: Duration,
-    /// The frame cadence's anchor and next deadline, sampled on the first
+    /// The frame cadence, sampled on the first
     /// [`next_work_frame`](Self::next_work_frame) await — the polling
     /// runtime's clock — never at construction, which may run outside that
     /// runtime (`Runtime` construction precedes `block_on`).
-    schedule: Option<(Instant, Instant)>,
+    schedule: Option<FrameSchedule>,
     pub(super) pending: PendingWork,
+}
+
+/// The frame cadence: the phase-defining anchor and the next frame deadline.
+#[derive(Clone, Copy)]
+struct FrameSchedule {
+    anchor: Instant,
+    next_deadline: Instant,
 }
 
 impl FrameScheduler {
@@ -102,25 +109,35 @@ impl FrameScheduler {
         // frame adds no render latency), and completing a frame then
         // advances to the first anchor-phase boundary strictly after now:
         // at most one immediate frame per stall, cadence preserved.
-        let (anchor, deadline) = *self.schedule.get_or_insert_with(|| {
-            let anchor = Instant::now();
-            // The first frame is due immediately, as `interval`'s first
-            // tick was.
-            (anchor, anchor)
-        });
-        sleep_until(deadline).await;
-        self.schedule = Some((
+        let FrameSchedule {
             anchor,
-            next_anchor_phase_deadline(anchor, self.period, Instant::now()),
-        ));
+            next_deadline,
+        } = *self.schedule.get_or_insert_with(|| {
+            let anchor = Instant::now();
+            FrameSchedule {
+                anchor,
+                // The first frame is due immediately, as `interval`'s
+                // first tick was.
+                next_deadline: anchor,
+            }
+        });
+        sleep_until(next_deadline).await;
+        self.schedule = Some(FrameSchedule {
+            anchor,
+            next_deadline: next_anchor_phase_deadline(anchor, self.period, Instant::now()),
+        });
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
     use std::num::NonZeroU32;
+    use std::pin::pin;
 
     use tokio::time::{Duration, Instant, advance, timeout};
+
+    use crate::poll_util::noop_context;
 
     use super::*;
 
@@ -203,6 +220,40 @@ mod tests {
             Instant::now(),
             anchor + Duration::from_millis(6),
             "missed frame deadlines must not replay as a catch-up burst"
+        );
+    }
+
+    // Cancel safety: the runtime's select! loop drops this future whenever
+    // another branch wins; a pending poll must not move the deadline. An
+    // implementation deriving the deadline from the await's own start time
+    // ("now + period" per call) drifts here and fails.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn dropping_a_pending_frame_future_preserves_the_deadline() {
+        let mut scheduler = FrameScheduler::new(frame_rate(250));
+
+        scheduler.record_redraw(true);
+        scheduler.next_work_frame().await;
+        let anchor = Instant::now();
+
+        // 1 ms into the 4 ms frame period, poll the frame future exactly
+        // once (registering its sleep) and drop it.
+        scheduler.record_redraw(true);
+        advance(Duration::from_millis(1)).await;
+        {
+            let fut = pin!(scheduler.next_work_frame());
+            assert!(
+                fut.poll(&mut noop_context()).is_pending(),
+                "mid-period frame future starts pending"
+            );
+        }
+
+        // Re-awaiting completes at the original 4 ms deadline, not 1 ms +
+        // one period.
+        scheduler.next_work_frame().await;
+        assert_eq!(
+            Instant::now(),
+            anchor + Duration::from_millis(4),
+            "the deadline survives dropping a pending frame future"
         );
     }
 

--- a/src/subscription/time.rs
+++ b/src/subscription/time.rs
@@ -10,6 +10,8 @@ use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use tokio::time::{Instant, sleep_until};
 
+use crate::time_util::next_anchor_phase_deadline;
+
 use super::SubscriptionSource;
 
 /// Events produced by the [`Timer`] subscription.
@@ -139,25 +141,6 @@ impl SubscriptionSource for Timer {
     }
 }
 
-/// The first anchor-phase boundary strictly after `now`: the smallest
-/// `anchor + k * interval` with `k >= 1` that lies after `now` (RFC 0009
-/// §4.2 post-miss cadence).
-fn next_anchor_phase_deadline(anchor: Instant, interval: Duration, now: Instant) -> Instant {
-    let elapsed_intervals = now.duration_since(anchor).as_nanos() / interval.as_nanos();
-    let offset_nanos = interval.as_nanos().saturating_mul(elapsed_intervals + 1);
-    // Assemble the offset as seconds + sub-second nanos rather than through
-    // `Duration::from_nanos`, whose u64 argument caps the offset at ~584
-    // years of nanoseconds — a saturated deadline would sit permanently in
-    // the past and turn every poll into an immediate tick, the forbidden
-    // burst. `Duration`'s seconds field is u64, so this stays exact (and the
-    // anchor phase preserved) far beyond any reachable horizon.
-    let offset = Duration::new(
-        u64::try_from(offset_nanos / 1_000_000_000).unwrap_or(u64::MAX),
-        u32::try_from(offset_nanos % 1_000_000_000).expect("sub-second nanos fit u32"),
-    );
-    anchor + offset
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,30 +191,6 @@ mod tests {
 
         // Different intervals should produce different IDs
         assert_ne!(timer1.key(), timer2.key());
-    }
-
-    #[test]
-    fn next_anchor_phase_deadline_stays_exact_past_u64_nanoseconds() {
-        // ~600 years past the anchor the offset no longer fits u64
-        // nanoseconds: a `Duration::from_nanos`-based implementation
-        // saturates the deadline permanently into the past, turning every
-        // poll into an immediate tick — a forever catch-up burst.
-        let anchor = Instant::now();
-        let interval = Duration::from_millis(1);
-        let now = anchor + Duration::from_secs(600 * 365 * 24 * 60 * 60);
-
-        let next = next_anchor_phase_deadline(anchor, interval, now);
-
-        assert!(next > now, "the deadline must stay strictly after now");
-        assert!(
-            next - now <= interval,
-            "the deadline is the first boundary after now, at most one interval away"
-        );
-        assert_eq!(
-            (next - anchor).as_nanos() % interval.as_nanos(),
-            0,
-            "the deadline stays on the anchor's phase"
-        );
     }
 
     // Paused-clock contract tests (RFC 0009 §4.2, INV-C3). The 1 ms and 2 ms

--- a/src/time_util.rs
+++ b/src/time_util.rs
@@ -1,0 +1,58 @@
+//! Shared anchor-phase deadline arithmetic for non-catch-up cadences.
+//!
+//! `Timer` (RFC 0009 §4.2) and the runtime's frame scheduler both deliver at
+//! most one tick however many interval boundaries have elapsed, and resume on
+//! the anchor's phase rather than resetting to "now + interval". The deadline
+//! step they share lives here.
+
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+/// The first anchor-phase boundary strictly after `now`: the smallest
+/// `anchor + k * interval` with `k >= 1` that lies after `now` (RFC 0009
+/// §4.2 post-miss cadence).
+pub fn next_anchor_phase_deadline(anchor: Instant, interval: Duration, now: Instant) -> Instant {
+    let elapsed_intervals = now.duration_since(anchor).as_nanos() / interval.as_nanos();
+    let offset_nanos = interval.as_nanos().saturating_mul(elapsed_intervals + 1);
+    // Assemble the offset as seconds + sub-second nanos rather than through
+    // `Duration::from_nanos`, whose u64 argument caps the offset at ~584
+    // years of nanoseconds — a saturated deadline would sit permanently in
+    // the past and turn every poll into an immediate tick, the forbidden
+    // burst. `Duration`'s seconds field is u64, so this stays exact (and the
+    // anchor phase preserved) far beyond any reachable horizon.
+    let offset = Duration::new(
+        u64::try_from(offset_nanos / 1_000_000_000).unwrap_or(u64::MAX),
+        u32::try_from(offset_nanos % 1_000_000_000).expect("sub-second nanos fit u32"),
+    );
+    anchor + offset
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_anchor_phase_deadline_stays_exact_past_u64_nanoseconds() {
+        // ~600 years past the anchor the offset no longer fits u64
+        // nanoseconds: a `Duration::from_nanos`-based implementation
+        // saturates the deadline permanently into the past, turning every
+        // poll into an immediate tick — a forever catch-up burst.
+        let anchor = Instant::now();
+        let interval = Duration::from_millis(1);
+        let now = anchor + Duration::from_secs(600 * 365 * 24 * 60 * 60);
+
+        let next = next_anchor_phase_deadline(anchor, interval, now);
+
+        assert!(next > now, "the deadline must stay strictly after now");
+        assert!(
+            next - now <= interval,
+            "the deadline is the first boundary after now, at most one interval away"
+        );
+        assert_eq!(
+            (next - anchor).as_nanos() % interval.as_nanos(),
+            0,
+            "the deadline stays on the anchor's phase"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #256. Follow-up to the #252 review: the frame scheduler used the same `interval` + `MissedTickBehavior::Skip` pattern the Timer fix removed. Stacked on #252 (shares the extracted deadline helper); review that first.

- **Behavior**: at sub-margin frame periods (above ~200 FPS; `FrameRate` accepts up to 1e9 FPS), a stall whose missed deadlines sit within tokio's ~5 ms Skip lateness margin replayed one frame tick per missed period, running `process_frame_tick` back to back. Frame deadlines are now explicit anchor-phase boundaries: at most one immediate frame after a stall, cadence resumed on the anchor's phase. At 60 FPS and other super-margin rates behavior is unchanged (Skip already suppressed the burst there — a missed deadline's lateness exceeds the margin before a second period fits inside it).
- **Shared helper**: `next_anchor_phase_deadline` moves from `subscription/time.rs` to a crate-internal `time_util` module, used by both `Timer` and `FrameScheduler`; the exact-past-u64-nanoseconds offset handling from the #252 re-review and its unit test move with it.
- **Anchor**: sampled on the first `next_work_frame` await (the polling runtime's clock), never at construction — closing the same constructed-outside-the-runtime clock-context hazard as Timer's first-poll anchor (`Runtime` construction runs before `block_on`, where `interval()` previously anchored against the ambient clock).
- **Docs**: removes the `FrameRate` rustdoc caveat #252 added for the high-FPS limitation, and replaces the event-loop comment's issue reference with the new non-catch-up description — both obsolete once this lands.
- **Preserved semantics**: park-while-idle, and an elapsed deadline still resolves immediately when work re-enables frame processing (no added render latency) — the two pre-existing paused-clock tests pass unchanged.
- `CHANGELOG: Fixed` entry alongside the Timer one.

## Verification

- New paused-clock tests: the sub-margin no-burst case (500 FPS, 5 ms stall — chosen so every missed deadline stays inside Skip's margin, exactly where the old scheduler bursts; asserted by cadence instants, no timeout races) and post-stall anchor-phase cadence (next boundary < one period after a late frame; fails a Delay-style "now + period" reset).
- Adversarial check: the burst test grafted onto the old Skip-based scheduler fails there and passes on the new implementation (verified by temporary revert).
- `cargo clippy --all-targets -- -D warnings`, full suite, and `typos` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)