### PR TITLE
docs(rfcs): drop RFC self-revision history, make README authoritative

### DIFF
--- a/docs/rfcs/0003-command-cancellation.md
+++ b/docs/rfcs/0003-command-cancellation.md
@@ -1043,14 +1043,14 @@ spawn multiple independently keyed tasks." This RFC keeps the first
 implementation small and explicit: the batch is the cancellation boundary, child
 keys warn and do nothing, child cancels fold.
 
-### Design history
+### Occupancy liveness and generation filtering
 
-Earlier drafts treated task liveness as occupancy and used generation filtering
-over the shared channels. Review reversed both decisions: a finished task with
-buffered output is still deliverable stale output, and a dying task can enqueue
-after a recorded generation release point. The prerequisite `Effect` leaf
-refactor (PR #137) keeps per-effect ids possible later, but this RFC deliberately
-ships the smaller per-command lifecycle first.
+Rejected. Task liveness is not occupancy, and delivery does not use generation
+filtering over the shared channels: a finished task with buffered output is
+still deliverable stale output, and a dying task can enqueue after a recorded
+generation release point. The prerequisite `Effect` leaf refactor (PR #137)
+keeps per-effect ids possible later, but this RFC deliberately ships the smaller
+per-command lifecycle first.
 
 ## 9. Implementation Plan
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -20,13 +20,12 @@
 
 > **Staging.** Stage 1 drives pure `update` transitions and effects
 > that become ready without an executor or the passage of time. Stage 2
-> — gated on RFC 0009 — adds a
-> store-held controlled time context and `advance`, making
-> time-dependent *command* effects (`Command::timeout`, retry backoff)
-> deliverable through ordinary `receive` flow (§4.3, §7). `Timer`-based
-> subscriptions are not staged here at all: TestStore never executes
-> subscription sources (§1.2), so lifting that is a separate
-> subscription-execution design, not stage 2.
+> — gated on RFC 0009 — adds a store-held controlled time context and
+> `advance`, making time-dependent *command* effects (`Command::timeout`,
+> retry backoff) deliverable through ordinary `receive` flow (§4.3, §7).
+> `Timer`-based subscriptions are not staged here at all: TestStore
+> never executes subscription sources (§1.2), so lifting that is a
+> separate subscription-execution design, not stage 2.
 
 ## Summary
 

--- a/docs/rfcs/0008-teststore.md
+++ b/docs/rfcs/0008-teststore.md
@@ -1,8 +1,6 @@
 # RFC 0008: TestStore — deterministic update and effect testing
 
 - Status: Implemented
-- Amended: 2026-07-25 — stage 2: the store-held controlled time context
-  and `advance` (§3, §4.3, §7), consuming RFC 0009's contract
 - Target: an additive test harness for the current `Application` API:
   pure `update` transitions and immediately ready effects (stage 1),
   plus time-dependent command effects under a store-held controlled
@@ -18,11 +16,11 @@
   to the crate's unconditional dependency features per RFC 0009 §5.1's
   decision
 - CHANGELOG: `Added` entry ships with the implementation release, not
-  with this RFC; stage 2 amended the same not-yet-released entry
+  with this RFC
 
 > **Staging.** Stage 1 drives pure `update` transitions and effects
 > that become ready without an executor or the passage of time. Stage 2
-> — specified by the 2026-07-25 amendment, gated on RFC 0009 — adds a
+> — gated on RFC 0009 — adds a
 > store-held controlled time context and `advance`, making
 > time-dependent *command* effects (`Command::timeout`, retry backoff)
 > deliverable through ordinary `receive` flow (§4.3, §7). `Timer`-based
@@ -53,8 +51,8 @@ Three decisions, ordered by urgency:
    designed here (open question 2).
 3. **Clock DI split** (§7): Clock injection is a separate RFC. This RFC
    does not gate on it, and stage 2 of TestStore gates on that RFC, not
-   the reverse. RFC 0009 is Implemented; the stage-2 amendment consumes
-   its contract and resolves the three design inputs its §5.1 recorded
+   the reverse. RFC 0009 is Implemented; stage 2 consumes
+   its contract and resolves the three design inputs its §5.1 records
    (§7).
 
 The harness itself: `tears::testing::TestStore<App>` wraps an
@@ -108,7 +106,7 @@ context the store itself owns (§4.3).
   runtime's own tests. This covers `Timer` and every other
   `SubscriptionSource`: subscription execution is out of scope in
   stage 1 and stage 2 alike — lifting it would be a separate
-  subscription-execution design, not the Clock DI stage-2 amendment
+  subscription-execution design, not the Clock DI work stage 2 covers
   (RFC 0009 §5.1), which delivers command time leaves only.
 - **Runtime integration contracts**: channel capacities, backpressure,
   batching, and scheduling (RFC 0006/0007) are properties of the runtime
@@ -282,7 +280,7 @@ generic) are implementation latitude.
   *leaf* after the clock moves (§4.1's budget is unchanged), and a leaf
   whose deadline the advance reached is deliverable at the next check
   whose scan polls it — the executor-progress readiness point RFC 0009
-  §3.2 left for this amendment to fix, with no wall-clock waiting.
+  §3.2 left for stage 2 to fix, with no wall-clock waiting.
   Tasks spawned onto the context by earlier effects may receive
   incidental polls while the barrier drives the executor (§4.3's
   negative space). The scan reaches *every* pending leaf and never
@@ -451,12 +449,6 @@ clause never applies to the store's own operations (INV-T12).
 
 ### 4.3 Time-gated leaves and the controlled context
 
-*Rewritten by the stage-2 amendment. Stage 1 required the reactor's
-genuine absence and failed the test on any poll of a time-dependent
-leaf; that contract, and the entered-runtime analysis behind it, lives
-in this section's pre-amendment text (git history) and survives here
-only as the I/O rule below and INV-T10's construction check.*
-
 The store owns a **controlled time context** in RFC 0009 §3.2's sense:
 a single-threaded executor context, constructed by `TestStore::new`,
 whose clock starts paused and which enables no I/O driver. Every poll
@@ -506,27 +498,22 @@ mid-leaf (a retry's backoff after a failed attempt) anchor at the
 virtual now of the scan that observed the failure, which the test's
 own script determines.
 
-**Construction check (INV-T10, revised).** `TestStore::new` still
+**Construction check (INV-T10).** `TestStore::new`
 checks `tokio::runtime::Handle::try_current()` and panics immediately,
 with a diagnostic naming the precondition, if any runtime context is
-entered — `#[tokio::test]` included, paused or not. Stage 1 rejected
-every ambient runtime because it required the reactor's absence; stage
-2 keeps the identical check with a different rationale, and this
-supersedes the pre-amendment §4.3/§7 expectation that the amendment
-would "accept that specific controlled context": the accepted
-controlled context is the *store's own*, so the caller-facing rule is
-unchanged — construct the store on a plain `#[test]`, never inside
+entered — `#[tokio::test]` included, paused or not. The only
+controlled context the store accepts is its *own*, so the caller-facing
+rule is: construct the store on a plain `#[test]`, never inside
 `#[tokio::test]`. An ambient runtime is rejected rather than adopted
 because the store cannot verify an ambient runtime's pausedness or
 thread model through any public surface, and because driving the
 store's own context from inside another runtime would block a runtime
 thread, which Tokio forbids. The check is structural and happens once,
 at construction: a store built outside a runtime but later driven from
-inside one is a misuse this RFC does not attempt to catch, as in
-stage 1.
+inside one is a misuse this RFC does not attempt to catch.
 
 **Outside the store's contract.** A user effect that spawns onto the
-ambient executor (`tokio::spawn` from inside a leaf's poll) now finds
+ambient executor (`tokio::spawn` from inside a leaf's poll) finds
 a context and succeeds, but the spawned task is outside the store's
 pending set: it is not counted in exhaustiveness (§6), and the store
 gives it no specified schedule — it may receive incidental polls
@@ -755,9 +742,8 @@ smuggled in half-specified (open question 2).
 **Decision: Clock injection is its own RFC; this RFC does not contain
 it.** Stage 2 of TestStore — deterministic driving of the
 time-dependent *command* effects (`timeout`, retry backoff, and future
-command-side coalescing timers such as debounce/throttle) — landed as
-the 2026-07-25 amendment to this document, after RFC 0009's
-acceptance. `Timer` and other
+command-side coalescing timers such as debounce/throttle) — gates on
+RFC 0009, which is Implemented. `Timer` and other
 subscription sources are not part of stage 2 (§1.2): they are not
 command leaves and TestStore never executes subscription sources.
 
@@ -775,8 +761,8 @@ Rationale:
 - Stage 1 is additive and independently shippable; bundling would gate
   it behind the larger design.
 
-The stage-2 amendment consumes RFC 0009's contract and resolves the
-three design inputs RFC 0009 §5.1 recorded for it:
+Stage 2 consumes RFC 0009's contract and resolves the
+three design inputs RFC 0009 §5.1 records for it:
 
 - **Deadline anchoring.** RFC 0004's first-poll anchor, restated over
   the store's scan sites: because `advance` anchors before it moves the
@@ -792,25 +778,21 @@ three design inputs RFC 0009 §5.1 recorded for it:
   clock alone leaves already-registered timer entries unfired and
   `Pending` under the store's manual polls. Readiness is then observed
   at the next check whose scan polls the leaf (§3.2), fixing the
-  executor-progress question RFC 0009 §3.2 left to this amendment;
+  executor-progress question RFC 0009 §3.2 left to stage 2;
   `advance` still polls no leaf after the clock moves. Tasks spawned
   onto the context may receive incidental polls during the barrier —
   unspecified progress, §4.3's negative space.
   The store owns its controlled time context outright; every ambient
-  runtime is still rejected at construction, superseding the
-  pre-amendment sketch's "accept that specific controlled context"
-  shape (§4.3). User effects that spawn tasks, and nested runtimes,
-  are outside the store's contract (§4.3).
+  runtime is rejected at construction (§4.3). User effects that spawn
+  tasks, and nested runtimes, are outside the store's contract (§4.3).
 - **Feature availability.** Per RFC 0009 §5.1's decision, the
   implementation task added `test-util` to the crate's unconditional
   `tokio` dependency features; RFC 0009 INV-C4 carries the load-path
   regression check that covered the flip, and this document adds no
   second check for it.
 
-`Timer` and other subscription sources stay out of scope in stage 2 as
-in stage 1 (§1.2; RFC 0009 §5.1). The pre-amendment §7 sketch and its
-INV-T10 scoping note are superseded by the resolutions above and by
-§4.3's revised construction check.
+`Timer` and other subscription sources stay out of scope in stage 2, as
+in stage 1 (§1.2; RFC 0009 §5.1).
 
 Excluded claims, recorded per the checklist's minimal-contract item: a
 claim that `advance(Duration::ZERO)`'s barrier re-fires
@@ -969,8 +951,7 @@ Enforcement classes follow the pre-review checklist's definitions
   `advance`, and
   `receive*` (whose failure is the quit-state diagnostic, not the
   reactor panic polling would produce) and the passing `finish`.
-- **INV-T10**: ambient-runtime rejection (revised by the stage-2
-  amendment; the stage-1 statement covered reactor absence) —
+- **INV-T10**: ambient-runtime rejection —
   `TestStore::new` panics immediately, before any other construction
   work — its own controlled context included — if
   `tokio::runtime::Handle::try_current()` succeeds. The store's own
@@ -1120,8 +1101,7 @@ rule, the no-side-effect claim, and the no-warning claim together
 - RFC 0009 — Clock DI: its §3.2 controlled time context and INV-C2/
   INV-C3, consumed by §4.3 and INV-T12; its §3.4 equal-deadline
   negative space, which §4.2's linearization supplies; its §5.1 design
-  inputs and `test-util` decision, resolved and carried out by §7's
-  amendment record.
+  inputs and `test-util` decision, resolved and carried out by §7.
 - `src/application.rs` — the trait whose bounds §2 pins.
 - `src/command/core.rs`, `src/command/runtime_parts.rs` — the
   decomposition boundary INV-T3 names.

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -391,9 +391,8 @@ property directly and pins the semantics in rustdoc. Unlike §4.1, it is
   tick per missed interval. This is a user-visible behavior change for
   short-interval timers under load, so it landed with a
   `CHANGELOG: Fixed` entry, not as a mere rustdoc adjustment.
-- **Anchor.**
-  The time anchor is fixed at the stream's **first poll** — not
-  `Timer::new`, which only stores the interval value, and not the
+- **Anchor.** The time anchor is fixed at the stream's **first poll** —
+  not `Timer::new`, which only stores the interval value, and not the
   `stream()` call, which only builds the stream. `stream()` may legally
   run outside the runtime that will poll the stream (on another thread,
   or in setup code outside a paused test runtime), and an anchor read

--- a/docs/rfcs/0009-clock-di.md
+++ b/docs/rfcs/0009-clock-di.md
@@ -1,10 +1,6 @@
 # RFC 0009: Clock DI — deterministic time via the virtual clock
 
 - Status: Implemented
-- Amended: 2026-07-26 — §5.5: the application recipe's documented home
-  moved from `docs/testing.md` to rustdoc (audience finding:
-  `docs/testing.md` is contributor test policy, not application-author
-  documentation)
 - Target: a crate-wide determinism contract for time-dependent behavior,
   with no new public API
 - Scope: the no-clock-abstraction decision, the single-time-source rule,
@@ -83,9 +79,9 @@ stage 2 consumes this contract; nothing here gates on TestStore.
   separate determinism axis with its own reproducibility design,
   deferred by RFC 0004 §5.2; a future backoff-policy RFC owns it.
 - **TestStore's time API.** The shape of `advance` on the store, and
-  how time-gated leaves join RFC 0008's §4.2 canonical order, is the
-  RFC 0008 stage-2 amendment's job. This RFC provides the contract that
-  amendment cites (§5.1).
+  how time-gated leaves join RFC 0008's §4.2 canonical order, is
+  RFC 0008 stage 2's job. This RFC provides the contract stage 2
+  cites (§5.1).
 - **Debounce/throttle and restart-rate semantics.** Their policies and
   invariants belong to their own RFCs; they consume this contract
   (§5.2, §5.3).
@@ -169,9 +165,7 @@ completion depends on the current time: now-reads (`Instant::now`,
 executor's virtualizable clock, i.e. through `tokio::time` types and
 functions. `Duration` values are plain data and are not time reads.
 
-Inventory of production time reads (refreshed 2026-07-26, after the
-§4.1 HTTP migration, the §4.2 `Timer` fix, and the frame-scheduler
-alignment):
+Inventory of production time reads:
 
 | Site | Read | Purpose | Conforming |
 | --- | --- | --- | --- |
@@ -397,7 +391,7 @@ property directly and pins the semantics in rustdoc. Unlike §4.1, it is
   tick per missed interval. This is a user-visible behavior change for
   short-interval timers under load, so it landed with a
   `CHANGELOG: Fixed` entry, not as a mere rustdoc adjustment.
-- **Anchor** (amended 2026-07-25; originally "stream construction").
+- **Anchor.**
   The time anchor is fixed at the stream's **first poll** — not
   `Timer::new`, which only stores the interval value, and not the
   `stream()` call, which only builds the stream. `stream()` may legally
@@ -443,9 +437,9 @@ property directly and pins the semantics in rustdoc. Unlike §4.1, it is
 
 ## 5. Consumers
 
-### 5.1 TestStore stage 2 (RFC 0008 §7 amendment)
+### 5.1 TestStore stage 2 (RFC 0008 §7)
 
-The stage-2 amendment gives the store a controlled time context and an
+Stage 2 gives the store a controlled time context and an
 advance operation, making RFC 0008 §4.3-class *command* time leaves
 (`timeout`, retry backoff) deliverable through ordinary `receive` flow.
 `Timer` is deliberately excluded: it is a subscription source, not a
@@ -455,32 +449,30 @@ command set at all. Delivering it would require a subscription-execution
 design — source spawn, ID reconciliation, restart, and source
 cancellation, everything the runtime's `SubscriptionManager` provides —
 which is out of scope for both RFCs; if a future need arises it is a
-separate, explicitly-designed amendment, not this stage-2 one.
+separate, explicitly-designed effort, not part of stage 2.
 `Timer`'s own determinism under the virtual clock is still pinned here
 (INV-C3), exercised directly against its stream rather than through
-TestStore. RFC 0008 §7's
-non-normative sketch pictured "a store-held clock handle"; this RFC's
-design supersedes that shape — there is no clock value to hold. The
+TestStore. This RFC provides no clock *value* to hold: the
 store holds a controlled time context (§3.2) and `advance` acts on that
-context's clock; the amendment specifies its API against this RFC, not
-against the sketch. What it cites here:
+context's clock. Stage 2 specifies its API against this RFC. What it
+cites here:
 INV-C2's explicit-advance determinism (the store's poll budget never
 idles the executor, so the auto-advance clause never applies) and
 INV-C3's transparency (store results are evidence about production time
 contracts, completing the INV-T3 argument on the time axis).
 
-Three design inputs recorded for that amendment:
+Three design inputs for stage 2:
 
 - **Deadline anchoring.** RFC 0004 anchors a timeout's deadline at the
   leaf's *first poll*, and the store's scans decide when that first
-  poll happens; the amendment's advance semantics must account for
+  poll happens; stage 2's advance semantics must account for
   scan-order-dependent anchoring rather than assuming
   construction-time anchoring. (`Timer`'s first-poll anchor
   (§4.2) is not a stage-2 concern: stage 2 delivers command time leaves
   only, never `Timer`.)
 - **Advance semantics and executor context.** Tokio's `advance` does
-  not wait for the sleeps it moves past to complete (§3.2), so the
-  amendment must fix whether the store's advance carries a timer-driver
+  not wait for the sleeps it moves past to complete (§3.2), so
+  stage 2 must fix whether the store's advance carries a timer-driver
   barrier or whether "ready after advance" means "ready once the
   executor is driven to progress, with no wall-clock wait". It must also
   fix the executor context the store owns or borrows — whether the store
@@ -525,8 +517,7 @@ own dev-dependencies and runs its tests on a paused single-threaded
 runtime; feature unification makes every tears time read virtual in
 those tests with no tears-side configuration.
 
-Deliverable (amended 2026-07-26; originally a `docs/testing.md`
-section): the recipe documented as rustdoc — with the README and
+Deliverable: the recipe documented as rustdoc — with the README and
 examples, the surface where the repository's application-author
 documentation lives, where `docs/testing.md` is contributor test
 policy — at two sites, each matched to the reader who needs it:

--- a/docs/rfcs/pre-review-checklist.md
+++ b/docs/rfcs/pre-review-checklist.md
@@ -547,15 +547,16 @@ changed-claims list.
 ## 7. Mechanical pass
 
 - Cross-references: open-question numbers point at their resolutions;
-  preamble/decision-scope status agrees with the body; the amendment
-  header line is updated **in place** — one `- Amended:` line naming
-  the latest amendment, never a second line appended, which starts
-  exactly the header log the process rule forbids (README: change
-  history lives in Git; superseded amendments stay recorded there and
-  in the body's own minimal `(amended DATE; originally X)` markers).
-  (From PR #257: the second amendment in an RFC's life appended its
-  line under the first — the convention's first exercise, unreadable
-  off the singular "is updated" alone.)
+  preamble/decision-scope status agrees with the body. An RFC records
+  no revision history of itself — no `Amended:` header line, no dated
+  changelog entry, and no in-body `(amended DATE; originally X)`
+  markers: the body states the current contract, and its change history
+  lives in Git (README). Grep a revised RFC for `Amended`, `amended`,
+  `originally`, and `pre-amendment`, and rewrite each hit that narrates
+  the document's own evolution into a present-tense statement of the
+  contract. (This replaces the earlier single-`Amended`-line
+  convention, which still kept in the document the history the README
+  assigns to Git.)
 - A `Status` flip to Implemented is a corrected claim about every
   sentence that described the pre-implementation state as current, in
   this RFC's body and in any other document that cites its state: grep
@@ -599,8 +600,8 @@ changed-claims list.
   `CHANGELOG: none` and the fix absent from `Scope`).
 - Resolving a decision is a corrected claim: grep for the decision's own
   vocabulary — its option labels ("(a)/(b)"), *pending*, *remaining
-  step*, *the input for the choice* — across the findings, every open
-  question's resolution text, and the amendment header (from PR #215:
+  step*, *the input for the choice* — across the findings and every open
+  question's resolution text (from PR #215:
   open question 8 still described F6 as the input to a choice the same
   amendment had already made).
 - The PR title, body, and stated review focus match the final RFC text
@@ -616,14 +617,15 @@ changed-claims list.
   explicit lint allow at its measurement sites" described an allow the
   RFC's own migration prerequisite had yet to add, inside an inventory
   framed as "at this RFC's writing").
-- Superseding another document's recorded expectation is a corrected
-  claim even when the expectation was non-normative: when a decision
-  replaces a sketch or shape another RFC recorded, name the
-  supersession where the decision lands, so the later amendment
-  reconciles against the decision rather than against two silently
-  divergent texts (from PR #242: the no-clock-handle design
-  contradicted RFC 0008 §7's "store-held clock handle" sketch until
-  §5.1 named the supersession).
+- Contradicting another document's stated contract is a corrected claim
+  even when what it stated was non-normative: when a decision here
+  conflicts with a shape another RFC currently states, reconcile the two
+  texts so they agree — edit the other RFC in place to state the current
+  contract, its superseded shape going to Git (README), never leaving
+  two silently divergent texts (from PR #242: the no-clock-handle design
+  conflicted with a "store-held clock handle" shape RFC 0008 §7 then
+  stated; both now state the current contract, the earlier shape in
+  Git).
 - A deliverable that names its home — the document, module, or surface
   it will land in — is checked against that home's existing audience
   and purpose: a repository document serves the readers it already has,


### PR DESCRIPTION
## Summary

README.md §Process already states the rule: an RFC body states the
**current contract, not its history** — change history lives in Git, not
in a header log, and dates appear in the body only where they aid
reproducibility (a measurement reference date), never as a changelog.

RFC 0008 and 0009 diverged from this. They carried `- Amended:` header
lines and in-body `(amended DATE; originally X)` markers, because
`pre-review-checklist.md` item 7 sanctioned a single replaced-in-place
`Amended:` line plus those markers — a reading that contradicted the
README rule it claimed to compress.

Per the maintainer's decision, README is the single authority (an RFC is
not a CHANGELOG; Git records history more reliably; and revision history
gives the *current* reader no value). This PR removes the divergence.

## Changes

- **0008, 0009** — delete the `- Amended:` header lines and every
  in-body `(amended DATE; originally X)` marker; reframe
  `stage-2 amendment` / `pre-amendment` / `revised` history narration as
  present-tense statements of the current contract (e.g. "stage 2", not
  "the stage-2 amendment"); drop the §5.5 inventory's
  `(refreshed DATE, after …)` framing.
- **0003** — restate the "Design history" subsection as a present-tense
  rejected-alternative rationale (`Occupancy liveness and generation
  filtering — Rejected.`), preserving its negative-space content.
- **pre-review-checklist.md** — rewrite item 7 to forbid any RFC
  self-revision-history recording (backed by a grep for
  `Amended`/`amended`/`originally`/`pre-amendment`); drop the "amendment
  header" grep target from the resolve-a-decision item; reconcile the
  supersession item to the edit-in-place mechanism.

## Not changed

- **README.md** — already authoritative; left as-is.
- **RFC 0006's two measurement reference dates** (`2026-07-17`,
  `2026-07-24`) — reproducibility dates README explicitly permits.
- **RFC 0004 §"Why this requires an RFC"** — its "originally tagged 'no
  RFC needed'" line is RFC-existence justification, not contract
  revision history; kept intentionally.

## Verification

- `grep` sweep: no `- Amended:` headers, no `(amended DATE; …)` markers,
  no `pre-amendment` narration remain in RFC bodies.
- Only body dates left are 0006's two measurement reference dates.
- `git diff --check` clean; no dangling references to removed constructs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)