### PR TITLE
docs(examples): add TestStore tests and a Testing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,41 @@ cargo run --example websocket --features ws,rustls
 cargo run --example http_todo --features http
 ```
 
+## Testing Your Application
+
+`tears::testing::TestStore` drives an `Application`'s `update` transitions and
+command effects synchronously and deterministically, with no wall-clock waiting.
+A test constructs the store from the application's flags, scripts messages with
+`send`, moves virtual time with `advance`, asserts effect output with
+`receive`/`receive_matching`/`receive_quit`, and closes the run with `finish`
+(which fails the test if any deliverable output or unfinished effect is left
+unaccounted for). Assertions are exhaustive by design.
+
+```rust,ignore
+use tears::testing::TestStore;
+
+let mut store = TestStore::<App>::new(flags);
+store.send(some_message);
+store.advance(Duration::from_millis(200)); // move a Command::timeout deadline
+store.receive_matching(|msg| matches!(msg, Message::Loaded(_)));
+store.finish();
+```
+
+`TestStore` is constructed on a plain `#[test]` (never `#[tokio::test]`; it owns
+its own paused time context) and does not execute subscription sources — it
+observes only the *declared* set via `subscription_ids`. See the
+[`tears::testing`](https://docs.rs/tears/latest/tears/testing/) module docs for
+the full contract, including deterministic time without `TestStore`. Worked,
+runnable tests ship with the command examples:
+
+```bash
+cargo test --example command_timeout_retry
+cargo test --example command_cancellation
+cargo test --example dashboard
+```
+
+Repository-wide test conventions live in [docs/testing.md](docs/testing.md).
+
 ## Optional Features
 
 Tears supports optional features that can be enabled in your `Cargo.toml`:

--- a/examples/command_cancellation.rs
+++ b/examples/command_cancellation.rs
@@ -251,3 +251,82 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
+/// Deterministic tests for this example's keyed-cancellation logic, driven by
+/// `tears::testing::TestStore` (RFC 0008). The store honors the same
+/// `CancelPolicy` admission the runtime does, so a superseded or explicitly
+/// cancelled search produces no output. The 400ms search delay is crossed with
+/// `advance`, never the wall clock; run them with
+/// `cargo test --example command_cancellation`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tears::testing::TestStore;
+
+    const SEARCH_DELAY: Duration = Duration::from_millis(400);
+
+    /// Builds the `Input` message a character keystroke would produce.
+    fn press(c: char) -> Message {
+        Message::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char(c),
+            KeyModifiers::empty(),
+        )))
+    }
+
+    /// Builds the `Input` message a non-character key would produce.
+    fn key(code: KeyCode) -> Message {
+        Message::Input(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
+    }
+
+    /// Under the default `CancelInFlight` policy, a second keystroke aborts the
+    /// first search, so only the most recently typed query ever delivers a
+    /// result and the store finishes with no orphaned effect.
+    #[test]
+    fn cancel_in_flight_delivers_only_the_latest_query() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(press('r')); // starts a search for "r"
+        store.send(press('u')); // supersedes it with a search for "ru"
+
+        store.advance(SEARCH_DELAY);
+        store.receive_matching(
+            |msg| matches!(msg, Message::SearchFinished { query, .. } if query == "ru"),
+        );
+        store.finish();
+    }
+
+    /// Under `KeepInFlight`, the running search is preserved and the newer
+    /// command is dropped, so the delivered result lags behind the typed query.
+    #[test]
+    fn keep_in_flight_preserves_the_running_search() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(key(KeyCode::Tab)); // switch to KeepInFlight
+        assert_eq!(store.state().policy, CancelPolicy::KeepInFlight);
+
+        store.send(press('r')); // starts a search for "r"
+        store.send(press('u')); // dropped; the "r" search keeps running
+
+        store.advance(SEARCH_DELAY);
+        store.receive_matching(
+            |msg| matches!(msg, Message::SearchFinished { query, .. } if query == "r"),
+        );
+        assert_eq!(store.state().query, "ru");
+        store.finish();
+    }
+
+    /// Pressing Esc issues an explicit `Command::cancel`, which removes the
+    /// in-flight search leaf without polling it, so advancing past the search
+    /// delay delivers nothing.
+    #[test]
+    fn esc_cancels_the_in_flight_search() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(press('r'));
+        store.send(key(KeyCode::Esc));
+        assert!(store.state().query.is_empty());
+
+        store.advance(SEARCH_DELAY);
+        store.finish();
+    }
+}

--- a/examples/command_timeout_retry.rs
+++ b/examples/command_timeout_retry.rs
@@ -231,3 +231,102 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
+/// Deterministic tests for this example's timeout and retry logic, driven by
+/// `tears::testing::TestStore` (RFC 0008). Every time-dependent command effect
+/// is moved forward with `advance`, so nothing waits on the wall clock; run
+/// them with `cargo test --example command_timeout_retry`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tears::testing::TestStore;
+
+    /// Builds the `Input` message a keystroke would produce, so a test can
+    /// script the same commands the terminal subscription feeds at runtime.
+    fn press(c: char) -> Message {
+        Message::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char(c),
+            KeyModifiers::empty(),
+        )))
+    }
+
+    /// A fetch that finishes before its deadline delivers its data, and the
+    /// timeout leaf that guarded it is driven to completion with nothing left
+    /// over.
+    #[test]
+    fn fast_fetch_completes_before_deadline() {
+        let mut store = TestStore::<App>::new(());
+
+        // 'f' starts `perform(fetch(200ms)).timeout(1s)`. The fetch is pending
+        // until virtual time reaches its 200ms sleep.
+        store.send(press('f'));
+        store.advance(Duration::from_millis(200));
+
+        store.receive_matching(|msg| matches!(msg, Message::Loaded(data) if data == "fast data"));
+        assert_eq!(store.state().log.last().unwrap(), "Loaded: fast data");
+        store.finish();
+    }
+
+    /// A fetch slower than its deadline delivers the timeout message and never
+    /// the (still-sleeping) data.
+    #[test]
+    fn slow_fetch_times_out() {
+        let mut store = TestStore::<App>::new(());
+
+        // 's' starts `perform(fetch(3s)).timeout(800ms)`. Advancing to the
+        // deadline fires the timeout before the inner fetch can finish.
+        store.send(press('s'));
+        store.advance(Duration::from_millis(800));
+
+        store.receive_matching(|msg| matches!(msg, Message::TimedOut));
+        assert_eq!(
+            store.state().log.last().unwrap(),
+            "Timed out before the deadline"
+        );
+        store.finish();
+    }
+
+    /// A flaky operation that fails twice then succeeds recovers on its third
+    /// attempt. Each 200ms attempt and each 300ms fixed backoff is a separate
+    /// virtual-time wait the retry leaf registers only after the previous one
+    /// is observed, so the test crosses them one `advance` at a time.
+    #[test]
+    fn retry_recovers_after_two_failures() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(press('r'));
+        store.advance(Duration::from_millis(200)); // attempt 1 fails
+        store.advance(Duration::from_millis(300)); // backoff before attempt 2
+        store.advance(Duration::from_millis(200)); // attempt 2 fails
+        store.advance(Duration::from_millis(300)); // backoff before attempt 3
+        store.advance(Duration::from_millis(200)); // attempt 3 succeeds
+
+        store.receive_matching(|msg| {
+            matches!(msg, Message::RetryFinished(Ok(data)) if data.contains("recovered on attempt 3"))
+        });
+        store.finish();
+    }
+
+    /// A retry policy that runs out of attempts delivers the final error, and
+    /// the reported attempt count matches the policy's limit.
+    #[test]
+    fn retry_gives_up_after_exhausting_attempts() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(press('x'));
+        store.advance(Duration::from_millis(200)); // attempt 1 fails
+        store.advance(Duration::from_millis(300)); // backoff before attempt 2
+        store.advance(Duration::from_millis(200)); // attempt 2 fails, none left
+
+        store.receive_matching(|msg| matches!(msg, Message::RetryFinished(Err(_))));
+        assert!(
+            store
+                .state()
+                .log
+                .last()
+                .unwrap()
+                .starts_with("Retry gave up after 2 attempt(s)")
+        );
+        store.finish();
+    }
+}

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -622,3 +622,93 @@ async fn main() -> Result<()> {
 
     Ok(())
 }
+
+/// Deterministic tests for this example's structured `update` logic, driven by
+/// `tears::testing::TestStore` (RFC 0008). This example's transitions are pure
+/// — most produce `Command::none()`, and the key handler produces follow-up
+/// messages via `Command::message` — so the store needs no virtual time here;
+/// run them with `cargo test --example dashboard`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+    use tears::testing::TestStore;
+
+    /// Builds the `Terminal` message a keystroke would produce, so a test can
+    /// exercise the same `handle_key_event` path the subscription feeds.
+    fn key(code: KeyCode) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
+    }
+
+    /// Sending the child message directly walks focus through the panels.
+    #[test]
+    fn focus_next_cycles_through_panels() {
+        let mut store = TestStore::<App>::new(());
+        assert_eq!(store.state().focus, Focus::Navigation);
+
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Tasks);
+
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+        store.finish();
+    }
+
+    /// A key event is dispatched through `handle_key_event`, whose returned
+    /// `Command::message(FocusNext)` the store delivers as the next message.
+    #[test]
+    fn tab_key_emits_focus_next() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(key(KeyCode::Tab));
+        store.receive_matching(|msg| matches!(msg, Message::FocusNext));
+
+        assert_eq!(store.state().focus, Focus::Tasks);
+        store.finish();
+    }
+
+    /// Toggling the selected task flips its `done` flag and records an activity
+    /// entry.
+    #[test]
+    fn toggle_marks_selected_task_done() {
+        let mut store = TestStore::<App>::new(());
+        assert!(!store.state().tasks.tasks[0].done);
+        let activity_before = store.state().activity.entries.len();
+
+        store.send(Message::Tasks(TaskMessage::Toggle));
+
+        assert!(store.state().tasks.tasks[0].done);
+        assert_eq!(store.state().activity.entries.len(), activity_before + 1);
+        store.finish();
+    }
+
+    /// Adding a task then deleting it returns to the original count while the
+    /// id counter keeps advancing.
+    #[test]
+    fn add_then_delete_returns_to_original_count() {
+        let mut store = TestStore::<App>::new(());
+        assert_eq!(store.state().tasks.tasks.len(), 3);
+        assert_eq!(store.state().tasks.next_id, 4);
+
+        store.send(Message::Tasks(TaskMessage::Add));
+        assert_eq!(store.state().tasks.tasks.len(), 4);
+
+        store.send(Message::Tasks(TaskMessage::Delete));
+        assert_eq!(store.state().tasks.tasks.len(), 3);
+        assert_eq!(store.state().tasks.next_id, 5);
+        store.finish();
+    }
+
+    /// Pressing 'q' asks the key handler for a `Quit` message, whose `update`
+    /// returns `Command::quit()`; the store observes both the message and the
+    /// quit request.
+    #[test]
+    fn quit_key_requests_shutdown() {
+        let mut store = TestStore::<App>::new(());
+
+        store.send(key(KeyCode::Char('q')));
+        store.receive_matching(|msg| matches!(msg, Message::Quit));
+        store.receive_quit();
+        store.finish();
+    }
+}


### PR DESCRIPTION
## Summary

Documents deterministic testing with `tears::testing::TestStore` (RFC 0008) by adding worked, runnable tests to the examples whose subject matter the store actually covers — command effects and pure `update` transitions — plus a README section that points downstream users at the API.

Rationale: `examples/` entries are runnable binaries, so a test harness has no natural `main`; the runnable-snippet home for the API itself already exists (the `tears::testing` module doctest). Co-locating tests with existing examples instead demonstrates the value proposition directly and makes the examples themselves verified.

## Changes

- **`command_timeout_retry`** (4 tests): fast fetch before deadline, slow fetch timing out, retry recovering after two failures, retry exhausting its attempts. Each `Command::timeout` deadline and retry backoff is crossed with `advance` — no wall-clock waiting.
- **`command_cancellation`** (3 tests): `CancelInFlight` delivering only the latest query, `KeepInFlight` preserving the running search, and explicit `Command::cancel` on Esc — each asserting a superseded or cancelled search produces no output (cancellation parity).
- **`dashboard`** (5 tests): structured `update` logic, the `Command::message` follow-up delivery path via `receive_matching`, and `receive_quit`.
- **`README`**: new "Testing Your Application" section covering the basic `TestStore` flow, the plain-`#[test]` / no-subscription-execution scope, links to the `tears::testing` module docs and `docs/testing.md`, and the `cargo test --example` commands.

`counter`'s headline is a Timer subscription, which `TestStore` does not execute, so it is intentionally left out of the introductory tests.

## Verification

- `cargo test --example command_timeout_retry --example command_cancellation --example dashboard` — 12 tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)