### PR TITLE
chore(lints): enable clippy allow_attributes_without_reason

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ similar_names = "allow"
 
 # Enable some restriction lints
 absolute_paths = "warn"
+allow_attributes_without_reason = "warn"
 cognitive_complexity = "warn"
 mod_module_files = "warn"
 str_to_string = "warn"

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -72,7 +72,8 @@
 #![allow(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
-    clippy::cast_sign_loss
+    clippy::cast_sign_loss,
+    reason = "metric reporting casts counters and nanosecond values to floating point for human-readable output; precision loss there is irrelevant"
 )]
 
 use std::fmt::Debug;
@@ -594,7 +595,10 @@ impl Subscriber for QuitDeliverySubscriber {
     // suggestion — would let a concurrent stale gauge event interleave its store
     // between the check and the apply, the exact reorder the `seq` ordering
     // exists to defeat (RFC 0006 §4.4).
-    #[allow(clippy::significant_drop_tightening)]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "the gauge high-water guard is deliberately held across the value stores so \"advance and apply\" is one step; tightening it would let a concurrent stale gauge event interleave a store between the check and the apply (RFC 0006 §4.4)"
+    )]
     fn event(&self, event: &Event<'_>) {
         let is_load = event.metadata().target() == "tears::runtime::load";
         let mut visitor = LoadVisitor::default();
@@ -766,7 +770,10 @@ impl Metrics {
     // Real wall-clock reads: RFC 0006's statistical acceptance criteria are
     // defined on real time, the one sanctioned exception to the
     // single-time-source rule (RFC 0009 §3.1).
-    #[allow(clippy::disallowed_methods)]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "calls std Instant::now to stamp the real wall-clock baseline; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+    )]
     fn new() -> Self {
         Self {
             start: Instant::now(),
@@ -804,12 +811,18 @@ impl Metrics {
         produced.saturating_sub(processed)
     }
 
-    #[allow(clippy::disallowed_methods)]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "calls std Instant::elapsed to read real wall-clock elapsed time; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+    )]
     fn elapsed_ns(&self) -> u64 {
         u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
     }
 
-    #[allow(clippy::disallowed_methods)]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "calls std Instant::elapsed to measure real wall-clock message latency; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+    )]
     fn push_latency(bucket: &Mutex<Vec<u64>>, sent_at: Instant) {
         let nanos = u64::try_from(sent_at.elapsed().as_nanos()).unwrap_or(u64::MAX);
         bucket.lock().expect("latency bucket poisoned").push(nanos);
@@ -836,7 +849,10 @@ impl SubscriptionSource for FloodSource {
     type Output = Msg;
     type Key = u32;
 
-    #[allow(clippy::disallowed_methods)]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "calls std Instant::now to stamp each message's send time and Instant::elapsed to record when the producer finishes, both real wall-clock reads; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+    )]
     fn stream(&self) -> BoxStream<'static, Msg> {
         let metrics = Arc::clone(&self.metrics);
         let total = self.cfg.total;
@@ -891,7 +907,10 @@ impl Application for LoadApp {
     type Message = Msg;
     type Flags = (ScenarioCfg, Arc<Metrics>);
 
-    #[allow(clippy::disallowed_methods)]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "calls std Instant::now to stamp each keyed-probe send time, a real wall-clock read; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+    )]
     fn new((cfg, metrics): Self::Flags) -> (Self, Command<Msg>) {
         let cmd = if cfg.keyed_probe {
             let mut ticker = interval(Duration::from_millis(25));
@@ -1010,7 +1029,10 @@ impl Application for LoadApp {
 }
 
 /// Busy-waits for `duration` to simulate CPU-bound work on the runtime task.
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "calls std Instant::now to busy-wait against a real wall-clock deadline while simulating CPU-bound work; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+)]
 fn spin(duration: Duration) {
     if duration.is_zero() {
         return;
@@ -1040,7 +1062,10 @@ struct Report {
     seq_broken: bool,
 }
 
-#[allow(clippy::disallowed_methods)]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "calls std Instant::now and Instant::elapsed to measure the scenario's real wall-clock duration; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
+)]
 async fn run_scenario(cfg: ScenarioCfg) -> Report {
     let rss_before = peak_rss_bytes();
     let metrics = Arc::new(Metrics::new());

--- a/examples/views.rs
+++ b/examples/views.rs
@@ -250,7 +250,10 @@ impl App {
 }
 
 /// Handle keyboard events based on current view
-#[allow(clippy::use_self)]
+#[allow(
+    clippy::use_self,
+    reason = "the example names the concrete View and Command<Message> types explicitly for reader clarity rather than Self"
+)]
 fn handle_key_event(view: &View, key: KeyEvent) -> Command<Message> {
     match view {
         View::Menu { .. } => match key.code {

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -1258,7 +1258,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform() {
-        #[allow(clippy::unused_async)]
+        #[allow(
+            clippy::unused_async,
+            reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
+        )]
         async fn fetch_value() -> i32 {
             42
         }
@@ -1273,7 +1276,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform_with_result() {
-        #[allow(clippy::unused_async)]
+        #[allow(
+            clippy::unused_async,
+            reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
+        )]
         async fn fallible_operation() -> Result<String, String> {
             Ok("success".to_owned())
         }
@@ -1383,7 +1389,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform_with_error_handling() {
-        #[allow(clippy::unused_async)]
+        #[allow(
+            clippy::unused_async,
+            reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
+        )]
         async fn may_fail(should_fail: bool) -> Result<i32, &'static str> {
             if should_fail {
                 Err("operation failed")

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -1049,7 +1049,10 @@ mod tests {
                 CancelPolicy::CancelInFlight,
                 command_stream(Command::future(async {
                     panic!("boom");
-                    #[allow(unreachable_code)]
+                    #[allow(
+                        unreachable_code,
+                        reason = "the value follows an unconditional panic! that never returns, but types the async block"
+                    )]
                     1
                 })),
             );

--- a/src/subscription/http/cell.rs
+++ b/src/subscription/http/cell.rs
@@ -20,7 +20,10 @@ pub(super) trait AnyCell: Any + Send + Sync + 'static {
     fn gc_inactive_data_and_should_evict(&self, cache_time: Duration) -> bool;
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "query cell is constructed only through the http feature's Query/QueryClient runtime path and the module tests"
+)]
 pub(super) struct Cell<T> {
     state: Mutex<CellState<T>>,
     tx: watch::Sender<QueryResult<T>>,
@@ -37,7 +40,10 @@ struct CellLifecycle {
     inactive_since: Option<Instant>,
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "subscription handle is constructed only by the http query runtime and exercised by the module tests"
+)]
 pub(super) struct CellSubscription<T>
 where
     T: Clone + Send + Sync + 'static,
@@ -50,7 +56,10 @@ where
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "inner cell state is populated and read only through the http cell's reconcile/complete/snapshot paths"
+)]
 struct CellState<T> {
     data: Option<T>,
     error: Option<QueryError>,
@@ -67,7 +76,10 @@ impl<T> Cell<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "constructor is reached only via new_subscribed on the http query path and the module tests"
+    )]
     pub(super) fn new() -> Self {
         let result = QueryResult::pending(FetchStatus::Idle);
         let (tx, _) = watch::channel(result);
@@ -92,7 +104,10 @@ where
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used only by the http query client's cell-creation path and the module tests"
+    )]
     pub(super) fn new_subscribed() -> (Arc<Self>, CellSubscription<T>) {
         let cell = Arc::new(Self::new());
         {
@@ -111,7 +126,10 @@ where
         (cell, subscription)
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "extra-subscriber path used only by the http query runtime and the module tests"
+    )]
     pub(super) fn subscribe(self: &Arc<Self>) -> CellSubscription<T> {
         {
             let mut lifecycle = self
@@ -129,7 +147,10 @@ where
         }
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "read only by the module's cfg(test) GC tests, so non-test http builds see no caller"
+    )]
     pub(super) fn snapshot(&self, config: &QueryConfig) -> QueryResult<T> {
         self.state
             .lock()
@@ -273,12 +294,18 @@ impl<T> CellSubscription<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared-borrow accessor kept for symmetry with receiver_mut; the stream only needs the mutable accessor, so this one has no caller"
+    )]
     pub(super) const fn receiver(&self) -> &watch::Receiver<QueryResult<T>> {
         &self.rx
     }
 
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "used only by the http subscription stream's watch_cell change-wait loop"
+    )]
     pub(super) const fn receiver_mut(&mut self) -> &mut watch::Receiver<QueryResult<T>> {
         &mut self.rx
     }
@@ -384,7 +411,10 @@ impl<T> CellState<T>
 where
     T: Clone,
 {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "invoked only through the http cell's reconcile/complete/snapshot paths"
+    )]
     fn snapshot(&self, config: &QueryConfig) -> QueryResult<T> {
         let is_stale = self.data.is_some()
             && (self.data_generation < Some(self.current_generation)

--- a/src/subscription/http/cell_core.rs
+++ b/src/subscription/http/cell_core.rs
@@ -22,11 +22,20 @@
 
 use loom::sync::atomic::{AtomicU64, Ordering};
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "sentinel is read only by CellCore, the loom-only test mirror, so a non-test loom-core build has no reader"
+)]
 const NONE: u64 = u64::MAX;
 
-#[allow(dead_code)]
-#[allow(clippy::struct_field_names)]
+#[allow(
+    dead_code,
+    reason = "loom-only concurrency mirror constructed only by its own cfg(test) loom model tests"
+)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "the three generation counters intentionally share the _generation suffix to mirror Cell's state fields"
+)]
 #[derive(Debug)]
 pub(super) struct CellCore {
     current_generation: AtomicU64,
@@ -34,7 +43,10 @@ pub(super) struct CellCore {
     last_error_generation: AtomicU64,
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "all methods are exercised only by the cfg(test) loom model tests, so a non-test loom-core build sees them as unused"
+)]
 impl CellCore {
     pub(super) fn new() -> Self {
         Self {

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -280,7 +280,10 @@ impl QueryClient {
     }
 }
 
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "generic downcast helper reached only from the cell-reuse (Occupied) branch, which dead-code analysis need not treat as instantiated"
+)]
 fn downcast_cell<T>(cell: Arc<dyn AnyCell>) -> Arc<Cell<T>>
 where
     T: Clone + Send + Sync + 'static,
@@ -1346,7 +1349,10 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "exhaustive async test walks a full invalidation-and-refetch coalescing scenario step by step"
+    )]
     async fn test_invalidations_during_one_fetch_window_coalesce_to_one_refetch() {
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));

--- a/src/subscription/http/reconcile.rs
+++ b/src/subscription/http/reconcile.rs
@@ -9,7 +9,10 @@ pub(super) enum ReconcileReason {
 }
 
 /// Snapshot of the state needed to decide whether reconcile should fetch.
-#[allow(clippy::struct_excessive_bools)]
+#[allow(
+    clippy::struct_excessive_bools,
+    reason = "struct models several independent boolean fetch-decision inputs, not a single state better expressed as an enum"
+)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct FetchDecisionInput {
     pub(super) has_data: bool,

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -233,7 +233,10 @@ impl SubscriptionSource for WebSocket {
     type Output = WebSocketMessage;
     type Key = String;
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(
+        clippy::too_many_lines,
+        reason = "the WebSocket connection state machine is expressed as one stream::unfold with every transition inline"
+    )]
     fn stream(&self) -> BoxStream<'static, WebSocketMessage> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -29,7 +29,10 @@ pub struct TestApp {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
+#[allow(
+    dead_code,
+    reason = "shared test fixture whose variants are not all constructed by every test module that imports it"
+)]
 pub enum TestMessage {
     Increment,
     Quit,

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -74,7 +74,10 @@ impl TraceRecorder {
     ///
     /// `#[path]` compiles this helper per integration-test target, so methods
     /// used by one test target can be dead code in another.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this level filter builder is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub const fn with_level(mut self, level: Level) -> Self {
         self.filter.level = Some(level);
@@ -94,14 +97,20 @@ impl TraceRecorder {
     }
 
     /// Returns the number of events that matched this recorder's filter.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this matched-event-count accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub fn event_count(&self) -> usize {
         self.state.events.load(Ordering::SeqCst)
     }
 
     /// Returns all bool values recorded for the named event field.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this bool-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub fn bool_values(&self, field: &str) -> Vec<bool> {
         self.state
@@ -115,7 +124,10 @@ impl TraceRecorder {
 
     /// Returns all unsigned-integer values recorded for the named event field
     /// (covers `u64` and `usize` fields).
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this unsigned-integer-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub fn u64_values(&self, field: &str) -> Vec<u64> {
         self.state
@@ -128,7 +140,10 @@ impl TraceRecorder {
     }
 
     /// Returns all string values recorded for the named event field.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this string-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub fn str_values(&self, field: &str) -> Vec<String> {
         self.state
@@ -142,7 +157,10 @@ impl TraceRecorder {
 
     /// Returns the sorted field-name set of every matching event, in arrival
     /// order — for asserting which fields appear together on one event.
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "shared test helper: this per-event field-name-set accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
+    )]
     #[must_use]
     pub fn field_name_sets(&self) -> Vec<Vec<String>> {
         self.state

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -38,7 +38,10 @@ struct CounterApp {
 
 #[derive(Debug, Clone)]
 enum CounterMessage {
-    #[allow(dead_code)]
+    #[allow(
+        dead_code,
+        reason = "this message variant completes the enum for the test app but is never constructed in this test"
+    )]
     Increment,
 }
 
@@ -147,7 +150,10 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
         fn new((): ()) -> (Self, Command<Message>) {
             let cmd = Command::future(async {
                 panic!("boom");
-                #[allow(unreachable_code)]
+                #[allow(
+                    unreachable_code,
+                    reason = "the preceding panic! diverges, so this trailing expression that types the async block is unreachable"
+                )]
                 Message::Quit
             });
 


### PR DESCRIPTION
## Summary

Enable the `allow_attributes_without_reason` clippy restriction lint in `Cargo.toml` so every `#[allow(...)]` must document *why* the allow is warranted.

Because CI runs `cargo clippy --all-targets --all-features -- -D warnings`, turning the lint on requires a `reason = "..."` on every existing allow. This PR backfills all of them (41 attributes across `src/`, `tests/`, `benches/`, and `examples/`). Multi-line allow blocks that already carried a reason are untouched.

Each reason states the concrete condition being allowed rather than filler, e.g.:
- feature/test-only `dead_code` scaffolding (`http` cell path, loom-only `cell_core` mirror, shared test helpers)
- deliberately-held drop guards (`significant_drop_tightening`, RFC 0006 §4.4)
- sanctioned real wall-clock reads in benches (`disallowed_methods`, RFC 0009 §3.1)
- async test fixtures that must return a future for `Command::perform` despite no `.await` (`unused_async`)
- structs modeling several independent boolean inputs (`struct_excessive_bools`)

## Notes

- No behavior change; docs/reasons only plus the one lint line.
- While backfilling, eight `#[allow(dead_code)]` in `src/subscription/http/cell.rs` were found to be reachable via the re-exported `Query`/`QueryClient` chain and thus arguably redundant today. They were left in place (reasons describe the narrow http-feature/test usage truthfully); pruning them is a separate cleanup.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)