### PR TITLE
refactor(runtime)!: remove Copy derive from RuntimeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** `RuntimeConfig` is `Clone` but no longer `Copy`; `Debug`, `Eq`,
+  and `PartialEq` remain, and `FrameRate` keeps its `Copy` (RFC 0007 §2.1)
+  - The type is the aggregation point for future runtime knobs, so a `Copy`
+    config would turn the first non-`Copy` field added later into a breaking
+    derive removal deferred onto whoever adds it; taking the removal now, while
+    the config is small, keeps that growth non-breaking
+  - The consuming setters now move the configuration, so discarding a setter's
+    return value and then using the original is a compile error rather than a
+    silent stale read
+  - Code that relied on the implicit copy adds an explicit `clone()`
+
+  Before:
+
+  ```rust
+  let config = RuntimeConfig::new(frame_rate);
+  let bounded = config.app_channel_capacity(capacity);
+  let runtime = Runtime::<MyApp>::with_config((), config);
+  ```
+
+  After:
+
+  ```rust
+  let config = RuntimeConfig::new(frame_rate);
+  let bounded = config.clone().app_channel_capacity(capacity);
+  let runtime = Runtime::<MyApp>::with_config((), config);
+  ```
+
 ## [0.10.2] - 2026-07-26
 
 ### Fixed

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -260,6 +260,10 @@ impl<App: Application> Runtime<App> {
     /// let runtime = Runtime::<MyApp>::with_config((), config);
     /// ```
     #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "RFC 0007 §2.2 pins the by-value signature"
+    )]
     pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self {
         // The single channel-construction path (RFC 0006 INV-L6): unset
         // capacities build the unchanged unbounded channels, `Some(n)` bound

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -262,7 +262,7 @@ impl<App: Application> Runtime<App> {
     #[must_use]
     #[expect(
         clippy::needless_pass_by_value,
-        reason = "RFC 0007 §2.2 pins the by-value signature"
+        reason = "RFC 0007 §2.2 pins the by-value signature; once a non-Copy field lands the lint stops firing and unfulfilled_lint_expectations forces this attribute out"
     )]
     pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self {
         // The single channel-construction path (RFC 0006 INV-L6): unset

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -32,8 +32,10 @@ use super::frame_rate::FrameRate;
 /// [`keyed_channel_capacity`](Self::keyed_channel_capacity),
 /// [`batch_max_messages`](Self::batch_max_messages)) opt into bounded delivery
 /// and follow the crate's combinator convention (like
-/// [`Command::timeout`](crate::Command::timeout)); each returns a modified
-/// copy and does not mutate in place.
+/// [`Command::timeout`](crate::Command::timeout)); each consumes the
+/// configuration and returns the modified value. `RuntimeConfig` is [`Clone`]
+/// but not [`Copy`], so a configuration reused after a setter call is cloned
+/// explicitly.
 ///
 /// There is deliberately no [`Default`] impl: the crate has no default frame
 /// rate, so a value would have to be invented inside the derive.
@@ -54,7 +56,7 @@ use super::frame_rate::FrameRate;
 ///     .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
 ///     .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"));
 /// ```
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RuntimeConfig {
     /// Target frame rate for the runtime's frame scheduler.
     pub(crate) frame_rate: FrameRate,
@@ -114,7 +116,7 @@ impl RuntimeConfig {
     /// producer gauges (`tears::runtime::load`, RFC 0006 §4.4) make that
     /// pattern visible; restructure the effect flow rather than resizing the
     /// channel (RFC 0006 §4.5).
-    #[must_use = "app_channel_capacity returns a modified config and does not mutate in place"]
+    #[must_use = "app_channel_capacity consumes the config and returns the modified value"]
     pub const fn app_channel_capacity(mut self, capacity: NonZeroUsize) -> Self {
         self.app_channel_capacity = Some(capacity);
         self
@@ -150,7 +152,7 @@ impl RuntimeConfig {
     /// quit buys suppression — a later cancel or supersede can still stop it —
     /// at the cost of waiting behind pending inputs under load
     /// (RFC 0006 §4.6).
-    #[must_use = "keyed_channel_capacity returns a modified config and does not mutate in place"]
+    #[must_use = "keyed_channel_capacity consumes the config and returns the modified value"]
     pub const fn keyed_channel_capacity(mut self, capacity: NonZeroUsize) -> Self {
         self.keyed_channel_capacity = Some(capacity);
         self
@@ -169,7 +171,7 @@ impl RuntimeConfig {
     /// The **documented recommendation is to leave this unset**: the 100µs time
     /// cap alone holds the frame branch stable under overload (RFC 0006 F5), so
     /// the count cap is a diagnostic knob, not a default (RFC 0007 §3.1).
-    #[must_use = "batch_max_messages returns a modified config and does not mutate in place"]
+    #[must_use = "batch_max_messages consumes the config and returns the modified value"]
     pub const fn batch_max_messages(mut self, max: NonZeroUsize) -> Self {
         self.batch_max_messages = Some(max);
         self
@@ -235,7 +237,7 @@ mod tests {
     }
 
     // INV-C2/INV-C6: the setters chain, each independently, and every setter
-    // returns a modified copy (`#[must_use]`) rather than mutating in place.
+    // returns the modified config (`#[must_use]`) rather than mutating in place.
     #[test]
     fn setters_chain_independently() {
         let config = RuntimeConfig::new(frame_rate(30))
@@ -249,12 +251,13 @@ mod tests {
         assert_eq!(config.batch_max_messages, Some(cap(4)));
     }
 
-    // INV-C3: a discarded setter call leaves the original value untouched
-    // (the consuming-call misuse guard the `#[must_use]` messages warn about).
+    // INV-C3: a setter called on a clone leaves the original untouched — the
+    // one discard shape that survives the move (the consuming-call misuse
+    // guard the `#[must_use]` messages warn about).
     #[test]
-    fn discarded_setter_leaves_original_unmodified() {
+    fn discarded_setter_on_a_clone_leaves_original_unmodified() {
         let config = RuntimeConfig::new(frame_rate(60));
-        let _ = config.app_channel_capacity(cap(1024));
+        let _ = config.clone().app_channel_capacity(cap(1024));
 
         assert_eq!(config.app_channel_capacity, None);
     }

--- a/src/runtime/config.rs
+++ b/src/runtime/config.rs
@@ -237,7 +237,7 @@ mod tests {
     }
 
     // INV-C2/INV-C6: the setters chain, each independently, and every setter
-    // returns the modified config (`#[must_use]`) rather than mutating in place.
+    // consumes the config and returns the modified value (`#[must_use]`).
     #[test]
     fn setters_chain_independently() {
         let config = RuntimeConfig::new(frame_rate(30))
@@ -251,14 +251,15 @@ mod tests {
         assert_eq!(config.batch_max_messages, Some(cap(4)));
     }
 
-    // INV-C3: a setter called on a clone leaves the original untouched — the
-    // one discard shape that survives the move (the consuming-call misuse
-    // guard the `#[must_use]` messages warn about).
+    // INV-C6: a setter called on a clone — the one discard shape that survives
+    // the move (the consuming-call misuse guard the `#[must_use]` messages
+    // warn about) — modifies only the clone and leaves the original untouched.
     #[test]
-    fn discarded_setter_on_a_clone_leaves_original_unmodified() {
+    fn setter_on_a_clone_modifies_only_the_clone() {
         let config = RuntimeConfig::new(frame_rate(60));
-        let _ = config.clone().app_channel_capacity(cap(1024));
+        let modified = config.clone().app_channel_capacity(cap(1024));
 
+        assert_eq!(modified.app_channel_capacity, Some(cap(1024)));
         assert_eq!(config.app_channel_capacity, None);
     }
 }


### PR DESCRIPTION
## Summary

Removes the `Copy` derive from `RuntimeConfig` — the only open deliverable of RFC 0007 (amended by the runtime-consolidation bundle, #270). `Clone`, `Debug`, `Eq`, `PartialEq` remain; `FrameRate` keeps its `Copy`.

Rationale (RFC 0007 §2.1): `RuntimeConfig` is the aggregation point for future runtime knobs, and a `Copy` config turns every future non-`Copy` field into a breaking derive removal deferred onto whoever adds it. Removing it now, on the 0.11.0 breaking budget while the config is small, keeps config growth non-breaking on this axis. As a side effect the consuming setters now move the config, so discarding a setter's return value and then using the original becomes a compile error instead of a silent stale read (the misuse guard's compile-time half, INV-C6).

## The four deliverables (RFC 0007 §2.1)

- (a) Derive change in `src/runtime/config.rs`.
- (b) Rustdoc updated from copy idioms to move-and-return builder wording: the struct doc's "returns a modified copy and does not mutate in place" and the three setters' `#[must_use]` messages. The sibling setters on `Command`/`RetryPolicy` keep the crate's older phrasing; harmonizing them is out of scope here.
- (c) Implicit-`Copy` inventory: exactly one site crate-wide — the `discarded_setter_leaves_original_unmodified` test, which relied on the implicit copy. Renamed to `discarded_setter_on_a_clone_leaves_original_unmodified` and migrated to the clone-discard shape §2.1 names as the surviving discard shape. Benches and the other tests already passed freshly constructed values.
- (d) Public-API diff (`cargo public-api`, working tree vs `main`): the only change is `impl core::marker::Copy for tears::RuntimeConfig` removed. The `api_surface` test job passes.

One addition outside the anticipated files: removing `Copy` makes `clippy::needless_pass_by_value` fire on `Runtime::with_config`. The suggested `&RuntimeConfig` would change the public signature RFC 0007 §2.2 pins, so it is suppressed with `#[expect(..., reason = "RFC 0007 §2.2 pins the by-value signature")]`, following the crate's existing suppression convention.

CHANGELOG: breaking `Changed` entry with a before/after migration example.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --bins --tests --examples --all-features`: 430 lib + 26 integration, 0 failed
- `cargo test --doc --all-features`: 51 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- MSRV `cargo +1.88.0 check --all-targets --all-features` clean
- `just bench-smoke`: all scenarios pass

RFC 0007's Accepted → Implemented status transition follows in a separate docs PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
