### PR TITLE
chore(lints): enable clippy allow_attributes, migrate allow to expect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ similar_names = "allow"
 
 # Enable some restriction lints
 absolute_paths = "warn"
+allow_attributes = "warn"
 allow_attributes_without_reason = "warn"
 cognitive_complexity = "warn"
 mod_module_files = "warn"

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -69,7 +69,7 @@
 
 // Metric reporting converts counters and nanosecond values to floating point
 // for human-readable output; precision loss there is irrelevant.
-#![allow(
+#![expect(
     clippy::cast_precision_loss,
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
@@ -214,7 +214,7 @@ struct QuitScenarioCfg {
     valid_trial: ValidTrial,
 }
 
-#[allow(clippy::too_many_lines, reason = "a flat table of scenario literals")]
+#[expect(clippy::too_many_lines, reason = "a flat table of scenario literals")]
 fn scenarios() -> Vec<ScenarioCfg> {
     vec![
         // Paced load well below consumer capacity: the baseline contract.
@@ -361,7 +361,7 @@ const QUIT_TRIALS: u32 = 200;
 /// (latency ~ drain time) is orders of magnitude above trial noise.
 const KEYED_QUIT_TRIALS: u32 = 20;
 
-#[allow(clippy::too_many_lines, reason = "a flat table of scenario literals")]
+#[expect(clippy::too_many_lines, reason = "a flat table of scenario literals")]
 fn quit_scenarios() -> Vec<QuitScenarioCfg> {
     // All quit scenarios use the overload update cost (25µs) so the backlog
     // drains slowly (~38k msg/s on the reference machine) and the depth at
@@ -595,7 +595,7 @@ impl Subscriber for QuitDeliverySubscriber {
     // suggestion — would let a concurrent stale gauge event interleave its store
     // between the check and the apply, the exact reorder the `seq` ordering
     // exists to defeat (RFC 0006 §4.4).
-    #[allow(
+    #[expect(
         clippy::significant_drop_tightening,
         reason = "the gauge high-water guard is deliberately held across the value stores so \"advance and apply\" is one step; tightening it would let a concurrent stale gauge event interleave a store between the check and the apply (RFC 0006 §4.4)"
     )]
@@ -770,7 +770,7 @@ impl Metrics {
     // Real wall-clock reads: RFC 0006's statistical acceptance criteria are
     // defined on real time, the one sanctioned exception to the
     // single-time-source rule (RFC 0009 §3.1).
-    #[allow(
+    #[expect(
         clippy::disallowed_methods,
         reason = "calls std Instant::now to stamp the real wall-clock baseline; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
     )]
@@ -811,7 +811,7 @@ impl Metrics {
         produced.saturating_sub(processed)
     }
 
-    #[allow(
+    #[expect(
         clippy::disallowed_methods,
         reason = "calls std Instant::elapsed to read real wall-clock elapsed time; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
     )]
@@ -819,7 +819,7 @@ impl Metrics {
         u64::try_from(self.start.elapsed().as_nanos()).unwrap_or(u64::MAX)
     }
 
-    #[allow(
+    #[expect(
         clippy::disallowed_methods,
         reason = "calls std Instant::elapsed to measure real wall-clock message latency; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
     )]
@@ -849,7 +849,7 @@ impl SubscriptionSource for FloodSource {
     type Output = Msg;
     type Key = u32;
 
-    #[allow(
+    #[expect(
         clippy::disallowed_methods,
         reason = "calls std Instant::now to stamp each message's send time and Instant::elapsed to record when the producer finishes, both real wall-clock reads; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
     )]
@@ -907,7 +907,7 @@ impl Application for LoadApp {
     type Message = Msg;
     type Flags = (ScenarioCfg, Arc<Metrics>);
 
-    #[allow(
+    #[expect(
         clippy::disallowed_methods,
         reason = "calls std Instant::now to stamp each keyed-probe send time, a real wall-clock read; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
     )]
@@ -1029,7 +1029,7 @@ impl Application for LoadApp {
 }
 
 /// Busy-waits for `duration` to simulate CPU-bound work on the runtime task.
-#[allow(
+#[expect(
     clippy::disallowed_methods,
     reason = "calls std Instant::now to busy-wait against a real wall-clock deadline while simulating CPU-bound work; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
 )]
@@ -1062,7 +1062,7 @@ struct Report {
     seq_broken: bool,
 }
 
-#[allow(
+#[expect(
     clippy::disallowed_methods,
     reason = "calls std Instant::now and Instant::elapsed to measure the scenario's real wall-clock duration; RFC 0006's acceptance criteria are defined on real time, the sanctioned single-time-source exception (RFC 0009 §3.1)"
 )]

--- a/examples/panic_hook.rs
+++ b/examples/panic_hook.rs
@@ -54,7 +54,7 @@ impl Application for PanicDemo {
         match msg {
             Message::Terminal(Event::Key(key)) => match key.code {
                 // Intentionally panic to demonstrate terminal recovery.
-                #[allow(clippy::panic, reason = "demonstrating panic recovery")]
+                #[expect(clippy::panic, reason = "demonstrating panic recovery")]
                 KeyCode::Char('p') => panic!("intentional panic triggered by 'p'"),
                 // Quit normally.
                 KeyCode::Char('q') => Command::quit(),

--- a/examples/views.rs
+++ b/examples/views.rs
@@ -250,10 +250,6 @@ impl App {
 }
 
 /// Handle keyboard events based on current view
-#[allow(
-    clippy::use_self,
-    reason = "the example names the concrete View and Command<Message> types explicitly for reader clarity rather than Self"
-)]
 fn handle_key_event(view: &View, key: KeyEvent) -> Command<Message> {
     match view {
         View::Menu { .. } => match key.code {

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -1258,7 +1258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform() {
-        #[allow(
+        #[expect(
             clippy::unused_async,
             reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
         )]
@@ -1276,7 +1276,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform_with_result() {
-        #[allow(
+        #[expect(
             clippy::unused_async,
             reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
         )]
@@ -1389,7 +1389,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_perform_with_error_handling() {
-        #[allow(
+        #[expect(
             clippy::unused_async,
             reason = "fixture must be async to produce a future for Command::perform even though it awaits nothing"
         )]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -74,7 +74,7 @@ mod tests {
     // Running multiple hook-swapping tests in parallel would let them clobber
     // each other's hooks, so both properties are asserted here in one go.
     #[test]
-    #[allow(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
     fn test_compose_hook_restores_then_delegates_once() {
         // Serialize against other tests that touch the global panic hook or
         // panic, so a concurrent panic cannot invoke our recording hook.

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -226,7 +226,7 @@ mod tests {
 
     /// Polls a fresh `send` future exactly once and asserts it resolved without
     /// suspending, returning the send result.
-    #[allow(
+    #[expect(
         clippy::panic,
         reason = "a suspended send is the failure this helper reports"
     )]

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -1035,7 +1035,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    #[allow(clippy::panic, reason = "the command intentionally panics")]
+    #[expect(clippy::panic, reason = "the command intentionally panics")]
     async fn keyed_task_panic_is_logged() {
         let recorder = TraceRecorder::new()
             .with_target("tears::runtime")
@@ -1049,7 +1049,7 @@ mod tests {
                 CancelPolicy::CancelInFlight,
                 command_stream(Command::future(async {
                     panic!("boom");
-                    #[allow(
+                    #[expect(
                         unreachable_code,
                         reason = "the value follows an unconditional panic! that never returns, but types the async block"
                     )]

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -888,7 +888,7 @@ mod tests {
 
         fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
-        #[allow(
+        #[expect(
             clippy::panic,
             clippy::manual_assert,
             reason = "the subscriber intentionally panics on its first event"

--- a/src/subscription/http.rs
+++ b/src/subscription/http.rs
@@ -57,7 +57,10 @@
 
 #[cfg(feature = "http")]
 mod cell;
-#[cfg(feature = "loom-core")]
+// `loom-core` is a test-only feature (its `CellCore` mirror is exercised solely
+// by the `#[cfg(test)]` loom model checks), so gate the module on `test` too:
+// a non-test `--all-features` build would otherwise compile it with no callers.
+#[cfg(all(feature = "loom-core", test))]
 mod cell_core;
 #[cfg(feature = "http")]
 mod config;

--- a/src/subscription/http/cell.rs
+++ b/src/subscription/http/cell.rs
@@ -20,10 +20,6 @@ pub(super) trait AnyCell: Any + Send + Sync + 'static {
     fn gc_inactive_data_and_should_evict(&self, cache_time: Duration) -> bool;
 }
 
-#[allow(
-    dead_code,
-    reason = "query cell is constructed only through the http feature's Query/QueryClient runtime path and the module tests"
-)]
 pub(super) struct Cell<T> {
     state: Mutex<CellState<T>>,
     tx: watch::Sender<QueryResult<T>>,
@@ -40,10 +36,6 @@ struct CellLifecycle {
     inactive_since: Option<Instant>,
 }
 
-#[allow(
-    dead_code,
-    reason = "subscription handle is constructed only by the http query runtime and exercised by the module tests"
-)]
 pub(super) struct CellSubscription<T>
 where
     T: Clone + Send + Sync + 'static,
@@ -56,10 +48,6 @@ where
 }
 
 #[derive(Debug)]
-#[allow(
-    dead_code,
-    reason = "inner cell state is populated and read only through the http cell's reconcile/complete/snapshot paths"
-)]
 struct CellState<T> {
     data: Option<T>,
     error: Option<QueryError>,
@@ -76,10 +64,6 @@ impl<T> Cell<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    #[allow(
-        dead_code,
-        reason = "constructor is reached only via new_subscribed on the http query path and the module tests"
-    )]
     pub(super) fn new() -> Self {
         let result = QueryResult::pending(FetchStatus::Idle);
         let (tx, _) = watch::channel(result);
@@ -104,10 +88,6 @@ where
         }
     }
 
-    #[allow(
-        dead_code,
-        reason = "used only by the http query client's cell-creation path and the module tests"
-    )]
     pub(super) fn new_subscribed() -> (Arc<Self>, CellSubscription<T>) {
         let cell = Arc::new(Self::new());
         {
@@ -126,10 +106,6 @@ where
         (cell, subscription)
     }
 
-    #[allow(
-        dead_code,
-        reason = "extra-subscriber path used only by the http query runtime and the module tests"
-    )]
     pub(super) fn subscribe(self: &Arc<Self>) -> CellSubscription<T> {
         {
             let mut lifecycle = self
@@ -147,10 +123,9 @@ where
         }
     }
 
-    #[allow(
-        dead_code,
-        reason = "read only by the module's cfg(test) GC tests, so non-test http builds see no caller"
-    )]
+    // Read only by the module's `#[cfg(test)]` GC tests; gate it on `test` so a
+    // non-test build has no unused method rather than an allow to suppress one.
+    #[cfg(test)]
     pub(super) fn snapshot(&self, config: &QueryConfig) -> QueryResult<T> {
         self.state
             .lock()
@@ -294,7 +269,7 @@ impl<T> CellSubscription<T>
 where
     T: Clone + Send + Sync + 'static,
 {
-    #[allow(
+    #[expect(
         dead_code,
         reason = "shared-borrow accessor kept for symmetry with receiver_mut; the stream only needs the mutable accessor, so this one has no caller"
     )]
@@ -302,10 +277,6 @@ where
         &self.rx
     }
 
-    #[allow(
-        dead_code,
-        reason = "used only by the http subscription stream's watch_cell change-wait loop"
-    )]
     pub(super) const fn receiver_mut(&mut self) -> &mut watch::Receiver<QueryResult<T>> {
         &mut self.rx
     }
@@ -411,10 +382,6 @@ impl<T> CellState<T>
 where
     T: Clone,
 {
-    #[allow(
-        dead_code,
-        reason = "invoked only through the http cell's reconcile/complete/snapshot paths"
-    )]
     fn snapshot(&self, config: &QueryConfig) -> QueryResult<T> {
         let is_stale = self.data.is_some()
             && (self.data_generation < Some(self.current_generation)

--- a/src/subscription/http/cell_core.rs
+++ b/src/subscription/http/cell_core.rs
@@ -22,17 +22,9 @@
 
 use loom::sync::atomic::{AtomicU64, Ordering};
 
-#[allow(
-    dead_code,
-    reason = "sentinel is read only by CellCore, the loom-only test mirror, so a non-test loom-core build has no reader"
-)]
 const NONE: u64 = u64::MAX;
 
-#[allow(
-    dead_code,
-    reason = "loom-only concurrency mirror constructed only by its own cfg(test) loom model tests"
-)]
-#[allow(
+#[expect(
     clippy::struct_field_names,
     reason = "the three generation counters intentionally share the _generation suffix to mirror Cell's state fields"
 )]
@@ -43,10 +35,6 @@ pub(super) struct CellCore {
     last_error_generation: AtomicU64,
 }
 
-#[allow(
-    dead_code,
-    reason = "all methods are exercised only by the cfg(test) loom model tests, so a non-test loom-core build sees them as unused"
-)]
 impl CellCore {
     pub(super) fn new() -> Self {
         Self {

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -280,10 +280,6 @@ impl QueryClient {
     }
 }
 
-#[allow(
-    dead_code,
-    reason = "generic downcast helper reached only from the cell-reuse (Occupied) branch, which dead-code analysis need not treat as instantiated"
-)]
 fn downcast_cell<T>(cell: Arc<dyn AnyCell>) -> Arc<Cell<T>>
 where
     T: Clone + Send + Sync + 'static,
@@ -1349,10 +1345,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(
-        clippy::too_many_lines,
-        reason = "exhaustive async test walks a full invalidation-and-refetch coalescing scenario step by step"
-    )]
     async fn test_invalidations_during_one_fetch_window_coalesce_to_one_refetch() {
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));

--- a/src/subscription/http/reconcile.rs
+++ b/src/subscription/http/reconcile.rs
@@ -9,7 +9,7 @@ pub(super) enum ReconcileReason {
 }
 
 /// Snapshot of the state needed to decide whether reconcile should fetch.
-#[allow(
+#[expect(
     clippy::struct_excessive_bools,
     reason = "struct models several independent boolean fetch-decision inputs, not a single state better expressed as an enum"
 )]

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -233,7 +233,7 @@ impl SubscriptionSource for WebSocket {
     type Output = WebSocketMessage;
     type Key = String;
 
-    #[allow(
+    #[expect(
         clippy::too_many_lines,
         reason = "the WebSocket connection state machine is expressed as one stream::unfold with every transition inline"
     )]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -29,10 +29,6 @@ pub struct TestApp {
 }
 
 #[derive(Debug, Clone)]
-#[allow(
-    dead_code,
-    reason = "shared test fixture whose variants are not all constructed by every test module that imports it"
-)]
 pub enum TestMessage {
     Increment,
     Quit,

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -57,7 +57,7 @@ impl Drop for SilentPanicHook {
 /// then resumed. Cancellation also restores the hook through the internal drop
 /// guard. This helper is for `current_thread` tests because it holds
 /// [`PANIC_HOOK_GUARD`] across `.await`.
-#[allow(
+#[expect(
     clippy::await_holding_lock,
     clippy::future_not_send,
     reason = "the helper intentionally serializes a process-global hook across a current-thread future"
@@ -93,7 +93,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "current_thread")]
-    #[allow(
+    #[expect(
         clippy::await_holding_lock,
         clippy::panic,
         reason = "the test verifies hook restoration across an intentional panic on one thread"

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -230,7 +230,7 @@ where
     finished: bool,
 }
 
-#[allow(
+#[expect(
     clippy::panic,
     reason = "assertion failures in a test harness are panics by design"
 )]
@@ -380,7 +380,7 @@ where
     /// quit request (assert that with [`receive_quit`](Self::receive_quit)),
     /// if nothing is deliverable, or if quit has already been observed.
     #[track_caller]
-    #[allow(
+    #[expect(
         clippy::needless_pass_by_value,
         reason = "the expected value is consumed by the assertion (RFC 0008 §2.1)"
     )]

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -1,3 +1,14 @@
+//! Shared tracing test recorder, included via `#[path]` into several
+//! integration-test targets. Each accessor is exercised by some targets and not
+//! others, so any given method reads as dead code in the targets that never
+//! call it. `#[expect(dead_code)]` cannot express that (it would be unfulfilled
+//! in the targets that *do* use the method), so the whole helper opts out of
+//! `dead_code` at the module level.
+#![allow(
+    dead_code,
+    reason = "shared cross-target test helper; per-target usage varies (see module docs)"
+)]
+
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -74,10 +85,6 @@ impl TraceRecorder {
     ///
     /// `#[path]` compiles this helper per integration-test target, so methods
     /// used by one test target can be dead code in another.
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this level filter builder is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub const fn with_level(mut self, level: Level) -> Self {
         self.filter.level = Some(level);
@@ -97,20 +104,12 @@ impl TraceRecorder {
     }
 
     /// Returns the number of events that matched this recorder's filter.
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this matched-event-count accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub fn event_count(&self) -> usize {
         self.state.events.load(Ordering::SeqCst)
     }
 
     /// Returns all bool values recorded for the named event field.
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this bool-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub fn bool_values(&self, field: &str) -> Vec<bool> {
         self.state
@@ -124,10 +123,6 @@ impl TraceRecorder {
 
     /// Returns all unsigned-integer values recorded for the named event field
     /// (covers `u64` and `usize` fields).
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this unsigned-integer-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub fn u64_values(&self, field: &str) -> Vec<u64> {
         self.state
@@ -140,10 +135,6 @@ impl TraceRecorder {
     }
 
     /// Returns all string values recorded for the named event field.
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this string-field accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub fn str_values(&self, field: &str) -> Vec<String> {
         self.state
@@ -157,10 +148,6 @@ impl TraceRecorder {
 
     /// Returns the sorted field-name set of every matching event, in arrival
     /// order — for asserting which fields appear together on one event.
-    #[allow(
-        dead_code,
-        reason = "shared test helper: this per-event field-name-set accessor is used by some integration-test targets but not all, so it reads as dead in targets that never call it"
-    )]
     #[must_use]
     pub fn field_name_sets(&self) -> Vec<Vec<String>> {
         self.state

--- a/tests/runtime_run.rs
+++ b/tests/runtime_run.rs
@@ -38,7 +38,7 @@ struct CounterApp {
 
 #[derive(Debug, Clone)]
 enum CounterMessage {
-    #[allow(
+    #[expect(
         dead_code,
         reason = "this message variant completes the enum for the test app but is never constructed in this test"
     )]
@@ -131,7 +131,7 @@ async fn test_runtime_run_end_to_end_basic() -> Result<()> {
 }
 
 #[tokio::test(flavor = "current_thread")]
-#[allow(
+#[expect(
     clippy::panic,
     reason = "the test intentionally panics inside a command"
 )]
@@ -150,7 +150,7 @@ async fn test_runtime_run_logs_command_task_panic() -> Result<()> {
         fn new((): ()) -> (Self, Command<Message>) {
             let cmd = Command::future(async {
                 panic!("boom");
-                #[allow(
+                #[expect(
                     unreachable_code,
                     reason = "the preceding panic! diverges, so this trailing expression that types the async block is unreachable"
                 )]


### PR DESCRIPTION
## Summary

Enable the `allow_attributes` clippy restriction lint and replace every `#[allow(...)]` with `#[expect(...)]`. `#[expect]` warns when the suppressed lint *stops* firing, so a suppression that is no longer needed is surfaced instead of lingering silently. Follow-up to #259 (which added `reason` to every allow).

## What the migration surfaced

Converting `allow` → `expect` immediately flagged 19 **unfulfilled expectations** — suppressions that no longer matched any lint, plus a few cases `#[expect]` structurally cannot express. Each was handled at the root rather than papered over:

- **Redundant suppressions removed (16).** Several `#[allow(dead_code)]` (plus one `too_many_lines` and one `use_self`) matched no lint anymore — e.g. the `http` cell types are reached through the re-exported `Query`/`QueryClient` path, so they were never dead. `#[expect]` made this visible; the attributes are simply deleted.
- **`CellCore` (`cell_core.rs`) — gated on `test`.** It is a loom-only test mirror behind the test-only `loom-core` feature. `mod cell_core` was `#[cfg(feature = "loom-core")]`, so a non-test `--all-features` build compiled it with no callers. Changed to `#[cfg(all(feature = "loom-core", test))]` — no dead_code suppression needed at all.
- **`Cell::snapshot` — gated on `test`.** Read only by `#[cfg(test)]` GC tests, so `#[cfg(test)]` on the method removes the dead code instead of suppressing it.
- **`tests/common/trace_recorder.rs` — module-level allow.** This shared helper is compiled into several integration-test targets via `#[path]`; a given accessor is used by some targets and dead in others. `#[expect(dead_code)]` cannot express that (it would be *unfulfilled* in the targets that use the method), so the module opts out with a single reasoned `#![allow(dead_code)]` — the idiomatic shared-test-helper form. `allow_attributes` does not flag inner (`#![...]`) attributes.

Net result: zero outer `#[allow]`, one documented module-level `#![allow]`, and 32 `#[expect]`.

## Notes

- No behavior change; attributes, one lint line, and two `#[cfg(test)]`/`test` gates on internal (`mod` / `pub(super)`) items. Public API surface unchanged.

## Verification

- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo clippy --all-targets -- -D warnings` (default features) ✅
- `cargo fmt --check` ✅
- Loom job: `RUSTFLAGS=--cfg loom cargo test --features loom-core --lib -- cell_core` ✅ (4 passed)
- `cargo test --all-features` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)