### PR TITLE
feat(runtime): add runtime_id to load gauge events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   let runtime = Runtime::<MyApp>::with_config((), config);
   ```
 
+- The `tears::runtime::load` producer-gauge event gained a `runtime_id` field —
+  the emitting runtime instance's process-local identifier, never reused within
+  the process — and the existing `seq` ordering counter (added in 0.10.1) is
+  now scoped per instance. The current value of each gauge is the value on the
+  greatest-`seq` event *among events carrying that `runtime_id`*, so a consumer
+  partitions by `runtime_id` first and never reads gauge events in arrival
+  order; the batch and capacity-wait events are unchanged and carry neither
+  field
+
 ## [0.10.2] - 2026-07-26
 
 ### Fixed

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -76,6 +76,7 @@
     reason = "metric reporting casts counters and nanosecond values to floating point for human-readable output; precision loss there is irrelevant"
 )]
 
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::process::ExitCode;
@@ -518,20 +519,19 @@ static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 /// scenario's slot.
 static LIVE_PRODUCERS: AtomicU64 = AtomicU64::new(0);
 
-/// The producer-gauge partition currently being read — the emitting runtime's
-/// `runtime_id` and the newest `seq` applied from it; `None` before the first
-/// gauge event (RFC 0006 §4.4). A gauge event's values reach [`LIVE_PRODUCERS`]
+/// Per-`runtime_id` high-water marks of the newest `seq` applied from each
+/// partition (RFC 0006 §4.4). A gauge event's values reach [`LIVE_PRODUCERS`]
 /// and [`Metrics::blocked_live`] only when its `seq` advances the high-water
 /// mark *of its own `runtime_id`*, so a reordered stale gauge event never
 /// supersedes the current value — the schema orders gauge events by `seq` within
 /// a `runtime_id`, never by arrival, and comparing `seq` across instances is
-/// meaningless. An event from a different `runtime_id` therefore opens a fresh
-/// partition rather than being ranked against the old one: scenarios run one
-/// runtime at a time behind [`await_quiescence`], so that is the next runtime
-/// taking over. It is a `Mutex`, not an atomic, so the advance and the value
-/// stores it guards happen as one step even if a future runtime dispatches gauge
-/// events off several producer threads at once.
-static GAUGE_PARTITION_SEEN: Mutex<Option<(u64, u64)>> = Mutex::new(None);
+/// meaningless. Keeping a mark per id (rather than only the newest partition)
+/// makes that hold structurally even for a straggler from an already-drained
+/// runtime; the runs never contend anyway, since scenarios run one runtime at a
+/// time behind [`await_quiescence`]. It is a `Mutex`, not an atomic, so the
+/// advance and the value stores it guards happen as one step even if a future
+/// runtime dispatches gauge events off several producer threads at once.
+static GAUGE_PARTITION_SEEN: Mutex<BTreeMap<u64, u64>> = Mutex::new(BTreeMap::new());
 
 /// Waits until the current runtime's producers have fully torn down (the gauge
 /// sum returns to 0) before the caller starts the next runtime — the teardown
@@ -551,9 +551,10 @@ async fn await_quiescence() {
          refusing to reuse the trial slot with a teardown still in flight",
     );
     // No high-water reset is needed here: the next runtime starts a fresh
-    // `LoadObserver` with its own `runtime_id`, so its gauge events open their
-    // own partition in [`GAUGE_PARTITION_SEEN`] instead of being ranked against
-    // the drained runtime's `seq` (RFC 0006 §4.4).
+    // `LoadObserver` with its own `runtime_id`, so its gauge events rank
+    // against their own entry in [`GAUGE_PARTITION_SEEN`], and a straggler
+    // from the drained runtime stays behind its partition's mark
+    // (RFC 0006 §4.4).
 }
 
 /// Records the instant the event loop's quit branch fires.
@@ -629,10 +630,11 @@ impl Subscriber for QuitDeliverySubscriber {
             let mut seen = GAUGE_PARTITION_SEEN
                 .lock()
                 .expect("gauge partition high-water mark poisoned");
-            if seen.is_some_and(|(seen_id, seen_seq)| seen_id == runtime_id && seq <= seen_seq) {
+            let mark = seen.entry(runtime_id).or_insert(0);
+            if seq <= *mark {
                 return;
             }
-            *seen = Some((runtime_id, seq));
+            *mark = seq;
             LIVE_PRODUCERS.store(visitor.gauge_sum(), Ordering::Relaxed);
             if let (Some(metrics), Some(blocked)) = (slot, visitor.blocked) {
                 metrics.blocked_live.store(blocked, Ordering::Relaxed);

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -518,16 +518,20 @@ static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 /// scenario's slot.
 static LIVE_PRODUCERS: AtomicU64 = AtomicU64::new(0);
 
-/// Newest producer-gauge `seq` applied for the current runtime (RFC 0006 §4.4).
-/// A gauge event's values reach [`LIVE_PRODUCERS`] and [`Metrics::blocked_live`]
-/// only when its `seq` advances this high-water mark, so a reordered stale gauge
-/// event never supersedes the current value — the schema orders gauge events by
-/// `seq`, not by arrival. It is a `Mutex`, not an atomic, so the advance and the
-/// value stores it guards happen as one step even if a future runtime dispatches
-/// gauge events off several producer threads at once. [`await_quiescence`] resets
-/// it to 0 per runtime, since `seq` restarts at 0 with each new runtime's
-/// `LoadObserver`.
-static GAUGE_SEQ_SEEN: Mutex<u64> = Mutex::new(0);
+/// The producer-gauge partition currently being read — the emitting runtime's
+/// `runtime_id` and the newest `seq` applied from it; `None` before the first
+/// gauge event (RFC 0006 §4.4). A gauge event's values reach [`LIVE_PRODUCERS`]
+/// and [`Metrics::blocked_live`] only when its `seq` advances the high-water
+/// mark *of its own `runtime_id`*, so a reordered stale gauge event never
+/// supersedes the current value — the schema orders gauge events by `seq` within
+/// a `runtime_id`, never by arrival, and comparing `seq` across instances is
+/// meaningless. An event from a different `runtime_id` therefore opens a fresh
+/// partition rather than being ranked against the old one: scenarios run one
+/// runtime at a time behind [`await_quiescence`], so that is the next runtime
+/// taking over. It is a `Mutex`, not an atomic, so the advance and the value
+/// stores it guards happen as one step even if a future runtime dispatches gauge
+/// events off several producer threads at once.
+static GAUGE_PARTITION_SEEN: Mutex<Option<(u64, u64)>> = Mutex::new(None);
 
 /// Waits until the current runtime's producers have fully torn down (the gauge
 /// sum returns to 0) before the caller starts the next runtime — the teardown
@@ -546,13 +550,10 @@ async fn await_quiescence() {
         "harness fault: a scenario's producers did not quiesce within 5s; \
          refusing to reuse the trial slot with a teardown still in flight",
     );
-    // The next runtime starts a fresh `LoadObserver` whose gauge `seq` restarts
-    // at 0, so clear the high-water mark; the barrier above guarantees the
-    // drained runtime emits no further gauge event that this reset could let a
-    // stale reading through.
-    *GAUGE_SEQ_SEEN
-        .lock()
-        .expect("gauge seq high-water mark poisoned") = 0;
+    // No high-water reset is needed here: the next runtime starts a fresh
+    // `LoadObserver` with its own `runtime_id`, so its gauge events open their
+    // own partition in [`GAUGE_PARTITION_SEEN`] instead of being ranked against
+    // the drained runtime's `seq` (RFC 0006 §4.4).
 }
 
 /// Records the instant the event loop's quit branch fires.
@@ -590,45 +591,48 @@ impl Subscriber for QuitDeliverySubscriber {
 
     fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
 
-    // The gauge high-water guard (`seen`) is deliberately held across the value
-    // stores below: releasing it after `*seen = seq` — the nursery lint's
-    // suggestion — would let a concurrent stale gauge event interleave its store
-    // between the check and the apply, the exact reorder the `seq` ordering
-    // exists to defeat (RFC 0006 §4.4).
+    // The gauge partition guard (`seen`) is deliberately held across the value
+    // stores below: releasing it after the high-water advance — the nursery
+    // lint's suggestion — would let a concurrent stale gauge event interleave
+    // its store between the check and the apply, the exact reorder the `seq`
+    // ordering exists to defeat (RFC 0006 §4.4).
     #[expect(
         clippy::significant_drop_tightening,
-        reason = "the gauge high-water guard is deliberately held across the value stores so \"advance and apply\" is one step; tightening it would let a concurrent stale gauge event interleave a store between the check and the apply (RFC 0006 §4.4)"
+        reason = "the gauge partition guard is deliberately held across the value stores so \"advance and apply\" is one step; tightening it would let a concurrent stale gauge event interleave a store between the check and the apply (RFC 0006 §4.4)"
     )]
     fn event(&self, event: &Event<'_>) {
         let is_load = event.metadata().target() == "tears::runtime::load";
         let mut visitor = LoadVisitor::default();
         event.record(&mut visitor);
 
-        // A producer-gauge event is a load-target event carrying `seq` (and
-        // `blocked`). Match on the target too, not on `seq` alone: were a `seq`
-        // field ever added to a `tears::runtime` DEBUG event, matching on `seq`
-        // alone would swallow it here and skip the quit-delivery match below.
-        // Order these by `seq`, not by arrival: apply the event's values only
-        // when its `seq` advances the high-water mark, so a reordered stale
-        // gauge event never supersedes the current value (RFC 0006 §4.4).
-        // Holding the high-water lock across the value stores makes "advance and
-        // apply" one step, so concurrent dispatch cannot interleave a stale
-        // store between the check and the apply. This gates both the
+        // A producer-gauge event is a load-target event carrying `runtime_id`
+        // and `seq` (and `blocked`). Match on the target too, not on those
+        // fields alone: were a `seq` field ever added to a `tears::runtime`
+        // DEBUG event, matching on `seq` alone would swallow it here and skip
+        // the quit-delivery match below. Order these by `seq` within their
+        // `runtime_id`, not by arrival: apply the event's values only when its
+        // `seq` advances the high-water mark of its own instance, so a
+        // reordered stale gauge event never supersedes the current value, and
+        // an event from another instance opens its own partition rather than
+        // being ranked against a `seq` that means nothing to it (RFC 0006
+        // §4.4). Holding the partition lock across the value stores makes
+        // "advance and apply" one step, so concurrent dispatch cannot interleave
+        // a stale store between the check and the apply. This gates both the
         // slot-independent teardown barrier and the per-trial `blocked` reading.
-        // The trial slot is cloned out first, before the high-water lock, so the
+        // The trial slot is cloned out first, before the partition lock, so the
         // two locks are never held at once.
-        if is_load && let Some(seq) = visitor.seq {
+        if is_load && let (Some(runtime_id), Some(seq)) = (visitor.runtime_id, visitor.seq) {
             let slot = TRIAL_METRICS
                 .lock()
                 .expect("trial metrics slot poisoned")
                 .clone();
-            let mut seen = GAUGE_SEQ_SEEN
+            let mut seen = GAUGE_PARTITION_SEEN
                 .lock()
-                .expect("gauge seq high-water mark poisoned");
-            if seq <= *seen {
+                .expect("gauge partition high-water mark poisoned");
+            if seen.is_some_and(|(seen_id, seen_seq)| seen_id == runtime_id && seq <= seen_seq) {
                 return;
             }
-            *seen = seq;
+            *seen = Some((runtime_id, seq));
             LIVE_PRODUCERS.store(visitor.gauge_sum(), Ordering::Relaxed);
             if let (Some(metrics), Some(blocked)) = (slot, visitor.blocked) {
                 metrics.blocked_live.store(blocked, Ordering::Relaxed);
@@ -669,9 +673,14 @@ impl Subscriber for QuitDeliverySubscriber {
 #[derive(Default)]
 struct LoadVisitor {
     matched_quit: bool,
+    /// Present only on a producer-gauge event: the emitting runtime instance's
+    /// process-local identifier (RFC 0006 §4.4). It partitions gauge events by
+    /// emitter — `seq` orders events only within one partition.
+    runtime_id: Option<u64>,
     /// Present only on a producer-gauge event: its monotone ordering counter
     /// (RFC 0006 §4.4). Its presence identifies the event as a gauge event, and
-    /// its value orders it against the other gauge events.
+    /// its value orders it against the other gauge events of the same
+    /// `runtime_id`.
     seq: Option<u64>,
     subscriptions: Option<u64>,
     unkeyed_commands: Option<u64>,
@@ -694,6 +703,7 @@ impl LoadVisitor {
 impl Visit for LoadVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
         match field.name() {
+            "runtime_id" => self.runtime_id = Some(value),
             "seq" => self.seq = Some(value),
             "subscriptions" => self.subscriptions = Some(value),
             "unkeyed_commands" => self.unkeyed_commands = Some(value),

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -77,6 +77,7 @@
 )]
 
 use std::collections::BTreeMap;
+use std::collections::btree_map::Entry;
 use std::fmt::Debug;
 use std::num::{NonZeroU32, NonZeroUsize};
 use std::process::ExitCode;
@@ -511,8 +512,8 @@ static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 
 /// The current producer-gauge sum
 /// (`subscriptions + unkeyed_commands + keyed_commands + blocked`), updated by
-/// [`QuitDeliverySubscriber`] from the greatest-`seq` gauge event regardless of
-/// the trial slot. Reaches 0 only when the *current* runtime has fully torn its
+/// [`QuitDeliverySubscriber`] from the greatest-`seq` gauge event within its
+/// own `runtime_id` partition, regardless of the trial slot. Reaches 0 only when the *current* runtime has fully torn its
 /// producers down; scenarios run one runtime at a time, so [`await_quiescence`]
 /// can wait on it as a common teardown barrier before the next runtime starts,
 /// keeping a late gauge/capacity event from one scenario out of the next
@@ -630,11 +631,19 @@ impl Subscriber for QuitDeliverySubscriber {
             let mut seen = GAUGE_PARTITION_SEEN
                 .lock()
                 .expect("gauge partition high-water mark poisoned");
-            let mark = seen.entry(runtime_id).or_insert(0);
-            if seq <= *mark {
-                return;
+            // `Vacant` — not a sentinel value — marks "never observed", so the
+            // first event of a partition is applied whatever its `seq`: the
+            // schema deliberately leaves the counter's initial value unpinned
+            // (RFC 0006 §4.4).
+            match seen.entry(runtime_id) {
+                Entry::Vacant(slot) => {
+                    slot.insert(seq);
+                }
+                Entry::Occupied(mut mark) if seq > *mark.get() => {
+                    mark.insert(seq);
+                }
+                Entry::Occupied(_) => return,
             }
-            *mark = seq;
             LIVE_PRODUCERS.store(visitor.gauge_sum(), Ordering::Relaxed);
             if let (Some(metrics), Some(blocked)) = (slot, visitor.blocked) {
                 metrics.blocked_live.store(blocked, Ordering::Relaxed);

--- a/benches/runtime_load.rs
+++ b/benches/runtime_load.rs
@@ -513,11 +513,11 @@ static TRIAL_METRICS: Mutex<Option<Arc<Metrics>>> = Mutex::new(None);
 /// The current producer-gauge sum
 /// (`subscriptions + unkeyed_commands + keyed_commands + blocked`), updated by
 /// [`QuitDeliverySubscriber`] from the greatest-`seq` gauge event within its
-/// own `runtime_id` partition, regardless of the trial slot. Reaches 0 only when the *current* runtime has fully torn its
-/// producers down; scenarios run one runtime at a time, so [`await_quiescence`]
-/// can wait on it as a common teardown barrier before the next runtime starts,
-/// keeping a late gauge/capacity event from one scenario out of the next
-/// scenario's slot.
+/// own `runtime_id` partition, regardless of the trial slot. Reaches 0 only
+/// when the *current* runtime has fully torn its producers down; scenarios run
+/// one runtime at a time, so [`await_quiescence`] can wait on it as a common
+/// teardown barrier before the next runtime starts, keeping a late
+/// gauge/capacity event from one scenario out of the next scenario's slot.
 static LIVE_PRODUCERS: AtomicU64 = AtomicU64::new(0);
 
 /// Per-`runtime_id` high-water marks of the newest `seq` applied from each

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -702,6 +702,68 @@ mod tests {
                  events: {seqs:?}"
             );
         }
+
+        // The enforcement check's other half (RFC 0006 §4.4): partitioning by
+        // `runtime_id` and applying the max-`seq` rule per partition recovers
+        // each instance's current values — `first` ended with both
+        // subscriptions dropped, `second` with two keyed entries live.
+        let subscriptions = recorder.u64_values("subscriptions");
+        let keyed = recorder.u64_values("keyed_commands");
+        let mut current: Vec<(u64, u64, u64, u64)> = Vec::new();
+        for i in 0..ids.len() {
+            match current.iter_mut().find(|(id, ..)| *id == ids[i]) {
+                Some(entry) if seqs[i] > entry.1 => {
+                    *entry = (ids[i], seqs[i], subscriptions[i], keyed[i]);
+                }
+                Some(_) => {}
+                None => current.push((ids[i], seqs[i], subscriptions[i], keyed[i])),
+            }
+        }
+        let recover = |id: u64| {
+            current
+                .iter()
+                .find(|(known, ..)| *known == id)
+                .map(|&(_, _, subs, keyed)| (subs, keyed))
+                .expect("both partitions were built above")
+        };
+        assert_eq!(
+            recover(ids[0]),
+            (0, 0),
+            "first's max-seq event must report its current values"
+        );
+        let second_id = *ids.iter().find(|id| **id != ids[0]).expect("two ids");
+        assert_eq!(
+            recover(second_id),
+            (0, 2),
+            "second's max-seq event must report its current values"
+        );
+    }
+
+    // INV-L13 (instance identity, non-reuse): a torn-down runtime's
+    // `runtime_id` is never handed out again within the process lifetime, so a
+    // subscriber's partition for a dead instance can never be reopened by a
+    // later one. The allocator is process-global, so a reuse bug (a free-list
+    // returning the dropped id) is reliably detected only single-threaded —
+    // under parallel test runs another thread may take the freed id first;
+    // this is a regression guard, not a parallel-proof detector.
+    #[test]
+    fn a_torn_down_observers_runtime_id_is_not_reused() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let first = LoadObserver::default();
+        drop(first.track_subscription());
+        drop(first);
+
+        let second = LoadObserver::default();
+        drop(second.track_subscription());
+
+        let ids = recorder.u64_values("runtime_id");
+        assert_eq!(ids.len(), 4, "four gauge changes fired: {ids:?}");
+        assert_ne!(
+            ids[0], ids[2],
+            "a torn-down runtime's id must not be reused: {ids:?}"
+        );
     }
 
     // Fast-path correctness: while nothing is listening for

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -544,6 +544,7 @@ impl Drop for DrainGuard<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::panic::{self, AssertUnwindSafe};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -709,22 +710,28 @@ mod tests {
         // subscriptions dropped, `second` with two keyed entries live.
         let subscriptions = recorder.u64_values("subscriptions");
         let keyed = recorder.u64_values("keyed_commands");
-        let mut current: Vec<(u64, u64, u64, u64)> = Vec::new();
-        for i in 0..ids.len() {
-            match current.iter_mut().find(|(id, ..)| *id == ids[i]) {
-                Some(entry) if seqs[i] > entry.1 => {
-                    *entry = (ids[i], seqs[i], subscriptions[i], keyed[i]);
-                }
-                Some(_) => {}
-                None => current.push((ids[i], seqs[i], subscriptions[i], keyed[i])),
+        for (name, values) in [
+            ("subscriptions", &subscriptions),
+            ("keyed_commands", &keyed),
+        ] {
+            assert_eq!(
+                values.len(),
+                ids.len(),
+                "every gauge event carries `{name}`: {ids:?} / {values:?}"
+            );
+        }
+        let mut current: BTreeMap<u64, (u64, u64, u64)> = BTreeMap::new();
+        for ((&id, &seq), (&subs, &keyed_now)) in
+            ids.iter().zip(&seqs).zip(subscriptions.iter().zip(&keyed))
+        {
+            let slot = current.entry(id).or_insert((seq, subs, keyed_now));
+            if seq > slot.0 {
+                *slot = (seq, subs, keyed_now);
             }
         }
         let recover = |id: u64| {
-            current
-                .iter()
-                .find(|(known, ..)| *known == id)
-                .map(|&(_, _, subs, keyed)| (subs, keyed))
-                .expect("both partitions were built above")
+            let &(_, subs, keyed_now) = current.get(&id).expect("both partitions were built above");
+            (subs, keyed_now)
         };
         assert_eq!(
             recover(ids[0]),

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -8,6 +8,13 @@
 //! fields, firing conditions) is pinned as RFC 0006 INV-L13; changing it is a
 //! contract change.
 //!
+//! Every gauge event also carries the emitting instance's `runtime_id`, a
+//! process-local `u64` allocated once per [`LoadObserver`] — that is, once per
+//! runtime, since the runtime builds one observer and clones it to every
+//! producer. It is an equality key for partitioning a multi-runtime process's
+//! gauge events, with no meaning in its magnitude or ordering, and it is never
+//! reused within the process lifetime ([`LoadObserver::new`]).
+//!
 //! The gauge counters live behind one mutex. Each change updates a field, bumps
 //! a monotone `seq`, and snapshots the field set together under that lock, then
 //! releases the lock before dispatching the snapshot to `tracing`. Two separate
@@ -19,8 +26,11 @@
 //!   reached and superseded before its own snapshot re-reads the counters — a
 //!   lone atomic would let a subscriber's high-water mark miss a peak. This
 //!   guarantee is about the snapshot, not about arrival order.
-//! - **Ordering** is carried by `seq`, not by arrival: the current value of each
-//!   gauge is the value on the greatest-`seq` event (RFC 0006 §4.4, INV-L13).
+//! - **Ordering** is carried by `seq`, not by arrival, and is per instance: the
+//!   current value of each gauge is the value on the greatest-`seq` event
+//!   *among events carrying that `runtime_id`* — a consumer partitions by
+//!   `runtime_id` first, and comparing `seq` across instances is meaningless
+//!   (RFC 0006 §4.4, INV-L13).
 //!   Dispatch happens off the lock, so the contract does not promise arrival
 //!   order matches `seq` order — consumers must order by `seq`. The single-
 //!   drainer funnel below does in fact serialize dispatch in `seq` order today,
@@ -65,8 +75,11 @@
 //! lint.
 
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Duration;
+
+static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 
 /// The runtime channel a bounded send blocked on — the capacity-wait event's
 /// `channel` field (`"shared"` or `"keyed"`).
@@ -117,12 +130,19 @@ pub fn capacity_wait(channel: Channel, waited: Duration) {
 
 /// Shared handle over the runtime's producer-count gauges (RFC 0006 §4.4).
 ///
-/// Cloning shares the same counters; every producer holds a clone and updates
-/// its own field, so a single subscriber sees the aggregate. All four counts
-/// are emitted together under `tears::runtime::load` whenever any one changes.
-#[derive(Clone, Default)]
+/// Cloning shares the same counters — and the same `runtime_id` — so every
+/// producer holds a clone, updates its own field, and a single subscriber sees
+/// the aggregate. All four counts are emitted together under
+/// `tears::runtime::load` whenever any one changes.
+#[derive(Clone)]
 pub struct LoadObserver {
     gauges: Arc<Mutex<Gauges>>,
+}
+
+impl Default for LoadObserver {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 // Deliberately not `Copy`/`Clone`: `capture` bumps `seq` through `&mut self`, so
@@ -132,11 +152,18 @@ pub struct LoadObserver {
 // own, but the rule is stated for `capture` regardless.
 #[derive(Default)]
 struct Gauges {
+    /// This observer's process-local instance identifier, carried on every gauge
+    /// event as `runtime_id` and fixed for the observer's lifetime. Held here
+    /// rather than on [`LoadObserver`] so [`Gauges::capture`] builds the whole
+    /// snapshot from the state it already has under the lock, and so every clone
+    /// necessarily reports the same identifier (RFC 0006 §4.4, INV-L13).
+    runtime_id: u64,
     /// Monotone per-observer counter, bumped once per captured gauge event and
     /// carried on it as `seq`. Captured under the same lock as the four counts,
     /// so a greater `seq` never carries an older value; a subscriber reads the
-    /// current value of each gauge from the greatest-`seq` event, so arrival
-    /// order is not load-bearing (RFC 0006 §4.4, INV-L13).
+    /// current value of each gauge from the greatest-`seq` event *of this
+    /// `runtime_id`*, so arrival order is not load-bearing (RFC 0006 §4.4,
+    /// INV-L13).
     seq: u64,
     subscriptions: usize,
     unkeyed_commands: usize,
@@ -159,12 +186,13 @@ impl Gauges {
     /// Takes `&mut self` so the bump lands in the shared state; the caller holds
     /// the lock, fixing the counts and `seq` together at the serialization
     /// point, so the snapshot reports the state that was reached (never a later
-    /// re-read) and its `seq` orders it against every other gauge event without
-    /// relying on arrival order. Dispatch to `tracing` happens later, off the
-    /// lock (`GaugeSnapshot::dispatch`).
+    /// re-read) and its `seq` orders it against every other gauge event of this
+    /// `runtime_id` without relying on arrival order. Dispatch to `tracing`
+    /// happens later, off the lock (`GaugeSnapshot::dispatch`).
     const fn capture(&mut self) -> GaugeSnapshot {
         self.seq = self.seq.wrapping_add(1);
         GaugeSnapshot {
+            runtime_id: self.runtime_id,
             seq: self.seq,
             subscriptions: self.subscriptions,
             unkeyed_commands: self.unkeyed_commands,
@@ -174,11 +202,12 @@ impl Gauges {
     }
 }
 
-/// One producer-gauge event's payload — the four counts and their ordering
-/// `seq` — captured under the lock and dispatched to `tracing` after the lock is
-/// released (RFC 0006 §4.4).
+/// One producer-gauge event's payload — the four counts, the emitting
+/// instance's `runtime_id`, and their ordering `seq` — captured under the lock
+/// and dispatched to `tracing` after the lock is released (RFC 0006 §4.4).
 #[derive(Clone, Copy)]
 struct GaugeSnapshot {
+    runtime_id: u64,
     seq: u64,
     subscriptions: usize,
     unkeyed_commands: usize,
@@ -198,6 +227,7 @@ impl GaugeSnapshot {
     fn dispatch(self) {
         tracing::debug!(
             target: "tears::runtime::load",
+            runtime_id = self.runtime_id,
             seq = self.seq,
             subscriptions = self.subscriptions,
             unkeyed_commands = self.unkeyed_commands,
@@ -227,6 +257,42 @@ impl Field {
 }
 
 impl LoadObserver {
+    /// Creates an observer with fresh, all-zero gauges and a newly allocated
+    /// `runtime_id` — the identifier every gauge event this observer emits
+    /// carries (RFC 0006 §4.4, INV-L13). The runtime builds exactly one and
+    /// clones it to its producers, so one observer is one runtime instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the process-wide `runtime_id` space is exhausted (the
+    /// allocator counter has reached `u64::MAX`): the identifier partitions a
+    /// subscriber's gauge events by emitting instance, so ids are never reused
+    /// within a process (RFC 0006 §4.4).
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            // Reusing an id would merge two runtimes' gauge events into one
+            // partition, and their independent `seq` streams with them. The
+            // allocator fails before it can reuse a value: on exhaustion the
+            // failed `fetch_update` stores nothing, leaving the counter
+            // saturated at `u64::MAX`, so this and every later allocation
+            // panics instead of wrapping into reuse.
+            //
+            // The remaining fields take `Gauges::default()`'s zero state. This
+            // is the only site that builds a `Gauges`, so nothing can observe
+            // the placeholder `runtime_id` that `Default` leaves behind.
+            gauges: Arc::new(Mutex::new(Gauges {
+                runtime_id: NEXT_RUNTIME_ID
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_add(1))
+                    .expect(
+                        "runtime id space exhausted; gauge runtime ids are never \
+                         reused within a process (RFC 0006 §4.4)",
+                    ),
+                ..Gauges::default()
+            })),
+        }
+    }
+
     /// Tracks one active subscription forwarding task: the returned guard raises
     /// the `subscriptions` gauge now and lowers it when dropped (task end or
     /// abort).
@@ -473,9 +539,10 @@ mod tests {
     use crate::test_support::{TraceRecorder, set_default_subscriber, with_silent_panic_hook};
 
     // INV-L13: every producer-gauge event carries the full field set together —
-    // the four gauges plus their ordering `seq` — so a subscriber reads a
-    // complete, ordered snapshot from any one event. The per-field recorder
-    // views flatten across events and cannot see this; the field-set view can.
+    // the four gauges plus the emitting instance's `runtime_id` and their
+    // ordering `seq` — so a subscriber reads a complete, attributable, ordered
+    // snapshot from any one event. The per-field recorder views flatten across
+    // events and cannot see this; the field-set view can.
     #[test]
     fn gauge_event_carries_the_full_field_set() {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");
@@ -494,6 +561,7 @@ mod tests {
         assert!(!gauge_events.is_empty(), "gauge events should have fired");
         for fields in gauge_events {
             for required in [
+                "runtime_id",
                 "seq",
                 "subscriptions",
                 "unkeyed_commands",
@@ -510,7 +578,8 @@ mod tests {
 
     // INV-L13 (ordering): every gauge event carries a monotone `seq`, one per
     // emission, so a subscriber orders the events by `seq` rather than by
-    // arrival — the current value of each gauge is the greatest-`seq` event's.
+    // arrival — the current value of each gauge is the greatest-`seq` event's
+    // among that `runtime_id`'s events.
     #[test]
     fn each_gauge_change_carries_a_monotone_seq() {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");
@@ -527,6 +596,95 @@ mod tests {
             vec![1, 2, 3, 4],
             "each of the four gauge changes emits one event with the next `seq`"
         );
+    }
+
+    // INV-L13 (instance identity): each runtime instance gets its own
+    // `runtime_id` and carries it on every gauge event, so a subscriber
+    // watching several runtimes in one process can attribute each event to its
+    // emitter. One observer is one runtime — the runtime builds exactly one and
+    // clones it to its producers, so a clone must report the same id rather
+    // than looking like a second runtime.
+    #[test]
+    fn each_observer_gets_its_own_runtime_id() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let first = LoadObserver::default();
+        let second = LoadObserver::default();
+        let first_clone = first.clone();
+        drop(first.track_subscription());
+        drop(second.track_subscription());
+        drop(first_clone.track_subscription());
+
+        let ids = recorder.u64_values("runtime_id");
+        assert_eq!(
+            ids.len(),
+            6,
+            "every gauge event carries a runtime_id: {ids:?}"
+        );
+        let (first_id, second_id) = (ids[0], ids[2]);
+        assert_ne!(
+            first_id, second_id,
+            "two runtime instances must not share a runtime_id: {ids:?}"
+        );
+        assert_eq!(
+            ids,
+            vec![first_id, first_id, second_id, second_id, first_id, first_id],
+            "each event carries its emitter's id, and a clone is the same \
+             instance rather than a new one: {ids:?}"
+        );
+    }
+
+    // INV-L13 (per-instance ordering): `seq` is strictly increasing among a
+    // given `runtime_id`'s events and runs independently per instance, so a
+    // subscriber partitions by `runtime_id` before applying the greatest-`seq`
+    // rule. Emissions are interleaved here, so neither arrival order nor a
+    // cross-instance `seq` comparison could stand in for that.
+    #[test]
+    fn gauge_seq_strictly_increases_within_each_runtime_id() {
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _guard = recorder.set_default();
+
+        let first = LoadObserver::default();
+        let second = LoadObserver::default();
+        let held = first.track_subscription();
+        second.set_keyed_entries(1);
+        let also_held = first.track_subscription();
+        second.set_keyed_entries(2);
+        drop(held);
+        drop(also_held);
+
+        // One `runtime_id` and one `seq` per gauge event, each log in arrival
+        // order, so the two line up index by index — the other two event kinds
+        // carry neither field, so nothing else can enter either log.
+        let ids = recorder.u64_values("runtime_id");
+        let seqs = recorder.u64_values("seq");
+        assert_eq!(ids.len(), 6, "six gauge changes fired: {ids:?}");
+        assert_eq!(
+            seqs.len(),
+            ids.len(),
+            "every gauge event carries both fields: {ids:?} / {seqs:?}"
+        );
+
+        let mut partitions: Vec<(u64, Vec<u64>)> = Vec::new();
+        for (id, seq) in ids.iter().zip(&seqs) {
+            match partitions.iter_mut().find(|(known, _)| known == id) {
+                Some((_, known_seqs)) => known_seqs.push(*seq),
+                None => partitions.push((*id, vec![*seq])),
+            }
+        }
+        assert_eq!(
+            partitions.len(),
+            2,
+            "two runtime instances must yield two partitions: {ids:?}"
+        );
+        for (id, seqs) in partitions {
+            assert!(
+                seqs.windows(2).all(|pair| pair[0] < pair[1]),
+                "runtime {id}'s seq must strictly increase across its own \
+                 events: {seqs:?}"
+            );
+        }
     }
 
     // Fast-path correctness: while nothing is listening for

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -149,8 +149,11 @@ impl Default for LoadObserver {
 // a by-value copy (`let mut g = *guard; g.capture()`) would bump a throwaway
 // while the shared `seq` stalled — the exact silently-dropped update this
 // ordering exists to prevent. The `pending` queue makes `Copy` impossible on its
-// own, but the rule is stated for `capture` regardless.
-#[derive(Default)]
+// own, but the rule is stated for `capture` regardless. Deliberately not
+// `Default` either: a defaulted `Gauges` would carry the placeholder
+// `runtime_id` `0` — a value the allocator never hands out — so construction
+// goes through `Gauges::new` and an id-less `Gauges` is unrepresentable
+// (INV-L13's distinct-per-instance requirement, held structurally).
 struct Gauges {
     /// This observer's process-local instance identifier, carried on every gauge
     /// event as `runtime_id` and fixed for the observer's lifetime. Held here
@@ -182,6 +185,22 @@ struct Gauges {
 }
 
 impl Gauges {
+    /// Builds the zero-count gauge state for the instance identified by
+    /// `runtime_id`. The only construction path, so a `Gauges` without an
+    /// allocated identifier cannot exist.
+    const fn new(runtime_id: u64) -> Self {
+        Self {
+            runtime_id,
+            seq: 0,
+            subscriptions: 0,
+            unkeyed_commands: 0,
+            keyed_commands: 0,
+            blocked: 0,
+            pending: VecDeque::new(),
+            draining: false,
+        }
+    }
+
     /// Bumps `seq` and captures the four counts plus that `seq` as one snapshot.
     /// Takes `&mut self` so the bump lands in the shared state; the caller holds
     /// the lock, fixing the counts and `seq` together at the serialization
@@ -259,8 +278,11 @@ impl Field {
 impl LoadObserver {
     /// Creates an observer with fresh, all-zero gauges and a newly allocated
     /// `runtime_id` — the identifier every gauge event this observer emits
-    /// carries (RFC 0006 §4.4, INV-L13). The runtime builds exactly one and
-    /// clones it to its producers, so one observer is one runtime instance.
+    /// carries (RFC 0006 §4.4, INV-L13). On the production path the runtime
+    /// builds exactly one and clones it to its producers, so one observer is
+    /// one runtime instance; test helpers may also build throwaway observers
+    /// shared with no runtime (`channel::channel`), which consume ids but
+    /// keep the distinct/non-reuse contract intact.
     ///
     /// # Panics
     ///
@@ -277,19 +299,14 @@ impl LoadObserver {
             // failed `fetch_update` stores nothing, leaving the counter
             // saturated at `u64::MAX`, so this and every later allocation
             // panics instead of wrapping into reuse.
-            //
-            // The remaining fields take `Gauges::default()`'s zero state. This
-            // is the only site that builds a `Gauges`, so nothing can observe
-            // the placeholder `runtime_id` that `Default` leaves behind.
-            gauges: Arc::new(Mutex::new(Gauges {
-                runtime_id: NEXT_RUNTIME_ID
+            gauges: Arc::new(Mutex::new(Gauges::new(
+                NEXT_RUNTIME_ID
                     .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_add(1))
                     .expect(
                         "runtime id space exhausted; gauge runtime ids are never \
                          reused within a process (RFC 0006 §4.4)",
                     ),
-                ..Gauges::default()
-            })),
+            ))),
         }
     }
 

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -131,5 +131,45 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
         "the keyed_commands gauge must fall back to zero: {keyed:?}"
     );
 
+    // INV-L13: every gauge event a real run emits carries the emitting
+    // instance's `runtime_id` and its ordering `seq`, and one run is one
+    // instance — the runtime builds a single `LoadObserver` at construction and
+    // clones it to every producer, so all of these events share one id. The
+    // `seq` values are checked for distinctness rather than for arrival-order
+    // monotonicity: the schema orders gauge events by `seq`, not by arrival
+    // (their strict increase per instance is pinned at the unit layer, where the
+    // emission order is deterministic).
+    let gauge_events: Vec<_> = recorder
+        .field_name_sets()
+        .into_iter()
+        .filter(|fields| fields.iter().any(|name| name == "subscriptions"))
+        .collect();
+    assert!(!gauge_events.is_empty(), "gauge events should have fired");
+    for fields in &gauge_events {
+        for required in ["runtime_id", "seq"] {
+            assert!(
+                fields.iter().any(|name| name == required),
+                "a gauge event is missing `{required}`: {fields:?}"
+            );
+        }
+    }
+
+    let ids = recorder.u64_values("runtime_id");
+    assert!(
+        ids.windows(2).all(|pair| pair[0] == pair[1]),
+        "one run is one runtime instance, so its gauge events share one \
+         runtime_id: {ids:?}"
+    );
+
+    let mut seqs = recorder.u64_values("seq");
+    let emitted = seqs.len();
+    seqs.sort_unstable();
+    seqs.dedup();
+    assert_eq!(
+        seqs.len(),
+        emitted,
+        "no two gauge events of one runtime may share a seq: {seqs:?}"
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Implements the RFC 0006 amendment's gauge-schema change (INV-L13, amended by the runtime-consolidation bundle, #270): the `tears::runtime::load` producer-gauge event now carries the emitting instance's `runtime_id`, and the existing `seq` ordering counter (shipped in 0.10.1) is scoped per instance. The current-value rule is now: partition gauge events by `runtime_id`, then take the greatest-`seq` event within the partition — never arrival order. The batch and capacity-wait events are unchanged and carry neither field, per the contract's deliberate gauge-only scoping.

## Implementation

- `runtime_id` is allocated in `LoadObserver::new()` from a process-global counter using the crate's established fail-before-reuse pattern (`fetch_update` + `checked_add`, panicking on exhaustion instead of wrapping into reuse), with a `# Panics` rustdoc section — the same shape as `NEXT_MOCK_SOURCE_ID` / `NEXT_QUERY_CLIENT_ID`. `Default` delegates to `new()`, so the runtime's single construction site is unchanged.
- The id is stored inside `Gauges` (behind the existing mutex), so `Gauges::capture` builds the whole snapshot — `runtime_id`, `seq`, four counts — from state it already holds under the lock: the capture is atomic with the count snapshot by construction, and clones of the runtime's observer necessarily report the same id. The off-lock dispatch funnel is untouched.
- Consumers: the load bench's quit-delivery subscriber already ordered by `seq` but compared it across runtime instances, relying on a per-runtime high-water reset. It now keys the high-water mark by `(runtime_id, seq)`; the reset in `await_quiescence` is removed as unnecessary. `tests/observability.rs` gains end-to-end assertions that a real run's gauge events all carry both fields and share one `runtime_id`.
- New unit tests: full field set, distinct ids across instances, clone-reports-same-id, and `seq` strictly increasing within each `runtime_id` under interleaved emissions. Failure paths were mutation-checked (dropping the field / pinning the id each fails exactly the intended tests).

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --bins --tests --examples --all-features`: 432 lib + all integration/example targets, 0 failed
- `cargo test --test api_surface -- --ignored`: 2 passed (no public-surface change; `LoadObserver::new` sits behind the `bench-internals`-gated, `doc(hidden)` re-export)
- `just bench-smoke`: full smoke profile passes; quit-delivery trials 5/5 valid in both quit scenarios (exercises the rewritten partition tracker in the live consumer)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean

RFC 0006's Accepted → Implemented status transition follows in a separate docs PR once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
