### PR TITLE
docs(command,subscription): unify consuming-setter must_use wording

### DIFF
--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -154,7 +154,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// Side effects still run. This is an optimization hint rather than a
     /// guarantee: the runtime may still redraw for other reasons, such as an
     /// initial frame or another message in the same batch.
-    #[must_use = "without_redraw returns a modified command and does not mutate in place"]
+    #[must_use = "without_redraw consumes the command and returns the modified value"]
     pub const fn without_redraw(mut self) -> Self {
         self.directives = self.directives.without_redraw();
         self
@@ -191,7 +191,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///     .scoped("pane-1")
     ///     .cancellable(CommandId::new("load"));
     /// ```
-    #[must_use = "cancellable returns a modified command and does not mutate in place"]
+    #[must_use = "cancellable consumes the command and returns the modified value"]
     pub fn cancellable(self, id: CommandId) -> Self {
         self.cancellable_with(id, CancelPolicy::CancelInFlight)
     }
@@ -227,7 +227,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///     .scoped("pane-1")
     ///     .cancellable_with(CommandId::new("load"), CancelPolicy::KeepInFlight);
     /// ```
-    #[must_use = "cancellable_with returns a modified command and does not mutate in place"]
+    #[must_use = "cancellable_with consumes the command and returns the modified value"]
     pub fn cancellable_with(mut self, id: CommandId, policy: CancelPolicy) -> Self {
         self.cancellation.key = Some(CancellableCommand { id, policy });
         self
@@ -268,7 +268,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///
     /// let cmd: Command<i32> = Command::cancel(CommandId::new("load")).scoped("pane-1");
     /// ```
-    #[must_use = "scoped returns a modified command and does not mutate in place"]
+    #[must_use = "scoped consumes the command and returns the modified value"]
     pub fn scoped<Scope>(mut self, scope: Scope) -> Self
     where
         Scope: Eq + Hash + Send + Sync + 'static,
@@ -327,7 +327,7 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// let cmd = Command::perform(async { "data".to_string() }, Message::Loaded)
     ///     .timeout(Duration::from_secs(5), || Message::TimedOut);
     /// ```
-    #[must_use = "timeout returns a modified command and does not mutate in place"]
+    #[must_use = "timeout consumes the command and returns the modified value"]
     pub fn timeout(
         mut self,
         duration: Duration,

--- a/src/command/retry.rs
+++ b/src/command/retry.rs
@@ -40,14 +40,14 @@ impl RetryPolicy {
     }
 
     /// Replace the delay strategy.
-    #[must_use = "with_backoff returns a modified policy and does not mutate in place"]
+    #[must_use = "with_backoff consumes the policy and returns the modified value"]
     pub const fn with_backoff(mut self, backoff: RetryBackoff) -> Self {
         self.backoff = backoff;
         self
     }
 
     /// Use the same delay before every subsequent attempt.
-    #[must_use = "with_fixed_backoff returns a modified policy and does not mutate in place"]
+    #[must_use = "with_fixed_backoff consumes the policy and returns the modified value"]
     pub const fn with_fixed_backoff(self, delay: Duration) -> Self {
         self.with_backoff(RetryBackoff::fixed(delay))
     }

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -135,7 +135,7 @@ impl<Msg: 'static> Subscription<Msg> {
     ///     .map(move |_| Message::Tick(pane_id))
     ///     .scoped(pane_id);
     /// ```
-    #[must_use = "scoped returns a modified subscription and does not mutate in place"]
+    #[must_use = "scoped consumes the subscription and returns the modified value"]
     pub fn scoped<Scope>(mut self, scope: Scope) -> Self
     where
         Scope: Eq + Hash + Send + Sync + 'static,


### PR DESCRIPTION
Resolves the wording split #271 introduced: `RuntimeConfig`'s three setters adopted move wording ("consumes … and returns the modified value") per RFC 0007 §2.1's copy-idiom deliverable, leaving the eight sibling consuming setters (`Command` ×5, `RetryPolicy` ×2, `Subscription::scoped`) on the older "returns a modified X and does not mutate in place".

This takes option 1 from the issue — harmonize forward — because the move wording is the more precise description of consuming setters on non-`Copy` types as well; "does not mutate in place" was always describing move semantics loosely. Diagnostic message strings only: no API surface, behavior, or CHANGELOG impact.

Two RFC code blocks now quote pre-unification strings and are deliberately NOT touched here: RFC 0004 §A.2 (normative appendix; the pinned claim is "message-bearing `#[must_use]`", not the string content — LG-0004-041 agrees) and RFC 0007 §2.1. Both are tracked in #279 and land with the 0006/0007 status-transition docs PR, which already carries the RFC-edit ceremony (checklist + verification-chain re-sync); keeping the RFC edits out of this PR keeps that ceremony in one place.

Verification: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --lib --all-features`, and `cargo test --doc --all-features` all exit 0. A grep confirms no "does not mutate in place" / "returns a modified copy" phrasing remains in `src/`.

Fixes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)