### PR TITLE
test(testing): isolate the IO-disabled leaf fixture from socket syscalls

### DIFF
--- a/src/testing.rs
+++ b/src/testing.rs
@@ -869,8 +869,7 @@ mod tests {
     #[cfg(all(not(loom), unix))]
     fn register_with_io_driver() {
         drop(AsyncFd::new(stdin()).expect(
-            "registering an fd should not have reached a fallible step in the \
-                 store's context",
+            "registering an fd should not have reached a fallible step in the store's context",
         ));
     }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -868,15 +868,18 @@ mod tests {
     /// panic.
     #[cfg(all(not(loom), unix))]
     fn register_with_io_driver() {
-        drop(
-            AsyncFd::new(stdin()).expect("registering without an I/O driver should have panicked"),
-        );
+        drop(AsyncFd::new(stdin()).expect(
+            "registering an fd should not have reached a fallible step in the \
+                 store's context",
+        ));
     }
 
     /// The non-Unix counterpart: no descriptor-registration API is
     /// available there, so the resource is created first — a creation
     /// failure panics here, with a message of its own, instead of
-    /// completing the leaf with a delivered message.
+    /// completing the leaf with a delivered message. Note that CI lints
+    /// only on Linux, so this branch is compiled by the Windows test job
+    /// but never clippy-checked.
     #[cfg(all(not(loom), not(unix)))]
     fn register_with_io_driver() {
         let socket =
@@ -895,7 +898,9 @@ mod tests {
     /// for the would-fail-if-polled class.
     #[cfg(not(loom))]
     fn io_command() -> Command<Msg> {
-        Command::perform(async { register_with_io_driver() }, |()| Msg::N(99))
+        Command::perform(async { register_with_io_driver() }, |()| {
+            unreachable!("the I/O-dependent leaf must fail the test before completing")
+        })
     }
 
     /// A `Command::timeout` leaf over a never-ready future: deliverable

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -764,6 +764,10 @@ mod tests {
 
     use std::any::Any;
     use std::future::pending;
+    #[cfg(all(not(loom), unix))]
+    use std::io::stdin;
+    #[cfg(all(not(loom), not(unix)))]
+    use std::net::UdpSocket as StdUdpSocket;
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -774,10 +778,12 @@ mod tests {
     use futures::channel::oneshot;
     use futures::stream;
     use ratatui::Frame;
-    // `tokio::net` is compiled out under `--cfg loom` (tokio gates it), so
-    // the I/O-dependent leaf helper and its tests are too.
-    #[cfg(not(loom))]
-    use tokio::net::TcpStream;
+    // Tokio's I/O resources are compiled out under `--cfg loom` (tokio gates
+    // them), so the I/O-dependent leaf helper and its tests are too.
+    #[cfg(all(not(loom), unix))]
+    use tokio::io::unix::AsyncFd;
+    #[cfg(all(not(loom), not(unix)))]
+    use tokio::net::UdpSocket;
     use tracing::Level;
 
     use crate::command::{Command, RetryPolicy};
@@ -849,17 +855,47 @@ mod tests {
         StartQuit,
     }
 
+    /// Registers an I/O resource with the runtime's I/O driver — the step
+    /// that panics inside the store's time-only context (RFC 0008 §4.3).
+    ///
+    /// Registration is deliberately the *first* fallible step: an already
+    /// open descriptor is registered as it is, so no syscall of the leaf's
+    /// own can fail ahead of the driver lookup. A leaf that opens its own
+    /// socket first is not so ordered — when the socket syscall fails
+    /// synchronously (a sandbox denying networking, an exhausted descriptor
+    /// table) the leaf completes with `Err` without ever reaching the
+    /// driver, and its mapped message is delivered instead of the expected
+    /// panic.
+    #[cfg(all(not(loom), unix))]
+    fn register_with_io_driver() {
+        drop(
+            AsyncFd::new(stdin()).expect("registering without an I/O driver should have panicked"),
+        );
+    }
+
+    /// The non-Unix counterpart: no descriptor-registration API is
+    /// available there, so the resource is created first — a creation
+    /// failure panics here, with a message of its own, instead of
+    /// completing the leaf with a delivered message.
+    #[cfg(all(not(loom), not(unix)))]
+    fn register_with_io_driver() {
+        let socket =
+            StdUdpSocket::bind("127.0.0.1:0").expect("binding a local UDP socket should succeed");
+        socket
+            .set_nonblocking(true)
+            .expect("setting non-blocking mode should succeed");
+        drop(
+            UdpSocket::from_std(socket)
+                .expect("registering without an I/O driver should have panicked"),
+        );
+    }
+
     /// A leaf that needs the I/O driver: polling it inside the store's
     /// time-only context fails the test (RFC 0008 §4.3), so it stands in
     /// for the would-fail-if-polled class.
     #[cfg(not(loom))]
     fn io_command() -> Command<Msg> {
-        Command::perform(
-            async {
-                drop(TcpStream::connect("127.0.0.1:9").await);
-            },
-            |()| Msg::N(99),
-        )
+        Command::perform(async { register_with_io_driver() }, |()| Msg::N(99))
     }
 
     /// A `Command::timeout` leaf over a never-ready future: deliverable


### PR DESCRIPTION
## Summary

Resolves the one-time order-dependent failure of `polling_an_io_dependent_leaf_fails_the_test` (observed 2026-07-31: `expected: N(1) / actual: N(99)` instead of the "IO is disabled" panic; passed in isolation and on re-runs). Test-only change — library behavior and the RFC 0008 contract are untouched.

## Root cause

The fixture's I/O-dependent leaf opened its own socket (`TcpStream::connect("127.0.0.1:9")`) before reaching the I/O driver. Tokio registers the socket with the driver — the step that panics under TestStore's time-only context — only after mio's non-blocking `connect` returns `EINPROGRESS`. When the socket syscall fails synchronously instead (any other errno), the leaf completes with `Err` without ever touching the driver, and `Command::perform` maps that completion to `N(99)` — the exact observed value, from the only `N(99)` producer in that store.

The trigger is environmental, not a shared-state leak: under a network-denying sandbox `connect(2)` returns `EPERM` and the failure reproduces on 100% of runs, verbatim; with the descriptor table exhausted `socket(2)` returns `EMFILE` with the same result. Plain re-runs (100× at 16 threads, 20× single-threaded) never hit it, matching the original one-off. The shared-runtime/reactor, leaked `EnterGuard`, panic-hook, and competing-leaf hypotheses were each eliminated by inspection.

## Fix

Two layers, so the expected panic is the only reachable outcome:

- **Driver registration is the leaf's first fallible step** (Unix): the leaf registers an already open descriptor (`AsyncFd::new(stdin())` — `std::io::Stdin` does not own fd 0, so nothing is closed) and no syscall of the leaf's own precedes the driver lookup. On non-Unix targets (no descriptor-registration API) the socket is still created first, with every pre-registration step `.expect()`-guarded.
- **Completion is self-describing on every platform**: the completion mapper is `unreachable!("the I/O-dependent leaf must fail the test before completing")` instead of a silent `Msg::N(99)` — no test expects the leaf's completion message, so any path that lets the leaf complete (including the non-Unix socket-first branch) now fails with a stated reason rather than a value mismatch.

The leaf still does nothing until polled, so the cancellation and post-quit tests that rely on it never being polled keep their meaning. No assertion loosened, no `#[ignore]`, no retry. The non-Unix helper's doc records that CI lints only on Linux, so that branch is compiled by the Windows test job but never clippy-checked.

No forced-failure regression test is included on purpose: the portable forcing mechanisms (`setrlimit`, a syscall-denying sandbox) are process-global and would corrupt parallel tests; the `unreachable!` mapper is the standing guard instead.

## Verification

On the initial isolation commit: 1000/1000 runs panic with "IO is disabled" including under the sandbox and under `EMFILE`; 30× full-suite runs under the previously 100%-failing sandbox: 0 failures; 50× at 16 threads and 20× single-threaded: 0 failures. Non-Unix branch validated by locally inverting the cfg gates: compiles, clippy-clean, 430/430 pass.

On the follow-up commits: `cargo fmt --all -- --check` exit 0; `cargo clippy --all-targets --all-features -- -D warnings` exit 0; testing module 42 passed / 0 failed; full lib 430 passed / 0 failed. Reviewer-verified: tokio-1.50 source confirms the driver-lookup panic precedes `add_source`, and the target test passes with stdin as tty / pipe / regular file / `/dev/null` / closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
