### PR TITLE
fix(runtime): skip terminal restore for panics contained by the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or the alternate screen, and the still-running application keeps drawing.
   Panics on the application's own driving path — `update`, `view`,
   `subscriptions`, a subscription's source constructor — still restore the
-  terminal exactly as before
+  terminal exactly as before, as do all panics under `panic = "abort"`
+  builds, where nothing can be contained. A contained panic's report is
+  written on the alternate screen in raw mode, so applications that want it
+  readable should point their panic reporter at a file or log target
 
 ## [0.10.2] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   order; the batch and capacity-wait events are unchanged and carry neither
   field
 
+### Fixed
+
+- `install_panic_hook` no longer restores the terminal for panics the runtime
+  contains. A panic inside a runtime-owned producer task — an unkeyed command
+  task, a keyed command task, or a subscription forwarder — is caught by the
+  runtime and leaves the application running (RFC 0011 §5, INV-LC8), so the
+  hook now delegates to the previously installed hook without leaving raw mode
+  or the alternate screen, and the still-running application keeps drawing.
+  Panics on the application's own driving path — `update`, `view`,
+  `subscriptions`, a subscription's source constructor — still restore the
+  terminal exactly as before
+
 ## [0.10.2] - 2026-07-26
 
 ### Fixed

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -171,6 +171,16 @@ owns the guard, catches an unexpected panic long enough to restore the previous
 hook, and only then resumes unwinding. Its guard uses `std::sync::Mutex`, so the
 helper is restricted to `current_thread` tests.
 
+Tests that assert on how the composed hook *classified* a panic (terminal
+restore skipped or taken) use `crate::test_support::HookProbe` instead: it
+installs a counting hook built from the real `compose_hook`, serves
+multi-thread runtimes and non-async tests, and filters its counts by worker
+thread name so a concurrent unrelated panic cannot move them. Callers hold
+`PANIC_HOOK_GUARD` themselves — including across `block_on` in non-async
+tests. It is lib-only: it needs the crate-private `compose_hook`, so the
+integration copy under `tests/common/panic_hook.rs` deliberately has no
+equivalent.
+
 Integration tests cannot use crate-private test support, so they use the focused
 local `with_silent_panic_hook` under `tests/common/panic_hook.rs`. Its guard uses
 `tokio::sync::Mutex` so it can be held across `.await` without blocking a runtime

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -57,8 +57,18 @@ tokio::task_local! {
 /// terminate the application (RFC 0011 §5, INV-LC8): the event loop keeps
 /// running and keeps drawing. Restoring the terminal for such a panic would
 /// drop a live UI out of raw mode and off the alternate screen, so the hook
-/// only delegates to the previous hook in that case, leaving the reporting
-/// unchanged.
+/// only delegates to the previous hook in that case.
+///
+/// The delegated report of a contained panic is therefore written while the
+/// terminal is still in raw mode and on the alternate screen: line breaks
+/// stair-step, and the report's cells linger until the next redraw happens to
+/// touch them. An application that wants contained-panic reports to stay
+/// readable should point its panic reporter at a file or log target rather
+/// than stderr.
+///
+/// Containment presupposes unwinding. Under `panic = "abort"` no panic is
+/// contained — every panic ends the process — so the hook restores the
+/// terminal unconditionally there, exactly as it does for driving-path panics.
 ///
 /// Call it only once. Each call wraps the previous hook, so repeated calls
 /// would restore the terminal multiple times (harmless, but pointless).
@@ -101,13 +111,16 @@ fn in_contained_producer() -> bool {
 /// `restore` is skipped for a panic unwinding out of a [`contained_producer`]
 /// poll, because the application it would restore the terminal away from is
 /// still running (INV-LC8); the delegation to `next` is unconditional either
-/// way.
+/// way. Under `panic = "abort"` the spawn sites' `catch_unwind` cannot contain
+/// anything and the process is about to die, so the restore is unconditional
+/// — the guard below is compile-time and untestable from this (necessarily
+/// unwinding) test suite.
 ///
 /// Extracted from [`install_panic_hook`] so the chaining order can be tested
 /// without touching a real terminal.
-fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook) -> PanicHook {
+pub fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook) -> PanicHook {
     Box::new(move |info| {
-        if !in_contained_producer() {
+        if cfg!(panic = "abort") || !in_contained_producer() {
             restore();
         }
         next(info);
@@ -116,102 +129,17 @@ fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook) -> 
 
 #[cfg(test)]
 mod tests {
-    use crate::test_support::PANIC_HOOK_GUARD;
+    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD};
 
     use super::*;
 
     use std::future::pending;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex, PoisonError};
-    use std::thread;
 
     use futures::future::join_all;
     use tokio::runtime::Builder;
     use tokio::sync::oneshot;
     use tokio::task::yield_now;
-
-    /// Records how a composed hook classified each panic, counting only panics
-    /// raised on the installing test's own worker threads.
-    ///
-    /// `set_hook`/`take_hook` mutate process-global state, so every test here
-    /// holds [`PANIC_HOOK_GUARD`] for its whole critical section. That
-    /// serializes the hook swaps but not the rest of the test binary: a test
-    /// that panics without taking the guard would still reach this hook. The
-    /// thread-name filter keeps such a panic out of the counts, since each
-    /// probe stamps a unique name on the worker threads it panics from.
-    struct HookProbe {
-        restores: Arc<AtomicUsize>,
-        delegations: Arc<AtomicUsize>,
-        previous: Option<PanicHook>,
-    }
-
-    impl HookProbe {
-        fn install(thread_prefix: &'static str) -> Self {
-            let restores = Arc::new(AtomicUsize::new(0));
-            let delegations = Arc::new(AtomicUsize::new(0));
-
-            let restore_counter = Arc::clone(&restores);
-            let delegation_counter = Arc::clone(&delegations);
-            let next: PanicHook = Box::new(move |_info| {
-                if on_thread(thread_prefix) {
-                    delegation_counter.fetch_add(1, Ordering::SeqCst);
-                }
-            });
-            let hook = compose_hook(
-                move || {
-                    if on_thread(thread_prefix) {
-                        restore_counter.fetch_add(1, Ordering::SeqCst);
-                    }
-                },
-                next,
-            );
-
-            let previous = panic::take_hook();
-            panic::set_hook(hook);
-            Self {
-                restores,
-                delegations,
-                previous: Some(previous),
-            }
-        }
-
-        /// The `(restores, delegations)` counts so far.
-        fn counts(&self) -> (usize, usize) {
-            (
-                self.restores.load(Ordering::SeqCst),
-                self.delegations.load(Ordering::SeqCst),
-            )
-        }
-
-        /// Reinstalls the previous hook. Assertions run only after this, so a
-        /// failing assertion still reports through the normal hook.
-        fn finish(mut self) {
-            self.restore_previous();
-        }
-
-        fn restore_previous(&mut self) {
-            if let Some(hook) = self.previous.take() {
-                panic::set_hook(hook);
-            }
-        }
-    }
-
-    impl Drop for HookProbe {
-        fn drop(&mut self) {
-            // `set_hook` panics when called from a panicking thread, so an
-            // unwinding test leaves the probe hook installed rather than
-            // aborting the process; the next test's `install` replaces it.
-            if !thread::panicking() {
-                self.restore_previous();
-            }
-        }
-    }
-
-    fn on_thread(prefix: &str) -> bool {
-        thread::current()
-            .name()
-            .is_some_and(|name| name.starts_with(prefix))
-    }
 
     /// Yields enough times to give the multi-thread scheduler opportunities to
     /// move the task to another worker between polls.

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -3,10 +3,25 @@
 //! This module is crate-internal; see [`install_panic_hook`](crate::install_panic_hook)
 //! (the sole public item re-exported from here) for the full documentation.
 
+use std::future::Future;
 use std::panic::{self, PanicHookInfo};
+
+use tokio::task::futures::TaskLocalFuture;
 
 /// The boxed panic hook type used by [`std::panic::set_hook`].
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+tokio::task_local! {
+    /// Marks the body of a runtime-owned producer task whose panics the runtime
+    /// contains.
+    ///
+    /// Tokio installs the value on entry to every `poll` of the wrapping future
+    /// and removes it on exit, including when that poll unwinds. The mark
+    /// therefore brackets a single synchronous `poll`: it can never span an
+    /// `.await` point, leak onto a worker thread that only parked the task, or
+    /// fail to follow a task that migrates to another worker thread.
+    static CONTAINED_PRODUCER: ();
+}
 
 /// Installs a panic hook that restores the terminal before delegating to the
 /// previously installed hook.
@@ -36,6 +51,15 @@ type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
 /// # }
 /// ```
 ///
+/// Panics the runtime contains are exempt from the restore. A panic inside a
+/// runtime-owned producer task — an unkeyed command task, a keyed command
+/// task, or a subscription forwarder — is caught by the runtime and does not
+/// terminate the application (RFC 0011 §5, INV-LC8): the event loop keeps
+/// running and keeps drawing. Restoring the terminal for such a panic would
+/// drop a live UI out of raw mode and off the alternate screen, so the hook
+/// only delegates to the previous hook in that case, leaving the reporting
+/// unchanged.
+///
 /// Call it only once. Each call wraps the previous hook, so repeated calls
 /// would restore the terminal multiple times (harmless, but pointless).
 pub fn install_panic_hook() {
@@ -51,13 +75,41 @@ pub fn install_panic_hook() {
     ));
 }
 
+/// Marks `body` as a runtime-owned producer task body whose panics the runtime
+/// contains (RFC 0011 §5, INV-LC8).
+///
+/// The panic hook runs *before* the spawn site's `catch_unwind` regains
+/// control, so without this mark it would restore the terminal for a panic
+/// that leaves the application running. Wrapping the task body makes the
+/// containment visible to the hook, which then skips the restore.
+///
+/// This is the single placement point for the mark: every runtime-owned
+/// producer spawn site wraps its task body with it, so unifying those spawn
+/// paths later moves one call each rather than a mechanism.
+pub fn contained_producer<F: Future>(body: F) -> TaskLocalFuture<(), F> {
+    CONTAINED_PRODUCER.scope((), body)
+}
+
+/// Reports whether the current thread is inside a [`contained_producer`] poll,
+/// i.e. whether a panic raised here is one the runtime contains.
+fn in_contained_producer() -> bool {
+    CONTAINED_PRODUCER.try_with(|&()| ()).is_ok()
+}
+
 /// Composes a panic hook that runs `restore` and then delegates to `next`.
+///
+/// `restore` is skipped for a panic unwinding out of a [`contained_producer`]
+/// poll, because the application it would restore the terminal away from is
+/// still running (INV-LC8); the delegation to `next` is unconditional either
+/// way.
 ///
 /// Extracted from [`install_panic_hook`] so the chaining order can be tested
 /// without touching a real terminal.
 fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook) -> PanicHook {
     Box::new(move |info| {
-        restore();
+        if !in_contained_producer() {
+            restore();
+        }
         next(info);
     })
 }
@@ -68,11 +120,107 @@ mod tests {
 
     use super::*;
 
+    use std::future::pending;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex, PoisonError};
+    use std::thread;
 
-    // A single test, because `set_hook`/`take_hook` mutate process-global state.
-    // Running multiple hook-swapping tests in parallel would let them clobber
-    // each other's hooks, so both properties are asserted here in one go.
+    use futures::future::join_all;
+    use tokio::runtime::Builder;
+    use tokio::sync::oneshot;
+    use tokio::task::yield_now;
+
+    /// Records how a composed hook classified each panic, counting only panics
+    /// raised on the installing test's own worker threads.
+    ///
+    /// `set_hook`/`take_hook` mutate process-global state, so every test here
+    /// holds [`PANIC_HOOK_GUARD`] for its whole critical section. That
+    /// serializes the hook swaps but not the rest of the test binary: a test
+    /// that panics without taking the guard would still reach this hook. The
+    /// thread-name filter keeps such a panic out of the counts, since each
+    /// probe stamps a unique name on the worker threads it panics from.
+    struct HookProbe {
+        restores: Arc<AtomicUsize>,
+        delegations: Arc<AtomicUsize>,
+        previous: Option<PanicHook>,
+    }
+
+    impl HookProbe {
+        fn install(thread_prefix: &'static str) -> Self {
+            let restores = Arc::new(AtomicUsize::new(0));
+            let delegations = Arc::new(AtomicUsize::new(0));
+
+            let restore_counter = Arc::clone(&restores);
+            let delegation_counter = Arc::clone(&delegations);
+            let next: PanicHook = Box::new(move |_info| {
+                if on_thread(thread_prefix) {
+                    delegation_counter.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+            let hook = compose_hook(
+                move || {
+                    if on_thread(thread_prefix) {
+                        restore_counter.fetch_add(1, Ordering::SeqCst);
+                    }
+                },
+                next,
+            );
+
+            let previous = panic::take_hook();
+            panic::set_hook(hook);
+            Self {
+                restores,
+                delegations,
+                previous: Some(previous),
+            }
+        }
+
+        /// The `(restores, delegations)` counts so far.
+        fn counts(&self) -> (usize, usize) {
+            (
+                self.restores.load(Ordering::SeqCst),
+                self.delegations.load(Ordering::SeqCst),
+            )
+        }
+
+        /// Reinstalls the previous hook. Assertions run only after this, so a
+        /// failing assertion still reports through the normal hook.
+        fn finish(mut self) {
+            self.restore_previous();
+        }
+
+        fn restore_previous(&mut self) {
+            if let Some(hook) = self.previous.take() {
+                panic::set_hook(hook);
+            }
+        }
+    }
+
+    impl Drop for HookProbe {
+        fn drop(&mut self) {
+            // `set_hook` panics when called from a panicking thread, so an
+            // unwinding test leaves the probe hook installed rather than
+            // aborting the process; the next test's `install` replaces it.
+            if !thread::panicking() {
+                self.restore_previous();
+            }
+        }
+    }
+
+    fn on_thread(prefix: &str) -> bool {
+        thread::current()
+            .name()
+            .is_some_and(|name| name.starts_with(prefix))
+    }
+
+    /// Yields enough times to give the multi-thread scheduler opportunities to
+    /// move the task to another worker between polls.
+    async fn yield_repeatedly() {
+        for _ in 0..8 {
+            yield_now().await;
+        }
+    }
+
     #[test]
     #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
     fn test_compose_hook_restores_then_delegates_once() {
@@ -120,6 +268,209 @@ mod tests {
             recorded,
             vec!["restore", "next"],
             "restore must run exactly once, before the delegated hook"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_contained_producer_panic_skips_restore_while_application_panic_restores() {
+        const PROBE: &str = "tears-panic-probe-contained";
+
+        let _hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name(PROBE)
+            .build()
+            .expect("probe runtime should build");
+        let probe = HookProbe::install(PROBE);
+
+        // A panic the runtime contains (INV-LC8): the application keeps
+        // running, so its terminal must be left as it is.
+        let contained = runtime.block_on(runtime.spawn(contained_producer(async {
+            panic!("contained producer panicked");
+        })));
+        let after_contained = probe.counts();
+        let survivor = runtime.block_on(runtime.spawn(async { 7_u32 }));
+
+        // A panic on the application's own path stays fail-fast and restores.
+        let application = runtime.block_on(runtime.spawn(async {
+            panic!("application panicked");
+        }));
+        let after_application = probe.counts();
+
+        probe.finish();
+
+        assert!(contained.is_err(), "the contained producer should panic");
+        assert_eq!(
+            after_contained,
+            (0, 1),
+            "a contained producer panic must delegate without restoring the terminal"
+        );
+        assert_eq!(
+            survivor.expect("the runtime should keep running after a contained panic"),
+            7,
+            "producers spawned after a contained panic must still run"
+        );
+        assert!(application.is_err(), "the application task should panic");
+        assert_eq!(
+            after_application,
+            (1, 2),
+            "an application panic must restore the terminal as before"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_contained_mark_does_not_span_await_points() {
+        const PROBE: &str = "tears-panic-probe-parked";
+
+        let _hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        // One worker thread, so the unrelated task below is guaranteed to run
+        // on the very thread that parked the contained producer — the exact
+        // condition a mark held across `.await` would misclassify.
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name(PROBE)
+            .build()
+            .expect("probe runtime should build");
+        let probe = HookProbe::install(PROBE);
+
+        let (parked_tx, parked_rx) = oneshot::channel();
+        let (resume_tx, resume_rx) = oneshot::channel();
+        let producer = runtime.spawn(contained_producer(async move {
+            let _ = parked_tx.send(());
+            let _ = resume_rx.await;
+            panic!("contained producer panicked after resuming");
+        }));
+        runtime.block_on(async {
+            let _ = parked_rx.await;
+        });
+
+        let unrelated = runtime.block_on(runtime.spawn(async {
+            panic!("unrelated task panicked");
+        }));
+        let after_unrelated = probe.counts();
+
+        // The producer resumes on a later poll — possibly on another worker
+        // thread — and its panic must still be classified as contained.
+        let _ = resume_tx.send(());
+        let resumed = runtime.block_on(producer);
+        let after_resumed = probe.counts();
+
+        probe.finish();
+
+        assert!(unrelated.is_err(), "the unrelated task should panic");
+        assert_eq!(
+            after_unrelated,
+            (1, 1),
+            "a panic on a thread that only parked a contained producer must restore"
+        );
+        assert!(resumed.is_err(), "the resumed producer should panic");
+        assert_eq!(
+            after_resumed,
+            (1, 2),
+            "the contained mark must be re-established on the poll that resumes the producer"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_contained_classification_survives_worker_migration() {
+        const PROBE: &str = "tears-panic-probe-migrating";
+        const TASKS: usize = 8;
+
+        let _hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(4)
+            .thread_name(PROBE)
+            .build()
+            .expect("probe runtime should build");
+        let probe = HookProbe::install(PROBE);
+
+        // Contained and uncontained panics interleave across four workers,
+        // each task yielding repeatedly before it panics. Whichever worker
+        // ends up polling a task, its classification must follow the task.
+        let outcomes = runtime.block_on(async {
+            let mut handles = Vec::with_capacity(TASKS * 2);
+            for _ in 0..TASKS {
+                handles.push(tokio::spawn(contained_producer(async {
+                    yield_repeatedly().await;
+                    panic!("contained producer panicked");
+                })));
+                handles.push(tokio::spawn(async {
+                    yield_repeatedly().await;
+                    panic!("application panicked");
+                }));
+            }
+            join_all(handles).await
+        });
+        let counts = probe.counts();
+
+        probe.finish();
+
+        assert!(
+            outcomes.iter().all(Result::is_err),
+            "every spawned task should panic"
+        );
+        assert_eq!(
+            counts,
+            (TASKS, TASKS * 2),
+            "only the uncontained half may restore, however the workers interleave"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_aborted_contained_producer_leaves_no_mark_on_the_worker() {
+        const PROBE: &str = "tears-panic-probe-aborted";
+
+        let _hook_guard = PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        // One worker thread, so the panic below lands on the same thread the
+        // aborted producer was polled and dropped on.
+        let runtime = Builder::new_multi_thread()
+            .worker_threads(1)
+            .thread_name(PROBE)
+            .build()
+            .expect("probe runtime should build");
+        let probe = HookProbe::install(PROBE);
+
+        let (parked_tx, parked_rx) = oneshot::channel();
+        let producer = runtime.spawn(contained_producer(async move {
+            let _ = parked_tx.send(());
+            pending::<()>().await;
+        }));
+        runtime.block_on(async {
+            let _ = parked_rx.await;
+        });
+
+        producer.abort();
+        // Joining the aborted handle waits until the task future has been
+        // dropped, so any mark the abort could have leaked would still be set.
+        let aborted = runtime.block_on(producer);
+        let unrelated = runtime.block_on(runtime.spawn(async {
+            panic!("unrelated task panicked after the abort");
+        }));
+        let counts = probe.counts();
+
+        probe.finish();
+
+        assert!(
+            aborted.is_err_and(|error| error.is_cancelled()),
+            "the producer should report as cancelled"
+        );
+        assert!(unrelated.is_err(), "the unrelated task should panic");
+        assert_eq!(
+            counts,
+            (1, 1),
+            "an aborted contained producer must not leave its mark on the worker thread"
         );
     }
 }

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -674,4 +674,49 @@ mod tests {
         )
         .await;
     }
+
+    // Guards the wiring, not the mechanism: `enqueue_command` must wrap the
+    // unkeyed task body in `contained_producer`, so the panic hook skips the
+    // terminal restore for a panic the runtime contains (RFC 0011 INV-LC8).
+    // The mechanism itself is covered in `crate::panic`; this row fails if a
+    // future rewrite of the spawn path drops the wrapper.
+    #[tokio::test]
+    #[expect(
+        clippy::panic,
+        reason = "driving the panic hook requires a real panic in the task body"
+    )]
+    async fn a_panicking_unkeyed_command_task_skips_the_terminal_restore() {
+        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let probe = crate::test_support::HookProbe::install(
+            "runtime::core::tests::a_panicking_unkeyed_command_task_skips_the_terminal_restore",
+        );
+
+        let mut core = RuntimeCore::<TestApp>::new(0);
+        core.enqueue_command(
+            Command::future(async {
+                panic!("boom");
+                #[expect(
+                    unreachable_code,
+                    reason = "the value follows an unconditional panic! that never returns, but types the async block"
+                )]
+                TestMessage::Increment
+            })
+            .into_runtime_parts(),
+        );
+
+        wait_until(
+            || probe.counts().1 == 1,
+            "the contained panic should reach the delegated hook",
+        )
+        .await;
+        let counts = probe.counts();
+        probe.finish();
+        assert_eq!(
+            counts,
+            (0, 1),
+            "an unkeyed command task panic must delegate without restoring"
+        );
+    }
 }

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -265,8 +265,8 @@ mod tests {
 
     use std::future::pending;
     use std::num::{NonZeroU64, NonZeroUsize};
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, PoisonError};
 
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
@@ -277,7 +277,7 @@ mod tests {
     use crate::runtime::AppInput;
     use crate::subscription::Subscription;
     use crate::subscription::time::Timer;
-    use crate::test_support::{TestApp, TestMessage, wait_until};
+    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD, TestApp, TestMessage, wait_until};
 
     #[test]
     fn test_new() {
@@ -685,11 +685,15 @@ mod tests {
         clippy::panic,
         reason = "driving the panic hook requires a real panic in the task body"
     )]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
+    )]
     async fn a_panicking_unkeyed_command_task_skips_the_terminal_restore() {
-        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+        let _hook_guard = PANIC_HOOK_GUARD
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let probe = crate::test_support::HookProbe::install(
+            .unwrap_or_else(PoisonError::into_inner);
+        let probe = HookProbe::install(
             "runtime::core::tests::a_panicking_unkeyed_command_task_skips_the_terminal_restore",
         );
 

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -18,6 +18,7 @@ use tokio::task::JoinSet;
 
 use crate::application::Application;
 use crate::command::{Action, RuntimeCommandParts, fold_leaves};
+use crate::panic::contained_producer;
 use crate::subscription::SubscriptionManager;
 
 use super::app_input::AppInputs;
@@ -183,7 +184,10 @@ impl<App: Application> RuntimeCore<App> {
                 let _command_guard = command_guard;
                 // Catch panics in the command's stream so a bug in a fetcher or
                 // effect is logged instead of vanishing into a detached task.
-                let result = AssertUnwindSafe(async move {
+                // `contained_producer` marks the body so the panic hook leaves
+                // the terminal of the still-running application alone
+                // (RFC 0011 INV-LC8).
+                let result = AssertUnwindSafe(contained_producer(async move {
                     futures::pin_mut!(stream);
                     while let Some(action) = stream.next().await {
                         match action {
@@ -207,7 +211,7 @@ impl<App: Application> RuntimeCore<App> {
                             }
                         }
                     }
-                })
+                }))
                 .catch_unwind()
                 .await;
 

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -566,8 +566,8 @@ mod tests {
 
     use std::future::pending;
     use std::num::NonZeroUsize;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, PoisonError};
     use std::time::Duration;
 
     use futures::stream;
@@ -579,7 +579,9 @@ mod tests {
 
     use crate::Command;
     use crate::command::{RetryPolicy, fold_leaves};
-    use crate::test_support::{TraceRecorder, wait_until, with_silent_panic_hook};
+    use crate::test_support::{
+        HookProbe, PANIC_HOOK_GUARD, TraceRecorder, wait_until, with_silent_panic_hook,
+    };
 
     fn actions<I>(items: I) -> BoxStream<'static, Action<i32>>
     where
@@ -1085,11 +1087,15 @@ mod tests {
         clippy::panic,
         reason = "driving the panic hook requires a real panic in the task body"
     )]
+    #[expect(
+        clippy::await_holding_lock,
+        reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
+    )]
     async fn a_panicking_keyed_command_task_skips_the_terminal_restore() {
-        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+        let _hook_guard = PANIC_HOOK_GUARD
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let probe = crate::test_support::HookProbe::install(
+            .unwrap_or_else(PoisonError::into_inner);
+        let probe = HookProbe::install(
             "runtime::keyed_commands::tests::a_panicking_keyed_command_task_skips_the_terminal_restore",
         );
 

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -10,6 +10,7 @@ use tokio_stream::StreamMap;
 
 use crate::command::{Action, CancelPolicy, CommandId};
 use crate::noop_waker::noop_context;
+use crate::panic::contained_producer;
 
 use super::channel;
 use super::load::{Channel, LoadObserver};
@@ -303,7 +304,10 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
         let task_id = id.clone();
 
         let abort = self.tasks.spawn(async move {
-            let result = AssertUnwindSafe(async move {
+            // `contained_producer` marks the body so the panic hook leaves the
+            // terminal of the still-running application alone (RFC 0011
+            // INV-LC8); the panic itself is caught and logged below.
+            let result = AssertUnwindSafe(contained_producer(async move {
                 futures::pin_mut!(stream);
                 while let Some(action) = stream.next().await {
                     match action {
@@ -330,7 +334,7 @@ impl<Msg: Send + 'static> KeyedCommands<Msg> {
                         }
                     }
                 }
-            })
+            }))
             .catch_unwind()
             .await;
 

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -1075,6 +1075,53 @@ mod tests {
         assert!(!contains_id);
     }
 
+    // Guards the wiring, not the mechanism: `start_run` must wrap the keyed
+    // task body in `contained_producer`, so the panic hook skips the terminal
+    // restore for a panic the runtime contains (RFC 0011 INV-LC8). The
+    // mechanism itself is covered in `crate::panic`; this row fails if a
+    // future rewrite of the spawn path drops the wrapper.
+    #[tokio::test]
+    #[expect(
+        clippy::panic,
+        reason = "driving the panic hook requires a real panic in the task body"
+    )]
+    async fn a_panicking_keyed_command_task_skips_the_terminal_restore() {
+        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let probe = crate::test_support::HookProbe::install(
+            "runtime::keyed_commands::tests::a_panicking_keyed_command_task_skips_the_terminal_restore",
+        );
+
+        let id = CommandId::new("panic-restore");
+        let mut manager = KeyedCommands::new(None, LoadObserver::default());
+        manager.spawn(
+            id,
+            CancelPolicy::CancelInFlight,
+            command_stream(Command::future(async {
+                panic!("boom");
+                #[expect(
+                    unreachable_code,
+                    reason = "the value follows an unconditional panic! that never returns, but types the async block"
+                )]
+                1
+            })),
+        );
+
+        wait_until(
+            || probe.counts().1 == 1,
+            "the contained panic should reach the delegated hook",
+        )
+        .await;
+        let counts = probe.counts();
+        probe.finish();
+        assert_eq!(
+            counts,
+            (0, 1),
+            "a keyed command task panic must delegate without restoring"
+        );
+    }
+
     #[tokio::test]
     async fn shutdown_aborts_keyed_tasks() {
         struct AbortGuard(Arc<AtomicBool>);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -157,6 +157,7 @@ use tokio::sync::mpsc;
 
 pub(crate) use core::{Subscription, SubscriptionId, SubscriptionSource};
 
+use crate::panic::contained_producer;
 use crate::runtime::channel;
 use crate::runtime::load::LoadObserver;
 
@@ -258,7 +259,10 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
             let _subscription_guard = subscription_guard;
             // Catch panics in the subscription's stream so a bug in a source is
             // logged instead of vanishing into a detached task.
-            let result = AssertUnwindSafe(async move {
+            // `contained_producer` marks the body so the panic hook leaves the
+            // terminal of the still-running application alone (RFC 0011
+            // INV-LC8).
+            let result = AssertUnwindSafe(contained_producer(async move {
                 while let Some(msg) = stream.next().await {
                     // Awaiting the send applies backpressure in bounded mode: the
                     // forwarding task stops polling the source stream until the
@@ -268,7 +272,7 @@ impl<Msg: Send + 'static> SubscriptionManager<Msg> {
                         break;
                     }
                 }
-            })
+            }))
             .catch_unwind()
             .await;
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -1326,4 +1326,62 @@ mod tests {
 
         Ok(())
     }
+
+    struct PanickingSource;
+
+    impl SubscriptionSource for PanickingSource {
+        type Output = i32;
+        type Key = ();
+
+        fn stream(&self) -> BoxStream<'static, i32> {
+            stream::once(async {
+                panic!("boom");
+                #[expect(
+                    unreachable_code,
+                    reason = "the value follows an unconditional panic! that never returns, but types the async block"
+                )]
+                0
+            })
+            .boxed()
+        }
+
+        fn key(&self) -> Self::Key {}
+    }
+
+    // Guards the wiring, not the mechanism: `spawn_subscription` must wrap the
+    // forwarder body in `contained_producer`, so the panic hook skips the
+    // terminal restore for a panic the runtime contains (RFC 0011 INV-LC8).
+    // The mechanism itself is covered in `crate::panic`; this row fails if a
+    // future rewrite of the spawn path drops the wrapper.
+    #[tokio::test]
+    #[expect(
+        clippy::panic,
+        reason = "driving the panic hook requires a real panic in the source stream"
+    )]
+    async fn a_panicking_subscription_forwarder_skips_the_terminal_restore() {
+        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let probe = crate::test_support::HookProbe::install(
+            "subscription::tests::a_panicking_subscription_forwarder_skips_the_terminal_restore",
+        );
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut manager =
+            SubscriptionManager::new(channel::Sender::from_unbounded(tx), LoadObserver::default());
+        manager.update(vec![Subscription::new(PanickingSource)]);
+
+        wait_until(
+            || probe.counts().1 == 1,
+            "the contained panic should reach the delegated hook",
+        )
+        .await;
+        let counts = probe.counts();
+        probe.finish();
+        assert_eq!(
+            counts,
+            (0, 1),
+            "a subscription forwarder panic must delegate without restoring"
+        );
+    }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -361,7 +361,7 @@ mod tests {
 
     use std::hash::{Hash, Hasher};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, PoisonError};
     use std::task::Poll;
 
     use color_eyre::eyre::Result;
@@ -369,7 +369,7 @@ mod tests {
     use tokio::time::{Duration, sleep, timeout};
 
     use crate::subscription::mock::MockSource;
-    use crate::test_support::{TraceRecorder, wait_until};
+    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD, TraceRecorder, wait_until};
 
     struct OneshotSource {
         value: i32,
@@ -1333,6 +1333,10 @@ mod tests {
         type Output = i32;
         type Key = ();
 
+        #[expect(
+            clippy::panic,
+            reason = "the source exists to raise a real panic in the forwarder"
+        )]
         fn stream(&self) -> BoxStream<'static, i32> {
             stream::once(async {
                 panic!("boom");
@@ -1355,14 +1359,14 @@ mod tests {
     // future rewrite of the spawn path drops the wrapper.
     #[tokio::test]
     #[expect(
-        clippy::panic,
-        reason = "driving the panic hook requires a real panic in the source stream"
+        clippy::await_holding_lock,
+        reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
     )]
     async fn a_panicking_subscription_forwarder_skips_the_terminal_restore() {
-        let _hook_guard = crate::test_support::PANIC_HOOK_GUARD
+        let _hook_guard = PANIC_HOOK_GUARD
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let probe = crate::test_support::HookProbe::install(
+            .unwrap_or_else(PoisonError::into_inner);
+        let probe = HookProbe::install(
             "subscription::tests::a_panicking_subscription_forwarder_skips_the_terminal_restore",
         );
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -12,7 +12,7 @@ use crate::command::Command;
 use crate::subscription::Subscription;
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
-pub use panic_hook::{PANIC_HOOK_GUARD, with_silent_panic_hook};
+pub use panic_hook::{HookProbe, PANIC_HOOK_GUARD, with_silent_panic_hook};
 pub use trace_recorder::{TraceRecorder, set_default_subscriber};
 
 mod async_utils;

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -10,6 +10,8 @@ use std::thread;
 
 use futures::FutureExt;
 
+use crate::panic::compose_hook;
+
 /// Serializes tests that install a process-global panic hook or deliberately
 /// trigger panics.
 ///
@@ -52,12 +54,6 @@ impl Drop for SilentPanicHook {
     }
 }
 
-/// Runs a future with a no-op process-global panic hook installed.
-///
-/// Panics from the future are caught long enough to restore the previous hook,
-/// then resumed. Cancellation also restores the hook through the internal drop
-/// guard. This helper is for `current_thread` tests because it holds
-/// [`PANIC_HOOK_GUARD`] across `.await`.
 /// Records how a [`compose_hook`](crate::panic::compose_hook)-composed hook
 /// classified each panic, counting only panics raised on threads whose name
 /// starts with the installing test's prefix.
@@ -88,7 +84,7 @@ impl HookProbe {
                 delegation_counter.fetch_add(1, Ordering::SeqCst);
             }
         });
-        let hook = crate::panic::compose_hook(
+        let hook = compose_hook(
             move || {
                 if on_thread(thread_prefix) {
                     restore_counter.fetch_add(1, Ordering::SeqCst);
@@ -144,6 +140,12 @@ fn on_thread(prefix: &str) -> bool {
         .is_some_and(|name| name.starts_with(prefix))
 }
 
+/// Runs a future with a no-op process-global panic hook installed.
+///
+/// Panics from the future are caught long enough to restore the previous hook,
+/// then resumed. Cancellation also restores the hook through the internal drop
+/// guard. This helper is for `current_thread` tests because it holds
+/// [`PANIC_HOOK_GUARD`] across `.await`.
 #[expect(
     clippy::await_holding_lock,
     clippy::future_not_send,

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -4,7 +4,8 @@
 
 use std::future::Future;
 use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
-use std::sync::{Mutex, PoisonError};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
 use std::thread;
 
 use futures::FutureExt;
@@ -57,6 +58,92 @@ impl Drop for SilentPanicHook {
 /// then resumed. Cancellation also restores the hook through the internal drop
 /// guard. This helper is for `current_thread` tests because it holds
 /// [`PANIC_HOOK_GUARD`] across `.await`.
+/// Records how a [`compose_hook`](crate::panic::compose_hook)-composed hook
+/// classified each panic, counting only panics raised on threads whose name
+/// starts with the installing test's prefix.
+///
+/// Unlike [`with_silent_panic_hook`] (current-thread, async), this probe also
+/// serves multi-thread runtimes and non-async tests; callers hold
+/// [`PANIC_HOOK_GUARD`] for their whole critical section themselves. That
+/// serializes the hook swaps but not the rest of the test binary: a test that
+/// panics without taking the guard would still reach this hook. The
+/// thread-name filter keeps such a panic out of the counts — libtest names
+/// each test's thread after the test's full path, and multi-thread tests
+/// stamp their runtime workers with their own prefix.
+pub struct HookProbe {
+    restores: Arc<AtomicUsize>,
+    delegations: Arc<AtomicUsize>,
+    previous: Option<PanicHook>,
+}
+
+impl HookProbe {
+    pub fn install(thread_prefix: &'static str) -> Self {
+        let restores = Arc::new(AtomicUsize::new(0));
+        let delegations = Arc::new(AtomicUsize::new(0));
+
+        let restore_counter = Arc::clone(&restores);
+        let delegation_counter = Arc::clone(&delegations);
+        let next: PanicHook = Box::new(move |_info| {
+            if on_thread(thread_prefix) {
+                delegation_counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        let hook = crate::panic::compose_hook(
+            move || {
+                if on_thread(thread_prefix) {
+                    restore_counter.fetch_add(1, Ordering::SeqCst);
+                }
+            },
+            next,
+        );
+
+        let previous = panic::take_hook();
+        panic::set_hook(hook);
+        Self {
+            restores,
+            delegations,
+            previous: Some(previous),
+        }
+    }
+
+    /// The `(restores, delegations)` counts so far.
+    pub fn counts(&self) -> (usize, usize) {
+        (
+            self.restores.load(Ordering::SeqCst),
+            self.delegations.load(Ordering::SeqCst),
+        )
+    }
+
+    /// Reinstalls the previous hook. Assertions run only after this, so a
+    /// failing assertion still reports through the normal hook.
+    pub fn finish(mut self) {
+        self.restore_previous();
+    }
+
+    fn restore_previous(&mut self) {
+        if let Some(hook) = self.previous.take() {
+            panic::set_hook(hook);
+        }
+    }
+}
+
+impl Drop for HookProbe {
+    fn drop(&mut self) {
+        // `set_hook` panics when called from a panicking thread, so an
+        // unwinding test leaves the probe hook installed rather than
+        // aborting the process; the next test's `install` replaces it.
+        if !thread::panicking() {
+            self.restore_previous();
+        }
+    }
+}
+
+fn on_thread(prefix: &str) -> bool {
+    thread::current()
+        .name()
+        .is_some_and(|name| name.starts_with(prefix))
+}
+
 #[expect(
     clippy::await_holding_lock,
     clippy::future_not_send,


### PR DESCRIPTION
## Summary

`install_panic_hook` restored the terminal unconditionally on any panic. But a panic inside a runtime-owned producer task — an unkeyed command task, a keyed command task, or a subscription forwarder — is contained by the runtime (RFC 0011 §5, INV-LC8): it is caught at the spawn site, logged, and the application keeps running. The unconditional restore fired before that containment could, dropping a live UI out of raw mode and off the alternate screen while the event loop kept drawing.

The hook now skips the terminal restore for contained panics; delegation to the previously installed hook (panic reporting) stays unconditional. Application driving-path panics — `update`, `view`, `subscriptions`, source constructors — restore exactly as before.

## Mechanism (no contract change)

- A tokio `task_local!` mark, applied via one wrapper — `contained_producer(body)` — at each of the three runtime-owned producer spawn sites (`RuntimeCore::enqueue_command`, `KeyedCommands::start_run`, `SubscriptionManager::spawn_subscription`; verified no other non-test spawn exists in `src/`). The wrapper is the single placement point, so a future unification of the spawn paths moves one call, not a mechanism.
- `TaskLocalFuture` sets the value on poll entry and clears it on poll exit — including unwinding exits and the drop path — so the mark brackets a single synchronous poll: it never spans an `.await`, never leaks onto a worker that only parked the task, and follows a migrating task. This is why a per-poll scope was chosen over a thread-local held across `.await` (which task migration would corrupt).
- The mark sits inside the existing `AssertUnwindSafe(...).catch_unwind()` (outermost, since `TaskLocalFuture` is not `UnwindSafe`); the hook runs while the guarded poll is still unwinding, so the mark is visible to it.
- Known widening, intentional: `TaskLocalFuture` also scopes the inner future's drop, so a panic in a producer's destructor during teardown is classified contained — that is still runtime-owned producer code, matching INV-LC8's intent.

## Tests

All four scenarios from the issue checklist, in `src/panic.rs` (counts filtered by per-test worker-thread names so unrelated panics in the test binary cannot move them):

1. contained producer panic → no restore, delegation still fires, a task spawned afterwards completes; end-to-end "app keeps running" remains covered by the pre-existing `test_runtime_run_logs_command_task_panic`
2. driving/application panic → restore fires as before
3. migration safety: a deterministic 1-worker test (an unrelated panic on the thread that parked a contained producer restores; the producer's post-resume panic is skipped) plus a 4-worker stress test (8 contained + 8 uncontained tasks yielding repeatedly; counts land exactly)
4. abort while guarded → no leaked mark on the worker; a subsequent unrelated panic restores

Mutation-checked in both directions: forcing the restore unconditional fails 1/3; forcing the mark always-on fails all panic tests.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --bins --tests --examples --all-features`: 434 lib + all integration/example targets, 0 failed; doc-tests 51 passed
- `cargo test --test api_surface -- --ignored`: 2 passed (no public API change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
