### PR TITLE
refactor(test-support): consolidate the panic-hook guard helper

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -155,10 +155,14 @@ across the two copies.
 
 ## Process-Global Panic Hook Tests
 
-Use `crate::test_support::PANIC_HOOK_GUARD` for crate-internal tests that directly
+Use `crate::test_support::hook_guard()` for crate-internal tests that directly
 call `std::panic::set_hook` or `std::panic::take_hook`. The panic hook is
 process-global and tests run in parallel by default, so hook-swapping tests can
-otherwise clobber each other or observe an unrelated panic.
+otherwise clobber each other or observe an unrelated panic. The helper locks the
+process-global `PANIC_HOOK_GUARD` and recovers from poisoning in one place —
+poisoning is ordinary here, since the tests it serializes panic on purpose, and
+recovering keeps one such panic from failing every later hook test with a poison
+error instead of its own assertion.
 
 Hold the guard for the full critical section: install or take the hook, trigger
 and catch the panic if needed, restore the previous hook, and then inspect any
@@ -176,7 +180,7 @@ restore skipped or taken) use `crate::test_support::HookProbe` instead: it
 installs a counting hook built from the real `compose_hook`, serves
 multi-thread runtimes and non-async tests, and filters its counts by worker
 thread name so a concurrent unrelated panic cannot move them. Callers hold
-`PANIC_HOOK_GUARD` themselves — including across `block_on` in non-async
+the guard themselves — including across `block_on` in non-async
 tests. It is lib-only: it needs the crate-private `compose_hook`, so the
 integration copy under `tests/common/panic_hook.rs` deliberately has no
 equivalent.
@@ -199,7 +203,7 @@ process-global hook around its own unwinds: tearing a coroutine down, it calls
 `take_hook`, installs a no-op so the internal unwind prints nothing, and
 reinstalls the previous hook afterwards (`generator`'s `gen_impl.rs`). A test
 running concurrently with that sequence is running concurrently with a hook
-swap it did not make — exactly what `PANIC_HOOK_GUARD` serializes. That the
+swap it did not make — exactly what the guard serializes. That the
 swap is performed by a dependency rather than by the test's own code changes
 nothing about the hazard. Robustness against future loom or generator versions
 is a secondary reason, and the cost is four models serializing against the
@@ -222,7 +226,7 @@ holding the guard, and the loom models running in the same binary. That
 diagnosis named generator's completion path as the primary cause, and it is a
 real path — `done()` raises `panic_any` in generator's `yield_.rs`, and loom's
 scheduler ends a coroutine body with it. Serializing both against
-`PANIC_HOOK_GUARD` closed the flake, with twelve consecutive green runs of the
+the guard closed the flake, with twelve consecutive green runs of the
 full lib suite where the same conditions had failed frequently before. The
 re-measurement above does not reproduce that path reaching an installed hook,
 and the two observations are left as they are rather than reconciled by

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -179,11 +179,10 @@ Tests that assert on how the composed hook *classified* a panic (terminal
 restore skipped or taken) use `crate::test_support::HookProbe` instead: it
 installs a counting hook built from the real `compose_hook`, serves
 multi-thread runtimes and non-async tests, and filters its counts by worker
-thread name so a concurrent unrelated panic cannot move them. Callers hold
-the guard themselves — including across `block_on` in non-async
-tests. It is lib-only: it needs the crate-private `compose_hook`, so the
-integration copy under `tests/common/panic_hook.rs` deliberately has no
-equivalent.
+thread name so a concurrent unrelated panic cannot move them. Callers hold the
+guard themselves — including across `block_on` in non-async tests. It is
+lib-only: it needs the crate-private `compose_hook`, so the integration copy
+under `tests/common/panic_hook.rs` deliberately has no equivalent.
 
 **A recording hook filters by thread name. That is the primary defence, and it
 is the recording test's own obligation.** The guard serializes hook swaps, not
@@ -203,10 +202,10 @@ process-global hook around its own unwinds: tearing a coroutine down, it calls
 `take_hook`, installs a no-op so the internal unwind prints nothing, and
 reinstalls the previous hook afterwards (`generator`'s `gen_impl.rs`). A test
 running concurrently with that sequence is running concurrently with a hook
-swap it did not make — exactly what the guard serializes. That the
-swap is performed by a dependency rather than by the test's own code changes
-nothing about the hazard. Robustness against future loom or generator versions
-is a secondary reason, and the cost is four models serializing against the
+swap it did not make — exactly what the guard serializes. That the swap is
+performed by a dependency rather than by the test's own code changes nothing
+about the hazard. Robustness against future loom or generator versions is a
+secondary reason, and the cost is four models serializing against the
 hook-holding tests, which is nothing.
 
 The guard is not, on the locked versions, holding back a stream of hook calls.
@@ -225,11 +224,11 @@ panics raised on other tests' threads: deliberate panics in tests that were not
 holding the guard, and the loom models running in the same binary. That
 diagnosis named generator's completion path as the primary cause, and it is a
 real path — `done()` raises `panic_any` in generator's `yield_.rs`, and loom's
-scheduler ends a coroutine body with it. Serializing both against
-the guard closed the flake, with twelve consecutive green runs of the
-full lib suite where the same conditions had failed frequently before. The
-re-measurement above does not reproduce that path reaching an installed hook,
-and the two observations are left as they are rather than reconciled by
+scheduler ends a coroutine body with it. Serializing both against the guard
+closed the flake, with twelve consecutive green runs of the full lib suite
+where the same conditions had failed frequently before. The re-measurement
+above does not reproduce that path reaching an installed hook, and the two
+observations are left as they are rather than reconciled by
 argument: whether a generator unwind reaches the hook you installed depends on
 how generator is managing the hook at that moment, which is the same take/set/
 restore sequence the paragraph above makes the guard's reason. The fix at the

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -129,12 +129,12 @@ pub fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook)
 
 #[cfg(test)]
 mod tests {
-    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD};
+    use crate::test_support::{HookProbe, hook_guard};
 
     use super::*;
 
     use std::future::pending;
-    use std::sync::{Arc, Mutex, PoisonError};
+    use std::sync::{Arc, Mutex};
 
     use futures::future::join_all;
     use tokio::runtime::Builder;
@@ -154,9 +154,7 @@ mod tests {
     fn test_compose_hook_restores_then_delegates_once() {
         // Serialize against other tests that touch the global panic hook or
         // panic, so a concurrent panic cannot invoke our recording hook.
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
 
         // Records the order (and therefore the count) of the two stages.
         // `restore` must run first so the terminal is usable before the
@@ -204,9 +202,7 @@ mod tests {
     fn test_contained_producer_panic_skips_restore_while_application_panic_restores() {
         const PROBE: &str = "tears-panic-probe-contained";
 
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         let runtime = Builder::new_multi_thread()
             .worker_threads(1)
             .thread_name(PROBE)
@@ -254,9 +250,7 @@ mod tests {
     fn test_contained_mark_does_not_span_await_points() {
         const PROBE: &str = "tears-panic-probe-parked";
 
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         // One worker thread, so the unrelated task below is guaranteed to run
         // on the very thread that parked the contained producer — the exact
         // condition a mark held across `.await` would misclassify.
@@ -311,9 +305,7 @@ mod tests {
         const PROBE: &str = "tears-panic-probe-migrating";
         const TASKS: usize = 8;
 
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         let runtime = Builder::new_multi_thread()
             .worker_threads(4)
             .thread_name(PROBE)
@@ -358,9 +350,7 @@ mod tests {
     fn test_aborted_contained_producer_leaves_no_mark_on_the_worker() {
         const PROBE: &str = "tears-panic-probe-aborted";
 
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         // One worker thread, so the panic below lands on the same thread the
         // aborted producer was polled and dropped on.
         let runtime = Builder::new_multi_thread()

--- a/src/runtime/core.rs
+++ b/src/runtime/core.rs
@@ -265,8 +265,8 @@ mod tests {
 
     use std::future::pending;
     use std::num::{NonZeroU64, NonZeroUsize};
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, PoisonError};
 
     use ratatui::backend::TestBackend;
     use ratatui::prelude::*;
@@ -277,7 +277,7 @@ mod tests {
     use crate::runtime::AppInput;
     use crate::subscription::Subscription;
     use crate::subscription::time::Timer;
-    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD, TestApp, TestMessage, wait_until};
+    use crate::test_support::{HookProbe, TestApp, TestMessage, hook_guard, wait_until};
 
     #[test]
     fn test_new() {
@@ -690,9 +690,7 @@ mod tests {
         reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
     )]
     async fn a_panicking_unkeyed_command_task_skips_the_terminal_restore() {
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         let probe = HookProbe::install(
             "runtime::core::tests::a_panicking_unkeyed_command_task_skips_the_terminal_restore",
         );

--- a/src/runtime/keyed_commands.rs
+++ b/src/runtime/keyed_commands.rs
@@ -566,8 +566,8 @@ mod tests {
 
     use std::future::pending;
     use std::num::NonZeroUsize;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Arc, PoisonError};
     use std::time::Duration;
 
     use futures::stream;
@@ -580,7 +580,7 @@ mod tests {
     use crate::Command;
     use crate::command::{RetryPolicy, fold_leaves};
     use crate::test_support::{
-        HookProbe, PANIC_HOOK_GUARD, TraceRecorder, wait_until, with_silent_panic_hook,
+        HookProbe, TraceRecorder, hook_guard, wait_until, with_silent_panic_hook,
     };
 
     fn actions<I>(items: I) -> BoxStream<'static, Action<i32>>
@@ -1092,9 +1092,7 @@ mod tests {
         reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
     )]
     async fn a_panicking_keyed_command_task_skips_the_terminal_restore() {
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         let probe = HookProbe::install(
             "runtime::keyed_commands::tests::a_panicking_keyed_command_task_skips_the_terminal_restore",
         );

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -361,7 +361,7 @@ mod tests {
 
     use std::hash::{Hash, Hasher};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex, PoisonError};
+    use std::sync::{Arc, Mutex};
     use std::task::Poll;
 
     use color_eyre::eyre::Result;
@@ -369,7 +369,7 @@ mod tests {
     use tokio::time::{Duration, sleep, timeout};
 
     use crate::subscription::mock::MockSource;
-    use crate::test_support::{HookProbe, PANIC_HOOK_GUARD, TraceRecorder, wait_until};
+    use crate::test_support::{HookProbe, TraceRecorder, hook_guard, wait_until};
 
     struct OneshotSource {
         value: i32,
@@ -1363,9 +1363,7 @@ mod tests {
         reason = "the test intentionally serializes the process-global hook across its current-thread awaits"
     )]
     async fn a_panicking_subscription_forwarder_skips_the_terminal_restore() {
-        let _hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let _hook_guard = hook_guard();
         let probe = HookProbe::install(
             "subscription::tests::a_panicking_subscription_forwarder_skips_the_terminal_restore",
         );

--- a/src/subscription/http/cell_core.rs
+++ b/src/subscription/http/cell_core.rs
@@ -110,27 +110,19 @@ impl CellCore {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{MutexGuard, PoisonError};
-
     use loom::sync::Arc;
     use loom::thread;
 
     use super::CellCore;
-    use crate::test_support::PANIC_HOOK_GUARD;
-
-    /// Serializes a loom model against the process-global panic-hook
-    /// tests, because a model *is* a hook swapper: loom drives each model
-    /// thread as a `generator` coroutine, and generator takes the global
-    /// hook, installs a no-op around its own unwind, and reinstalls the
-    /// previous one. That is the swap this guard exists to serialize —
-    /// the recording tests' thread-name filter guards their counts, but
-    /// not against a hook being swapped under them (docs/testing.md
-    /// "Process-Global Panic Hook Tests").
-    fn hook_guard() -> MutexGuard<'static, ()> {
-        PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-    }
+    use crate::test_support::hook_guard;
+    // Each model holds the guard for its duration, because a loom model
+    // *is* a hook swapper: loom drives each model thread as a `generator`
+    // coroutine, and generator takes the global hook, installs a no-op
+    // around its own unwind, and reinstalls the previous one. That is the
+    // swap the guard exists to serialize — the recording tests'
+    // thread-name filter guards their counts, but not against a hook being
+    // swapped under them (docs/testing.md "Process-Global Panic Hook
+    // Tests").
 
     #[test]
     fn single_flight_selects_at_most_one_fetcher_per_generation() {

--- a/src/subscription/http/cell_core.rs
+++ b/src/subscription/http/cell_core.rs
@@ -110,11 +110,6 @@ impl CellCore {
 
 #[cfg(test)]
 mod tests {
-    use loom::sync::Arc;
-    use loom::thread;
-
-    use super::CellCore;
-    use crate::test_support::hook_guard;
     // Each model holds the guard for its duration, because a loom model
     // *is* a hook swapper: loom drives each model thread as a `generator`
     // coroutine, and generator takes the global hook, installs a no-op
@@ -123,6 +118,12 @@ mod tests {
     // thread-name filter guards their counts, but not against a hook being
     // swapped under them (docs/testing.md "Process-Global Panic Hook
     // Tests").
+
+    use loom::sync::Arc;
+    use loom::thread;
+
+    use super::CellCore;
+    use crate::test_support::hook_guard;
 
     #[test]
     fn single_flight_selects_at_most_one_fetcher_per_generation() {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -12,7 +12,7 @@ use crate::command::Command;
 use crate::subscription::Subscription;
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
-pub use panic_hook::{HookProbe, PANIC_HOOK_GUARD, with_silent_panic_hook};
+pub use panic_hook::{HookProbe, hook_guard, with_silent_panic_hook};
 pub use trace_recorder::{TraceRecorder, set_default_subscriber};
 
 mod async_utils;

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -5,7 +5,7 @@
 use std::future::Future;
 use std::panic::{self, AssertUnwindSafe, PanicHookInfo};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::thread;
 
 use futures::FutureExt;
@@ -19,6 +19,21 @@ use crate::panic::compose_hook;
 /// records hook activity and a test that panics must not run concurrently, or
 /// the panicking test's hook invocation would pollute the recording one.
 pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
+
+/// Locks [`PANIC_HOOK_GUARD`], recovering from poisoning.
+///
+/// Poisoning is the ordinary case here, not a corruption signal: the guard
+/// serializes access to a process-global hook rather than to data, and the
+/// tests it serializes panic on purpose, so any of them may unwind while
+/// holding it. Recovering means one such panic fails its own test instead
+/// of every later hook test, which would otherwise report a poison error in
+/// place of their own assertions. This is the only place the recovery is
+/// spelled out; hook tests call this rather than locking the static.
+pub fn hook_guard() -> MutexGuard<'static, ()> {
+    PANIC_HOOK_GUARD
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
 
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
 
@@ -155,9 +170,7 @@ pub async fn with_silent_panic_hook<F, T>(future: F) -> T
 where
     F: Future<Output = T>,
 {
-    let _hook_guard = PANIC_HOOK_GUARD
-        .lock()
-        .unwrap_or_else(PoisonError::into_inner);
+    let _hook_guard = hook_guard();
     run_with_silent_panic_hook(future).await
 }
 
@@ -196,9 +209,7 @@ mod tests {
         const PROBE: &str =
             "test_support::panic_hook::tests::silent_scope_restores_the_previous_hook";
 
-        let hook_guard = PANIC_HOOK_GUARD
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let guard = hook_guard();
         let original = panic::take_hook();
         let hook_calls = Arc::new(AtomicUsize::new(0));
         let recorded_calls = Arc::clone(&hook_calls);
@@ -218,7 +229,7 @@ mod tests {
         let restored_hook = panic::take_hook();
         panic::set_hook(original);
         drop(restored_hook);
-        drop(hook_guard);
+        drop(guard);
 
         assert!(outcome.is_err());
         assert!(probe.is_err());

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -18,7 +18,7 @@ use crate::panic::compose_hook;
 /// The panic hook is process-global and shared across threads, so a test that
 /// records hook activity and a test that panics must not run concurrently, or
 /// the panicking test's hook invocation would pollute the recording one.
-pub static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
+static PANIC_HOOK_GUARD: Mutex<()> = Mutex::new(());
 
 /// Locks [`PANIC_HOOK_GUARD`], recovering from poisoning.
 ///
@@ -74,10 +74,10 @@ impl Drop for SilentPanicHook {
 /// starts with the installing test's prefix.
 ///
 /// Unlike [`with_silent_panic_hook`] (current-thread, async), this probe also
-/// serves multi-thread runtimes and non-async tests; callers hold
-/// [`PANIC_HOOK_GUARD`] for their whole critical section themselves. That
-/// serializes the hook swaps but not the rest of the test binary: a test that
-/// panics without taking the guard would still reach this hook. The
+/// serves multi-thread runtimes and non-async tests; callers call
+/// [`hook_guard`] and hold it for their whole critical section themselves.
+/// That serializes the hook swaps but not the rest of the test binary: a
+/// test that panics without taking the guard would still reach this hook. The
 /// thread-name filter keeps such a panic out of the counts — libtest names
 /// each test's thread after the test's full path, and multi-thread tests
 /// stamp their runtime workers with their own prefix.


### PR DESCRIPTION
## Summary

The follow-up deferred from #282's review (first reviewer, finding 6c): the `PANIC_HOOK_GUARD.lock().unwrap_or_else(PoisonError::into_inner)` idiom, duplicated across the crate's hook tests, is consolidated into one helper.

- `test_support::hook_guard() -> MutexGuard<'static, ()>` now owns the lock and the poison recovery, with the reasoning documented once: poisoning is the ordinary case for this guard — the tests it serializes panic on purpose — so recovering keeps one test's panic from failing every later hook test.
- Eleven call sites migrate to it (`panic.rs` ×5, `subscription.rs`, `runtime/core.rs`, `runtime/keyed_commands.rs`, `test_support/panic_hook.rs` ×2, and `cell_core.rs`, whose private copy is deleted). The guard static is no longer re-exported; the helper is the single way to take it.
- `tests/common/panic_hook.rs` is deliberately untouched: the `#[cfg(test)]` test-support module does not exist in an integration binary's view of the crate, and the documented duplication policy already records the deeper difference — the integration copy uses `tokio::sync::Mutex` (held across `.await`), which has no poisoning, so the consolidated idiom never occurred there.
- Three remaining `unwrap_or_else(PoisonError::into_inner)` sites (`runtime/load.rs`, `command/effect.rs` ×2) guard unrelated mutexes and are left alone.
- `docs/testing.md` points at the helper; the rule's substance is unchanged.

## Verification

`cargo test --lib` 400 passed, `--features loom-core --lib` 401 passed, `--all-targets --all-features` 473 passed — zero failures; `clippy --all-targets --all-features -D warnings` clean; `fmt`/`typos`/`diff --check` clean. `docs/rfcs/` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)