### PR TITLE
docs(rfcs): transition RFC 0006 and 0007 to Implemented

### DIFF
--- a/docs/rfcs/0004-command-timeout-retry.md
+++ b/docs/rfcs/0004-command-timeout-retry.md
@@ -522,9 +522,9 @@ impl RetryPolicy {
     pub const fn max_attempts(&self) -> NonZeroUsize;
     #[must_use]
     pub const fn backoff(&self) -> &RetryBackoff;
-    #[must_use = "with_backoff returns a modified policy and does not mutate in place"]
+    #[must_use = "with_backoff consumes the policy and returns the modified value"]
     pub const fn with_backoff(self, backoff: RetryBackoff) -> Self;
-    #[must_use = "with_fixed_backoff returns a modified policy and does not mutate in place"]
+    #[must_use = "with_fixed_backoff consumes the policy and returns the modified value"]
     pub const fn with_fixed_backoff(self, delay: Duration) -> Self;
 }
 

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -1,6 +1,6 @@
 # RFC 0006: Runtime Load Control
 
-- Status: Accepted (section 5.1 records the bounded acceptance results)
+- Status: Implemented (section 5.1 records the bounded acceptance results)
 - Target: release-gate decision for 0.10.0 (section 3); implementation after
   0.10.0 (additive); the gauge-event `runtime_id` schema addition lands
   at 0.11.0 (a schema change, hence a contract change under INV-L13 —
@@ -20,8 +20,7 @@
 > delegated to the separate `RuntimeConfig` RFC — capacity values,
 > recommended defaults, the section 5.1 bounded-run parameters, and the CI
 > smoke-profile question — are settled there and implemented; RFC 0007
-> itself is Accepted with its own §2.1 `Copy` removal as the open
-> deliverable, which nothing here depends on, so no
+> is itself Implemented, so no
 > prerequisite of the implementation PR remains open (sections 3.2, 6). The
 > three contracts flagged for settling before the post-0.10.0
 > implementation — the exact scope of the memory bound (INV-L1), the quit
@@ -299,9 +298,8 @@ constructor `Runtime::with_config(flags, config)`, with `Runtime::new`
 unchanged and equivalent to the default configuration. The exact public
 shape — constructor signature, field set, naming, and
 construction/validation style — is fixed by the separate `RuntimeConfig`
-RFC (its delegated surface is implemented; the RFC itself is Accepted
-with its own §2.1 `Copy` removal as the open deliverable — section 6),
-so the load-control implementation PR could
+RFC (its delegated surface is implemented; the RFC is itself
+Implemented — section 6), so the load-control implementation PR could
 start. The verdict here needs only the additivity argument, which holds
 for any shape that keeps `Runtime::new` unchanged. Bounded behavior
 activates only through that surface:
@@ -336,10 +334,9 @@ load-control implementation (sections 4–6) landed after 0.10.0 behind
 ### 4.1 Configuration surface
 
 `RuntimeConfig` — public shape fixed by the separate `RuntimeConfig` RFC
-(delegated surface implemented; the RFC itself Accepted with its own
-§2.1 `Copy` removal as the open deliverable — section 3.2) — carries the
-three controls below. That RFC adopts these names unchanged and groups
-the frame rate into the same config, so
+(delegated surface implemented; the RFC is itself Implemented —
+section 3.2) — carries the three controls below. That RFC adopts these
+names unchanged and groups the frame rate into the same config, so
 `Runtime::with_config(flags, config)` takes the frame rate inside
 `config`; the semantics stated here are the contract.
 
@@ -1498,9 +1495,9 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
 
 Every question below is resolved — in this RFC, or by the `RuntimeConfig`
 RFC, whose delegated decisions are implemented (that RFC is itself
-Accepted with its own §2.1 `Copy` removal as the open deliverable, which
-no question here waits on) and which fixes the public `RuntimeConfig`
-API (and with it questions 1, 5, and the default-value half of 2), the
+Implemented, and no question here waited on its §2.1 `Copy`-removal
+deliverable) and which fixes the public `RuntimeConfig` API (and with
+it questions 1, 5, and the default-value half of 2), the
 section 5.1 bounded-run parameters (configuration under test, backlog
 depths, trial counts), and the CI smoke-profile decision. No open
 question remains as a prerequisite of the implementation PR

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -20,9 +20,9 @@
 > delegated to the separate `RuntimeConfig` RFC — capacity values,
 > recommended defaults, the section 5.1 bounded-run parameters, and the CI
 > smoke-profile question — are settled there and implemented; RFC 0007
-> is itself Implemented, so no
-> prerequisite of the implementation PR remains open (sections 3.2, 6). The
-> three contracts flagged for settling before the post-0.10.0
+> is itself Implemented, so no prerequisite of the implementation PR
+> remains open (sections 3.2, 6). The three contracts flagged for
+> settling before the post-0.10.0
 > implementation — the exact scope of the memory bound (INV-L1), the quit
 > delivery path, and cross-channel fairness — are settled (open
 > questions 3, 7, and 6; sections 4.5, 4.6, and 4.7), as are the INV-L4
@@ -298,9 +298,8 @@ constructor `Runtime::with_config(flags, config)`, with `Runtime::new`
 unchanged and equivalent to the default configuration. The exact public
 shape — constructor signature, field set, naming, and
 construction/validation style — is fixed by the separate `RuntimeConfig`
-RFC (its delegated surface is implemented; the RFC is itself
-Implemented — section 6), so the load-control implementation PR could
-start. The verdict here needs only the additivity argument, which holds
+RFC (Implemented — section 6), so the load-control implementation PR
+could start. The verdict here needs only the additivity argument, which holds
 for any shape that keeps `Runtime::new` unchanged. Bounded behavior
 activates only through that surface:
 
@@ -334,9 +333,9 @@ load-control implementation (sections 4–6) landed after 0.10.0 behind
 ### 4.1 Configuration surface
 
 `RuntimeConfig` — public shape fixed by the separate `RuntimeConfig` RFC
-(delegated surface implemented; the RFC is itself Implemented —
-section 3.2) — carries the three controls below. That RFC adopts these
-names unchanged and groups the frame rate into the same config, so
+(Implemented — section 3.2) — carries the three controls below. That
+RFC adopts these names unchanged and groups the frame rate into the
+same config, so
 `Runtime::with_config(flags, config)` takes the frame rate inside
 `config`; the semantics stated here are the contract.
 
@@ -1494,10 +1493,8 @@ is therefore `app_channel_capacity + concurrent shared-channel producers`
 ## 6. Open questions (all resolved)
 
 Every question below is resolved — in this RFC, or by the `RuntimeConfig`
-RFC, whose delegated decisions are implemented (that RFC is itself
-Implemented, and no question here waited on its §2.1 `Copy`-removal
-deliverable) and which fixes the public `RuntimeConfig` API (and with
-it questions 1, 5, and the default-value half of 2), the
+RFC (Implemented), which fixes the public `RuntimeConfig` API (and
+with it questions 1, 5, and the default-value half of 2), the
 section 5.1 bounded-run parameters (configuration under test, backlog
 depths, trial counts), and the CI smoke-profile decision. No open
 question remains as a prerequisite of the implementation PR

--- a/docs/rfcs/0006-runtime-load-control.md
+++ b/docs/rfcs/0006-runtime-load-control.md
@@ -22,13 +22,12 @@
 > smoke-profile question — are settled there and implemented; RFC 0007
 > is itself Implemented, so no prerequisite of the implementation PR
 > remains open (sections 3.2, 6). The three contracts flagged for
-> settling before the post-0.10.0
-> implementation — the exact scope of the memory bound (INV-L1), the quit
-> delivery path, and cross-channel fairness — are settled (open
-> questions 3, 7, and 6; sections 4.5, 4.6, and 4.7), as are the INV-L4
-> acceptance formulation, the `batch_max_messages` semantics, and the
-> observability schema (sections 4.1, 4.4, 5). None of them gated the 0.10.0
-> release.
+> settling before the post-0.10.0 implementation — the exact scope of
+> the memory bound (INV-L1), the quit delivery path, and cross-channel
+> fairness — are settled (open questions 3, 7, and 6; sections 4.5,
+> 4.6, and 4.7), as are the INV-L4 acceptance formulation, the
+> `batch_max_messages` semantics, and the observability schema
+> (sections 4.1, 4.4, 5). None of them gated the 0.10.0 release.
 
 ## Summary
 
@@ -335,9 +334,8 @@ load-control implementation (sections 4–6) landed after 0.10.0 behind
 `RuntimeConfig` — public shape fixed by the separate `RuntimeConfig` RFC
 (Implemented — section 3.2) — carries the three controls below. That
 RFC adopts these names unchanged and groups the frame rate into the
-same config, so
-`Runtime::with_config(flags, config)` takes the frame rate inside
-`config`; the semantics stated here are the contract.
+same config, so `Runtime::with_config(flags, config)` takes the frame
+rate inside `config`; the semantics stated here are the contract.
 
 - `app_channel_capacity: Option<NonZeroUsize>` — `None` (default) keeps the
   unbounded shared channel; `Some(n)` bounds it.

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -1,7 +1,6 @@
 # RFC 0007: RuntimeConfig public API and load-control acceptance parameters
 
-- Status: Accepted (the §2.1 `Copy` removal is the open deliverable;
-  everything else is implemented)
+- Status: Implemented
 - Target: the prerequisite RFC 0006 delegated to a separate document
   (RFC 0006 sections 3.2, 6); plus one breaking change for 0.11.0
   decided here — `RuntimeConfig` drops its `Copy` derive (§2.1)
@@ -10,8 +9,8 @@
   interaction position, the RFC 0006 section 5.1 bounded-run parameters,
   and the CI smoke-profile decision
 - Feature flag: none
-- CHANGELOG: `Added` entries (`RuntimeConfig`, `Runtime::with_config`) land
-  at the load-control implementation release, not with this RFC.
+- CHANGELOG: `Added` entries (`RuntimeConfig`, `Runtime::with_config`)
+  landed at the load-control implementation release, not with this RFC.
   `Changed` (breaking) — `RuntimeConfig` no longer implements `Copy`;
   `Clone`, `Debug`, `Eq`, and `PartialEq` remain, and `FrameRate` stays
   `Copy`. Lands at 0.11.0 with the §2.1 derive-removal deliverable
@@ -104,13 +103,13 @@ pub struct RuntimeConfig {
 
 impl RuntimeConfig {
     #[must_use]
-    pub fn new(frame_rate: FrameRate) -> Self;
-    #[must_use = "app_channel_capacity returns a modified config and does not mutate in place"]
-    pub fn app_channel_capacity(self, capacity: NonZeroUsize) -> Self;
-    #[must_use = "keyed_channel_capacity returns a modified config and does not mutate in place"]
-    pub fn keyed_channel_capacity(self, capacity: NonZeroUsize) -> Self;
-    #[must_use = "batch_max_messages returns a modified config and does not mutate in place"]
-    pub fn batch_max_messages(self, max: NonZeroUsize) -> Self;
+    pub const fn new(frame_rate: FrameRate) -> Self;
+    #[must_use = "app_channel_capacity consumes the config and returns the modified value"]
+    pub const fn app_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    #[must_use = "keyed_channel_capacity consumes the config and returns the modified value"]
+    pub const fn keyed_channel_capacity(self, capacity: NonZeroUsize) -> Self;
+    #[must_use = "batch_max_messages consumes the config and returns the modified value"]
+    pub const fn batch_max_messages(self, max: NonZeroUsize) -> Self;
 }
 ```
 
@@ -151,12 +150,7 @@ impl RuntimeConfig {
   convention (`RetryPolicy::with_backoff`,
   `RetryPolicy::with_fixed_backoff` — `src/command/retry.rs`);
   `Runtime::with_config` carries `#[must_use]` too, matching
-  `Runtime::new`'s existing attribute. While the `Copy` derive is still
-  present (the open deliverable, Derives below), a discarded setter
-  call additionally compiles with the original left usable in play —
-  the `#[must_use]` warning is the only guard for that shape today, and
-  the derive removal is what converts its compile-time half into an
-  error. Pinned as INV-C6 (§7).
+  `Runtime::new`'s existing attribute. Pinned as INV-C6 (§7).
 - **Validation style**: none, by construction. Every capacity is
   `NonZeroUsize`, so a zero capacity is unrepresentable, and the frame
   rate arrives as the already-validated `FrameRate` type — validation
@@ -177,22 +171,22 @@ impl RuntimeConfig {
   non-breaking on this axis. What `Copy` bought — harness and test code
   free of explicit clones — is recoverable with `Clone` at the cost of
   a visible `clone()`. `FrameRate` keeps `Copy`: it is word-sized with
-  no growth ambition (`src/runtime/frame_rate.rs`). The current code
-  still derives `Copy` (`src/runtime/config.rs`); removing it is this
-  amendment's implementation deliverable, in four parts: (a) the derive
-  change itself; (b) updating the rustdoc that leans on copy idioms
-  (the "returns a modified copy" / "does not mutate in place" phrasing,
-  `src/runtime/config.rs`), which describes a move-and-return builder
-  once `Copy` is gone; (c) an inventory of implicit-`Copy` uses —
-  assignments and by-value passes that copy silently today — migrated
-  to `clone()` or borrows; (d) a public-API diff check at
-  implementation time confirming the only surface change is the `Copy`
+  no growth ambition (`src/runtime/frame_rate.rs`). The derive is
+  removed (`src/runtime/config.rs`); the amendment's implementation
+  deliverable had four parts: (a) the derive change itself; (b) the
+  rustdoc that leaned on copy idioms (the "returns a modified copy" /
+  "does not mutate in place" phrasing, `src/runtime/config.rs`)
+  rewritten to describe a move-and-return builder; (c) an inventory of
+  implicit-`Copy` uses — assignments and by-value passes that copied
+  silently — migrated to `clone()` or borrows; (d) a public-API diff
+  check confirming the only surface change is the `Copy`
   implementation's removal.
 
 ### 2.2 Constructor integration
 
 ```rust
 impl<App: Application> Runtime<App> {
+    #[must_use]
     pub fn new(flags: App::Flags, frame_rate: FrameRate) -> Self;   // unchanged
     #[must_use]
     pub fn with_config(flags: App::Flags, config: RuntimeConfig) -> Self;  // new

--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -171,16 +171,10 @@ impl RuntimeConfig {
   non-breaking on this axis. What `Copy` bought — harness and test code
   free of explicit clones — is recoverable with `Clone` at the cost of
   a visible `clone()`. `FrameRate` keeps `Copy`: it is word-sized with
-  no growth ambition (`src/runtime/frame_rate.rs`). The derive is
-  removed (`src/runtime/config.rs`); the amendment's implementation
-  deliverable had four parts: (a) the derive change itself; (b) the
-  rustdoc that leaned on copy idioms (the "returns a modified copy" /
-  "does not mutate in place" phrasing, `src/runtime/config.rs`)
-  rewritten to describe a move-and-return builder; (c) an inventory of
-  implicit-`Copy` uses — assignments and by-value passes that copied
-  silently — migrated to `clone()` or borrows; (d) a public-API diff
-  check confirming the only surface change is the `Copy`
-  implementation's removal.
+  no growth ambition (`src/runtime/frame_rate.rs`). `RuntimeConfig` does
+  not derive `Copy` (`src/runtime/config.rs`); its rustdoc describes a
+  move-and-return builder, and the public surface differs from the
+  `Copy` era only by that implementation's removal.
 
 ### 2.2 Constructor integration
 


### PR DESCRIPTION
## Summary

Transitions RFC 0006 and RFC 0007 from Accepted to Implemented: both conformance deliverables are on main — the `RuntimeConfig` `Copy`-derive removal (#271, RFC 0007 §2.1) and the gauge `runtime_id` schema addition (#272, RFC 0006 §4.4) — satisfying the transition criterion recorded at bundle acceptance. Retensing only; no contract change.

## Changes

- **RFC 0007**: Status → Implemented; header's shipped `Added` entries past-tensed; §2.1's two interim-state passages retensed (the "derive is still present" sentence deleted — the surviving text states the post-removal behavior directly and still pins everything INV-C6 requires; the four-part deliverable past-tensed).
- **RFC 0006**: Status → Implemented; the four references to RFC 0007's accepted-with-open-deliverable status (decision-scope blockquote, §4 intro, §4.1, §6) now say Implemented.
- **Code-block sync (closes #279)**: RFC 0004 §A.2's two `must_use` strings adopt #278's wording; RFC 0007 §2.1's three adopt #271's wording (that block had been stale since the derive removal itself, not since #278). Adversarial review additionally caught two long-standing fidelity gaps fixed here: the same block's four setter signatures gain the `const` the code has always had, and §2.2's `Runtime::new` gains the `#[must_use]` its own prose asserts. After the sync, every entry in both blocks matches the code (machine-checked).
- **Verification chain (gitignored tmp/, recorded here for the review trail)**: `STATUS_STRICT` widened to `(?:Accepted|Implemented)`; the revocation denylist gains `retracted/reverted/deprecated/abandoned/rolled back/no longer in effect/void` after a review bypass showed "retracted" passing the analysis layer; corpus re-pinned; amendment-log entry appended. Verifier green; failure paths exercised (a `Superseded` and a `retracted` status each FAIL).
- **RFC 0010 untouched**: the N16 row's "is drafted as" (§9.1) is stale but sits in the dated §9 snapshot the §8.1 ruling keeps non-living and the verifier byte-binds; deferred deliberately, disposition recorded in the amendment log.

## Pre-review checklist (per-item verdicts, after adversarial review)

1. Quantifiers vs inventory — pass ("four references" enumerated exactly; five-string inventory exact; no other RFC quotes the retired wording)
2. Adversarial counterexample per invariant — pass (no invariant added/reworded; the gate-widening attack produced the denylist fix)
3. Enforcement class declared — pass/N-A (no new invariant; INV-C6 untouched)
4. Code claims vs code — pass after fixes (initially FAILED adversarial review on the shipped-`Added` tense and the block/code `const` divergence; both fixed, doc↔code match machine-checked)
5. Normative force and readiness — pass (deliverable (d)'s "at implementation time" hedge dropped)
6. Re-derive, don't patch — pass (deleted interim sentence loses no INV-C6 content — verified against §7's invariant text)
7. Mechanical pass — pass after fixes (typos clean; one Status declaration per file, in-header; no history/date language added; reflow fixed)
8. Minimal contract — pass (retensing removes text; nothing gained or lost)

Adversarial review (independent pass, mission = No-Go): initial verdict **No-Go** with 6 findings; all fixed here except the deliberately deferred N16 (above) — its factual-grounding sweep verified all four §2.1 deliverable parts and every §4.4 runtime_id requirement against the code, and re-derived the corpus pin in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
