### PR TITLE
docs(rfcs): mark RFC 0008 and RFC 0009 as Implemented

### DIFF
--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -1,6 +1,6 @@
 # RFC 0008: TestStore — deterministic update and effect testing
 
-- Status: Accepted
+- Status: Implemented
 - Amended: 2026-07-25 — stage 2: the store-held controlled time context
   and `advance` (§3, §4.3, §7), consuming RFC 0009's contract
 - Target: an additive test harness for the current `Application` API:
@@ -53,7 +53,7 @@ Three decisions, ordered by urgency:
    designed here (open question 2).
 3. **Clock DI split** (§7): Clock injection is a separate RFC. This RFC
    does not gate on it, and stage 2 of TestStore gates on that RFC, not
-   the reverse. RFC 0009 is Accepted; the stage-2 amendment consumes
+   the reverse. RFC 0009 is Implemented; the stage-2 amendment consumes
    its contract and resolves the three design inputs its §5.1 recorded
    (§7).
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -14,11 +14,11 @@
   controlled-time contract (`advance`, anchoring, the store-owned
   executor context — §3.2, §4.3, §7)
 - Feature flag: none (precedent: `subscription::mock` ships
-  unconditionally); stage 2's implementation adds tokio's `test-util`
+  unconditionally); stage 2's implementation added tokio's `test-util`
   to the crate's unconditional dependency features per RFC 0009 §5.1's
   decision
-- CHANGELOG: `Added` entry lands at the implementation release, not with
-  this RFC; stage 2 amends the same not-yet-released entry
+- CHANGELOG: `Added` entry ships with the implementation release, not
+  with this RFC; stage 2 amended the same not-yet-released entry
 
 > **Staging.** Stage 1 drives pure `update` transitions and effects
 > that become ready without an executor or the passage of time. Stage 2
@@ -39,8 +39,8 @@ Three decisions, ordered by urgency:
    `Debug` on the store, `PartialEq` scoped to the equality-asserting
    methods only, and `Clone` nowhere. Retrofitting a bound onto
    `Application::Message` later would be a silent breaking change for
-   every existing application, so the placement is pinned now, before any
-   TestStore code exists, and constrains future RFCs (INV-T1, INV-T2).
+   every existing application, so the placement was pinned before any
+   TestStore code existed, and constrains future RFCs (INV-T1, INV-T2).
 2. **Exhaustive assertions** (§6): exhaustive is the only mode.
    Undelivered deliverable output — a ready message never
    received, an effect stream never driven to completion — fails the
@@ -357,25 +357,27 @@ boundary (`into_runtime_parts`) so that what the store observes —
 directives, cancellation metadata, effects — is what the runtime
 observes (INV-T3).
 
-**Named prerequisite — per-leaf parts.** Today that boundary folds a
-multi-leaf effect into one stream before the parts exist:
-`into_runtime_parts` calls `Effect::into_stream()`, which merges the
-leaves through an unordered select (`src/command/core.rs`,
-`src/command/effect.rs`). A store built on the current parts type
-therefore could not implement §4.2's per-leaf canonical order without
-re-deriving the leaves in parallel — exactly what INV-T3 forbids — and
-relying on the merged stream happening to yield in declaration order
-would rest on a coincidental property of the select combinator, not on
-any contract. Stage-1 implementation is therefore gated on a
-prerequisite refactor, owned by this RFC's implementation task:
-`RuntimeCommandParts` carries the effect's leaves unfolded, in
-`Command::batch`'s flattened declaration order, and each consumer folds
-or drives them at its own consumption site — the runtime merging them
-at its spawn site exactly as `into_stream()` merges them today (a
-behavior-preserving relocation of the existing fold; `Effect` already
-keeps its leaves apart to preserve leaf identity for future per-leaf
-consumers, per its own comment in `src/command/effect.rs`), the store
-keeping them apart. INV-T3 names this revised boundary.
+**Named prerequisite — per-leaf parts.** At this RFC's drafting that
+boundary folded a multi-leaf effect into one stream before the parts
+existed: `into_runtime_parts` called `Effect::into_stream()`, which
+merged the leaves through an unordered select. A store built on that
+parts type could not have implemented §4.2's per-leaf canonical order
+without re-deriving the leaves in parallel — exactly what INV-T3
+forbids — and relying on the merged stream happening to yield in
+declaration order would have rested on a coincidental property of the
+select combinator, not on any contract. Stage-1 implementation was
+therefore gated on a prerequisite refactor, owned by this RFC's
+implementation task and since landed: `RuntimeCommandParts` carries the
+effect's leaves unfolded, in `Command::batch`'s flattened declaration
+order (`into_runtime_parts` calls `Effect::into_leaves()`,
+`src/command/core.rs`, `src/command/runtime_parts.rs`), and each
+consumer folds or drives them at its own consumption site — the
+runtime merging them at its spawn site with `fold_leaves`, exactly as
+the pre-refactor `into_stream()` merged them (a behavior-preserving
+relocation of the existing fold; `Effect` already kept its leaves
+apart to preserve leaf identity for per-leaf consumers, per its own
+comment in `src/command/effect.rs`), the store keeping them apart.
+INV-T3 names this revised boundary.
 
 **Deliverability and the poll budget.** A leaf's output is
 **deliverable** at a given check when the leaf yields it on that
@@ -800,9 +802,9 @@ three design inputs RFC 0009 §5.1 recorded for it:
   shape (§4.3). User effects that spawn tasks, and nested runtimes,
   are outside the store's contract (§4.3).
 - **Feature availability.** Per RFC 0009 §5.1's decision, the
-  implementation task adds `test-util` to the crate's unconditional
+  implementation task added `test-util` to the crate's unconditional
   `tokio` dependency features; RFC 0009 INV-C4 carries the load-path
-  regression check that covers the flip, and this document adds no
+  regression check that covered the flip, and this document adds no
   second check for it.
 
 `Timer` and other subscription sources stay out of scope in stage 2 as
@@ -858,8 +860,9 @@ Enforcement classes follow the pre-review checklist's definitions
   review of the store's single command-intake site (it accepts the
   parts type and touches no `Command` or `Effect` internals), and
   review of the runtime's spawn site for the prerequisite's
-  behavior-preservation half (the relocated fold merges the leaves
-  exactly as `into_stream()` does today). This is what makes TestStore
+  behavior-preservation half (the relocated fold, `fold_leaves`, merges
+  the leaves exactly as the pre-refactor `into_stream()` did). This is
+  what makes TestStore
   results evidence about real commands rather than about a test-only
   model.
 - **INV-T4**: the store introduces no nondeterminism of its own —

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -34,8 +34,9 @@ Four decisions:
    code goes through the virtualizable clock. The `std` entry points
    that read the current time or wait on its passage are banned
    mechanically via clippy's `disallowed-methods`, whose entries are
-   derived as an inventory in §3.1. Two HTTP-module files violate the
-   rule today; migrating them is this RFC's named prerequisite (§4.1).
+   derived as an inventory in §3.1. The two HTTP-module files that
+   violated the rule at drafting migrated under this RFC's named
+   prerequisite (§4.1); every library time read now conforms.
 3. **Controlled-context contract** (§3.2, INV-C2, INV-C3). A consumer
    that controls the clock may rely on: virtual time advances only under
    the controller's action (plus the executor's idle auto-advance, which
@@ -168,8 +169,9 @@ completion depends on the current time: now-reads (`Instant::now`,
 executor's virtualizable clock, i.e. through `tokio::time` types and
 functions. `Duration` values are plain data and are not time reads.
 
-Inventory of production time reads (refreshed 2026-07-25, after the
-§4.2 `Timer` fix and the frame-scheduler alignment):
+Inventory of production time reads (refreshed 2026-07-26, after the
+§4.1 HTTP migration, the §4.2 `Timer` fix, and the frame-scheduler
+alignment):
 
 | Site | Read | Purpose | Conforming |
 | --- | --- | --- | --- |
@@ -179,8 +181,8 @@ Inventory of production time reads (refreshed 2026-07-25, after the
 | `src/runtime.rs` (event loop) | `tokio::time::Instant` | micro-batch window deadline (RFC 0006 mechanism) | yes |
 | `src/runtime/frame_scheduler.rs` | `tokio::time::sleep_until`, `tokio::time::Instant` | frame cadence | yes |
 | `src/runtime/channel.rs` (bounded send) | `tokio::time::Instant` | capacity-wait duration in load events (RFC 0006 observability) | yes |
-| `src/subscription/http/cell.rs` | `std::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | **no — §4.1 migration** |
-| `src/subscription/http/query.rs` | `std::time::Instant` | `elapsed_ms` tracing field | **no — §4.1 migration** |
+| `src/subscription/http/cell.rs` | `tokio::time::Instant` | `stale_time` / `cache_time` decisions, `time_since_data` | yes (migrated, §4.1) |
+| `src/subscription/http/query.rs` | `tokio::time::Instant` | `elapsed_ms` tracing field | yes (migrated, §4.1) |
 
 The rule's mechanical floor is an inventory of the `std` entry points
 whose call reads the current time, blocks on its passage, or configures
@@ -235,8 +237,8 @@ blocking of `close` and so falls in the timed-wait-configuration
 class — are uncallable on the crate's stable toolchain and join the
 table on stabilization; `recv_deadline`, equally unstable, is listed
 ahead of that defensively because it completes a family already
-present, and the §4.1 implementation task confirms the lint accepts its
-path.
+present, and the §4.1 implementation task confirmed the lint accepts
+its path.
 
 Dependencies are scoped the same way: the executor clock itself
 (`tokio::time`) is the crate's one sanctioned time source, and no
@@ -251,8 +253,8 @@ never virtual).
 Outside library code, exactly one deliberate exception exists:
 `benches/runtime_load.rs` measures real wall-clock latency because
 RFC 0006's statistical acceptance criteria are defined on real time.
-The §4.1 migration, which lands the lint configuration, adds an explicit
-lint allow at the bench's measurement sites in the same change. Unit
+The §4.1 migration, which landed the lint configuration, added an
+explicit lint allow at the bench's measurement sites in the same change. Unit
 and integration tests contain no `std::time` reads today and fall under
 the same rule.
 
@@ -356,7 +358,7 @@ Pinned deliberately as *not* guaranteed:
 
 ## 4. Implementation deliverables
 
-Both deliverables below are owned by this RFC's implementation task.
+Both deliverables below landed with this RFC's implementation task.
 
 ### 4.1 HTTP time-source migration (prerequisite)
 
@@ -364,8 +366,9 @@ Both deliverables below are owned by this RFC's implementation task.
 `src/subscription/http/cell.rs` (lifecycle `inactive_since`, data
 `data_timestamp`, and the `stale_time`/`cache_time` comparisons over
 them) and `src/subscription/http/query.rs` (the `elapsed_ms` tracing
-read) read `std::time::Instant` and are the only library sites outside
-the rule. They migrate to the virtualizable clock's `Instant`.
+read) read `std::time::Instant` at this RFC's drafting and were the
+only library sites outside the rule. They migrated to the
+virtualizable clock's `Instant`.
 
 - The migration is behavior-preserving in unpaused contexts: the
   virtualizable `Instant` reads the same platform monotonic clock when
@@ -373,27 +376,27 @@ the rule. They migrate to the virtualizable clock's `Instant`.
   public signature (`inactive_since` is `pub(super)`; the rest are
   module-internal), so the change is invisible outside the module.
 - The payoff is that HTTP staleness and cache-eviction behavior —
-  contract-bearing time comparisons — become testable under a
-  controlled context like every other time-dependent contract.
-- INV-C1's mechanical enforcement turns on with this migration; the
-  lint cannot land first.
+  contract-bearing time comparisons — are testable under a controlled
+  context like every other time-dependent contract.
+- INV-C1's mechanical enforcement turned on with this migration; the
+  lint could not land first.
 
 ### 4.2 Timer contract alignment
 
-`src/subscription/time.rs`'s `Timer` does not currently satisfy the
-non-catch-up contract (§3.2, INV-C3): it leans on Tokio's
+The pre-fix `src/subscription/time.rs` `Timer` did not satisfy the
+non-catch-up contract (§3.2, INV-C3): it leaned on Tokio's
 `MissedTickBehavior::Skip`, whose skip engages only once a tick is late
 by more than a fixed margin (5 ms in tokio 1.50.0's `interval.rs`), so a
-short-interval timer replays one tick per missed interval after a delay.
-This deliverable changes `Timer` to provide the non-catch-up property
-directly and pins the semantics in rustdoc. Unlike §4.1, it is **not**
-behavior-preserving.
+short-interval timer replayed one tick per missed interval after a
+delay. This deliverable changed `Timer` to provide the non-catch-up
+property directly and pins the semantics in rustdoc. Unlike §4.1, it is
+**not** behavior-preserving.
 
 - **Observable change.** After a delay spanning several intervals,
   `Timer` yields exactly one tick — no catch-up burst — instead of one
   tick per missed interval. This is a user-visible behavior change for
-  short-interval timers under load, so it lands with a `CHANGELOG: Fixed`
-  entry, not as a mere rustdoc adjustment.
+  short-interval timers under load, so it landed with a
+  `CHANGELOG: Fixed` entry, not as a mere rustdoc adjustment.
 - **Anchor** (amended 2026-07-25; originally "stream construction").
   The time anchor is fixed at the stream's **first poll** — not
   `Timer::new`, which only stores the interval value, and not the
@@ -432,9 +435,9 @@ behavior-preserving.
     late tick, the next boundary can be less than one interval away and
     still fires. It preserves the drift-corrected cadence the `Timer`
     rustdoc describes.
-- **rustdoc.** `Timer` gains a first-tick, non-catch-up, and post-miss
-  cadence sentence citing this RFC as the semantics of record, and names
-  the first-poll anchor.
+- **rustdoc.** `Timer`'s rustdoc carries the first-tick, non-catch-up,
+  and post-miss cadence sentences citing this RFC as the semantics of
+  record, and names the first-poll anchor.
 - **Tests.** INV-C3's paused-clock tests at 1 ms and 2 ms intervals are
   the proof; a Skip-margin-dependent implementation fails them.
 
@@ -486,14 +489,15 @@ Three design inputs recorded for that amendment:
   itself spawns (`tokio::spawn`) or nests a runtime is handled. Recorded
   here as stage-2 design inputs, not resolved by this RFC.
 - **Feature availability.** The executor's pause-and-advance facilities
-  sit behind the `tokio` `test-util` feature, today a dev-dependency
-  only. **Decision:** when the first in-crate controlled-context
-  consumer lands — TestStore stage 2 is the named owner — `test-util`
-  joins the crate's unconditional `tokio` dependency features. tears
-  adds no feature flag of its own, per the no-feature-flag precedent
-  for test support (RFC 0008 §3.3): pausing is opt-in at runtime
-  construction, so the unconditional feature changes no production
-  behavior (INV-C4 continues to hold and its check covers this flip).
+  sit behind the `tokio` `test-util` feature, before this decision a
+  dev-dependency feature only. **Decision:** `test-util` joined the
+  crate's unconditional `tokio` dependency features with the first
+  in-crate controlled-context consumer — TestStore stage 2, the named
+  owner. tears adds no feature flag of its own, per the no-feature-flag
+  precedent for test support (RFC 0008 §3.3): pausing is opt-in at
+  runtime construction, so the unconditional feature changes no
+  production behavior (INV-C4 continues to hold and its check covered
+  the flip).
 
 ### 5.2 Debounce / throttle (future keyed-lifecycle work)
 
@@ -555,8 +559,8 @@ Enforcement classes follow the pre-review checklist's definitions.
   points appears in the repository's Rust targets except the named
   bench exception (§3.1) at its explicitly allowed measurement sites.
   Structural-mechanical: clippy `disallowed-methods` in `clippy.toml`
-  carries exactly §3.1's banned-entry-point inventory (landing with the
-  §4.1 migration, which removes the last violations), failing the
+  carries exactly §3.1's banned-entry-point inventory (landed with the
+  §4.1 migration, which removed the last violations), failing the
   workspace lint gate on any reintroduction. The platform-gated `std::os`
   socket timeout setters are carried as `allow-invalid = true` entries
   (§3.1) and so are enforced mechanically wherever CI resolves them —
@@ -590,27 +594,25 @@ Enforcement classes follow the pre-review checklist's definitions.
   the executor is driven to progress.
 - **INV-C3**: the time-dependent contracts pinned by RFC 0004 and by
   `Timer`'s semantics hold identically under the virtual clock.
-  `Timer`'s current rustdoc documents only the missed-tick Skip
-  behavior, and the current implementation does not in fact provide the
-  non-catch-up contract at short intervals: it composes
-  `MissedTickBehavior::Skip` with `.skip(1)`, but Tokio's Skip engages
-  only once a tick is late by more than a fixed margin (5 ms in
-  tokio 1.50.0's `interval.rs`), so a paused-clock advance spanning
-  several sub-margin intervals replays one tick per interval — a
-  catch-up burst this contract forbids. `.skip(1)` supplies only the
-  first-tick timing (no tick at the construction instant); it does not
-  suppress catch-up. The §4.2 implementation task pins the contract by
-  making `Timer` provide the non-catch-up property directly (rather than
-  leaning on Tokio's lateness-margin Skip) and adds a first-tick,
-  non-catch-up, and post-miss cadence sentence to `Timer`'s rustdoc
-  citing this RFC as the semantics of record, so INV-C3 references a
-  written contract the code actually satisfies rather than an
-  implementation accident it does not. The contract is stated as
-  observable properties (§4.2), not as a claim about `.skip(1)` or any
-  other mechanism, so the implementation is free to drop them.
-  Behavioral: the existing paused-clock timeout/retry suites
+  The pre-fix `Timer` did not provide the non-catch-up contract at
+  short intervals: it composed `MissedTickBehavior::Skip` with
+  `.skip(1)`, but Tokio's Skip engages only once a tick is late by more
+  than a fixed margin (5 ms in tokio 1.50.0's `interval.rs`), so a
+  paused-clock advance spanning several sub-margin intervals replayed
+  one tick per interval — a catch-up burst this contract forbids
+  (`.skip(1)` supplied only the first-tick timing, not catch-up
+  suppression). The §4.2 fix makes `Timer` provide the non-catch-up
+  property directly (rather than leaning on Tokio's lateness-margin
+  Skip), and its rustdoc carries the first-tick, non-catch-up, and
+  post-miss cadence sentences citing this RFC as the semantics of
+  record, so INV-C3 references a written contract the code actually
+  satisfies rather than an implementation accident it does not. The
+  contract is stated as observable properties (§4.2), not as a claim
+  about any mechanism, so a reimplementation is free to change
+  mechanisms again.
+  Behavioral: the paused-clock timeout/retry suites
   (`src/command/effect.rs`, `src/command/retry.rs`, `src/runtime.rs`)
-  are the timeout/retry half; new paused-clock `Timer` tests pin the
+  are the timeout/retry half; the paused-clock `Timer` tests pin the
   timer half at short intervals (1 ms and 2 ms, chosen to fall inside
   Tokio's lateness margin so a Skip-dependent implementation fails them),
   covering the §4.2 observable properties:
@@ -650,12 +652,13 @@ Enforcement classes follow the pre-review checklist's definitions.
   rests on tokio's never-paused fast path (the read path adds one
   atomic load), but the runtime reads virtual now per iteration in hot
   loops (e.g. the micro-batch window in `src/runtime.rs`), so the §5.1
-  implementation task carries a load-path regression check rather than
-  a bespoke wall-clock comparison: RFC 0006's acceptance criteria must
-  continue to pass on its reference machine after the flip, under
-  RFC 0006's own measurement conditions and gating. That reuses an
-  apparatus with a defined pass/fail and environment scope instead of
-  reading "observably free" off a two-run criterion difference. The §4
+  flip carried a load-path regression check rather than a bespoke
+  wall-clock comparison: RFC 0006's acceptance criteria must continue
+  to pass on its reference machine after the flip, under RFC 0006's own
+  measurement conditions and gating — the post-flip run met them,
+  recorded with the flip's change history. That reuses an apparatus
+  with a defined pass/fail and environment scope instead of reading
+  "observably free" off a two-run criterion difference. The §4
   migration's
   behavior-preservation half is structural too: the diff is a type
   swap with no logic change, and the existing HTTP suite stays green.

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,15 +1,10 @@
 # RFC 0009: Clock DI — deterministic time via the virtual clock
 
 - Status: Implemented
-- Amended: 2026-07-25 — §4.2/INV-C3: `Timer`'s anchor moved from stream
-  construction to the stream's first poll (review finding: a stream
-  built outside the polling runtime's clock context anchored against
-  the wrong clock and ticked immediately or never)
 - Amended: 2026-07-26 — §5.5: the application recipe's documented home
   moved from `docs/testing.md` to rustdoc (audience finding:
-  `docs/testing.md` is contributor test policy, and the repository's
-  user-facing documentation surfaces are the README, rustdoc, and
-  examples)
+  `docs/testing.md` is contributor test policy, not application-author
+  documentation)
 - Target: a crate-wide determinism contract for time-dependent behavior,
   with no new public API
 - Scope: the no-clock-abstraction decision, the single-time-source rule,
@@ -526,11 +521,11 @@ own dev-dependencies and runs its tests on a paused single-threaded
 runtime; feature unification makes every tears time read virtual in
 those tests with no tears-side configuration.
 
-Deliverable (amended 2026-07-26; originally "a deterministic-time
-section in `docs/testing.md`" — an audience mismatch: that file is
-contributor test policy, and the repository's user-facing documentation
-surfaces are the README, rustdoc, and examples): the recipe documented
-as rustdoc, at two sites, each matched to the reader who needs it —
+Deliverable (amended 2026-07-26; originally a `docs/testing.md`
+section): the recipe documented as rustdoc — with the README and
+examples, the surface where the repository's application-author
+documentation lives, where `docs/testing.md` is contributor test
+policy — at two sites, each matched to the reader who needs it:
 
 - the `tears::testing` module doc carries the recipe (`test-util` in
   the application's dev-dependencies, a paused single-threaded runtime,

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -5,6 +5,11 @@
   construction to the stream's first poll (review finding: a stream
   built outside the polling runtime's clock context anchored against
   the wrong clock and ticked immediately or never)
+- Amended: 2026-07-26 — §5.5: the application recipe's documented home
+  moved from `docs/testing.md` to rustdoc (audience finding:
+  `docs/testing.md` is contributor test policy, and the repository's
+  user-facing documentation surfaces are the README, rustdoc, and
+  examples)
 - Target: a crate-wide determinism contract for time-dependent behavior,
   with no new public API
 - Scope: the no-clock-abstraction decision, the single-time-source rule,
@@ -67,8 +72,8 @@ stage 2 consumes this contract; nothing here gates on TestStore.
   behavior-changing deliverable carrying a `CHANGELOG: Fixed` entry.
 - The `tokio` `test-util` feature decision for in-crate controlled
   contexts (§5.1).
-- A deterministic-time testing recipe in `docs/testing.md` for
-  application authors (§5.5) — a documentation deliverable, not
+- A deterministic-time testing recipe for application authors,
+  delivered as rustdoc (§5.5) — a documentation deliverable, not
   contract surface.
 
 ### 1.2 Out of scope
@@ -519,10 +524,26 @@ this contract. Their jitter, if any, is randomness — out of scope here
 A downstream application enables the `tokio` `test-util` feature in its
 own dev-dependencies and runs its tests on a paused single-threaded
 runtime; feature unification makes every tears time read virtual in
-those tests with no tears-side configuration. Deliverable: a
-deterministic-time section in `docs/testing.md` documenting the recipe
-(paused runtime, explicit advance, the §3.2 auto-advance caveat). The
-caveat is named concretely: awaiting real network I/O under a paused
+those tests with no tears-side configuration.
+
+Deliverable (amended 2026-07-26; originally "a deterministic-time
+section in `docs/testing.md`" — an audience mismatch: that file is
+contributor test policy, and the repository's user-facing documentation
+surfaces are the README, rustdoc, and examples): the recipe documented
+as rustdoc, at two sites, each matched to the reader who needs it —
+
+- the `tears::testing` module doc carries the recipe (`test-util` in
+  the application's dev-dependencies, a paused single-threaded runtime,
+  explicit advance, the §3.2 auto-advance caveat), stated against
+  TestStore's own scope boundary: TestStore drives command time leaves
+  with no ambient runtime, and the paused-runtime recipe is the
+  instrument for what TestStore never executes — subscription sources
+  and §4.1's HTTP staleness (RFC 0008 §1.2);
+- `QueryConfig`'s rustdoc (`stale_time`/`cache_time`) names the
+  auto-advance caveat at the site whose tests hit it, linking the
+  module-doc recipe.
+
+The caveat is named concretely: awaiting real network I/O under a paused
 runtime lets the executor judge itself idle and auto-advance the clock
 to the next timer before the I/O completes, so a test exercising §4.1's
 HTTP staleness must drive time and I/O explicitly rather than awaiting a
@@ -650,7 +671,7 @@ guarantees (INV-C2, INV-C3), the neutrality guarantee and the §5.1
 feature flip (INV-C4), the §4.1 migration (INV-C1 turn-on plus
 INV-C4's preservation check), and the §4.2 `Timer` contract-alignment
 fix (INV-C3's timer half, plus the `CHANGELOG: Fixed` entry for its
-observable behavior change). The `docs/testing.md` recipe (§5.5) is
+observable behavior change). The rustdoc recipe (§5.5) is
 documentation and carries no invariant.
 
 ## 7. Open questions
@@ -683,5 +704,6 @@ consumers (§5) does.
   the §4.1 migration sites.
 - `benches/runtime_load.rs` — the named real-time exception.
 - `clippy.toml` — INV-C1's mechanical enforcement site.
-- `docs/testing.md` — the paused-time testing conventions §5.5 extends.
+- `src/testing.rs` (module doc), `src/subscription/http/config.rs`
+  (`QueryConfig`) — the §5.5 recipe's rustdoc homes.
 - `docs/rfcs/pre-review-checklist.md` — enforcement-class definitions.

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,6 +1,6 @@
 # RFC 0009: Clock DI — deterministic time via the virtual clock
 
-- Status: Accepted
+- Status: Implemented
 - Amended: 2026-07-25 — §4.2/INV-C3: `Timer`'s anchor moved from stream
   construction to the stream's first poll (review finding: a stream
   built outside the polling runtime's clock context anchored against

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -548,7 +548,14 @@ changed-claims list.
 
 - Cross-references: open-question numbers point at their resolutions;
   preamble/decision-scope status agrees with the body; the amendment
-  header line is updated.
+  header line is updated **in place** — one `- Amended:` line naming
+  the latest amendment, never a second line appended, which starts
+  exactly the header log the process rule forbids (README: change
+  history lives in Git; superseded amendments stay recorded there and
+  in the body's own minimal `(amended DATE; originally X)` markers).
+  (From PR #257: the second amendment in an RFC's life appended its
+  line under the first — the convention's first exercise, unreadable
+  off the singular "is updated" alone.)
 - Citations of another document's invariants name things that actually
   exist there, and a corrected claim is corrected everywhere: grep for
   the old term across the RFC, its references section, and the index

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -556,6 +556,18 @@ changed-claims list.
   (From PR #257: the second amendment in an RFC's life appended its
   line under the first — the convention's first exercise, unreadable
   off the singular "is updated" alone.)
+- A `Status` flip to Implemented is a corrected claim about every
+  sentence that described the pre-implementation state as current, in
+  this RFC's body and in any other document that cites its state: grep
+  for pre-implementation framing (*today*, *currently*, *lands*,
+  *implementation task*, *prerequisite*, *migrate*) and restate landed
+  deliverables in the present tense, keeping pre-implementation facts
+  in explicit past tense only where they still carry the rationale —
+  and refresh any state inventory the body dates (from PR #257: both
+  RFCs flipped to Implemented while the bodies still said "Two
+  HTTP-module files violate the rule today", "`Timer` does not
+  currently satisfy", "Today that boundary folds", and §3.1's
+  inventory still listed the migrated files as non-conforming).
 - Citations of another document's invariants name things that actually
   exist there, and a corrected claim is corrected everywhere: grep for
   the old term across the RFC, its references section, and the index

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -605,6 +605,15 @@ changed-claims list.
   divergent texts (from PR #242: the no-clock-handle design
   contradicted RFC 0008 §7's "store-held clock handle" sketch until
   §5.1 named the supersession).
+- A deliverable that names its home — the document, module, or surface
+  it will land in — is checked against that home's existing audience
+  and purpose: a repository document serves the readers it already has,
+  and content aimed at a different reader is misplaced even when
+  correct. Match the deliverable to the surface whose audience is its
+  intended reader before naming it (from PR #257: RFC 0009 §5.5 placed
+  a downstream-application testing recipe in `docs/testing.md`,
+  contributor test policy — the deliverable moved to rustdoc, the
+  crate's user-facing surface alongside the README and examples).
 - `typos` and `git diff --check` are clean.
 - English only (repository artifact).
 

--- a/src/subscription/http/config.rs
+++ b/src/subscription/http/config.rs
@@ -3,6 +3,20 @@ use std::time::Duration;
 /// Configuration for query behavior.
 ///
 /// This controls how queries retain data and when they consider it stale.
+///
+/// # Testing staleness deterministically
+///
+/// The `stale_time` and `cache_time` comparisons read the executor's
+/// virtualizable clock (RFC 0009 §4.1), so they can be tested on a paused
+/// single-threaded runtime (`#[tokio::test(start_paused = true)]`, with
+/// tokio's `test-util` feature in your dev-dependencies) and driven with
+/// `tokio::time::advance` — no wall-clock waiting. One caveat: a paused
+/// runtime auto-advances the clock whenever the executor is idle, so a
+/// test awaiting real network I/O can jump past a staleness deadline
+/// before the response arrives. Drive time and I/O explicitly — feed
+/// responses through test-controlled sources, then advance — rather than
+/// awaiting a live socket. See the [`testing`](crate::testing) module doc
+/// for the full recipe.
 #[derive(Debug, Clone)]
 pub struct QueryConfig {
     /// How long data is considered fresh before becoming stale.

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -51,6 +51,47 @@
 //! sibling leaves asserts the store's linearization and must not be cited as
 //! evidence of runtime ordering.
 //!
+//! # Deterministic time without `TestStore`
+//!
+//! `TestStore` covers `update` transitions and command effects. For what it
+//! never executes — subscription sources, and the `http` feature's
+//! staleness and cache-eviction behavior (`QueryConfig`'s
+//! `stale_time`/`cache_time`) —
+//! the same determinism is available directly from the executor: tears
+//! reads time exclusively through the virtualizable clock (`tokio::time`;
+//! RFC 0009), so a paused runtime makes every tears time read virtual with
+//! no tears-side configuration.
+//!
+//! 1. Enable tokio's `test-util` feature in your dev-dependencies:
+//!
+//!    ```toml
+//!    [dev-dependencies]
+//!    tokio = { version = "1", features = ["macros", "rt", "test-util"] }
+//!    ```
+//!
+//! 2. Run the test on a paused single-threaded runtime:
+//!    `#[tokio::test(start_paused = true)]`. (`#[tokio::test]` uses the
+//!    `current_thread` flavor by default, the only flavor that supports
+//!    pausing; the production multi-thread runtime cannot be paused.)
+//!
+//! 3. Move virtual time explicitly with `tokio::time::advance`. No
+//!    time-gated behavior fires before its deadline, and once an advance
+//!    reaches a deadline the gated behavior becomes ready without
+//!    wall-clock waiting (RFC 0009 §3.2).
+//!
+//! **Auto-advance versus real I/O**: a paused runtime auto-advances the
+//! clock to the earliest pending timer deadline whenever the executor is
+//! idle. Awaiting real network I/O under a paused runtime therefore lets
+//! the executor judge itself idle and jump the clock to the next timer
+//! before the I/O completes — a test exercising HTTP
+//! `stale_time`/`cache_time` behavior must drive time and I/O explicitly
+//! (feed responses through test-controlled sources, then advance) rather
+//! than awaiting a live socket.
+//!
+//! `TestStore` itself needs none of this: it owns its paused context and
+//! is constructed on a plain `#[test]`, never inside `#[tokio::test]`,
+//! paused or not.
+//!
 //! [`Command::batch`]: crate::Command::batch
 //! [`Command::timeout`]: crate::Command::timeout
 


### PR DESCRIPTION
## Summary

Flips RFC 0008 (TestStore) and RFC 0009 (Clock DI) from Accepted to Implemented, after verifying every deliverable and invariant of both RFCs against the code on main — and synchronizes both bodies to the implemented state, per the process rule that an RFC's body states the current contract.

- **RFC 0008** — verified complete: the ten-method `tears::testing::TestStore` surface with §2.1's exact bound placement, the `RuntimeCommandParts` per-leaf prerequisite (§4.1) with the behavior-preserving runtime fold, behavioral tests for INV-T1 through INV-T13 (42 `testing::` tests plus the INV-T1/T2 compile tests), the §5/§6 quit, redraw, cancellation-parity, and exhaustiveness semantics, and the unreleased CHANGELOG `Added` entry in its final stage-2 shape.
- **RFC 0009** — verified complete except the §5.5 documentation deliverable: the §3.1 lint inventory in `clippy.toml` (row-for-row, including the `allow-invalid` unix rows and the defensive `recv_deadline` entry), the §4.1 HTTP time-source migration, the §4.2 `Timer` non-catch-up fix with its rustdoc contract and CHANGELOG `Fixed` entry, the INV-C2/INV-C3 paused-clock suites (1 ms and 2 ms, post-miss cadence, first-poll anchor including the cross-context half), the `test-util` feature flip with the INV-C4 load-path regression run recorded on #254, and production neutrality (INV-C4).

## The §5.5 gap, and its amendment

RFC 0009 §5.5 named `docs/testing.md` as the home of the downstream deterministic-time recipe, and the section was never written. Writing it there surfaced a second, prior defect: `docs/testing.md` is contributor test policy — its readers develop this repository — while the recipe's reader is an application author, and the repository's user-facing documentation surfaces are the README, rustdoc, and examples. So this PR:

1. **Amends RFC 0009 §5.5** (header, §1.1, §5.5, §6 coverage, §8 references): the deliverable's home moves to rustdoc, at two sites matched to their readers — the `tears::testing` module doc (the recipe, stated against TestStore's scope boundary: the paused-runtime recipe covers exactly what the store never executes) and `QueryConfig`'s rustdoc (the auto-advance-versus-real-I/O caveat, at the `stale_time`/`cache_time` site whose tests hit it). The caveat's concrete content is unchanged.
2. **Implements the amended deliverable** as rustdoc in `src/testing.rs` and `src/subscription/http/config.rs`.
3. **Flips both RFC statuses to Implemented**, updating RFC 0008's summary sentence that still described RFC 0009 as Accepted.

## Body synchronization to the implemented state (review fix)

Review found the flip left both bodies describing pre-implementation state as current. Fixed by restating landed deliverables in the present tense, keeping pre-implementation facts as explicit past tense where they still carry the rationale:

- **RFC 0009**: the summary's "two HTTP-module files violate the rule today", §3.1's inventory rows for the migrated HTTP files (now conforming, inventory refreshed 2026-07-26), §4.1 ("they migrate" → migrated; enforcement "turns on" → turned on), §4.2 ("does not currently satisfy" → pre-fix past tense; "lands with a CHANGELOG entry" → landed), §5.1 ("today a dev-dependency only" → joined the unconditional features with TestStore stage 2), and INV-C1/INV-C3/INV-C4 (lint landed; Skip + `.skip(1)` described as the pre-fix implementation; the post-flip load-path run stated as met).
- **RFC 0008**: §4.1's "Today that boundary folds…" restated over the landed shape (`into_runtime_parts` → `Effect::into_leaves()`, the runtime folding with `fold_leaves` at its spawn site), plus the header's `test-util`/CHANGELOG lines, §2's "pinned now, before any TestStore code exists", §7's feature-availability bullet, and INV-T3's "as `into_stream()` does today".

The pre-review checklist gains three clarifications from this PR's own findings: a deliverable's named home is checked against that home's existing audience; item 7's amendment-header clause pins the Amended line as replaced in place (one line, never appended); and a Status flip to Implemented corrects every sentence framing the pre-implementation state as current, with the grep vocabulary named.

## Verification

- Full RFC-to-code audit of both documents (public surface, every invariant's named behavioral/structural check, CHANGELOG entries, module docs); code claims in the restated §4.1/§4.2/INV-C3 text re-verified against `src/command/core.rs`, `src/command/runtime_parts.rs`, `src/runtime/core.rs`, and `src/subscription/time.rs` as they exist now.
- `cargo test --all-targets` all green; `cargo clippy --all-targets` and `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps` (default and `--all-features`) clean; doctests pass in both feature configurations; `typos` and `git diff --check` clean.
- INV-C4's post-flip RFC 0006 harness run is recorded in the comments of #254.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
