### PR TITLE
test(runtime): add RFC 0011 lifecycle contract tests

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -549,8 +549,8 @@ mod tests {
     use std::future::pending;
     use std::hash::{Hash, Hasher};
     use std::num::NonZeroU32;
-    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use futures::stream::{self, BoxStream, iter};
     use ratatui::backend::TestBackend;
@@ -1990,6 +1990,266 @@ mod tests {
             )
             .await;
         }
+
+        Ok(())
+    }
+
+    // --- RFC 0011 steady-state phase order ----------------------------------
+    //
+    // The white-box seam RFC 0011 §8 names for INV-LC1/INV-LC2: drive
+    // `process_input_batch`/`process_frame_tick` directly with a recording
+    // application whose `view` and `subscriptions` append the state they
+    // observed to a shared log, so the phase sequence of a batch and of a frame
+    // pass is asserted rather than inferred from the pending flags.
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum Phase {
+        View(i32),
+        Subscriptions(i32),
+    }
+
+    #[derive(Clone, Default)]
+    struct PhaseLog(Arc<Mutex<Vec<Phase>>>);
+
+    impl PhaseLog {
+        fn push(&self, phase: Phase) {
+            self.0
+                .lock()
+                .expect("phase log mutex should not be poisoned")
+                .push(phase);
+        }
+
+        fn entries(&self) -> Vec<Phase> {
+            self.0
+                .lock()
+                .expect("phase log mutex should not be poisoned")
+                .clone()
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum PhaseMessage {
+        Bump,
+        BumpWithoutRedraw,
+    }
+
+    struct PhaseApp {
+        state: i32,
+        log: PhaseLog,
+    }
+
+    impl Application for PhaseApp {
+        type Message = PhaseMessage;
+        type Flags = PhaseLog;
+
+        fn new(log: PhaseLog) -> (Self, Command<Self::Message>) {
+            // The init command opts out of a redraw deliberately: the runtime
+            // never consults that directive (RFC 0011 §3.2), so the first
+            // render still starts out pending — the eligibility half of
+            // INV-LC4 asserted below.
+            (Self { state: 0, log }, Command::none().without_redraw())
+        }
+
+        fn update(&mut self, msg: Self::Message) -> Command<Self::Message> {
+            self.state += 1;
+            match msg {
+                PhaseMessage::Bump => Command::none(),
+                PhaseMessage::BumpWithoutRedraw => Command::none().without_redraw(),
+            }
+        }
+
+        fn view(&self, _frame: &mut Frame<'_>) {
+            self.log.push(Phase::View(self.state));
+        }
+
+        fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+            self.log.push(Phase::Subscriptions(self.state));
+            vec![]
+        }
+    }
+
+    fn phase_runtime(log: &PhaseLog) -> Runtime<PhaseApp> {
+        Runtime::<PhaseApp>::new(log.clone(), frame_rate(60))
+    }
+
+    fn phase_counts(entries: &[Phase]) -> (usize, usize) {
+        let views = entries
+            .iter()
+            .filter(|phase| matches!(phase, Phase::View(_)))
+            .count();
+        let reevaluations = entries
+            .iter()
+            .filter(|phase| matches!(phase, Phase::Subscriptions(_)))
+            .count();
+        (views, reevaluations)
+    }
+
+    // INV-LC1: rendering and subscription re-evaluation are frame-phase
+    // activities — neither runs inside an input batch, however many messages
+    // the batch processes. The clock is paused so all three messages land in
+    // one batch.
+    #[tokio::test(start_paused = true)]
+    async fn input_batch_neither_renders_nor_reevaluates_subscriptions() {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+
+        for _ in 0..2 {
+            runtime
+                .core
+                .msg_tx
+                .try_send(PhaseMessage::Bump)
+                .expect("receiver should be open");
+        }
+        runtime.process_message_batch(PhaseMessage::Bump);
+
+        assert_eq!(
+            runtime.core.app.state, 3,
+            "the batch should process all three messages"
+        );
+        assert_eq!(
+            log.entries(),
+            Vec::<Phase>::new(),
+            "an input batch must perform no render and no subscription re-evaluation"
+        );
+    }
+
+    // INV-LC1: one frame pass consumes the pending work a batch recorded
+    // exactly once — at most one render and at most one re-evaluation — and a
+    // following pass with nothing pending performs neither.
+    #[tokio::test(start_paused = true)]
+    async fn frame_pass_renders_once_and_reevaluates_once_per_pending_batch() -> Result<()> {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        for _ in 0..2 {
+            runtime
+                .core
+                .msg_tx
+                .try_send(PhaseMessage::Bump)
+                .expect("receiver should be open");
+        }
+        runtime.process_message_batch(PhaseMessage::Bump);
+        runtime.process_frame_tick(&mut terminal)?;
+
+        let after_pass = log.entries();
+        assert_eq!(
+            phase_counts(&after_pass),
+            (1, 1),
+            "one frame pass performs at most one render and one re-evaluation: {after_pass:?}"
+        );
+
+        runtime.process_frame_tick(&mut terminal)?;
+        assert_eq!(
+            log.entries(),
+            after_pass,
+            "a frame pass with no pending work performs neither step"
+        );
+
+        Ok(())
+    }
+
+    // INV-LC2: within one frame pass the render step precedes subscription
+    // re-evaluation, and both steps observe the pass's current state — so the
+    // subscriptions this pass starts are those of a state it has just rendered.
+    #[tokio::test(start_paused = true)]
+    async fn frame_pass_renders_before_reevaluating_and_both_observe_the_same_state() -> Result<()>
+    {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        runtime.process_message_batch(PhaseMessage::Bump);
+        runtime.process_frame_tick(&mut terminal)?;
+
+        assert_eq!(
+            log.entries(),
+            vec![Phase::View(1), Phase::Subscriptions(1)],
+            "the render step must precede re-evaluation, both on the pass's current state"
+        );
+
+        Ok(())
+    }
+
+    // INV-LC2: pending work does not queue per state, so a state that requested
+    // a redraw is not itself promised a render. A redraw-requesting batch
+    // followed by a `without_redraw` batch leaves the redraw pending; the pass
+    // renders the newer state once and the intermediate state is never drawn.
+    #[tokio::test(start_paused = true)]
+    async fn frame_pass_renders_only_the_latest_state_after_a_superseding_batch() -> Result<()> {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        // Clear the bootstrap redraw so only the batches below decide whether a
+        // redraw is pending at the pass.
+        runtime.scheduler.pending.needs_redraw = false;
+
+        runtime.process_message_batch(PhaseMessage::Bump);
+        runtime.process_message_batch(PhaseMessage::BumpWithoutRedraw);
+        assert!(
+            runtime.scheduler.pending.needs_redraw,
+            "the suppressing batch must not clear the redraw the earlier batch requested"
+        );
+
+        runtime.process_frame_tick(&mut terminal)?;
+
+        assert_eq!(
+            log.entries(),
+            vec![Phase::View(2), Phase::Subscriptions(2)],
+            "exactly one render, of the latest state; the superseded state is never drawn"
+        );
+
+        Ok(())
+    }
+
+    // INV-LC2: a pass entered with no redraw pending re-evaluates subscriptions
+    // with no preceding render — suppression suppresses the redraw, never the
+    // re-evaluation (RFC 0002 non-negotiable B, seen from the lifecycle side).
+    #[tokio::test(start_paused = true)]
+    async fn frame_pass_with_no_redraw_pending_still_reevaluates_subscriptions() -> Result<()> {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        runtime.scheduler.pending.needs_redraw = false;
+        runtime.process_message_batch(PhaseMessage::BumpWithoutRedraw);
+        assert!(
+            !runtime.scheduler.pending.needs_redraw,
+            "the suppressing batch must leave no redraw pending"
+        );
+
+        runtime.process_frame_tick(&mut terminal)?;
+
+        assert_eq!(
+            log.entries(),
+            vec![Phase::Subscriptions(1)],
+            "re-evaluation must still run, with no preceding render"
+        );
+
+        Ok(())
+    }
+
+    // INV-LC4 (eligibility half): the first render starts out pending, so a
+    // freshly constructed runtime's first frame pass renders even though no
+    // message has been processed — unconditionally, and independently of the
+    // init command's redraw directive, which `PhaseApp` sets to
+    // `without_redraw` and the runtime never consults (RFC 0011 §3.2). The
+    // ordering half of INV-LC4 is structural: production exposes no stable
+    // observable phase between the init dispatch and its effect's first poll.
+    #[tokio::test(start_paused = true)]
+    async fn first_frame_pass_renders_without_any_message_processed() -> Result<()> {
+        let log = PhaseLog::default();
+        let mut runtime = phase_runtime(&log);
+        let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        runtime.process_frame_tick(&mut terminal)?;
+
+        assert_eq!(
+            log.entries(),
+            vec![Phase::View(0)],
+            "the first pass renders the initial state and re-evaluates nothing"
+        );
 
         Ok(())
     }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1997,10 +1997,11 @@ mod tests {
     // --- RFC 0011 steady-state phase order ----------------------------------
     //
     // The white-box seam RFC 0011 §8 names for INV-LC1/INV-LC2: drive
-    // `process_input_batch`/`process_frame_tick` directly with a recording
-    // application whose `view` and `subscriptions` append the state they
-    // observed to a shared log, so the phase sequence of a batch and of a frame
-    // pass is asserted rather than inferred from the pending flags.
+    // `process_message_batch` (the test wrapper over `process_input_batch`) and
+    // `process_frame_tick` directly with a recording application whose `view`
+    // and `subscriptions` append the state they observed to a shared log, so the
+    // phase sequence of a batch and of a frame pass is asserted rather than
+    // inferred from the pending flags.
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
     enum Phase {
@@ -2121,6 +2122,11 @@ mod tests {
         let log = PhaseLog::default();
         let mut runtime = phase_runtime(&log);
         let mut terminal = Terminal::new(TestBackend::new(80, 24))?;
+
+        // Clear the bootstrap redraw so the pass's single render is
+        // attributable to the redraw the batch below records, not to the flag
+        // the constructor set.
+        runtime.scheduler.pending.needs_redraw = false;
 
         for _ in 0..2 {
             runtime

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -62,13 +62,23 @@ struct Transitions {
     subscriptions: Arc<AtomicUsize>,
 }
 
+/// One reading of [`Transitions`]. Named after the counters rather than
+/// positionally indexed, so a violated postcondition names the transition that
+/// ran instead of an index into a triple.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TransitionCounts {
+    updates: usize,
+    views: usize,
+    subscriptions: usize,
+}
+
 impl Transitions {
-    fn snapshot(&self) -> [usize; 3] {
-        [
-            self.updates.load(Ordering::SeqCst),
-            self.views.load(Ordering::SeqCst),
-            self.subscriptions.load(Ordering::SeqCst),
-        ]
+    fn snapshot(&self) -> TransitionCounts {
+        TransitionCounts {
+            updates: self.updates.load(Ordering::SeqCst),
+            views: self.views.load(Ordering::SeqCst),
+            subscriptions: self.subscriptions.load(Ordering::SeqCst),
+        }
     }
 }
 
@@ -93,10 +103,24 @@ impl Drop for DropFlag {
 /// The producer gauges RFC 0006 §4.4 defines and RFC 0011 INV-LC7 reads.
 const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
 
-fn producer_gauges_are_zero(recorder: &TraceRecorder) -> bool {
-    PRODUCER_GAUGES
-        .iter()
-        .all(|field| matches!(recorder.u64_values(field).last(), None | Some(&0)))
+/// Whether every producer gauge has reached its terminal reading.
+///
+/// A gauge whose producer the row actually starts (`expected_active`) must read
+/// zero: "no event ever" is not a settled gauge but a silenced instrument, and
+/// accepting `None` there would let a mutation that stops the emission
+/// altogether — a renamed target or field, a lowered level, an emission moved
+/// off the teardown path — satisfy INV-LC7 on iteration zero. A gauge the row
+/// never raises has no event of its own to wait for, so `None` and a trailing
+/// zero both count for it.
+fn producer_gauges_are_zero(recorder: &TraceRecorder, expected_active: &[&str]) -> bool {
+    PRODUCER_GAUGES.iter().all(|field| {
+        let last = recorder.u64_values(field).last().copied();
+        if expected_active.contains(field) {
+            last == Some(0)
+        } else {
+            matches!(last, None | Some(0))
+        }
+    })
 }
 
 fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
@@ -136,6 +160,14 @@ const SETTLE_STEPS: usize = 1_000;
 /// fixed pass count: abort is a request, and the aborted task's future (with the
 /// RAII state it holds) is dropped on a later executor poll (RFC 0011 §4.4).
 ///
+/// `expected_active` names the gauges this row's application actually raises.
+/// Each is asserted to have risen *before* the settle loop starts, so the "the
+/// producers wound down" half cannot be satisfied by producers that were never
+/// observed running: without that positive half a silenced gauge reads as
+/// permanently settled and the loop returns on its first iteration. The gauges
+/// outside the set are the ones the row genuinely never raises, and they are
+/// held to the weaker `None`-or-zero reading.
+///
 /// `dismantled` names the task futures whose drop flags must all have flipped by
 /// the time the loop exits. They are checked alongside the gauges because the
 /// keyed gauge is count-based and publishes zero at the owner's drop, ahead of
@@ -144,16 +176,26 @@ const SETTLE_STEPS: usize = 1_000;
 async fn assert_two_stage_postconditions(
     recorder: &TraceRecorder,
     transitions: &Transitions,
-    immediate: [usize; 3],
+    immediate: TransitionCounts,
+    expected_active: &[&str],
     dismantled: &[(&str, &Arc<AtomicBool>)],
 ) {
+    for field in expected_active {
+        let values = recorder.u64_values(field);
+        assert!(
+            values.iter().any(|&value| value > 0),
+            "the {field} gauge must have risen while this row's producer ran, \
+             or its fall to zero witnesses nothing: {values:?}"
+        );
+    }
+
     for _ in 0..SETTLE_STEPS {
         assert_eq!(
             transitions.snapshot(),
             immediate,
             "no update/view/subscriptions call may run after the terminating operation"
         );
-        if producer_gauges_are_zero(recorder)
+        if producer_gauges_are_zero(recorder, expected_active)
             && dismantled
                 .iter()
                 .all(|(_, flag)| flag.load(Ordering::SeqCst))
@@ -164,7 +206,7 @@ async fn assert_two_stage_postconditions(
     }
 
     assert!(
-        producer_gauges_are_zero(recorder),
+        producer_gauges_are_zero(recorder, expected_active),
         "every producer gauge must settle to zero: subscriptions={:?} unkeyed={:?} keyed={:?}",
         recorder.u64_values("subscriptions"),
         recorder.u64_values("unkeyed_commands"),
@@ -191,49 +233,91 @@ enum QuitMessage {
     Tick,
 }
 
-/// Keeps all three producer kinds running until the quit arrives: a keyed
-/// parked effect from `new`, an unkeyed parked effect from the first processed
-/// message, and a `Timer` subscription that supplies the messages.
-struct QuitApp {
+#[derive(Clone)]
+struct QuitFlags {
     transitions: Transitions,
     route: QuitRoute,
+    keyed_effect_dropped: Arc<AtomicBool>,
+    unkeyed_effect_dropped: Arc<AtomicBool>,
+}
+
+impl QuitFlags {
+    fn new(route: QuitRoute) -> Self {
+        Self {
+            transitions: Transitions::default(),
+            route,
+            keyed_effect_dropped: Arc::new(AtomicBool::new(false)),
+            unkeyed_effect_dropped: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// The parked effects this app leaves running, as settle-loop witnesses.
+    fn parked_effects(&self) -> Vec<(&str, &Arc<AtomicBool>)> {
+        vec![
+            ("the keyed init effect", &self.keyed_effect_dropped),
+            (
+                "the unkeyed effect the first update started",
+                &self.unkeyed_effect_dropped,
+            ),
+        ]
+    }
+}
+
+/// Keeps all three producer kinds running until the quit arrives: a keyed
+/// parked effect from `new`, an unkeyed parked effect from the first processed
+/// message, and a `Timer` subscription that supplies the messages. Both parked
+/// effects carry a drop witness, so a controlled termination is held to
+/// dismantling them and not merely to publishing zeroed gauges.
+struct QuitApp {
+    flags: QuitFlags,
     ticks: usize,
 }
 
 impl Application for QuitApp {
     type Message = QuitMessage;
-    type Flags = (Transitions, QuitRoute);
+    type Flags = QuitFlags;
 
-    fn new((transitions, route): Self::Flags) -> (Self, Command<Self::Message>) {
-        (
-            Self {
-                transitions,
-                route,
-                ticks: 0,
-            },
-            Command::future(pending::<QuitMessage>()).cancellable(CommandId::new("parked-keyed")),
-        )
+    fn new(flags: QuitFlags) -> (Self, Command<Self::Message>) {
+        // Armed on the future value, outside the `async move` body — see
+        // [`DropFlag`] for why a body-constructed guard cannot witness a task
+        // cancelled before its first poll.
+        let guard = DropFlag(Arc::clone(&flags.keyed_effect_dropped));
+        let command = Command::future(async move {
+            let _guard = guard;
+            pending::<QuitMessage>().await
+        })
+        .cancellable(CommandId::new("parked-keyed"));
+
+        (Self { flags, ticks: 0 }, command)
     }
 
     fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
-        self.transitions.updates.fetch_add(1, Ordering::SeqCst);
+        self.flags
+            .transitions
+            .updates
+            .fetch_add(1, Ordering::SeqCst);
         self.ticks += 1;
         if self.ticks == 1 {
-            return Command::future(pending::<QuitMessage>());
+            let guard = DropFlag(Arc::clone(&self.flags.unkeyed_effect_dropped));
+            return Command::future(async move {
+                let _guard = guard;
+                pending::<QuitMessage>().await
+            });
         }
 
-        match self.route {
+        match self.flags.route {
             QuitRoute::Unkeyed => Command::quit(),
             QuitRoute::Keyed => Command::quit().cancellable(CommandId::new("keyed-quit")),
         }
     }
 
     fn view(&self, _frame: &mut Frame<'_>) {
-        self.transitions.views.fetch_add(1, Ordering::SeqCst);
+        self.flags.transitions.views.fetch_add(1, Ordering::SeqCst);
     }
 
     fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
-        self.transitions
+        self.flags
+            .transitions
             .subscriptions
             .fetch_add(1, Ordering::SeqCst);
         vec![timer_subscription(|| QuitMessage::Tick)]
@@ -244,9 +328,9 @@ async fn assert_quit_route_terminates(route: QuitRoute) -> Result<()> {
     let recorder = TraceRecorder::new().with_target("tears::runtime::load");
     let _guard = recorder.set_default();
 
-    let transitions = Transitions::default();
+    let flags = QuitFlags::new(route);
     let mut terminal = common::test_terminal()?;
-    let runtime = Runtime::<QuitApp>::new((transitions.clone(), route), frame_rate(60));
+    let runtime = Runtime::<QuitApp>::new(flags.clone(), frame_rate(60));
 
     let outcome = timeout(Duration::from_secs(5), runtime.run(&mut terminal))
         .await
@@ -256,13 +340,23 @@ async fn assert_quit_route_terminates(route: QuitRoute) -> Result<()> {
         outcome.is_ok(),
         "a {route:?} quit classifies the run as Ok(())"
     );
-    let immediate = transitions.snapshot();
+    let immediate = flags.transitions.snapshot();
     assert!(
-        immediate[0] >= 2,
+        immediate.updates >= 2,
         "the run should reach the quitting message: {immediate:?}"
     );
 
-    assert_two_stage_postconditions(&recorder, &transitions, immediate, &[]).await;
+    // A run that reaches its second message has started all three producer
+    // kinds: the keyed init effect, the `Timer` subscription that delivered the
+    // messages, and the unkeyed effect the first update returned.
+    assert_two_stage_postconditions(
+        &recorder,
+        &flags.transitions,
+        immediate,
+        &PRODUCER_GAUGES,
+        &flags.parked_effects(),
+    )
+    .await;
 
     Ok(())
 }
@@ -359,10 +453,9 @@ async fn render_error_returns_err_and_reaches_both_postconditions() -> Result<()
     let recorder = TraceRecorder::new().with_target("tears::runtime::load");
     let _guard = recorder.set_default();
 
-    let transitions = Transitions::default();
+    let flags = QuitFlags::new(QuitRoute::Unkeyed);
     let mut terminal = Terminal::new(FailingBackend::new())?;
-    let runtime =
-        Runtime::<QuitApp>::new((transitions.clone(), QuitRoute::Unkeyed), frame_rate(60));
+    let runtime = Runtime::<QuitApp>::new(flags.clone(), frame_rate(60));
 
     let outcome = timeout(Duration::from_secs(5), runtime.run(&mut terminal))
         .await
@@ -372,13 +465,30 @@ async fn render_error_returns_err_and_reaches_both_postconditions() -> Result<()
         outcome.is_err(),
         "a render error classifies the run as Err: {outcome:?}"
     );
-    let immediate = transitions.snapshot();
+    let immediate = flags.transitions.snapshot();
     assert!(
-        immediate[1] >= 1,
+        immediate.views >= 1,
         "the failing render step invoked view before the backend rejected the draw: {immediate:?}"
     );
+    // Not a contract claim — it pins this row's arrangement, and with it the
+    // producer set below. The runtime's first frame deadline is already elapsed
+    // when the loop starts, so the failing render precedes the subscription's
+    // first 10ms tick: `update` never runs, and the unkeyed effect it would have
+    // returned is never created. If that ordering ever changes this assertion
+    // fires, rather than the row silently under-checking a producer it started.
+    assert_eq!(
+        immediate.updates, 0,
+        "the render fails before any message is delivered: {immediate:?}"
+    );
 
-    assert_two_stage_postconditions(&recorder, &transitions, immediate, &[]).await;
+    assert_two_stage_postconditions(
+        &recorder,
+        &flags.transitions,
+        immediate,
+        &["subscriptions", "keyed_commands"],
+        &[("the keyed init effect", &flags.keyed_effect_dropped)],
+    )
+    .await;
 
     Ok(())
 }
@@ -433,6 +543,9 @@ impl SubscriptionSource for ProbeSource {
     type Key = ();
 
     fn stream(&self) -> BoxStream<'static, Self::Output> {
+        // Every deliberate panic in this section is phrased as a failing
+        // assertion on the condition that selects the row: it reads as the
+        // negated precondition it is, and it keeps `clippy::panic` unengaged.
         assert!(
             !self.panic_in_constructor,
             "deliberate panic: a subscription's lazy source constructor, on the driving task"
@@ -454,10 +567,6 @@ struct AbruptApp {
     flags: AbruptFlags,
 }
 
-#[expect(
-    clippy::panic,
-    reason = "`subscriptions` panics deliberately to exercise INV-LC6's two subscriptions rows"
-)]
 impl Application for AbruptApp {
     type Message = AbruptMessage;
     type Flags = AbruptFlags;
@@ -504,17 +613,16 @@ impl Application for AbruptApp {
             .transitions
             .subscriptions
             .fetch_add(1, Ordering::SeqCst);
-        match self.flags.site {
-            PanicSite::SubscriptionsBootstrap => {
-                panic!("deliberate panic: subscriptions, at the bootstrap call site");
-            }
-            // The bootstrap call is the first one; a later call can only come
-            // from a re-evaluation after a processed message.
-            PanicSite::SubscriptionsSteady if previous >= 1 => {
-                panic!("deliberate panic: subscriptions, at the steady call site");
-            }
-            _ => {}
-        }
+        assert!(
+            self.flags.site != PanicSite::SubscriptionsBootstrap,
+            "deliberate panic: subscriptions, at the bootstrap call site"
+        );
+        // The bootstrap call is the first one; a later call can only come from a
+        // re-evaluation after a processed message.
+        assert!(
+            self.flags.site != PanicSite::SubscriptionsSteady || previous == 0,
+            "deliberate panic: subscriptions, at the steady call site"
+        );
 
         vec![Subscription::new(ProbeSource {
             dropped: Arc::clone(&self.flags.source_dropped),
@@ -550,15 +658,27 @@ async fn assert_transition_panic_tears_down(site: PanicSite, source_starts: bool
         "the {site:?} panic must propagate to run()'s caller"
     );
 
+    // `AbruptApp` starts a keyed init effect and, once a stream exists, one
+    // subscription; its `update` returns `Command::none()`, so the
+    // `unkeyed_commands` gauge is never raised on any of these rows.
+    let mut expected_active = vec!["keyed_commands"];
     let mut dismantled = vec![("the keyed init effect", &flags.keyed_effect_dropped)];
     if source_starts {
+        expected_active.push("subscriptions");
         // Once the stream is dropped it can never be polled again — a stronger
         // witness than counting polls over a finite window.
         dismantled.push(("the subscription's stream", &flags.source_dropped));
     }
 
     let immediate = flags.transitions.snapshot();
-    assert_two_stage_postconditions(&recorder, &flags.transitions, immediate, &dismantled).await;
+    assert_two_stage_postconditions(
+        &recorder,
+        &flags.transitions,
+        immediate,
+        &expected_active,
+        &dismantled,
+    )
+    .await;
 
     Ok(())
 }
@@ -590,6 +710,9 @@ async fn dropping_the_run_future_reaches_both_postconditions() -> Result<()> {
         &recorder,
         &flags.transitions,
         immediate,
+        // The run got far enough to start its subscription; `AbruptApp` never
+        // returns an unkeyed command.
+        &["keyed_commands", "subscriptions"],
         &[
             ("the keyed init effect", &flags.keyed_effect_dropped),
             ("the subscription's stream", &flags.source_dropped),
@@ -702,10 +825,19 @@ impl Application for InertApp {
     }
 }
 
+/// How many run-queue drains [`drain_executor`] performs.
+///
+/// Unlike [`SETTLE_STEPS`] this is not a bound on waiting for something to
+/// happen but a fixed budget for proving that nothing does: there is no event to
+/// poll for, so the count is simply a number of complete `current_thread` run
+/// queue drains (see [`SETTLE_STEPS`] for why one `yield_now` is one drain)
+/// after which no further transition may appear.
+const DRAIN_PASSES: usize = 32;
+
 /// Gives the executor every chance to poll a task that a conforming
 /// construction never spawned.
 async fn drain_executor() {
-    for _ in 0..32 {
+    for _ in 0..DRAIN_PASSES {
         yield_now().await;
     }
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -76,6 +76,12 @@ impl Transitions {
 /// once the executor has processed the abort request, so this witnesses the
 /// quiescent stage rather than merely the request — and, for a subscription
 /// source, proves the stream can never be polled again.
+///
+/// A witness must be owned by the future *value*, never constructed in the
+/// future's body: a runtime-owned task can be cancelled before its first poll,
+/// and tokio dismantles such a task by dropping the un-started future without
+/// running a line of it. A body-constructed guard would then never exist, and
+/// no amount of settling could flip a flag that was never armed.
 struct DropFlag(Arc<AtomicBool>);
 
 impl Drop for DropFlag {
@@ -99,6 +105,27 @@ fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
         .all(|field| recorder.u64_values(field).is_empty())
 }
 
+/// How many settle steps [`assert_two_stage_postconditions`] may take before it
+/// reports the quiescent postcondition as unmet.
+///
+/// This counts executor drains, not intervals, so host load cannot consume it.
+/// One step is one `yield_now`, and under the `current_thread` scheduler that is
+/// a complete drain of the run queue: the caller's waker goes on the deferred
+/// list, so `block_on` keeps popping tasks until the queue is empty before it
+/// wakes the deferred wakers and polls the caller again. The teardown needs
+/// exactly one such drain — aborting a task leaves it queued and cancelled, and
+/// running it drops the future — so the bound carries three orders of magnitude
+/// of margin over the mechanism it waits on.
+///
+/// A step must not advance the paused clock, which rules out a
+/// `sleep`/`timeout` bound however appealing "settled or never will" sounds as a
+/// formulation. Advancing virtual time hands a producer that the teardown failed
+/// to cancel a second way to stop — its own timer firing into the channel whose
+/// receiver the teardown dropped — and these rows exist to catch exactly that
+/// failure. `yield_now` reschedules through the deferred list, which keeps the
+/// scheduler off the parking path and therefore keeps the clock still.
+const SETTLE_STEPS: usize = 1_000;
+
 /// INV-LC7's bounded settle loop, doubling as INV-LC6's re-checked
 /// no-further-transition assertion.
 ///
@@ -112,14 +139,15 @@ fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
 /// `dismantled` names the task futures whose drop flags must all have flipped by
 /// the time the loop exits. They are checked alongside the gauges because the
 /// keyed gauge is count-based and publishes zero at the owner's drop, ahead of
-/// the executor dismantling the task futures themselves.
+/// the executor dismantling the task futures themselves. Every such flag must be
+/// armed by the future *value* rather than by its body — see [`DropFlag`].
 async fn assert_two_stage_postconditions(
     recorder: &TraceRecorder,
     transitions: &Transitions,
     immediate: [usize; 3],
     dismantled: &[(&str, &Arc<AtomicBool>)],
 ) {
-    for _ in 0..1_000 {
+    for _ in 0..SETTLE_STEPS {
         assert_eq!(
             transitions.snapshot(),
             immediate,
@@ -435,9 +463,14 @@ impl Application for AbruptApp {
     type Flags = AbruptFlags;
 
     fn new(flags: AbruptFlags) -> (Self, Command<Self::Message>) {
-        let dropped = Arc::clone(&flags.keyed_effect_dropped);
+        // Armed here, outside the future's body, so the effect's future value
+        // owns the witness from the moment it exists. The init effect's task can
+        // be cancelled before its first poll — a bootstrap-time panic tears the
+        // runtime down without the executor ever reaching it — and tokio then
+        // dismantles it by dropping the un-started future.
+        let guard = DropFlag(Arc::clone(&flags.keyed_effect_dropped));
         let command = Command::future(async move {
-            let _guard = DropFlag(dropped);
+            let _guard = guard;
             pending::<AbruptMessage>().await
         })
         .cancellable(CommandId::new("parked-keyed"));

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -1,0 +1,901 @@
+//! Integration tests for RFC 0011's runtime lifecycle contract at the layer
+//! its invariants place them: the controlled and abrupt termination routes and
+//! their two-stage postconditions (INV-LC5/INV-LC6/INV-LC7), panic containment
+//! for runtime-owned producer tasks (INV-LC8), and the construction-inertness
+//! contract whose behavior change lands with the 0.11.0 lifecycle work
+//! (INV-LC3, RFC 0011 §3.4).
+//!
+//! The steady-state phase-order invariants (INV-LC1/INV-LC2) and the
+//! first-render eligibility half of INV-LC4 are white-box and live in
+//! `src/runtime.rs`. INV-LC9, the ordering half of INV-LC4, and the synchrony
+//! half of INV-LC6 are structural checks (RFC 0011 §8): they have no behavioral
+//! seam a test can anchor on.
+
+mod common;
+#[path = "common/panic_hook.rs"]
+mod panic_hook;
+#[path = "common/trace_recorder.rs"]
+mod trace_recorder;
+
+use std::convert::Infallible;
+use std::future::pending;
+use std::io;
+use std::num::{NonZeroU32, NonZeroU64};
+use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use color_eyre::eyre::Result;
+use futures::FutureExt;
+use futures::stream::{self, StreamExt};
+use ratatui::Terminal;
+use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
+use ratatui::buffer::Cell;
+use ratatui::layout::{Position, Size};
+use ratatui::prelude::Frame;
+use tears::command::CommandId;
+use tears::prelude::*;
+use tears::subscription::time::Timer;
+use tears::{BoxStream, SubscriptionSource};
+use tokio::task::yield_now;
+use tokio::time::{Duration, timeout};
+use trace_recorder::TraceRecorder;
+
+fn frame_rate(value: u32) -> FrameRate {
+    FrameRate::new(NonZeroU32::new(value).expect("frame rate must be non-zero"))
+        .expect("frame rate must be valid")
+}
+
+fn timer_subscription<Msg: Send + 'static>(make: fn() -> Msg) -> Subscription<Msg> {
+    Subscription::new(Timer::new(NonZeroU64::new(10).expect("non-zero"))).map(move |_| make())
+}
+
+// --- Shared observation surfaces --------------------------------------------
+
+/// Counts every application transition the runtime invokes, so a test can
+/// assert that none of them runs again after a terminating operation (RFC 0011
+/// §4.4's immediate postcondition, item 1).
+#[derive(Clone, Default)]
+struct Transitions {
+    updates: Arc<AtomicUsize>,
+    views: Arc<AtomicUsize>,
+    subscriptions: Arc<AtomicUsize>,
+}
+
+impl Transitions {
+    fn snapshot(&self) -> [usize; 3] {
+        [
+            self.updates.load(Ordering::SeqCst),
+            self.views.load(Ordering::SeqCst),
+            self.subscriptions.load(Ordering::SeqCst),
+        ]
+    }
+}
+
+/// Flips its flag when dropped. A runtime-owned task's future is dropped only
+/// once the executor has processed the abort request, so this witnesses the
+/// quiescent stage rather than merely the request — and, for a subscription
+/// source, proves the stream can never be polled again.
+struct DropFlag(Arc<AtomicBool>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+/// The producer gauges RFC 0006 §4.4 defines and RFC 0011 INV-LC7 reads.
+const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
+
+fn producer_gauges_are_zero(recorder: &TraceRecorder) -> bool {
+    PRODUCER_GAUGES
+        .iter()
+        .all(|field| matches!(recorder.u64_values(field).last(), None | Some(&0)))
+}
+
+fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
+    PRODUCER_GAUGES
+        .iter()
+        .all(|field| recorder.u64_values(field).is_empty())
+}
+
+/// INV-LC7's bounded settle loop, doubling as INV-LC6's re-checked
+/// no-further-transition assertion.
+///
+/// The transition counters are compared on every iteration — immediately after
+/// the terminating operation and again across each of the settle loop's yields
+/// — because a settle-only check would pass an implementation that defers its
+/// cancellation requests by a scheduler pass. The quiescent half never asserts a
+/// fixed pass count: abort is a request, and the aborted task's future (with the
+/// RAII state it holds) is dropped on a later executor poll (RFC 0011 §4.4).
+///
+/// `dismantled` names the task futures whose drop flags must all have flipped by
+/// the time the loop exits. They are checked alongside the gauges because the
+/// keyed gauge is count-based and publishes zero at the owner's drop, ahead of
+/// the executor dismantling the task futures themselves.
+async fn assert_two_stage_postconditions(
+    recorder: &TraceRecorder,
+    transitions: &Transitions,
+    immediate: [usize; 3],
+    dismantled: &[(&str, &Arc<AtomicBool>)],
+) {
+    for _ in 0..1_000 {
+        assert_eq!(
+            transitions.snapshot(),
+            immediate,
+            "no update/view/subscriptions call may run after the terminating operation"
+        );
+        if producer_gauges_are_zero(recorder)
+            && dismantled
+                .iter()
+                .all(|(_, flag)| flag.load(Ordering::SeqCst))
+        {
+            return;
+        }
+        yield_now().await;
+    }
+
+    assert!(
+        producer_gauges_are_zero(recorder),
+        "every producer gauge must settle to zero: subscriptions={:?} unkeyed={:?} keyed={:?}",
+        recorder.u64_values("subscriptions"),
+        recorder.u64_values("unkeyed_commands"),
+        recorder.u64_values("keyed_commands"),
+    );
+    for (name, flag) in dismantled {
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "the executor must dismantle {name} once the requested cancellations are processed"
+        );
+    }
+}
+
+// --- INV-LC5: controlled termination ----------------------------------------
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum QuitRoute {
+    Unkeyed,
+    Keyed,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum QuitMessage {
+    Tick,
+}
+
+/// Keeps all three producer kinds running until the quit arrives: a keyed
+/// parked effect from `new`, an unkeyed parked effect from the first processed
+/// message, and a `Timer` subscription that supplies the messages.
+struct QuitApp {
+    transitions: Transitions,
+    route: QuitRoute,
+    ticks: usize,
+}
+
+impl Application for QuitApp {
+    type Message = QuitMessage;
+    type Flags = (Transitions, QuitRoute);
+
+    fn new((transitions, route): Self::Flags) -> (Self, Command<Self::Message>) {
+        (
+            Self {
+                transitions,
+                route,
+                ticks: 0,
+            },
+            Command::future(pending::<QuitMessage>()).cancellable(CommandId::new("parked-keyed")),
+        )
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
+        self.transitions.updates.fetch_add(1, Ordering::SeqCst);
+        self.ticks += 1;
+        if self.ticks == 1 {
+            return Command::future(pending::<QuitMessage>());
+        }
+
+        match self.route {
+            QuitRoute::Unkeyed => Command::quit(),
+            QuitRoute::Keyed => Command::quit().cancellable(CommandId::new("keyed-quit")),
+        }
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {
+        self.transitions.views.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        self.transitions
+            .subscriptions
+            .fetch_add(1, Ordering::SeqCst);
+        vec![timer_subscription(|| QuitMessage::Tick)]
+    }
+}
+
+async fn assert_quit_route_terminates(route: QuitRoute) -> Result<()> {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let transitions = Transitions::default();
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<QuitApp>::new((transitions.clone(), route), frame_rate(60));
+
+    let outcome = timeout(Duration::from_secs(5), runtime.run(&mut terminal))
+        .await
+        .expect("the quit should exit the loop before the timeout");
+
+    assert!(
+        outcome.is_ok(),
+        "a {route:?} quit classifies the run as Ok(())"
+    );
+    let immediate = transitions.snapshot();
+    assert!(
+        immediate[0] >= 2,
+        "the run should reach the quitting message: {immediate:?}"
+    );
+
+    assert_two_stage_postconditions(&recorder, &transitions, immediate, &[]).await;
+
+    Ok(())
+}
+
+// INV-LC5: an unkeyed quit under running producers exits the loop, returns
+// `Ok(())`, and invokes no further transition; INV-LC7's settle loop then
+// witnesses the producers winding down.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn unkeyed_quit_returns_ok_and_reaches_both_postconditions() -> Result<()> {
+    assert_quit_route_terminates(QuitRoute::Unkeyed).await
+}
+
+// INV-LC5: a keyed quit — delivered in band through its run's private channel —
+// reaches the same postconditions with the same `Ok(())` classification.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn keyed_quit_returns_ok_and_reaches_both_postconditions() -> Result<()> {
+    assert_quit_route_terminates(QuitRoute::Keyed).await
+}
+
+/// A backend whose every draw fails, so the runtime's render step takes the
+/// render-error controlled termination route (RFC 0011 §4.1). Everything else
+/// delegates to a `TestBackend`, whose error type is `Infallible`.
+struct FailingBackend {
+    inner: TestBackend,
+}
+
+impl FailingBackend {
+    fn new() -> Self {
+        Self {
+            inner: TestBackend::new(80, 24),
+        }
+    }
+}
+
+/// Widens a `TestBackend` result into this backend's error type. `TestBackend`'s
+/// error type is uninhabited, so the `Err` arm cannot be constructed.
+fn lift<T>(result: Result<T, Infallible>) -> Result<T, io::Error> {
+    result.map_err(|never| match never {})
+}
+
+impl Backend for FailingBackend {
+    type Error = io::Error;
+
+    fn draw<'a, I>(&mut self, _content: I) -> Result<(), Self::Error>
+    where
+        I: Iterator<Item = (u16, u16, &'a Cell)>,
+    {
+        Err(io::Error::other("injected render failure"))
+    }
+
+    fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+        lift(self.inner.hide_cursor())
+    }
+
+    fn show_cursor(&mut self) -> Result<(), Self::Error> {
+        lift(self.inner.show_cursor())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<Position, Self::Error> {
+        lift(self.inner.get_cursor_position())
+    }
+
+    fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> Result<(), Self::Error> {
+        lift(self.inner.set_cursor_position(position))
+    }
+
+    fn clear(&mut self) -> Result<(), Self::Error> {
+        lift(self.inner.clear())
+    }
+
+    fn clear_region(&mut self, clear_type: ClearType) -> Result<(), Self::Error> {
+        lift(self.inner.clear_region(clear_type))
+    }
+
+    fn size(&self) -> Result<Size, Self::Error> {
+        lift(self.inner.size())
+    }
+
+    fn window_size(&mut self) -> Result<WindowSize, Self::Error> {
+        lift(self.inner.window_size())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        lift(self.inner.flush())
+    }
+}
+
+// INV-LC5: a failing render step is a controlled cause too — the loop exits, the
+// return value classifies the reason as `Err`, no further transition runs, and
+// the producers wind down through the same settle loop as the quit rows even
+// though this exit bypasses the explicit shutdown routine (RFC 0011 §4.2).
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn render_error_returns_err_and_reaches_both_postconditions() -> Result<()> {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let transitions = Transitions::default();
+    let mut terminal = Terminal::new(FailingBackend::new())?;
+    let runtime =
+        Runtime::<QuitApp>::new((transitions.clone(), QuitRoute::Unkeyed), frame_rate(60));
+
+    let outcome = timeout(Duration::from_secs(5), runtime.run(&mut terminal))
+        .await
+        .expect("the render error should exit the loop before the timeout");
+
+    assert!(
+        outcome.is_err(),
+        "a render error classifies the run as Err: {outcome:?}"
+    );
+    let immediate = transitions.snapshot();
+    assert!(
+        immediate[1] >= 1,
+        "the failing render step invoked view before the backend rejected the draw: {immediate:?}"
+    );
+
+    assert_two_stage_postconditions(&recorder, &transitions, immediate, &[]).await;
+
+    Ok(())
+}
+
+// --- INV-LC6: abrupt termination --------------------------------------------
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PanicSite {
+    None,
+    Update,
+    View,
+    SubscriptionsBootstrap,
+    SubscriptionsSteady,
+    SourceConstructor,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum AbruptMessage {
+    Tick,
+}
+
+#[derive(Clone)]
+struct AbruptFlags {
+    transitions: Transitions,
+    site: PanicSite,
+    keyed_effect_dropped: Arc<AtomicBool>,
+    source_dropped: Arc<AtomicBool>,
+}
+
+impl AbruptFlags {
+    fn new(site: PanicSite) -> Self {
+        Self {
+            transitions: Transitions::default(),
+            site,
+            keyed_effect_dropped: Arc::new(AtomicBool::new(false)),
+            source_dropped: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+/// A subscription source that emits one message and then parks forever while
+/// holding a drop flag, so the forwarder task's dismantling is observable.
+/// Optionally panics inside `stream()` — the lazy source constructor, which the
+/// reconcile calls on the driving task.
+struct ProbeSource {
+    dropped: Arc<AtomicBool>,
+    panic_in_constructor: bool,
+}
+
+impl SubscriptionSource for ProbeSource {
+    type Output = AbruptMessage;
+    type Key = ();
+
+    fn stream(&self) -> BoxStream<'static, Self::Output> {
+        assert!(
+            !self.panic_in_constructor,
+            "deliberate panic: a subscription's lazy source constructor, on the driving task"
+        );
+
+        let guard = DropFlag(Arc::clone(&self.dropped));
+        stream::once(async { AbruptMessage::Tick })
+            .chain(stream::once(async move {
+                let _guard = guard;
+                pending::<AbruptMessage>().await
+            }))
+            .boxed()
+    }
+
+    fn key(&self) -> Self::Key {}
+}
+
+struct AbruptApp {
+    flags: AbruptFlags,
+}
+
+#[expect(
+    clippy::panic,
+    reason = "`subscriptions` panics deliberately to exercise INV-LC6's two subscriptions rows"
+)]
+impl Application for AbruptApp {
+    type Message = AbruptMessage;
+    type Flags = AbruptFlags;
+
+    fn new(flags: AbruptFlags) -> (Self, Command<Self::Message>) {
+        let dropped = Arc::clone(&flags.keyed_effect_dropped);
+        let command = Command::future(async move {
+            let _guard = DropFlag(dropped);
+            pending::<AbruptMessage>().await
+        })
+        .cancellable(CommandId::new("parked-keyed"));
+
+        (Self { flags }, command)
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
+        self.flags
+            .transitions
+            .updates
+            .fetch_add(1, Ordering::SeqCst);
+        assert!(
+            self.flags.site != PanicSite::Update,
+            "deliberate panic: update, on the driving task"
+        );
+        Command::none()
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {
+        self.flags.transitions.views.fetch_add(1, Ordering::SeqCst);
+        assert!(
+            self.flags.site != PanicSite::View,
+            "deliberate panic: view, on the driving task"
+        );
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        let previous = self
+            .flags
+            .transitions
+            .subscriptions
+            .fetch_add(1, Ordering::SeqCst);
+        match self.flags.site {
+            PanicSite::SubscriptionsBootstrap => {
+                panic!("deliberate panic: subscriptions, at the bootstrap call site");
+            }
+            // The bootstrap call is the first one; a later call can only come
+            // from a re-evaluation after a processed message.
+            PanicSite::SubscriptionsSteady if previous >= 1 => {
+                panic!("deliberate panic: subscriptions, at the steady call site");
+            }
+            _ => {}
+        }
+
+        vec![Subscription::new(ProbeSource {
+            dropped: Arc::clone(&self.flags.source_dropped),
+            panic_in_constructor: self.flags.site == PanicSite::SourceConstructor,
+        })]
+    }
+}
+
+/// Drives one INV-LC6 panic row: the unwind must propagate to `run()`'s caller,
+/// and from the moment it completes no transition may run — checked immediately
+/// and re-checked across the settle loop — while the runtime-owned tasks are
+/// wound down.
+///
+/// `source_starts` says whether the row got far enough to start the
+/// subscription's stream; the bootstrap-`subscriptions` and source-constructor
+/// rows panic before any stream exists.
+async fn assert_transition_panic_tears_down(site: PanicSite, source_starts: bool) -> Result<()> {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let flags = AbruptFlags::new(site);
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<AbruptApp>::new(flags.clone(), frame_rate(60));
+
+    let outcome = panic_hook::with_silent_panic_hook(
+        AssertUnwindSafe(timeout(Duration::from_secs(5), runtime.run(&mut terminal)))
+            .catch_unwind(),
+    )
+    .await;
+
+    assert!(
+        outcome.is_err(),
+        "the {site:?} panic must propagate to run()'s caller"
+    );
+
+    let mut dismantled = vec![("the keyed init effect", &flags.keyed_effect_dropped)];
+    if source_starts {
+        // Once the stream is dropped it can never be polled again — a stronger
+        // witness than counting polls over a finite window.
+        dismantled.push(("the subscription's stream", &flags.source_dropped));
+    }
+
+    let immediate = flags.transitions.snapshot();
+    assert_two_stage_postconditions(&recorder, &flags.transitions, immediate, &dismantled).await;
+
+    Ok(())
+}
+
+// INV-LC6: dropping the `run` future mid-run (a caller's `select!`/timeout)
+// performs the ownership teardown and the cancellation requests itself; no
+// transition runs afterwards, and both producer kinds are dismantled.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn dropping_the_run_future_reaches_both_postconditions() -> Result<()> {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let flags = AbruptFlags::new(PanicSite::None);
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<AbruptApp>::new(flags.clone(), frame_rate(60));
+
+    let mut run = Box::pin(runtime.run(&mut terminal));
+    let cancelled = timeout(Duration::from_millis(50), &mut run).await;
+    assert!(
+        cancelled.is_err(),
+        "the run must still be in progress when the caller cancels it"
+    );
+
+    // The terminating operation.
+    drop(run);
+
+    let immediate = flags.transitions.snapshot();
+    assert_two_stage_postconditions(
+        &recorder,
+        &flags.transitions,
+        immediate,
+        &[
+            ("the keyed init effect", &flags.keyed_effect_dropped),
+            ("the subscription's stream", &flags.source_dropped),
+        ],
+    )
+    .await;
+
+    Ok(())
+}
+
+// INV-LC6: a panic in `update` — application code on the driving task — stays
+// fail-fast and propagates, and the unwind still performs the teardown.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_panic_in_update_propagates_and_reaches_both_postconditions() -> Result<()> {
+    assert_transition_panic_tears_down(PanicSite::Update, true).await
+}
+
+// INV-LC6: same for a panic in `view`.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_panic_in_view_propagates_and_reaches_both_postconditions() -> Result<()> {
+    assert_transition_panic_tears_down(PanicSite::View, true).await
+}
+
+// INV-LC6: same for a panic in `subscriptions` at the bootstrap call site,
+// raised on its first call, before the loop.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_bootstrap_subscriptions_panic_propagates_and_reaches_both_postconditions() -> Result<()>
+{
+    assert_transition_panic_tears_down(PanicSite::SubscriptionsBootstrap, false).await
+}
+
+// INV-LC6: same for a panic in `subscriptions` at the steady call site, raised
+// only on a re-evaluation after a processed message.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_steady_subscriptions_panic_propagates_and_reaches_both_postconditions() -> Result<()> {
+    assert_transition_panic_tears_down(PanicSite::SubscriptionsSteady, true).await
+}
+
+// INV-LC6: same for a panic in a declared subscription's lazy source
+// constructor, which runs inside the reconcile on the driving task — distinct
+// from INV-LC8's forwarder-task row.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_source_constructor_panic_propagates_and_reaches_both_postconditions() -> Result<()> {
+    assert_transition_panic_tears_down(PanicSite::SourceConstructor, false).await
+}
+
+// --- INV-LC3 and the never-run-drop row of INV-LC6 --------------------------
+
+#[derive(Clone, Default)]
+struct InertProbe {
+    effect_started: Arc<AtomicBool>,
+    source_started: Arc<AtomicBool>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InertMessage {
+    #[expect(
+        dead_code,
+        reason = "an inert runtime never delivers a message, so this variant only types the application"
+    )]
+    Never,
+}
+
+struct InertSource {
+    started: Arc<AtomicBool>,
+}
+
+impl SubscriptionSource for InertSource {
+    type Output = InertMessage;
+    type Key = ();
+
+    fn stream(&self) -> BoxStream<'static, Self::Output> {
+        self.started.store(true, Ordering::SeqCst);
+        stream::pending().boxed()
+    }
+
+    fn key(&self) -> Self::Key {}
+}
+
+/// Records whether the init command's effect was ever polled and whether a
+/// subscription source was ever started.
+struct InertApp {
+    probe: InertProbe,
+}
+
+impl Application for InertApp {
+    type Message = InertMessage;
+    type Flags = InertProbe;
+
+    fn new(probe: InertProbe) -> (Self, Command<Self::Message>) {
+        let started = Arc::clone(&probe.effect_started);
+        let command = Command::future(async move {
+            started.store(true, Ordering::SeqCst);
+            pending::<InertMessage>().await
+        });
+
+        (Self { probe }, command)
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
+        Command::none()
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {}
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        vec![Subscription::new(InertSource {
+            started: Arc::clone(&self.probe.source_started),
+        })]
+    }
+}
+
+/// Gives the executor every chance to poll a task that a conforming
+/// construction never spawned.
+async fn drain_executor() {
+    for _ in 0..32 {
+        yield_now().await;
+    }
+}
+
+// INV-LC3: constructing a `Runtime` spawns no runtime-owned task, polls no
+// command effect, and starts no subscription source — construction is inert
+// (RFC 0011 §3.1). Today the constructor dispatches the init command itself, so
+// this asserts the post-conformance contract of the §3.4 deliverable.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[ignore = "RFC 0011 §3.4 conformance lands with the 0.11.0 lifecycle change"]
+async fn constructing_a_runtime_starts_no_effect_and_no_subscription_source() {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let probe = InertProbe::default();
+    let runtime = Runtime::<InertApp>::new(probe.clone(), frame_rate(60));
+
+    drain_executor().await;
+
+    assert!(
+        !probe.effect_started.load(Ordering::SeqCst),
+        "construction must not poll the init command's effect"
+    );
+    assert!(
+        !probe.source_started.load(Ordering::SeqCst),
+        "construction must not start a subscription source"
+    );
+    assert!(
+        no_producer_gauge_event_fired(&recorder),
+        "construction must fire no producer-gauge event"
+    );
+
+    drop(runtime);
+}
+
+// INV-LC6 (never-run-drop row): with the §3.4 change landed there is nothing to
+// wind down when a constructed-but-never-run runtime is dropped, and this row
+// asserts exactly that, reusing INV-LC3's recorder setup (RFC 0011 §8).
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+#[ignore = "RFC 0011 §3.4 conformance lands with the 0.11.0 lifecycle change"]
+async fn dropping_a_never_run_runtime_winds_down_nothing() {
+    let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+    let _guard = recorder.set_default();
+
+    let probe = InertProbe::default();
+    drop(Runtime::<InertApp>::new(probe.clone(), frame_rate(60)));
+
+    drain_executor().await;
+
+    assert!(
+        !probe.effect_started.load(Ordering::SeqCst),
+        "a never-run runtime must have executed no effect"
+    );
+    assert!(
+        !probe.source_started.load(Ordering::SeqCst),
+        "a never-run runtime must have started no subscription source"
+    );
+    assert!(
+        no_producer_gauge_event_fired(&recorder),
+        "a never-run runtime's lifetime must fire no producer-gauge event"
+    );
+}
+
+// --- INV-LC8: panic containment for runtime-owned producer tasks ------------
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PanickingProducer {
+    UnkeyedCommand,
+    KeyedCommand,
+    SubscriptionForwarder,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ContainmentMessage {
+    Tick,
+}
+
+#[expect(
+    clippy::panic,
+    reason = "the effect panics deliberately to exercise INV-LC8's command-task rows"
+)]
+fn panicking_effect() -> Command<ContainmentMessage> {
+    Command::future(async {
+        panic!("runtime-owned command task panicked");
+        #[expect(
+            unreachable_code,
+            reason = "the preceding panic! diverges, so this trailing expression that types the async block is unreachable"
+        )]
+        ContainmentMessage::Tick
+    })
+}
+
+/// A source whose constructor succeeds and whose stream panics while the
+/// forwarder task polls it — the forwarder row, distinct from INV-LC6's
+/// constructor-panic row, which unwinds on the driving task.
+struct PanickingStreamSource;
+
+impl SubscriptionSource for PanickingStreamSource {
+    type Output = ContainmentMessage;
+    type Key = ();
+
+    #[expect(
+        clippy::panic,
+        reason = "the stream panics deliberately to exercise INV-LC8's forwarder row"
+    )]
+    fn stream(&self) -> BoxStream<'static, Self::Output> {
+        stream::once(async {
+            panic!("subscription stream panicked inside the forwarder task");
+            #[expect(
+                unreachable_code,
+                reason = "the preceding panic! diverges, so this trailing expression that types the async block is unreachable"
+            )]
+            ContainmentMessage::Tick
+        })
+        .boxed()
+    }
+
+    fn key(&self) -> Self::Key {}
+}
+
+/// Runs one panicking producer alongside a surviving `Timer` subscription whose
+/// later messages must still reach `update`, then quits normally.
+struct ContainmentApp {
+    kind: PanickingProducer,
+    transitions: Transitions,
+    ticks: usize,
+}
+
+const SURVIVING_TICKS: usize = 3;
+
+impl Application for ContainmentApp {
+    type Message = ContainmentMessage;
+    type Flags = (PanickingProducer, Transitions);
+
+    fn new((kind, transitions): Self::Flags) -> (Self, Command<Self::Message>) {
+        let command = match kind {
+            PanickingProducer::UnkeyedCommand => panicking_effect(),
+            PanickingProducer::KeyedCommand => {
+                panicking_effect().cancellable(CommandId::new("panicking-keyed"))
+            }
+            PanickingProducer::SubscriptionForwarder => Command::none(),
+        };
+
+        (
+            Self {
+                kind,
+                transitions,
+                ticks: 0,
+            },
+            command,
+        )
+    }
+
+    fn update(&mut self, _msg: Self::Message) -> Command<Self::Message> {
+        self.transitions.updates.fetch_add(1, Ordering::SeqCst);
+        self.ticks += 1;
+        if self.ticks >= SURVIVING_TICKS {
+            Command::quit()
+        } else {
+            Command::none()
+        }
+    }
+
+    fn view(&self, _frame: &mut Frame<'_>) {
+        self.transitions.views.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn subscriptions(&self) -> Vec<Subscription<Self::Message>> {
+        self.transitions
+            .subscriptions
+            .fetch_add(1, Ordering::SeqCst);
+        let surviving = timer_subscription(|| ContainmentMessage::Tick);
+        if self.kind == PanickingProducer::SubscriptionForwarder {
+            vec![Subscription::new(PanickingStreamSource), surviving]
+        } else {
+            vec![surviving]
+        }
+    }
+}
+
+async fn assert_producer_panic_is_contained(kind: PanickingProducer) -> Result<()> {
+    let transitions = Transitions::default();
+    let mut terminal = common::test_terminal()?;
+    let runtime = Runtime::<ContainmentApp>::new((kind, transitions.clone()), frame_rate(60));
+
+    let outcome = panic_hook::with_silent_panic_hook(timeout(
+        Duration::from_secs(5),
+        runtime.run(&mut terminal),
+    ))
+    .await
+    .expect("a contained producer panic must leave the run able to quit before the timeout");
+
+    assert!(
+        outcome.is_ok(),
+        "a {kind:?} panic must not terminate the application: {outcome:?}"
+    );
+    assert!(
+        transitions.updates.load(Ordering::SeqCst) >= SURVIVING_TICKS,
+        "the surviving producer's later messages must still reach update after the {kind:?} panic"
+    );
+
+    Ok(())
+}
+
+// INV-LC8: a panic in an unkeyed command task does not terminate the
+// application — the loop keeps running and a surviving producer's later
+// messages still arrive at `update`.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_panicking_unkeyed_command_task_does_not_terminate_the_application() -> Result<()> {
+    assert_producer_panic_is_contained(PanickingProducer::UnkeyedCommand).await
+}
+
+// INV-LC8: same for a keyed command task. RFC 0003 §7.3 requires only that the
+// panic is logged; the continuation property is this invariant's, so this row is
+// not redundant with the keyed logging test.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_panicking_keyed_command_task_does_not_terminate_the_application() -> Result<()> {
+    assert_producer_panic_is_contained(PanickingProducer::KeyedCommand).await
+}
+
+// INV-LC8: same for a subscription forwarder whose source constructor succeeds
+// and whose stream panics while the forwarder task polls it.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn a_panicking_subscription_forwarder_does_not_terminate_the_application() -> Result<()> {
+    assert_producer_panic_is_contained(PanickingProducer::SubscriptionForwarder).await
+}


### PR DESCRIPTION
## Summary

Drafts the contract-test layer for RFC 0011 (runtime lifecycle) ahead of its implementation work: a coverage map of every §8 invariant against the existing suites, 20 new tests closing the gaps the map found, and an explicit list of the invariant halves that need a new observation hook before they can be tested at all. Tests only — no production source, no `docs/rfcs/`, no CHANGELOG (matching the repo's test-only-commit convention).

## What lands

**White-box phase-order tests** (`src/runtime.rs` `mod tests`): a recording application whose `view`/`subscriptions` log the state they observe, driven through `process_input_batch`/`process_frame_tick` directly, asserting INV-LC1 (input batches neither render nor re-evaluate; a frame pass does each once), INV-LC2 (render before re-evaluation, both observing the same latest state, suppression scoped to render only), and INV-LC4's eligibility half (first frame pass renders with no message processed, ignoring the init command's redraw directive).

**Integration lifecycle tests** (`tests/lifecycle.rs`, all `current_thread` + `start_paused`, no sleeps): the ten INV-LC5/LC6 termination rows — unkeyed quit, keyed quit, render error (via a `FailingBackend`, since `TestBackend`'s error is `Infallible`), run-future drop, and panics in `update` / `view` / bootstrap `subscriptions` / steady `subscriptions` / a source constructor — each asserting both INV-LC7 postcondition stages through a bounded settle loop that re-checks the no-further-transitions counters on every yield and uses task-drop-flag witnesses where the count-based keyed gauge publishes zero ahead of the executor dismantling the futures. Plus the three INV-LC8 containment rows (unkeyed, keyed, forwarder panic → application keeps running with surviving producers).

**Two post-conformance tests, `#[ignore = "RFC 0011 §3.4 conformance lands with the 0.11.0 lifecycle change"]`**: inert construction and never-run drop. Both verified to fail for exactly the intended reason when run with `--ignored` on current `main` — they encode the §3.4 target contract, not current behavior.

## Deliberately not covered (needs hooks or structural review — input for the pending-work-aggregation follow-up)

- INV-LC9 (driver exclusivity): structural by the RFC; review, not observation.
- INV-LC4 ordering half: no stable observable phase exists between init dispatch and the effect's first poll (§3.3 records this as negative space).
- INV-LC6 synchrony half: distinguishing "cancellation requested within the drop" from "requested one poll later" needs a synchronously readable outstanding-task observable.
- The keyed-gauge quiescence blind spot above is the concrete motivation for an aggregated pending-work observable.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --bins --tests --examples --all-features`: 436 lib; `tests/lifecycle.rs` 12 passed / 2 ignored; 0 failures anywhere
- Mutation checks (applied temporarily, reverted): swapping render/re-evaluation order, breaking `PendingWork`'s initial redraw, and removing the subscription-manager drop abort each fail exactly the intended tests; removing `run()`'s shutdown call fails nothing — the tests pin the RFC's postconditions, not the mechanism.


---

**Update**: the macOS CI failures were root-caused to an un-armable drop witness (constructed in the future's body, so a cancelled-before-first-poll init task dropped the un-started future without ever arming it) and fixed in `727f4d4` — witnesses are now armed on the future value, and the settle bound is a documented scheduler-pass count. Full analysis and corrected reproduction data in the linked issue.

Fixes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
