### PR TITLE
feat(reducer): land the cleanup hooks and the composition surface

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -25,6 +25,7 @@
 //! ```
 
 mod cancellation;
+mod cleanup;
 pub(crate) mod core;
 mod effect;
 mod kernel_parts;
@@ -34,6 +35,7 @@ mod runtime_parts;
 
 pub(crate) use cancellation::CancellableCommand;
 pub use cancellation::{CancelPolicy, CommandId};
+pub(crate) use cleanup::CleanupRegistration;
 pub(crate) use core::Command;
 pub(crate) use kernel_parts::{KernelParts, SpawnEntry};
 pub use retry::{RetryBackoff, RetryContext, RetryError, RetryPolicy, RetryStopReason};

--- a/src/command/cleanup.rs
+++ b/src/command/cleanup.rs
@@ -1,0 +1,66 @@
+//! The cleanup-hook carrier: what [`Command::on_teardown`] puts on a
+//! command.
+//!
+//! A registration is command *metadata*, like a teardown prefix and unlike
+//! an effect leaf: dispatching the command arms it and starts nothing. What
+//! starts it is a later teardown whose prefix covers its scope, at that
+//! teardown's application point (RFC 0014 §4.4, RFC 0013 §5).
+//!
+//! The finalizer's `Output = ()` is the signature half of INV-RC8's
+//! no-output clause: there is no message for a cleanup run to return, so the
+//! path back into the runtime is closed in the type rather than by the
+//! kernel remembering to ignore something. The other half is structural and
+//! lives at the run's construction site, where the kernel hands a cleanup
+//! run no lane sender and no directive capability
+//! (`kernel::producer::CleanupHarness`).
+//!
+//! [`Command::on_teardown`]: super::Command::on_teardown
+
+use futures::FutureExt;
+use futures::future::BoxFuture;
+
+use crate::structural_key::{ScopePath, StructuralKey};
+
+/// One armed finalizer and the composition boundary it is registered
+/// against.
+///
+/// It carries no message type: a cleanup run produces none, so a
+/// registration survives [`Command::map`](super::Command::map) unchanged
+/// rather than being re-wrapped at every boundary that maps a message type.
+pub struct CleanupRegistration {
+    /// The scope this registration is anchored at — the path a teardown
+    /// prefix has to cover to consume it (RFC 0013 INV-ST1).
+    ///
+    /// Empty at construction and qualified by
+    /// [`Command::scoped`](super::Command::scoped) and by the combinators,
+    /// exactly as a teardown prefix is (RFC 0005 INV-18's coverage).
+    pub scope: ScopePath,
+    /// The finalizer itself.
+    pub finalizer: BoxFuture<'static, ()>,
+}
+
+impl CleanupRegistration {
+    /// A registration anchored at the root, for a finalizer under
+    /// `Command`'s ordinary effect bounds.
+    pub fn new(finalizer: impl Future<Output = ()> + Send + 'static) -> Self {
+        Self {
+            scope: ScopePath::empty(),
+            finalizer: finalizer.boxed(),
+        }
+    }
+
+    /// Qualifies this registration with one already-erased boundary segment.
+    ///
+    /// Takes the erased segment rather than the scope value so that one
+    /// `scoped` call can share a single erasure across every carrier at its
+    /// boundary — the spawn key, the explicit cancels, the teardown
+    /// prefixes, and this — without the scope type itself being `Clone`
+    /// (RFC 0005 §8.1).
+    #[must_use]
+    pub fn scoped_with(self, segment: StructuralKey) -> Self {
+        Self {
+            scope: self.scope.prefixed_key(segment),
+            finalizer: self.finalizer,
+        }
+    }
+}

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -16,6 +16,7 @@ use crate::structural_key::{ScopePath, StructuralKey};
 
 use super::Action;
 use super::cancellation::{CancelPolicy, CancellableCommand, CommandCancellation, CommandId};
+use super::cleanup::CleanupRegistration;
 use super::effect::Effect;
 use super::retry::{self, RetryContext, RetryError, RetryPolicy};
 use super::runtime_directives::RuntimeDirectives;
@@ -51,6 +52,10 @@ pub struct Command<Msg: Send + 'static> {
     // beside `cancellation` rather than as an effect leaf (RFC 0013 §3.3,
     // RFC 0014 §3.4).
     teardowns: Vec<ScopePath>,
+    // Cleanup finalizers to arm. A carrier for the same reason teardown is
+    // one, on the other side of the phase order: a registration applies in
+    // the spawn phase and starts nothing there (RFC 0014 §3.4, §4.4).
+    cleanups: Vec<CleanupRegistration>,
 }
 
 impl<Msg: Send + 'static> Command<Msg> {
@@ -63,6 +68,7 @@ impl<Msg: Send + 'static> Command<Msg> {
                 cancels: Vec::new(),
             },
             teardowns: Vec::new(),
+            cleanups: Vec::new(),
         }
     }
 
@@ -144,6 +150,7 @@ impl<Msg: Send + 'static> Command<Msg> {
             self.effect.into_leaves(),
             self.cancellation,
             self.teardowns,
+            self.cleanups,
         )
     }
 
@@ -295,6 +302,12 @@ impl<Msg: Send + 'static> Command<Msg> {
             .map(|prefix| prefix.prefixed_key(segment.clone()))
             .collect();
 
+        self.cleanups = self
+            .cleanups
+            .into_iter()
+            .map(|registration| registration.scoped_with(segment.clone()))
+            .collect();
+
         // Per-carrier keys and scopes. The key half reaches a batched
         // child's own key; the scope half is what an *unkeyed* carrier
         // gets, so a prefix teardown can select it (RFC 0014 INV-RC7).
@@ -344,6 +357,42 @@ impl<Msg: Send + 'static> Command<Msg> {
     {
         Self {
             teardowns: vec![ScopePath::empty().prefixed(scope)],
+            ..Self::none()
+        }
+    }
+
+    /// Registers `finalizer` to run when a teardown selects the structural
+    /// scope at this call boundary.
+    ///
+    /// The finalizer is an ordinary future under this type's existing effect
+    /// bounds, with `Output = ()` rather than a message because a cleanup
+    /// run produces none (RFC 0014 §4.4). It runs **at most once**, started
+    /// at the application point of the teardown that consumes it, and is not
+    /// re-fired by a later teardown of the same prefix. Termination is not a
+    /// teardown: it discards whatever is still unfired and cancels whatever
+    /// is running.
+    ///
+    /// Like [`Command::teardown`] this carries no effect stream, so
+    /// [`Command::is_none`] stays `true`, and it composes through
+    /// [`Command::scoped`] exactly as a teardown prefix does (RFC 0013
+    /// INV-ST2, RFC 0005 INV-18's coverage). Its external side effects are
+    /// its whole purpose and are not restricted; what is closed is the path
+    /// back into the runtime.
+    ///
+    /// Crate-private for now, for the reason [`Command::teardown`] is: the
+    /// runtime that starts a finalizer is the kernel of RFC 0014, and a
+    /// public constructor the current runtime would accept and ignore is the
+    /// silent mismatch RFC 0007 INV-C5 prohibits.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the kernel that starts a registered finalizer lands after this carrier"
+        )
+    )]
+    pub(crate) fn on_teardown(finalizer: impl Future<Output = ()> + Send + 'static) -> Self {
+        Self {
+            cleanups: vec![CleanupRegistration::new(finalizer)],
             ..Self::none()
         }
     }
@@ -567,6 +616,7 @@ impl<Msg: Send + 'static> Command<Msg> {
         let mut effects = Vec::new();
         let mut cancels = Vec::new();
         let mut teardowns = Vec::new();
+        let mut cleanups = Vec::new();
 
         for mut cmd in commands {
             any_child = true;
@@ -593,6 +643,7 @@ impl<Msg: Send + 'static> Command<Msg> {
             }
             cancels.extend(cmd.cancellation.cancels);
             teardowns.extend(cmd.teardowns);
+            cleanups.extend(cmd.cleanups);
             effects.push(cmd.effect);
         }
 
@@ -602,6 +653,7 @@ impl<Msg: Send + 'static> Command<Msg> {
                 directives,
                 cancellation: CommandCancellation { key: None, cancels },
                 teardowns,
+                cleanups,
             }
         } else {
             Self::none()
@@ -700,6 +752,10 @@ impl<Msg: Send + 'static> Command<Msg> {
         let directives = self.directives;
         let cancellation = self.cancellation;
         let teardowns = self.teardowns;
+        // Carried across the message-type change untouched: a registration
+        // holds no message type to map, its finalizer's `Output` being `()`
+        // (RFC 0014 §4.4).
+        let cleanups = self.cleanups;
         let effect = self.effect.map(f);
 
         Command {
@@ -707,6 +763,7 @@ impl<Msg: Send + 'static> Command<Msg> {
             directives,
             cancellation,
             teardowns,
+            cleanups,
         }
     }
 }

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -383,17 +383,20 @@ impl<Msg: Send + 'static> Command<Msg> {
         not(test),
         expect(
             dead_code,
-            reason = "the combinators whose journal drain aggregates a teardown land after this carrier"
+            reason = "reached only through the kernel's own consumers, which no non-test build can \
+                      construct until the entry point is switched over"
         )
     )]
     pub(crate) fn merging_teardowns(mut self, other: Self) -> Self {
         debug_assert!(
             other.is_none()
+                && other.directives == RuntimeDirectives::DEFAULT
                 && other.cleanups.is_empty()
                 && other.cancellation.key.is_none()
                 && other.cancellation.cancels.is_empty(),
-            "merging_teardowns aggregates teardown entries only; everything else on `other` \
-             would be dropped silently"
+            "merging_teardowns aggregates teardown entries only; an effect, a redraw directive, a \
+             cleanup registration, a spawn key, or an explicit cancel on `other` would be dropped \
+             silently"
         );
         self.teardowns.extend(other.teardowns);
         self
@@ -425,7 +428,8 @@ impl<Msg: Send + 'static> Command<Msg> {
         not(test),
         expect(
             dead_code,
-            reason = "the kernel that starts a registered finalizer lands after this carrier"
+            reason = "the kernel that starts a registered finalizer is here, but no non-test build \
+                      can reach it until the entry point is switched over to it"
         )
     )]
     pub(crate) fn on_teardown(finalizer: impl Future<Output = ()> + Send + 'static) -> Self {

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -361,6 +361,44 @@ impl<Msg: Send + 'static> Command<Msg> {
         }
     }
 
+    /// Takes `other`'s teardown prefixes onto this command and **nothing
+    /// else** — not its effect, not its directives, not its cancellation
+    /// metadata, not its cleanup registrations.
+    ///
+    /// This is aggregation of an already-originated teardown, which RFC 0013
+    /// §7.2's origination review names as a free transformation: the entry
+    /// still comes from a [`Command::teardown`] call, and there is no route
+    /// here from a raw prefix. A `debug_assert` holds `other` to that shape
+    /// so this cannot quietly become a general-purpose merge.
+    ///
+    /// The one caller is a combinator's journal drain, which has to put a
+    /// removal's teardown on a command the application returned.
+    /// [`Command::batch`] would be wrong there twice over: it folds the
+    /// redraw directive across its children, so an update that returned
+    /// [`Command::without_redraw`] would silently regain its redraw, and it
+    /// warns about a child spawn key for a command the boundary is only
+    /// passing through. A boundary adds identity carriers and nothing else
+    /// (RFC 0014 §2.5).
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "the combinators whose journal drain aggregates a teardown land after this carrier"
+        )
+    )]
+    pub(crate) fn merging_teardowns(mut self, other: Self) -> Self {
+        debug_assert!(
+            other.is_none()
+                && other.cleanups.is_empty()
+                && other.cancellation.key.is_none()
+                && other.cancellation.cancels.is_empty(),
+            "merging_teardowns aggregates teardown entries only; everything else on `other` \
+             would be dropped silently"
+        );
+        self.teardowns.extend(other.teardowns);
+        self
+    }
+
     /// Registers `finalizer` to run when a teardown selects the structural
     /// scope at this call boundary.
     ///

--- a/src/command/kernel_parts.rs
+++ b/src/command/kernel_parts.rs
@@ -7,7 +7,7 @@
 //! execution 3-tuple, and the kernel takes the buckets below, which name the
 //! phases RFC 0014 §3.4 orders — a cancel phase (`cancels`, `teardowns`)
 //! that precedes every spawn of the same command, then a spawn phase
-//! (`spawns`) in declaration order.
+//! (`spawns` in declaration order, and `cleanups`).
 
 // The kernel that reads these buckets is still being scaffolded, so outside
 // the command layer's own tests nothing consumes them yet.
@@ -26,6 +26,7 @@ use crate::structural_key::ScopePath;
 
 use super::Action;
 use super::cancellation::{CancellableCommand, CommandId};
+use super::cleanup::CleanupRegistration;
 
 /// One command, read as the kernel's phase buckets.
 pub struct KernelParts<Msg: Send + 'static> {
@@ -40,6 +41,11 @@ pub struct KernelParts<Msg: Send + 'static> {
     /// Scope prefixes to tear down, applied in the cancel phase alongside
     /// `cancels`, with which teardown commutes (RFC 0013 §3.3).
     pub teardowns: Vec<ScopePath>,
+    /// Cleanup finalizers to arm, applied in the spawn phase — after the
+    /// same command's cancel phase, so a teardown-and-reregister command
+    /// consumes the old occupant's hooks and leaves the new registration
+    /// armed (RFC 0014 §3.4, §4.4).
+    pub cleanups: Vec<CleanupRegistration>,
     /// Producer runs to start, in the command's flattened declaration order
     /// (RFC 0008 §4.1).
     pub spawns: Vec<SpawnEntry<Msg>>,

--- a/src/command/runtime_parts.rs
+++ b/src/command/runtime_parts.rs
@@ -13,6 +13,7 @@ use crate::structural_key::ScopePath;
 
 use super::Action;
 use super::cancellation::CommandCancellation;
+use super::cleanup::CleanupRegistration;
 use super::effect::{Leaf, LeafKind};
 use super::kernel_parts::{KernelParts, SpawnEntry};
 use super::runtime_directives::RuntimeDirectives;
@@ -34,8 +35,8 @@ use super::{CancellableCommand, CommandId};
 /// the store's, [`into_kernel_parts`](Self::into_kernel_parts) the kernel's.
 /// The execution reading returns streams only, so the metadata the kernel
 /// reading needs — per-leaf spawn keys and scopes, leaf kinds, teardown
-/// prefixes — is not merely unused by the older consumers but structurally
-/// out of their reach.
+/// prefixes, cleanup registrations — is not merely unused by the older
+/// consumers but structurally out of their reach.
 ///
 /// [`Command::batch`]: super::Command::batch
 #[must_use = "Runtime command parts may contain side effects and directives that must be handled by the runtime."]
@@ -45,6 +46,7 @@ pub struct RuntimeCommandParts<Msg: Send + 'static> {
     cancels: Vec<CommandId>,
     key: Option<CancellableCommand>,
     teardowns: Vec<ScopePath>,
+    cleanups: Vec<CleanupRegistration>,
 }
 
 impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
@@ -53,6 +55,7 @@ impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
         leaves: Vec<Leaf<Msg>>,
         cancellation: CommandCancellation,
         teardowns: Vec<ScopePath>,
+        cleanups: Vec<CleanupRegistration>,
     ) -> Self {
         Self {
             directives,
@@ -60,6 +63,7 @@ impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
             cancels: cancellation.cancels,
             key: cancellation.key,
             teardowns,
+            cleanups,
         }
     }
 
@@ -76,9 +80,9 @@ impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
     /// the command-level spawn key, and the leaf streams in declaration
     /// order.
     ///
-    /// Leaf metadata and teardown prefixes are not returned, so the
-    /// consumers of this reading cannot observe them — including an
-    /// immediate-quit leaf, which comes back as the ordinary
+    /// Leaf metadata, teardown prefixes, and cleanup registrations are not
+    /// returned, so the consumers of this reading cannot observe them —
+    /// including an immediate-quit leaf, which comes back as the ordinary
     /// single-`Action::Quit` stream it has always been.
     pub(crate) fn into_execution_parts(
         self,
@@ -129,6 +133,7 @@ impl<Msg: Send + 'static> RuntimeCommandParts<Msg> {
             quit_now,
             cancels: self.cancels,
             teardowns: self.teardowns,
+            cleanups: self.cleanups,
             spawns,
         }
     }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -492,7 +492,7 @@ impl<P: Program> Kernel<P> {
     ///   bounded settle RFC 0008 §9.6 names.
     ///
     /// [`RunName`]: crate::testing::driver::RunName
-    fn start_cleanup(&mut self, registration: CleanupRegistration) -> RunToken {
+    fn start_cleanup(&mut self, registration: CleanupRegistration) {
         let token = self.next_token;
         self.next_token += 1;
         let CleanupRegistration { scope, finalizer } = registration;
@@ -503,7 +503,6 @@ impl<P: Program> Kernel<P> {
         }
         .start(token, scope, finalizer);
         self.registry.insert(entry);
-        token
     }
 
     /// Controlled termination: the phase transition plus the immediate

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -47,6 +47,7 @@ pub mod accounting;
 #[cfg(all(feature = "loom-core", test))]
 pub mod accounting_core;
 pub mod arbiter;
+pub mod cleanup;
 #[cfg(test)]
 pub mod conformance;
 pub mod lane;
@@ -65,7 +66,7 @@ use ratatui::Terminal;
 use ratatui::backend::Backend;
 use tokio::task::{Id as TaskId, JoinError, JoinSet};
 
-use crate::command::{Command, CommandId, SpawnEntry};
+use crate::command::{CleanupRegistration, Command, CommandId, SpawnEntry};
 use crate::reducer::Program;
 use crate::runtime::channel::channel_observed;
 use crate::runtime::config::RuntimeConfig;
@@ -73,6 +74,7 @@ use crate::runtime::load::{Channel, LoadObserver};
 use crate::structural_key::ScopePath;
 use crate::testing::driver::{AcceptanceRecorder, IntentRecorder};
 
+use cleanup::CleanupLedger;
 use lane::{
     ControlReceiver, ControlSender, DataReceiver, DataSender, Envelope, GateMode, RunToken,
     SendGate, control_lane,
@@ -165,6 +167,14 @@ pub struct Kernel<P: Program> {
     flags: Option<P::Flags>,
     state: Option<P::State>,
     registry: ScopeRegistry,
+    /// Armed, not-yet-fired cleanup finalizers (RFC 0014 §4.4).
+    ///
+    /// Beside the registry rather than in it: a registration is not a run —
+    /// nothing is executing, nothing is deliverable, nothing can exit — and
+    /// the two are only related by a teardown's application point, which
+    /// stops the runs under its prefix and consumes the registrations under
+    /// it in the same step.
+    cleanups: CleanupLedger,
     join_set: JoinSet<()>,
     task_index: HashMap<TaskId, RunToken>,
     // The receivers are dropped at the immediate postcondition, which is
@@ -230,6 +240,7 @@ impl<P: Program> Kernel<P> {
             flags: Some(flags),
             state: None,
             registry: ScopeRegistry::new(observer.clone()),
+            cleanups: CleanupLedger::new(),
             join_set: JoinSet::new(),
             task_index: HashMap::new(),
             data_rx: Some(data_rx),
@@ -397,6 +408,7 @@ impl<P: Program> Kernel<P> {
                 DispatchStep::Cancel(id) => self.apply_cancel(&id),
                 DispatchStep::Teardown(prefix) => self.apply_teardown(&prefix),
                 DispatchStep::Spawn(spawn) => self.apply_spawn(spawn),
+                DispatchStep::Cleanup(registration) => self.cleanups.register(registration),
                 DispatchStep::Quit => self.apply_quit(ExitReason::Quit),
             }
         }
@@ -463,6 +475,37 @@ impl<P: Program> Kernel<P> {
         token
     }
 
+    /// Starts one consumed cleanup registration as a runtime-owned run.
+    ///
+    /// Two things separate it from [`Kernel::spawn_producer`], and both are
+    /// contract:
+    ///
+    /// - it goes through [`producer::CleanupHarness`], whose fields hold no
+    ///   lane sender, so the run has no route back into the runtime by
+    ///   construction (INV-RC8's no-output clause, structural);
+    /// - it is **not** appended to `started`. That list exists to mint a
+    ///   [`RunName`], whose kind is one of the three producer kinds and
+    ///   whose only uses are naming a run to `grant` and tagging ledger
+    ///   records (RFC 0008 §9.4). A cleanup run presents no send-intent and
+    ///   makes no ledger record, so there is nothing for a name to do; how a
+    ///   test observes one is the application-side instrumentation and the
+    ///   bounded settle RFC 0008 §9.6 names.
+    ///
+    /// [`RunName`]: crate::testing::driver::RunName
+    fn start_cleanup(&mut self, registration: CleanupRegistration) -> RunToken {
+        let token = self.next_token;
+        self.next_token += 1;
+        let CleanupRegistration { scope, finalizer } = registration;
+        let entry = producer::CleanupHarness {
+            join_set: &mut self.join_set,
+            task_index: &mut self.task_index,
+            gate: &self.gate,
+        }
+        .start(token, scope, finalizer);
+        self.registry.insert(entry);
+        token
+    }
+
     /// Controlled termination: the phase transition plus the immediate
     /// postcondition, shared by every cause (RFC 0011 §4.4).
     ///
@@ -488,11 +531,19 @@ impl<P: Program> Kernel<P> {
     /// what makes the "no output undelivered at termination is ever
     /// delivered late" half hold for envelopes the park already took off a
     /// lane (RFC 0011 §4.4).
+    ///
+    /// The cleanup ledger is discarded here and fires nothing: termination
+    /// is not a teardown (RFC 0014 INV-RC8's last clause). Cleanup runs a
+    /// teardown already started are aborted by `abort_all` along with every
+    /// other runtime-owned run — the same call, the same transition, no
+    /// grace window (RFC 0011 §4.4's zero-grace frame applies to cleanup
+    /// itself).
     fn immediate_postcondition(&mut self) {
         self.data_rx = None;
         self.data_buf.clear();
         self.control_rx = None;
         self.control_buf.clear();
+        self.cleanups.discard_all();
         self.registry.abort_all();
     }
 

--- a/src/kernel/cleanup.rs
+++ b/src/kernel/cleanup.rs
@@ -1,0 +1,182 @@
+//! The cleanup ledger: the kernel's armed, not-yet-fired finalizers.
+//!
+//! One ledger for the whole kernel, holding every registration a dispatch
+//! has armed and not yet handed to a teardown. Three operations, and they
+//! are the whole of INV-RC8's bookkeeping half:
+//!
+//! - **arm** — a dispatch's spawn phase adds a registration
+//!   ([`register`](CleanupLedger::register));
+//! - **consume** — a teardown's application point *removes* the
+//!   registrations under its prefix and starts them
+//!   ([`take_under`](CleanupLedger::take_under)). Removal is what makes the
+//!   hook at-most-once: a second teardown of the same prefix finds nothing
+//!   left, so idempotence is structural rather than a flag the ledger has to
+//!   remember to check (RFC 0013 INV-ST5);
+//! - **discard** — termination drops what is still armed
+//!   ([`discard_all`](CleanupLedger::discard_all)), because termination is
+//!   not a teardown and fires no hooks (RFC 0011 §4.4 takes precedence).
+//!
+//! What the ledger deliberately does *not* hold is a started cleanup run:
+//! once a registration is consumed the ledger has nothing about it, and the
+//! run it became is the registry's like any other. That is also why an
+//! already-started cleanup run is not selectable by a later teardown
+//! (RFC 0013 §3.1) — there is nothing here for one to select, and the
+//! registry excludes the run kind.
+
+use std::mem;
+
+use crate::command::CleanupRegistration;
+use crate::structural_key::ScopePath;
+
+/// The armed finalizers, in arming order.
+#[derive(Default)]
+pub struct CleanupLedger {
+    /// Registrations that no teardown has consumed yet.
+    ///
+    /// A `Vec` because the operations are "append" and "take every entry
+    /// under a prefix": prefix membership is a path comparison rather than a
+    /// lookup key, so an index over exact scopes would answer the wrong
+    /// question. Which structure this is stays mechanism (RFC 0013 §3.7),
+    /// and the order it preserves is arming order.
+    entries: Vec<CleanupRegistration>,
+}
+
+impl CleanupLedger {
+    /// An empty ledger.
+    pub const fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+        }
+    }
+
+    /// Arms one registration.
+    pub fn register(&mut self, registration: CleanupRegistration) {
+        self.entries.push(registration);
+    }
+
+    /// Removes and returns every registration whose scope lies under
+    /// `prefix`, in arming order.
+    ///
+    /// The same complete-prefix comparison from the path root that selects
+    /// runs (RFC 0013 INV-ST1), applied to registrations: a registration
+    /// anchored *at* the prefix is consumed, and shorter, reordered, subset,
+    /// and deeper-position anchors are not.
+    ///
+    /// Consuming rather than marking is what makes the finalizer run at most
+    /// once across any number of teardowns.
+    pub fn take_under(&mut self, prefix: &ScopePath) -> Vec<CleanupRegistration> {
+        let (selected, kept) = mem::take(&mut self.entries)
+            .into_iter()
+            .partition(|registration| registration.scope.starts_with(prefix));
+        self.entries = kept;
+        selected
+    }
+
+    /// Drops every armed registration without firing any.
+    ///
+    /// Termination's, and only termination's: it is not a teardown, so the
+    /// hooks it discards never run (RFC 0014 INV-RC8's last clause).
+    pub fn discard_all(&mut self) {
+        self.entries.clear();
+    }
+
+    /// How many registrations are armed.
+    pub const fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether nothing is armed.
+    pub const fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::future::ready;
+
+    fn path(segments: &[&'static str]) -> ScopePath {
+        // Root-first storage: the *last* `prefixed` call names the outermost
+        // segment, so the slice reads root-first when applied in reverse.
+        segments
+            .iter()
+            .rev()
+            .fold(ScopePath::empty(), |acc, segment| acc.prefixed(*segment))
+    }
+
+    fn armed(ledger: &mut CleanupLedger, scope: &ScopePath) {
+        let mut registration = CleanupRegistration::new(ready(()));
+        registration.scope = scope.clone();
+        ledger.register(registration);
+    }
+
+    #[test]
+    fn a_prefix_consumes_the_registrations_under_it_and_leaves_the_rest() {
+        let mut ledger = CleanupLedger::new();
+        armed(&mut ledger, &path(&["pane"]));
+        armed(&mut ledger, &path(&["pane", "field"]));
+        armed(&mut ledger, &path(&["other"]));
+        armed(&mut ledger, &ScopePath::empty());
+
+        let taken = ledger.take_under(&path(&["pane"]));
+
+        assert_eq!(taken.len(), 2, "the anchor itself and the deeper anchor");
+        assert_eq!(
+            ledger.len(),
+            2,
+            "a sibling anchor and a root anchor are outside the prefix"
+        );
+    }
+
+    // INV-RC8's at-most-once clause, in the ledger: consumption removes, so a
+    // repeat application of the same prefix has nothing left to start
+    // (RFC 0013 INV-ST5's "re-firing nothing").
+    #[test]
+    fn a_second_application_of_the_same_prefix_consumes_nothing() {
+        let mut ledger = CleanupLedger::new();
+        armed(&mut ledger, &path(&["pane"]));
+
+        assert_eq!(ledger.take_under(&path(&["pane"])).len(), 1);
+        assert!(ledger.take_under(&path(&["pane"])).is_empty());
+        assert!(ledger.is_empty());
+    }
+
+    #[test]
+    fn a_prefix_nothing_is_anchored_under_consumes_nothing() {
+        let mut ledger = CleanupLedger::new();
+        armed(&mut ledger, &path(&["pane"]));
+
+        assert!(ledger.take_under(&path(&["nothing-is-here"])).is_empty());
+        assert_eq!(ledger.len(), 1, "and leaves what was armed alone");
+    }
+
+    // Selection is the run predicate applied to anchors: a shorter, a
+    // reordered, and a deeper-position anchor are all outside the prefix.
+    #[test]
+    fn anchor_selection_is_a_complete_prefix_from_the_root() {
+        let mut ledger = CleanupLedger::new();
+        armed(&mut ledger, &path(&["pane"]));
+        armed(&mut ledger, &path(&["field", "pane"]));
+        armed(&mut ledger, &path(&["outer", "pane", "field"]));
+
+        assert!(ledger.take_under(&path(&["pane", "field"])).is_empty());
+        assert_eq!(ledger.len(), 3, "none of the three is under it");
+    }
+
+    #[test]
+    fn termination_discards_every_armed_registration() {
+        let mut ledger = CleanupLedger::new();
+        armed(&mut ledger, &path(&["pane"]));
+        armed(&mut ledger, &ScopePath::empty());
+
+        ledger.discard_all();
+
+        assert!(ledger.is_empty());
+        assert!(
+            ledger.take_under(&ScopePath::empty()).is_empty(),
+            "the root prefix covers everything, and there is nothing left for it"
+        );
+    }
+}

--- a/src/kernel/conformance.rs
+++ b/src/kernel/conformance.rs
@@ -80,24 +80,37 @@
 //! | `parked control-quit wake` | [`park`] | INV-RC16 |
 //! | `parked subscription-quiescence wake` | [`park`] | INV-RC16 |
 //!
-//! Two neighbours sit beside the twelve, in the same files and under the
+//! Four neighbours sit beside the twelve, in the same files and under the
 //! same rules: [`delivery`] carries INV-RC10's flood rows (FIFO prefix,
-//! backlog-proportional passes, a render between batches), and [`teardown`]
+//! backlog-proportional passes, a render between batches); [`teardown`]
 //! carries RFC 0013 §7.1's kernel rows — INV-ST1, INV-ST3, INV-ST5, INV-ST6,
 //! and INV-ST7's observable half, with the kernel carriers INV-RC6 and
 //! INV-RC7, plus the divergent composition where a run's placement prefix
-//! and its key's scope disagree and both still reach it.
+//! and its key's scope disagree and both still reach it; [`cleanup`] carries
+//! INV-RC8's behavioral clauses and INV-RC12 (a)'s cleanup kind; and
+//! [`combinator`] carries INV-RC2, INV-RC3, and INV-RC4's rows as the kernel
+//! applies them, over a program that is a closed combinator stack rather
+//! than the scripted reducer.
 //!
 //! # What this surface does not reach
 //!
 //! The behavioral rows above are §13.1's twelve series and their named
 //! neighbours. What stays open is the implementation-acceptance tier
-//! RFC 0014 §13.1 lists rather than anything this harness cannot build:
-//! cleanup hooks (INV-RC8), the combinator surface (INV-RC2–INV-RC4), the
+//! RFC 0014 §13.1 lists rather than anything this harness cannot build: the
 //! observability vocabulary (INV-RC15's behavioral neighbour), and the
 //! structural halves that no finite script can carry — INV-RC16's arming,
-//! §3.5's unbiased pass initiation, INV-RC12 (c), and INV-ST7's absence
-//! half, each of which is structural by its own statement.
+//! §3.5's unbiased pass initiation, INV-RC12 (c), INV-ST7's absence half,
+//! and INV-RC8's no-output clause, each of which is structural by its own
+//! statement.
+//!
+//! One clause of INV-RC12 (a) is unreachable for a different reason, and it
+//! is a construction limit rather than an open row: outside termination
+//! nothing stop-requests a *cleanup* run — a teardown excludes the kind, a
+//! cancel and a supersession address keyed slots, a re-evaluation addresses
+//! subscription runs — and at termination there is no admission site left
+//! for one to defer. [`cleanup`] carries the reachable half (an in-flight
+//! cleanup run defers nothing) and the registry's barrier predicate, which
+//! reads subscription runs only, is the structural carrier for the rest.
 //!
 //! One behavioral limit is worth naming because a script runs into it: the
 //! uniform barrier's deferral of a *later* pass's admissions. A stop
@@ -108,6 +121,8 @@
 //! side and takes the structural class for it.
 
 pub mod bounded;
+pub mod cleanup;
+pub mod combinator;
 pub mod delivery;
 pub mod lifecycle;
 pub mod park;

--- a/src/kernel/conformance/cleanup.rs
+++ b/src/kernel/conformance/cleanup.rs
@@ -1,0 +1,437 @@
+//! Cleanup hooks, RFC 0014 INV-RC8's clauses.
+//!
+//! Every row runs through the production dispatch path, pass-unit driven: a
+//! registration reaches the kernel only as the lowered part of a command the
+//! application returned, and so does the teardown that starts it — no driver
+//! method arms one and none fires one (RFC 0008 §9.2).
+//!
+//! # Which clause each row carries
+//!
+//! | clause (RFC 0014 §4.4) | row |
+//! | --- | --- |
+//! | started at the application point | [`a_teardown_starts_the_prefix_s_registration_at_its_application_point`] |
+//! | at most once, consumed not re-run | [`a_repeated_teardown_starts_no_consumed_hook_again`] |
+//! | no runtime-visible output | [`an_ordinary_cleanup_run_is_invisible_to_the_application`] (regression neighbour — see below) |
+//! | termination discards unfired hooks | [`termination_discards_an_unfired_registration`] |
+//! | termination cancels running ones | [`termination_cancels_a_running_cleanup_run`] |
+//!
+//! # The no-output clause is structural-primary
+//!
+//! It is reviewed at the cleanup task's **construction site**
+//! ([`CleanupHarness`](crate::kernel::producer::CleanupHarness)), where the
+//! run is handed no lane sender, no ingress, and no directive capability.
+//! That is the evidence, and it has to be, because no cleanup run that
+//! *attempts* an output exists for a test to observe failing: a passing test
+//! would witness the absence of the attempt rather than of the output
+//! (RFC 0014 INV-RC8). The behavioral neighbour below is one regression row
+//! over an ordinary finalizer — nothing delivered to `update`, no
+//! termination, no redraw and no subscription dirt attributable to it — and
+//! it no more proves the absence of the capability than a finite scenario
+//! proves a pool's absence.
+//!
+//! # Where a claim is read
+//!
+//! A finalizer's own progress is application-side, in a [`Beacon`] it marks
+//! and a [`DropMark`] its body holds: a cleanup run presents no send-intent
+//! and makes no ledger record, so it is named by no [`RunName`] and reported
+//! in no step's `started` list (RFC 0008 §9.4), and the bounded
+//! [`settle`](crate::testing::driver::TestDriver::settle) is what gives it
+//! turns to run in. Non-delivery is read from the reducer's own journal, as
+//! everywhere else in this suite.
+//!
+//! [`RunName`]: crate::testing::driver::RunName
+
+use std::future::pending;
+
+use crate::command::Command;
+use crate::kernel::arbiter::WakeSource;
+
+use super::support::{
+    Beacon, DropMark, Feed, ProbeSource, Script, TEST_TURNS, accept, cap, config, driver_with,
+    marking_effect, parking_effect,
+};
+
+/// A finalizer that marks `ran` and ends.
+fn finalizer(ran: Beacon) -> Command<u8> {
+    Command::on_teardown(async move {
+        ran.mark();
+    })
+}
+
+/// A finalizer that marks `started` on its first poll and then parks
+/// forever, holding a guard that marks `reclaimed` when the run is
+/// dismantled.
+///
+/// The guard is captured by the future rather than created inside it, so a
+/// registration cancelled before its first poll still marks — which is what
+/// makes the termination row read the reclamation rather than the run's
+/// having gotten far enough to notice.
+fn parked_finalizer(started: Beacon, reclaimed: Beacon) -> Command<u8> {
+    let guard = DropMark::new(reclaimed);
+    Command::on_teardown(async move {
+        let _reclaimed = guard;
+        started.mark();
+        pending::<()>().await;
+    })
+}
+
+// The application point: a registration is inert until a teardown whose
+// prefix covers its scope applies, and it starts *there* — in the cancel
+// phase of the command that carried the teardown, concurrently with the
+// quiescence of the runs that same point stopped.
+//
+// The negative half is what makes the row about the application point rather
+// than about the finalizer eventually running: the turns spent reaching the
+// init effect's own completion are turns the finalizer would have run in had
+// arming started it.
+#[test]
+fn a_teardown_starts_the_prefix_s_registration_at_its_application_point() {
+    let (ran, booted) = (Beacon::default(), Beacon::default());
+    let (mut driver, journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            marking_effect(booted.clone()),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane")]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    driver.settle(TEST_TURNS, || booted.marked());
+    assert!(
+        !ran.marked(),
+        "arming a registration starts nothing: the turns that ran the init effect to its end \
+         would have run the finalizer too"
+    );
+
+    accept(&mut driver, trigger);
+    let stepped = driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown trigger is in the lane");
+
+    assert_eq!(journal.reduced(), vec![1], "the teardown was dispatched");
+    assert!(
+        stepped.started.is_empty(),
+        "a cleanup run presents no send-intent and makes no ledger record, so no name is minted \
+         for it (RFC 0008 §9.4)"
+    );
+    driver.settle(TEST_TURNS, || ran.marked());
+    assert_eq!(ran.marks(), 1);
+}
+
+// INV-RC8's at-most-once clause, and RFC 0013 INV-ST5's "re-fires nothing":
+// consumption removes the registration, so the second application of the
+// same prefix has nothing left to start. The kernel keeps no fired-flag for
+// a later path to read wrongly — the ledger entry is simply gone.
+#[test]
+fn a_repeated_teardown_starts_no_consumed_hook_again() {
+    let ran = Beacon::default();
+    let (mut driver, journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1, 2]),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane"), Command::teardown("pane")]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the first trigger is in the lane");
+    driver.settle(TEST_TURNS, || ran.marked());
+    assert_eq!(ran.marks(), 1);
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the second trigger is in the lane");
+    driver.settle(TEST_TURNS, || true);
+
+    assert_eq!(
+        ran.marks(),
+        1,
+        "the consumed hook is not re-fired by a second application of its prefix"
+    );
+    assert_eq!(journal.reduced(), vec![1, 2]);
+}
+
+// Selection isolation for registrations (RFC 0013 INV-ST6 applied to the
+// cleanup half of INV-ST1's selection set): a teardown of a sibling prefix
+// consumes nothing, and the registration is still there for its own prefix.
+#[test]
+fn a_sibling_prefix_consumes_no_registration() {
+    let ran = Beacon::default();
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1, 2]),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("other-pane"), Command::teardown("pane")]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the sibling teardown is in the lane");
+    driver.settle(TEST_TURNS, || true);
+    assert!(!ran.marked(), "a sibling prefix selected no registration");
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the covering teardown is in the lane");
+    driver.settle(TEST_TURNS, || ran.marked());
+}
+
+// The no-output clause's behavioral neighbour. An ordinary finalizer runs to
+// completion and the application observes nothing of it: no `update`
+// invocation, no termination, and — through the pass that reflects its
+// exit — no render and no re-evaluation, so it is not a source of redraw or
+// of subscription dirt either.
+//
+// This is a regression row, not the clause's evidence. The evidence is the
+// construction-site review named in this module's docs.
+#[test]
+fn an_ordinary_cleanup_run_is_invisible_to_the_application() {
+    let ran = Beacon::default();
+    let (mut driver, journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane")]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown trigger is in the lane");
+    driver.settle(TEST_TURNS, || ran.marked());
+    let (views, evaluations) = (journal.views(), journal.evaluations());
+
+    let stepped = driver
+        .step_pass(WakeSource::ProducerExit)
+        .expect("the finished cleanup run's exit is observable");
+
+    assert!(
+        stepped.terminated.is_none(),
+        "a cleanup run cannot originate a quit: it holds no control-lane sender"
+    );
+    assert_eq!(
+        journal.reduced(),
+        vec![1],
+        "and no message of its reached update: it holds no data-lane sender"
+    );
+    assert_eq!(
+        journal.views(),
+        views,
+        "its quiescence marks no redraw, so the pass that reflected it rendered nothing"
+    );
+    assert_eq!(
+        journal.evaluations(),
+        evaluations,
+        "and marks no subscription dirt, so that pass re-evaluated nothing (RFC 0014 §5.2)"
+    );
+}
+
+// INV-RC8's last clause, first half: termination is not a teardown. An
+// armed registration is discarded rather than fired, and the discard happens
+// at the immediate postcondition — before the settle that follows it, so
+// there is no window in which the hook could start.
+#[test]
+fn termination_discards_an_unfired_registration() {
+    let ran = Beacon::default();
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::quit()]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger);
+    let stepped = driver
+        .step_pass(WakeSource::Data)
+        .expect("the quit trigger is in the lane");
+
+    assert!(
+        stepped.terminated.is_some(),
+        "the update-returned quit terminated at its dispatch"
+    );
+    assert!(
+        !ran.marked(),
+        "termination fires no hooks: the settle it performed drained every runtime-owned task, \
+         and no cleanup run was among them"
+    );
+}
+
+// INV-RC8's last clause, second half: a cleanup run already in flight is
+// cancelled like every other runtime-owned task, with no grace window. The
+// reclamation is read from the guard the finalizer's body holds, which the
+// abort drops.
+#[test]
+fn termination_cancels_a_running_cleanup_run() {
+    let (started, reclaimed) = (Beacon::default(), Beacon::default());
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1, 2]),
+            parked_finalizer(started.clone(), reclaimed.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane"), Command::quit()]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown trigger is in the lane");
+    driver.settle(TEST_TURNS, || started.marked());
+    assert!(
+        !reclaimed.marked(),
+        "the finalizer is running and holding its guard"
+    );
+
+    accept(&mut driver, trigger);
+    let stepped = driver
+        .step_pass(WakeSource::Data)
+        .expect("the quit trigger is in the lane");
+
+    assert!(stepped.terminated.is_some());
+    assert!(
+        reclaimed.marked(),
+        "termination cancelled the running cleanup run along with every other owned task"
+    );
+}
+
+// INV-RC12 (a), the cleanup kind: a cleanup run in flight defers no
+// subscription admission. The barrier's predicate reads subscription runs
+// only, which is where the invariant's other half — a *stop-requested*
+// cleanup run — lives: outside termination nothing stop-requests a cleanup
+// run (a teardown excludes the kind, a cancel and a supersession address
+// keyed slots, a re-evaluation addresses subscription runs), and at
+// termination there is no admission site left for anything to defer. The
+// reachable half is the one below.
+#[test]
+fn an_in_flight_cleanup_run_defers_no_subscription_admission() {
+    let (started, reclaimed) = (Beacon::default(), Beacon::default());
+    let source = ProbeSource::silent("feed");
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1, 2]),
+            parked_finalizer(started.clone(), reclaimed.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane")])
+        .feeding([Feed::new(source.clone())])
+        .wanting([])
+        .redeclaring(2, ["feed"]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+    assert_eq!(source.admissions(), 0, "the feed is not declared yet");
+
+    accept(&mut driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown trigger is in the lane");
+    driver.settle(TEST_TURNS, || started.marked());
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the re-declaring trigger is in the lane");
+
+    assert_eq!(
+        source.admissions(),
+        1,
+        "the re-evaluation admitted while a cleanup run was in flight"
+    );
+    assert!(
+        !reclaimed.marked(),
+        "and that run was still in flight when it did"
+    );
+}
+
+// RFC 0014 §3.4's spawn-phase rule, and §11's *cancel-phase cleanup
+// registration* adversary: one command tears a prefix down and registers a
+// new hook under it. Because registration applies in the spawn phase, the
+// teardown consumes the **old** occupant's hook and leaves the new one
+// armed — a plan that registered in the cancel phase would consume the
+// registration it had just armed, and the new occupant would be left with
+// none.
+#[test]
+fn a_teardown_and_reregister_command_consumes_the_old_hook_and_arms_the_new_one() {
+    let (first, second) = (Beacon::default(), Beacon::default());
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1, 2]),
+            finalizer(first.clone()).scoped("pane"),
+        ]))
+        .replying([
+            // The shape a combinator produces: the boundary's teardown of
+            // its own segment, merged with the child's command already
+            // qualified by that segment.
+            Command::batch([
+                Command::teardown("pane"),
+                finalizer(second.clone()).scoped("pane"),
+            ]),
+            Command::teardown("pane"),
+        ]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown-and-reregister trigger is in the lane");
+    driver.settle(TEST_TURNS, || first.marked());
+    assert!(
+        !second.marked(),
+        "the registration this same command armed was not consumed by its own teardown"
+    );
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the second teardown is in the lane");
+    driver.settle(TEST_TURNS, || second.marked());
+
+    assert_eq!(first.marks(), 1, "and the old hook fired exactly once");
+}
+
+// The cleanup window's placement (RFC 0013 §1.2, §5): a finalizer starts at
+// the head of the stop-requested→quiesced interval and runs *concurrently*
+// with the quiescence of the runs the same application point stopped —
+// nothing waits for anything. Both the torn-down run's reclamation and the
+// finalizer's completion are reached by the same bounded settle.
+#[test]
+fn a_finalizer_runs_concurrently_with_the_quiescence_it_accompanies() {
+    let (ran, reclaimed) = (Beacon::default(), Beacon::default());
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            super::support::holding_effect(reclaimed.clone()).scoped("pane"),
+            finalizer(ran.clone()).scoped("pane"),
+        ]))
+        .replying([Command::teardown("pane")]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger);
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the teardown trigger is in the lane");
+
+    driver.settle(TEST_TURNS, || ran.marked() && reclaimed.marked());
+}

--- a/src/kernel/conformance/cleanup.rs
+++ b/src/kernel/conformance/cleanup.rs
@@ -36,6 +36,18 @@
 //! it no more proves the absence of the capability than a finite scenario
 //! proves a pool's absence.
 //!
+//! # The mutation run against the spawn-phase rows
+//!
+//! §11's *cancel-phase cleanup registration* adversary is a plan that
+//! satisfies every other row here, so the rows that exclude it were checked
+//! by mutation. Moving the registration entries into the cancel phase —
+//! chained with the explicit cancels, ahead of the teardowns — leaves 180
+//! rows passing and fails exactly three: this module's
+//! [`a_teardown_and_reregister_command_consumes_the_old_hook_and_arms_the_new_one`],
+//! and the two plan-level rows beside the lowering,
+//! `kernel::lowering::tests::a_teardown_and_reregister_command_arms_the_new_hook_after_the_teardown`
+//! and `kernel::lowering::tests::the_quit_still_completes_a_command_that_also_arms_a_hook`.
+//!
 //! # Where a claim is read
 //!
 //! A finalizer's own progress is application-side, in a [`Beacon`] it marks

--- a/src/kernel/conformance/cleanup.rs
+++ b/src/kernel/conformance/cleanup.rs
@@ -12,8 +12,15 @@
 //! | started at the application point | [`a_teardown_starts_the_prefix_s_registration_at_its_application_point`] |
 //! | at most once, consumed not re-run | [`a_repeated_teardown_starts_no_consumed_hook_again`] |
 //! | no runtime-visible output | [`an_ordinary_cleanup_run_is_invisible_to_the_application`] (regression neighbour — see below) |
-//! | termination discards unfired hooks | [`termination_discards_an_unfired_registration`] |
+//! | termination discards unfired hooks | [`termination_discards_an_unfired_registration`], [`a_final_update_that_tears_down_and_quits_fires_no_hook_from_termination`] |
 //! | termination cancels running ones | [`termination_cancels_a_running_cleanup_run`] |
+//!
+//! RFC 0013 §7.2's own two cleanup rows are
+//! [`a_teardown_starts_the_prefix_s_registration_at_its_application_point`]
+//! and
+//! [`a_teardown_and_reregister_command_consumes_the_old_hook_and_arms_the_new_one`];
+//! its final-update row is the one named above, which returns the teardown
+//! and the quit from **one** update.
 //!
 //! # The no-output clause is structural-primary
 //!
@@ -48,7 +55,7 @@ use crate::kernel::arbiter::WakeSource;
 
 use super::support::{
     Beacon, DropMark, Feed, ProbeSource, Script, TEST_TURNS, accept, cap, config, driver_with,
-    marking_effect, parking_effect,
+    holding_effect, marking_effect, parking_effect,
 };
 
 /// A finalizer that marks `ran` and ends.
@@ -412,15 +419,26 @@ fn a_teardown_and_reregister_command_consumes_the_old_hook_and_arms_the_new_one(
 // The cleanup window's placement (RFC 0013 §1.2, §5): a finalizer starts at
 // the head of the stop-requested→quiesced interval and runs *concurrently*
 // with the quiescence of the runs the same application point stopped —
-// nothing waits for anything. Both the torn-down run's reclamation and the
-// finalizer's completion are reached by the same bounded settle.
+// nothing waits for anything.
+//
+// **What is constructible here, and what is not.** The clause claims
+// concurrency, not an order, and the constructible content is two facts.
+// First, the start does not *follow* quiescence: a pass is a synchronous
+// region, so when `step_pass` returns — the teardown having applied inside
+// it — the torn-down run has not been dismantled yet, and the finalizer was
+// already spawned. Second, neither blocked on the other: one bounded settle
+// reaches both. A *strict* interleaving — the finalizer's own progress
+// before the quiescence — is not constructible and is not claimed: the
+// abort is issued before the cleanup spawn, so this executor dismantles the
+// aborted task first, and a row asserting the reverse would be asserting
+// against the contract rather than for it.
 #[test]
-fn a_finalizer_runs_concurrently_with_the_quiescence_it_accompanies() {
+fn a_finalizer_starts_before_the_quiescence_it_accompanies_and_waits_for_none_of_it() {
     let (ran, reclaimed) = (Beacon::default(), Beacon::default());
     let (mut driver, _journal) = driver_with(
         Script::new(Command::batch([
             parking_effect([1]),
-            super::support::holding_effect(reclaimed.clone()).scoped("pane"),
+            holding_effect(reclaimed.clone()).scoped("pane"),
             finalizer(ran.clone()).scoped("pane"),
         ]))
         .replying([Command::teardown("pane")]),
@@ -433,5 +451,65 @@ fn a_finalizer_runs_concurrently_with_the_quiescence_it_accompanies() {
         .step_pass(WakeSource::Data)
         .expect("the teardown trigger is in the lane");
 
+    assert!(
+        !reclaimed.marked(),
+        "the pass returned with the torn-down run not yet quiesced, so the finalizer this pass \
+         started did not begin after that quiescence"
+    );
     driver.settle(TEST_TURNS, || ran.marked() && reclaimed.marked());
+}
+
+// RFC 0013 §7.2's final-update row: a teardown and a quit returned by the
+// **same** update. The teardown applies in the cancel phase and the quit at
+// the dispatch's completion, so this is the one command in which both
+// halves of §6 meet.
+//
+// What the row pins is that termination fires no hook. The registration the
+// teardown covered was consumed and started by the teardown — that is the
+// teardown's doing, not termination's — and the registration under a prefix
+// the teardown does *not* cover is discarded unfired. Meanwhile RFC 0011
+// §4.4's two postconditions hold unchanged: the step reports the
+// termination, and the settle that follows it has reclaimed every
+// runtime-owned task, the cleanup run this same command started included.
+#[test]
+fn a_final_update_that_tears_down_and_quits_fires_no_hook_from_termination() {
+    let (cleanup_reclaimed, elsewhere, occupant) =
+        (Beacon::default(), Beacon::default(), Beacon::default());
+    let (mut driver, _journal) = driver_with(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            holding_effect(occupant.clone()).scoped("pane"),
+            // Its own start is not the subject here — termination may
+            // cancel it before its first poll — so only the guard it holds
+            // is read.
+            parked_finalizer(Beacon::default(), cleanup_reclaimed.clone()).scoped("pane"),
+            finalizer(elsewhere.clone()).scoped("other-pane"),
+        ]))
+        .replying([Command::batch([Command::teardown("pane"), Command::quit()])]),
+        config().batch_max_messages(cap(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    accept(&mut driver, trigger);
+    let stepped = driver
+        .step_pass(WakeSource::Data)
+        .expect("the trigger is in the lane");
+
+    assert!(
+        stepped.terminated.is_some(),
+        "the quit applied at the completion of the update that also tore down"
+    );
+    assert!(
+        !elsewhere.marked(),
+        "termination is not a teardown: the registration outside the torn-down prefix was \
+         discarded rather than fired"
+    );
+    assert!(
+        occupant.marked(),
+        "the quiescent postcondition reclaimed the torn-down run"
+    );
+    assert!(
+        cleanup_reclaimed.marked(),
+        "and the cleanup run the teardown had just started, with no grace window"
+    );
 }

--- a/src/kernel/conformance/combinator.rs
+++ b/src/kernel/conformance/combinator.rs
@@ -23,7 +23,18 @@
 //! | [`closing_a_row_tears_down_the_runs_under_it`] | INV-RC3's drain, as the kernel applies it |
 //! | [`dismissing_the_slot_tears_down_its_occupant_s_runs`] | INV-RC3's dismissal shape, likewise |
 //! | [`a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh`] | INV-RC3's no-diff adversary and INV-RC4's batch remove-and-reinsert |
-//! | [`a_message_for_a_closed_row_starts_nothing`] | §2.5's routing boundary, INV-ST8 |
+//! | [`a_key_addressed_message_after_a_reinsert_reaches_the_new_instance`] | INV-ST8's positive half, §2.5's third routing clause |
+//! | [`a_message_for_a_closed_row_starts_nothing`] | §2.5's routing boundary, INV-ST8's negative half |
+//!
+//! # The one row a mutation was run against
+//!
+//! The no-diff adversary is the only row here whose subject an unrelated
+//! mechanism could satisfy, so it is the one that was checked by mutation
+//! rather than by reading. Replacing the drain with a state-diff-equivalent
+//! one — returning only the keys absent from the collection when the drain
+//! runs — leaves every other row in this file passing and fails that row on
+//! its unkeyed-run assertion. The row's own comment records why the
+//! assertion is on the unkeyed run and not the keyed one.
 //!
 //! [`ReducerExt::into_program`]: crate::reducer::combinator::ReducerExt::into_program
 
@@ -58,25 +69,53 @@ enum PaneMsg {
     Anon,
 }
 
-/// One pane instance: the runs it starts hold `reclaimed`, and it declares
-/// `declares` when it has one.
+/// One pane instance.
+///
+/// The two run beacons are separate on purpose. A keyed run can be reclaimed
+/// by two different things — a prefix teardown, or a same-identity
+/// supersession — while an **unkeyed** run has no identity to supersede, so
+/// only a teardown reaches it. A row that wants to witness the journal's
+/// teardown and nothing else asserts on `anon`.
 struct PaneState {
-    reclaimed: Beacon,
+    /// Marked when the run `PaneMsg::Work` starts is reclaimed.
+    keyed: Beacon,
+    /// Marked when the run `PaneMsg::Anon` starts is reclaimed.
+    anon: Beacon,
+    /// Marked every time *this instance's* state is reduced — how a row
+    /// tells the predecessor's state from the successor's.
+    seen: Beacon,
+    /// The source this instance declares, when it declares one.
     declares: Option<ProbeSource>,
 }
 
 impl PaneState {
-    const fn new(reclaimed: Beacon) -> Self {
+    /// Both runs marking one beacon, for rows that do not need them apart.
+    fn new(reclaimed: Beacon) -> Self {
+        Self::with_runs(reclaimed.clone(), reclaimed)
+    }
+
+    /// The keyed run and the unkeyed run marking their own beacons.
+    fn with_runs(keyed: Beacon, anon: Beacon) -> Self {
         Self {
-            reclaimed,
+            keyed,
+            anon,
+            seen: Beacon::default(),
             declares: None,
+        }
+    }
+
+    /// An instance whose *reductions* are what the row watches.
+    fn watching(seen: Beacon) -> Self {
+        Self {
+            seen,
+            ..Self::new(Beacon::default())
         }
     }
 
     fn declaring(reclaimed: Beacon, source: ProbeSource) -> Self {
         Self {
-            reclaimed,
             declares: Some(source),
+            ..Self::new(reclaimed)
         }
     }
 }
@@ -89,12 +128,14 @@ impl Reducer for Pane {
     type Message = PaneMsg;
 
     fn reduce(&self, state: &mut PaneState, message: PaneMsg) -> Command<PaneMsg> {
+        state.seen.mark();
         // Parks forever holding a drop-marking guard, so the run's
         // reclamation is what the row reads.
-        let effect = holding_effect(state.reclaimed.clone()).map(|_| PaneMsg::Work);
         match message {
-            PaneMsg::Work => effect.cancellable(CommandId::new("work")),
-            PaneMsg::Anon => effect,
+            PaneMsg::Work => holding_effect(state.keyed.clone())
+                .map(|_| PaneMsg::Work)
+                .cancellable(CommandId::new("work")),
+            PaneMsg::Anon => holding_effect(state.anon.clone()).map(|_| PaneMsg::Work),
         }
     }
 
@@ -154,7 +195,7 @@ impl Reducer for Root {
                     .successors
                     .pop_front()
                     .expect("the script supplies one successor per recreate");
-                let reclaimed = successor.reclaimed.clone();
+                let reclaimed = successor.keyed.clone();
                 state.panes.remove(&key);
                 state.panes.insert(key, successor);
                 // Placed under the same segment the boundary uses, so the
@@ -255,17 +296,17 @@ fn init(setup: Setup) -> (RootState, Command<Msg>) {
         successors,
         trigger,
     } = setup;
+    // Built rather than mutated: `from_iter` records no removal at all, and
+    // a first presentation into an empty slot records none either, so
+    // bootstrap leaves the journals clean. Reaching for `insert` here would
+    // owe a teardown to the first message that arrives — the rule the
+    // collection module states for mutating outside a `reduce`.
     let mut state = RootState {
-        panes: Keyed::new(),
+        panes: panes.into_iter().collect(),
         modal: Slot::empty(),
         acts,
         successors,
     };
-    // First insertions and a first presentation, so neither records a
-    // removal: bootstrap opens instances rather than replacing any.
-    for (key, pane) in panes {
-        state.panes.insert(key, pane);
-    }
     if let Some(occupant) = modal {
         state.modal.present(occupant);
     }
@@ -473,30 +514,108 @@ fn dismissing_the_slot_tears_down_its_occupant_s_runs() {
 // nothing; and the command it returns carries both the journal's teardown
 // **and** the successor's keyed spawn, under one prefix and one identity.
 // The cancel phase precedes every spawn of the same command, so the old
-// instance's run is reclaimed and the successor starts fresh rather than
+// instance's runs are reclaimed and the successor starts fresh rather than
 // being replaced or suppressed by what it succeeded.
+//
+// **The load-bearing assertion is the *anonymous* run's reclamation.** The
+// old instance holds one keyed run and one unkeyed one. The successor's
+// spawn carries the same qualified identity as the old keyed run, so a
+// kernel with no journal at all would still reclaim *that* one by
+// `CancelInFlight` supersession — asserting on it would let a diff-based
+// journal pass. The unkeyed run has no identity to supersede: a prefix
+// teardown is the only thing that reaches it, and the journal is the only
+// thing that emits one here. Verified by mutation: with the drain filtered
+// to keys absent at drain time (a state-diff-equivalent journal), this row
+// fails on `old_anon` while every other row in this file still passes.
 #[test]
 fn a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh() {
-    let (old, new) = (Beacon::default(), Beacon::default());
+    let (old_keyed, old_anon, new) = (Beacon::default(), Beacon::default(), Beacon::default());
     let mut driver = driver(
-        Setup::new(vec![Msg::Row(1, PaneMsg::Work), Msg::Act(1)])
-            .opening(vec![(1, PaneState::new(old.clone()))])
-            .acting(1, Act::Recreate(1))
-            .succeeding(PaneState::new(new.clone())),
+        Setup::new(vec![
+            Msg::Row(1, PaneMsg::Work),
+            Msg::Row(1, PaneMsg::Anon),
+            Msg::Act(1),
+        ])
+        .opening(vec![(
+            1,
+            PaneState::with_runs(old_keyed.clone(), old_anon.clone()),
+        )])
+        .acting(1, Act::Recreate(1))
+        .succeeding(PaneState::new(new.clone())),
     );
     let trigger = driver.boot().started[0].clone();
 
-    deliver(&mut driver, &trigger);
+    let started = deliver(&mut driver, &trigger);
+    assert!(matches!(started.as_slice(), [RunKind::Keyed(_)]));
+    let started = deliver(&mut driver, &trigger);
+    assert!(
+        matches!(started.as_slice(), [RunKind::Anonymous]),
+        "the old instance also holds a run no identity can supersede: {started:?}"
+    );
+
     let started = deliver(&mut driver, &trigger);
 
     assert!(
         matches!(started.as_slice(), [RunKind::Keyed(_)]),
         "the same command's spawn phase started the successor: {started:?}"
     );
-    driver.settle(TEST_TURNS, || old.marked());
+    driver.settle(TEST_TURNS, || old_anon.marked());
+    assert!(
+        old_keyed.marked(),
+        "the old keyed run went with it, by teardown and supersession alike"
+    );
     assert!(
         !new.marked(),
         "and the successor is the run that survives the application point"
+    );
+}
+
+// RFC 0013 INV-ST8's positive half, and RFC 0014 §2.5's third routing
+// clause: key-addressed external input arriving after a same-key
+// remove-and-reinsert reaches the **new** instance. Input carries no run
+// origin — only producer output does — so the key is the whole of the
+// routing, and the key now names the successor. The row reads it from the
+// two instances' own reduction counts, so "reached the new instance" is the
+// successor's *state* having been reduced rather than an inference from a
+// command.
+#[test]
+fn a_key_addressed_message_after_a_reinsert_reaches_the_new_instance() {
+    let (predecessor, successor) = (Beacon::default(), Beacon::default());
+    let mut driver = driver(
+        Setup::new(vec![
+            Msg::Row(1, PaneMsg::Work),
+            Msg::Act(1),
+            Msg::Row(1, PaneMsg::Work),
+        ])
+        .opening(vec![(1, PaneState::watching(predecessor.clone()))])
+        .acting(1, Act::Recreate(1))
+        .succeeding(PaneState::watching(successor.clone())),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    deliver(&mut driver, &trigger);
+    assert_eq!(
+        (predecessor.marks(), successor.marks()),
+        (1, 0),
+        "the first message reached the instance that was open then"
+    );
+
+    deliver(&mut driver, &trigger);
+    let started = deliver(&mut driver, &trigger);
+
+    assert_eq!(
+        successor.marks(),
+        1,
+        "the message after the reinsert was reduced against the successor's own state"
+    );
+    assert_eq!(
+        predecessor.marks(),
+        1,
+        "and the predecessor's state saw nothing further"
+    );
+    assert!(
+        matches!(started.as_slice(), [RunKind::Keyed(_)]),
+        "the successor answered it with its own run: {started:?}"
     );
 }
 

--- a/src/kernel/conformance/combinator.rs
+++ b/src/kernel/conformance/combinator.rs
@@ -1,0 +1,523 @@
+//! The composition combinators, driven through the kernel.
+//!
+//! The unit rows beside the combinators themselves
+//! ([`crate::reducer::combinator`]) read a boundary's *command*: which
+//! carriers it qualified, which teardowns it merged. These rows read what
+//! the kernel then **does** with them — runs reclaimed, identities kept
+//! apart, successors started fresh — through the production dispatch path,
+//! pass-unit driven.
+//!
+//! The program under test is a closed combinator stack
+//! ([`ReducerExt::into_program`]), so every row here is also the evidence
+//! that a stack closed this way is a [`Program`] the kernel and the driver
+//! drive like any other — with no `Application` anywhere in the topology
+//! (INV-RC1's composed half).
+//!
+//! # The rows and what they carry
+//!
+//! | row | invariant |
+//! | --- | --- |
+//! | [`sibling_boundaries_keep_equal_local_ids_apart`] | INV-RC2 at the lowering seam, both halves |
+//! | [`a_row_s_subscriptions_are_qualified_and_retracted_with_it`] | INV-RC2's declaration half, INV-RC6 through a boundary |
+//! | [`an_anonymous_child_effect_is_reached_by_its_boundary_s_teardown`] | INV-RC7 through a combinator |
+//! | [`closing_a_row_tears_down_the_runs_under_it`] | INV-RC3's drain, as the kernel applies it |
+//! | [`dismissing_the_slot_tears_down_its_occupant_s_runs`] | INV-RC3's dismissal shape, likewise |
+//! | [`a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh`] | INV-RC3's no-diff adversary and INV-RC4's batch remove-and-reinsert |
+//! | [`a_message_for_a_closed_row_starts_nothing`] | §2.5's routing boundary, INV-ST8 |
+//!
+//! [`ReducerExt::into_program`]: crate::reducer::combinator::ReducerExt::into_program
+
+use std::collections::{HashMap, VecDeque};
+
+use futures::StreamExt;
+use futures::stream;
+use ratatui::Frame;
+use ratatui::backend::TestBackend;
+
+use crate::command::{Command, CommandId};
+use crate::kernel::arbiter::WakeSource;
+use crate::reducer::Reducer;
+use crate::reducer::collection::{Keyed, Slot};
+use crate::reducer::combinator::{ForEach, IntoProgram, Presented, ReducerExt};
+use crate::subscription::Subscription;
+use crate::testing::driver::{RunKind, RunName, TestDriver};
+
+use super::support::{
+    Beacon, ProbeSource, TEST_TURNS, accept, cap, config, holding_effect, terminal,
+};
+
+/// What a pane is asked to do.
+#[derive(Clone, Copy, Debug)]
+enum PaneMsg {
+    /// Start a run under the pane's own local id — the same id in every
+    /// pane, so only the boundary keeps two of them apart.
+    Work,
+    /// Start an unkeyed run: an anonymous effect spawned through a
+    /// composition boundary, which nothing but its scope can address
+    /// (INV-RC7).
+    Anon,
+}
+
+/// One pane instance: the runs it starts hold `reclaimed`, and it declares
+/// `declares` when it has one.
+struct PaneState {
+    reclaimed: Beacon,
+    declares: Option<ProbeSource>,
+}
+
+impl PaneState {
+    const fn new(reclaimed: Beacon) -> Self {
+        Self {
+            reclaimed,
+            declares: None,
+        }
+    }
+
+    fn declaring(reclaimed: Beacon, source: ProbeSource) -> Self {
+        Self {
+            reclaimed,
+            declares: Some(source),
+        }
+    }
+}
+
+/// The child reducer every boundary in the stack composes.
+struct Pane;
+
+impl Reducer for Pane {
+    type State = PaneState;
+    type Message = PaneMsg;
+
+    fn reduce(&self, state: &mut PaneState, message: PaneMsg) -> Command<PaneMsg> {
+        // Parks forever holding a drop-marking guard, so the run's
+        // reclamation is what the row reads.
+        let effect = holding_effect(state.reclaimed.clone()).map(|_| PaneMsg::Work);
+        match message {
+            PaneMsg::Work => effect.cancellable(CommandId::new("work")),
+            PaneMsg::Anon => effect,
+        }
+    }
+
+    fn subscriptions(&self, state: &PaneState) -> Vec<Subscription<PaneMsg>> {
+        state
+            .declares
+            .iter()
+            .map(|source| Subscription::new(source.clone()).map(|_| PaneMsg::Work))
+            .collect()
+    }
+}
+
+/// What one scripted step tells the root to do.
+#[derive(Clone, Copy, Debug)]
+enum Act {
+    /// Remove the pane under `key`.
+    Close(u8),
+    /// Remove and re-insert `key` in one update, returning a keyed run
+    /// placed under that same key — so one command carries the journal's
+    /// teardown *and* the successor's spawn (RFC 0013 R4).
+    Recreate(u8),
+    /// Empty the slot.
+    Dismiss,
+}
+
+/// The root state: the two collections the boundaries project, plus the
+/// script.
+struct RootState {
+    panes: Keyed<u8, PaneState>,
+    modal: Slot<PaneState>,
+    acts: HashMap<u8, Act>,
+    /// The instance each [`Act::Recreate`] installs, in order. The test
+    /// builds them so it can watch each instance's runs separately.
+    successors: VecDeque<PaneState>,
+}
+
+/// The root reducer: it owns the collections and nothing else.
+struct Root;
+
+impl Reducer for Root {
+    type State = RootState;
+    type Message = Msg;
+
+    fn reduce(&self, state: &mut RootState, message: Msg) -> Command<Msg> {
+        let Msg::Act(step) = message else {
+            // Every other message is claimed by a boundary before it gets
+            // here; reaching this arm would mean the routing failed.
+            return Command::none();
+        };
+        match state.acts.get(&step).copied() {
+            Some(Act::Close(key)) => {
+                state.panes.remove(&key);
+                Command::none()
+            }
+            Some(Act::Recreate(key)) => {
+                let successor = state
+                    .successors
+                    .pop_front()
+                    .expect("the script supplies one successor per recreate");
+                let reclaimed = successor.reclaimed.clone();
+                state.panes.remove(&key);
+                state.panes.insert(key, successor);
+                // Placed under the same segment the boundary uses, so the
+                // journal's teardown and this spawn address one prefix.
+                holding_effect(reclaimed)
+                    .map(|_| Msg::Act(0))
+                    .cancellable(CommandId::new("work"))
+                    .scoped(key)
+            }
+            Some(Act::Dismiss) => {
+                state.modal.dismiss();
+                Command::none()
+            }
+            None => Command::none(),
+        }
+    }
+}
+
+/// The root message type.
+#[derive(Clone, Debug)]
+enum Msg {
+    /// Root-handled: run the scripted act for this step.
+    Act(u8),
+    /// Routed to the pane under this key.
+    Row(u8, PaneMsg),
+    /// Routed to the slot's occupant.
+    Modal(PaneMsg),
+}
+
+fn row_extract(message: Msg) -> Result<(u8, PaneMsg), Msg> {
+    match message {
+        Msg::Row(key, pane) => Ok((key, pane)),
+        other => Err(other),
+    }
+}
+
+fn modal_extract(message: Msg) -> Result<PaneMsg, Msg> {
+    match message {
+        Msg::Modal(pane) => Ok(pane),
+        other => Err(other),
+    }
+}
+
+/// What the program is told at `init`.
+struct Setup {
+    /// Panes open before any message arrives, in insertion order.
+    panes: Vec<(u8, PaneState)>,
+    /// The slot's initial occupant.
+    modal: Option<PaneState>,
+    /// The scripted acts, by step.
+    acts: HashMap<u8, Act>,
+    /// One instance per [`Act::Recreate`], in order.
+    successors: VecDeque<PaneState>,
+    /// The messages the init effect emits, one per grant.
+    trigger: Vec<Msg>,
+}
+
+impl Setup {
+    fn new(trigger: Vec<Msg>) -> Self {
+        Self {
+            panes: Vec::new(),
+            modal: None,
+            acts: HashMap::new(),
+            successors: VecDeque::new(),
+            trigger,
+        }
+    }
+
+    fn opening(mut self, panes: Vec<(u8, PaneState)>) -> Self {
+        self.panes = panes;
+        self
+    }
+
+    fn presenting(mut self, occupant: PaneState) -> Self {
+        self.modal = Some(occupant);
+        self
+    }
+
+    fn acting(mut self, step: u8, act: Act) -> Self {
+        self.acts.insert(step, act);
+        self
+    }
+
+    fn succeeding(mut self, successor: PaneState) -> Self {
+        self.successors.push_back(successor);
+        self
+    }
+}
+
+/// The init effect: emits each scripted trigger and then parks forever, so
+/// the triggers arrive one grant at a time and no producer exit accompanies
+/// them.
+fn init(setup: Setup) -> (RootState, Command<Msg>) {
+    let Setup {
+        panes,
+        modal,
+        acts,
+        successors,
+        trigger,
+    } = setup;
+    let mut state = RootState {
+        panes: Keyed::new(),
+        modal: Slot::empty(),
+        acts,
+        successors,
+    };
+    // First insertions and a first presentation, so neither records a
+    // removal: bootstrap opens instances rather than replacing any.
+    for (key, pane) in panes {
+        state.panes.insert(key, pane);
+    }
+    if let Some(occupant) = modal {
+        state.modal.present(occupant);
+    }
+    (
+        state,
+        Command::stream(stream::iter(trigger).chain(stream::pending())),
+    )
+}
+
+fn view(_state: &RootState, _frame: &mut Frame<'_>) {}
+
+/// The closed stack: a `for_each` over the panes, a `presented` slot, and
+/// the root `init`/`view` that close it.
+type Composed = IntoProgram<Presented<ForEach<Root, Pane, u8>, Pane, &'static str>, Setup>;
+
+fn program() -> Composed {
+    Root.for_each(
+        Pane,
+        |state: &RootState| &state.panes,
+        |state: &mut RootState| &mut state.panes,
+        row_extract,
+        Msg::Row,
+    )
+    .presented(
+        Pane,
+        "modal",
+        |state: &RootState| &state.modal,
+        |state: &mut RootState| &mut state.modal,
+        modal_extract,
+        Msg::Modal,
+    )
+    .into_program(init, view)
+}
+
+/// A driver over the closed stack, one message per pass.
+fn driver(setup: Setup) -> TestDriver<Composed, TestBackend> {
+    TestDriver::new(
+        program(),
+        setup,
+        config().batch_max_messages(cap(1)),
+        terminal(),
+    )
+}
+
+/// Releases the next scripted trigger and runs the pass it begins.
+fn deliver(driver: &mut TestDriver<Composed, TestBackend>, trigger: &RunName) -> Vec<RunKind> {
+    accept(driver, trigger.clone());
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the scripted trigger is in the lane")
+        .started
+        .iter()
+        .map(RunName::kind)
+        .collect()
+}
+
+// INV-RC2 at the lowering seam, both halves at once. Two panes reduce the
+// *same* child with the *same* local id, and the boundary is the only thing
+// keeping the two runs apart: were the ids to alias, the second pane's
+// `CancelInFlight` spawn would replace the first pane's run and reclaim it.
+// The teardown half then shows the qualification reaching the placement
+// scope too — closing pane 1 selects its run and leaves pane 2's.
+#[test]
+fn sibling_boundaries_keep_equal_local_ids_apart() {
+    let (first, second) = (Beacon::default(), Beacon::default());
+    let mut driver = driver(
+        Setup::new(vec![
+            Msg::Row(1, PaneMsg::Work),
+            Msg::Row(2, PaneMsg::Work),
+            Msg::Act(1),
+        ])
+        .opening(vec![
+            (1, PaneState::new(first.clone())),
+            (2, PaneState::new(second.clone())),
+        ])
+        .acting(1, Act::Close(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    let started = deliver(&mut driver, &trigger);
+    assert!(matches!(started.as_slice(), [RunKind::Keyed(_)]));
+    let started = deliver(&mut driver, &trigger);
+    assert!(matches!(started.as_slice(), [RunKind::Keyed(_)]));
+
+    driver.settle(TEST_TURNS, || true);
+    assert!(
+        !first.marked(),
+        "the second pane's same-local-id spawn did not replace the first pane's run"
+    );
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || first.marked());
+
+    assert!(
+        !second.marked(),
+        "closing one pane selected only the runs placed under its own key"
+    );
+}
+
+// INV-RC2's declaration half through the kernel, with INV-RC6 as its second
+// clause. Two panes declare the same source under the same local key, and
+// both are admitted — which they could not be if the boundary had not
+// qualified the declared identities, since a live run for an id suppresses
+// a second admission of it. Closing one pane then stops that pane's
+// subscription run and leaves the other's.
+#[test]
+fn a_row_s_subscriptions_are_qualified_and_retracted_with_it() {
+    let (first, second) = (ProbeSource::silent("feed"), ProbeSource::silent("feed"));
+    let mut driver = driver(
+        Setup::new(vec![Msg::Act(1)])
+            .opening(vec![
+                (1, PaneState::declaring(Beacon::default(), first.clone())),
+                (2, PaneState::declaring(Beacon::default(), second.clone())),
+            ])
+            .acting(1, Act::Close(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    assert_eq!(
+        (first.admissions(), second.admissions()),
+        (1, 1),
+        "both panes' declarations were admitted, so their identities differ"
+    );
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || first.quiescences() > 0);
+
+    assert_eq!(
+        second.quiescences(),
+        0,
+        "the sibling pane's subscription run is untouched"
+    );
+}
+
+// INV-RC7 through a composition boundary: an effect the child returned
+// *without* a key has no logical identity at all, and the only thing that
+// can address it is the scope its boundary placed it under. Closing the row
+// reaches it.
+#[test]
+fn an_anonymous_child_effect_is_reached_by_its_boundary_s_teardown() {
+    let reclaimed = Beacon::default();
+    let mut driver = driver(
+        Setup::new(vec![Msg::Row(1, PaneMsg::Anon), Msg::Act(1)])
+            .opening(vec![(1, PaneState::new(reclaimed.clone()))])
+            .acting(1, Act::Close(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    let started = deliver(&mut driver, &trigger);
+    assert!(
+        matches!(started.as_slice(), [RunKind::Anonymous]),
+        "the child's unkeyed effect started an anonymous run: {started:?}"
+    );
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || reclaimed.marked());
+}
+
+// INV-RC3's drain as the kernel applies it: the removal the parent's own
+// `update` recorded becomes a teardown in that same update's command, and
+// the runs under the removed row are reclaimed by it. Nothing in the
+// reducer wrote `.teardown(...)` — the boundary did.
+#[test]
+fn closing_a_row_tears_down_the_runs_under_it() {
+    let reclaimed = Beacon::default();
+    let mut driver = driver(
+        Setup::new(vec![Msg::Row(1, PaneMsg::Work), Msg::Act(1)])
+            .opening(vec![(1, PaneState::new(reclaimed.clone()))])
+            .acting(1, Act::Close(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || true);
+    assert!(!reclaimed.marked(), "the row's run is live");
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || reclaimed.marked());
+}
+
+// The dismissal shape of the same drain, through the slot boundary: the
+// teardown the journal yields is of the boundary's own segment, and it
+// reaches the occupant's runs.
+#[test]
+fn dismissing_the_slot_tears_down_its_occupant_s_runs() {
+    let reclaimed = Beacon::default();
+    let mut driver = driver(
+        Setup::new(vec![Msg::Modal(PaneMsg::Work), Msg::Act(1)])
+            .presenting(PaneState::new(reclaimed.clone()))
+            .acting(1, Act::Dismiss),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || true);
+    assert!(!reclaimed.marked());
+
+    deliver(&mut driver, &trigger);
+    driver.settle(TEST_TURNS, || reclaimed.marked());
+}
+
+// RFC 0014 §11's *diff-based removal detection* and *fold-era batch*
+// adversaries in one row. The update removes key 1 and re-inserts it, so
+// the collection is byte-for-byte what it was and a diff would report
+// nothing; and the command it returns carries both the journal's teardown
+// **and** the successor's keyed spawn, under one prefix and one identity.
+// The cancel phase precedes every spawn of the same command, so the old
+// instance's run is reclaimed and the successor starts fresh rather than
+// being replaced or suppressed by what it succeeded.
+#[test]
+fn a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh() {
+    let (old, new) = (Beacon::default(), Beacon::default());
+    let mut driver = driver(
+        Setup::new(vec![Msg::Row(1, PaneMsg::Work), Msg::Act(1)])
+            .opening(vec![(1, PaneState::new(old.clone()))])
+            .acting(1, Act::Recreate(1))
+            .succeeding(PaneState::new(new.clone())),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    deliver(&mut driver, &trigger);
+    let started = deliver(&mut driver, &trigger);
+
+    assert!(
+        matches!(started.as_slice(), [RunKind::Keyed(_)]),
+        "the same command's spawn phase started the successor: {started:?}"
+    );
+    driver.settle(TEST_TURNS, || old.marked());
+    assert!(
+        !new.marked(),
+        "and the successor is the run that survives the application point"
+    );
+}
+
+// RFC 0014 §2.5's routing boundary, which is also INV-ST8's "does not
+// re-route key-addressed input": a message for a key the collection no
+// longer holds reaches no reducer, so nothing is started and no successor
+// inherits it.
+#[test]
+fn a_message_for_a_closed_row_starts_nothing() {
+    let mut driver = driver(
+        Setup::new(vec![Msg::Act(1), Msg::Row(1, PaneMsg::Work)])
+            .opening(vec![(1, PaneState::new(Beacon::default()))])
+            .acting(1, Act::Close(1)),
+    );
+    let trigger = driver.boot().started[0].clone();
+
+    deliver(&mut driver, &trigger);
+    let started = deliver(&mut driver, &trigger);
+
+    assert!(
+        started.is_empty(),
+        "the closed row claimed nothing and started nothing: {started:?}"
+    );
+}

--- a/src/kernel/lowering.rs
+++ b/src/kernel/lowering.rs
@@ -36,7 +36,8 @@
 //! [`RuntimeCommandParts::into_kernel_parts`]: crate::command::RuntimeCommandParts::into_kernel_parts
 
 use crate::command::{
-    CancelPolicy, CancellableCommand, CommandId, KernelParts, RuntimeCommandParts, SpawnEntry,
+    CancelPolicy, CancellableCommand, CleanupRegistration, CommandId, KernelParts,
+    RuntimeCommandParts, SpawnEntry,
 };
 use crate::structural_key::ScopePath;
 
@@ -89,6 +90,12 @@ pub enum DispatchStep<Msg: Send + 'static> {
     Teardown(ScopePath),
     /// Spawn phase: start one producer run.
     Spawn(SpawnEntry<Msg>),
+    /// Spawn phase: arm one cleanup finalizer against its scope.
+    ///
+    /// It starts nothing here — arming is the whole of what a registration
+    /// does at its own dispatch, and a later teardown whose prefix covers
+    /// its scope is what starts it (RFC 0014 §4.4).
+    Cleanup(CleanupRegistration),
     /// The dispatch's completion: apply the `update`-returned quit.
     Quit,
 }
@@ -101,13 +108,6 @@ pub struct DispatchPlan<Msg: Send + 'static> {
     /// a position in the dispatch.
     pub redraw: bool,
     /// Every step the command carries, in application order.
-    ///
-    /// One kind of entry is not here yet: cleanup registrations, which
-    /// RFC 0014 §3.4 places in the spawn phase — after the same command's
-    /// cancel phase, so a teardown-and-reregister command consumes the old
-    /// hooks and leaves the new registration armed. They land with the
-    /// cleanup run kind, as a variant of [`DispatchStep`] ordered with the
-    /// spawns.
     pub steps: Vec<DispatchStep<Msg>>,
 }
 
@@ -119,20 +119,29 @@ pub struct DispatchPlan<Msg: Send + 'static> {
 ///    children included (RFC 0013 INV-ST3);
 /// 2. the **spawn phase**, in the command's flattened declaration order, so
 ///    two same-key spawns in one batch apply as two consecutive dispatches
-///    and the second is a replacement under its own policy;
+///    and the second is a replacement under its own policy, plus the
+///    command's cleanup registrations — which the phase order places here
+///    and not in the cancel phase, so a teardown-and-reregister command
+///    consumes the *old* occupant's hooks and leaves the new registration
+///    armed (RFC 0014 §4.4; §11's *cancel-phase cleanup registration*
+///    adversary is what that excludes);
 /// 3. the **quit**, if the command carried one, at the dispatch's
 ///    *completion* — siblings this same command spawned exist by then and
 ///    are torn down by termination rather than skipped (RFC 0014 §3.3).
 ///
 /// Cancels and teardowns commute, so their relative order carries no
 /// meaning: both are strict, idempotent revocations, and a prefix covering
-/// an explicitly cancelled id applies the same removal twice.
+/// an explicitly cancelled id applies the same removal twice. Spawns and
+/// cleanup registrations commute for a different reason: a spawn neither
+/// reads nor writes the cleanup ledger, and arming a registration starts
+/// nothing, so no observation separates the two orders.
 pub fn dispatch_plan<Msg: Send + 'static>(parts: KernelParts<Msg>) -> DispatchPlan<Msg> {
     let KernelParts {
         redraw,
         quit_now,
         cancels,
         teardowns,
+        cleanups,
         spawns,
     } = parts;
 
@@ -141,6 +150,7 @@ pub fn dispatch_plan<Msg: Send + 'static>(parts: KernelParts<Msg>) -> DispatchPl
         .map(DispatchStep::Cancel)
         .chain(teardowns.into_iter().map(DispatchStep::Teardown))
         .chain(spawns.into_iter().map(DispatchStep::Spawn))
+        .chain(cleanups.into_iter().map(DispatchStep::Cleanup))
         .chain(quit_now.then_some(DispatchStep::Quit))
         .collect();
 
@@ -206,6 +216,7 @@ mod tests {
                 DispatchStep::Cancel(_) => "cancel",
                 DispatchStep::Teardown(_) => "teardown",
                 DispatchStep::Spawn(_) => "spawn",
+                DispatchStep::Cleanup(_) => "cleanup",
                 DispatchStep::Quit => "quit",
             })
             .collect()
@@ -414,6 +425,53 @@ mod tests {
     #[test]
     fn a_command_with_nothing_to_apply_plans_no_steps() {
         assert!(planned(Command::none()).is_empty());
+    }
+
+    // RFC 0014 §3.4: a registration applies in the **spawn** phase, after
+    // this same command's cancel phase. §11's *cancel-phase cleanup
+    // registration* adversary is the plan that puts it first — a
+    // teardown-and-reregister command would then consume the registration it
+    // had just armed, and the new occupant would leave no hook behind.
+    #[test]
+    fn a_teardown_and_reregister_command_arms_the_new_hook_after_the_teardown() {
+        let steps = planned(Command::batch([
+            Command::on_teardown(async {}),
+            Command::teardown("pane-1"),
+        ]));
+
+        assert_eq!(
+            steps,
+            vec!["teardown", "cleanup"],
+            "the teardown consumes the old occupant's hooks, and the new registration is armed \
+             after it"
+        );
+    }
+
+    #[test]
+    fn a_registration_lowers_to_a_spawn_phase_entry_and_no_run() {
+        let parts = lowered(Command::on_teardown(async {}));
+
+        assert_eq!(parts.cleanups.len(), 1);
+        assert!(
+            parts.spawns.is_empty(),
+            "arming a registration starts nothing"
+        );
+        assert!(parts.teardowns.is_empty());
+    }
+
+    // The registration's own dispatch never precedes the quit either: a quit
+    // applies at the dispatch's completion, and a registration armed by that
+    // same command is discarded by the termination it causes rather than
+    // outliving it.
+    #[test]
+    fn the_quit_still_completes_a_command_that_also_arms_a_hook() {
+        let steps = planned(Command::batch([
+            Command::quit(),
+            Command::on_teardown(async {}),
+            Command::message(1),
+        ]));
+
+        assert_eq!(steps, vec!["spawn", "cleanup", "quit"]);
     }
 
     // The keyed slot policy, and its correspondence with the pure state

--- a/src/kernel/producer.rs
+++ b/src/kernel/producer.rs
@@ -1,10 +1,16 @@
 //! Producer task bodies and the policy every runtime-owned run shares.
 //!
-//! One harness for every kind — keyed command, anonymous command,
+//! One harness for every producer kind — keyed command, anonymous command,
 //! subscription forwarder — so task ownership, panic containment, gauge
 //! accounting, and the send-stop policy have a single implementation and no
 //! per-kind variant for a contract to slip through (RFC 0014 INV-RC1's
 //! "effect-task ownership and bookkeeping" and "task body policy" rows).
+//!
+//! Cleanup runs take [`CleanupHarness`] instead, and the split is deliberate
+//! rather than incidental: they share the task-body policy through
+//! [`spawn_contained`] and differ in exactly one thing — the cleanup
+//! construction site is handed **no lane sender and no ingress**, which is
+//! the structural half of INV-RC8's no-output clause.
 //!
 //! Policy, stated once:
 //!
@@ -29,7 +35,7 @@ use std::sync::Arc;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
-use tokio::task::{Id as TaskId, JoinSet};
+use tokio::task::{AbortHandle, Id as TaskId, JoinSet};
 
 use crate::command::Action;
 use crate::panic::contained_producer;
@@ -123,12 +129,65 @@ pub fn subscription_body<Msg: Send + 'static>(stream: BoxStream<'static, Msg>) -
 /// membership mutation point, because a keyed entry's lifetime is the
 /// runtime's rather than its task's — a draining entry outlives its task, so
 /// no task-scoped guard could carry it.
+///
+/// Cleanup runs contribute to none at all, and that is contract rather than
+/// an omission: the schema's producer gauges count the three producer kinds,
+/// and a cleanup run is none of them (RFC 0006 §5.2's successor note,
+/// RFC 0014 §9 row 9). What still accounts for it is the settle drain, which
+/// is total over the join set.
 fn gauge_guard(observer: &LoadObserver, kind: &RunKind) -> Option<GaugeGuard> {
     match kind {
-        RunKind::Keyed(_) => None,
+        RunKind::Keyed(_) | RunKind::Cleanup => None,
         RunKind::Anon => Some(observer.track_unkeyed_command()),
         RunKind::Sub(_) => Some(observer.track_subscription()),
     }
+}
+
+/// Spawns one runtime-owned task under the policy every run kind shares:
+/// panic containment, the one join set, the task index, and a gauge guard
+/// dropped on every exit path.
+///
+/// A free function rather than a method so that both harnesses below reach
+/// exactly the same body — there is one task-body policy for every
+/// runtime-owned run, cleanup runs included (RFC 0014 INV-RC1's "task body
+/// policy" row).
+fn spawn_contained(
+    join_set: &mut JoinSet<()>,
+    task_index: &mut HashMap<TaskId, RunToken>,
+    token: RunToken,
+    gauge: Option<GaugeGuard>,
+    run: BoxFuture<'static, ()>,
+) -> AbortHandle {
+    let abort = join_set.spawn(async move {
+        // Held for the whole body and dropped on every exit path —
+        // completion, abort, and panic unwind alike (RFC 0006 §4.4).
+        let _gauge = gauge;
+        // `contained_producer` marks the poll so the panic hook skips
+        // restoring the terminal of an application that keeps running
+        // (RFC 0011 INV-LC8). The catch is what discharges the one
+        // diagnostic obligation the successor still carries — RFC 0003
+        // §7.3's keyed-panic log event, which RFC 0011 §5.1 carves out
+        // of its diagnostic negative space — for every producer kind
+        // rather than per kind.
+        let outcome = AssertUnwindSafe(contained_producer(run))
+            .catch_unwind()
+            .await;
+        if let Err(payload) = outcome {
+            tracing::error!(
+                target: "tears::kernel",
+                panic = ?payload,
+                "producer task panicked"
+            );
+            // Re-raised so the exit still reaches the join set as a
+            // panic rather than as an ordinary completion, which is what
+            // the pass's exit reflection reads. `resume_unwind` does not
+            // run the panic hook again, so the report above stays the
+            // only one.
+            resume_unwind(payload);
+        }
+    });
+    task_index.insert(abort.id(), token);
+    abort
 }
 
 /// The spawn-side policy every runtime-owned producer run shares.
@@ -195,36 +254,7 @@ impl<Msg: Send + 'static> ProducerHarness<'_, Msg> {
         );
         let gauge = gauge_guard(self.observer, &kind);
         let run = body(EffectCtx { handle });
-
-        let abort = self.join_set.spawn(async move {
-            // Held for the whole body and dropped on every exit path —
-            // completion, abort, and panic unwind alike (RFC 0006 §4.4).
-            let _gauge = gauge;
-            // `contained_producer` marks the poll so the panic hook skips
-            // restoring the terminal of an application that keeps running
-            // (RFC 0011 INV-LC8). The catch is what discharges the one
-            // diagnostic obligation the successor still carries — RFC 0003
-            // §7.3's keyed-panic log event, which RFC 0011 §5.1 carves out
-            // of its diagnostic negative space — for every producer kind
-            // rather than per kind.
-            let outcome = AssertUnwindSafe(contained_producer(run))
-                .catch_unwind()
-                .await;
-            if let Err(payload) = outcome {
-                tracing::error!(
-                    target: "tears::kernel",
-                    panic = ?payload,
-                    "producer task panicked"
-                );
-                // Re-raised so the exit still reaches the join set as a
-                // panic rather than as an ordinary completion, which is what
-                // the pass's exit reflection reads. `resume_unwind` does not
-                // run the panic hook again, so the report above stays the
-                // only one.
-                resume_unwind(payload);
-            }
-        });
-        self.task_index.insert(abort.id(), token);
+        let abort = spawn_contained(self.join_set, self.task_index, token, gauge, run);
 
         RunEntry {
             token,
@@ -235,6 +265,78 @@ impl<Msg: Send + 'static> ProducerHarness<'_, Msg> {
             exited: false,
             counter,
             gate,
+            abort,
+        }
+    }
+}
+
+/// The spawn-side policy a **cleanup** run takes.
+///
+/// A separate type from [`ProducerHarness`], and the separation is where
+/// INV-RC8's no-output clause is enforced: these fields are the whole of
+/// what a cleanup run's construction can reach, and no lane sender is among
+/// them — no [`DataSender`], no [`ControlSender`], no [`IngressHandle`] to
+/// carry one, and no directive path. A cleanup run therefore has no route
+/// back into the runtime *by construction* rather than by its body's
+/// discipline: it cannot deliver a message, cannot originate a quit, and
+/// cannot mark redraw or subscription dirt, because there is nothing here to
+/// hand it that would.
+///
+/// That clause is structural-primary for the reason RFC 0014 INV-RC8 states:
+/// no cleanup run that *attempts* an output exists for a test to observe
+/// failing, so a review of this construction site is the evidence and a
+/// behavioral row over an ordinary finalizer is its regression neighbour.
+///
+/// Everything else is shared with the producer harness through
+/// [`spawn_contained`]: the same join set, the same task index, the same
+/// panic containment, the same abort handle. A cleanup run is
+/// runtime-**owned** exactly like the rest, which is what makes termination
+/// cancel it and the settle drain account for it.
+pub struct CleanupHarness<'a> {
+    /// The single join set every runtime-owned run is spawned into.
+    pub join_set: &'a mut JoinSet<()>,
+    /// Task-id to run-token index, so an exit observation names its run.
+    pub task_index: &'a mut HashMap<TaskId, RunToken>,
+    /// The kernel's send gate.
+    ///
+    /// Carried only to fill the registry entry's field, which every run has.
+    /// Nothing ever waits on it for a cleanup run: waiting happens in
+    /// [`IngressHandle`], and this harness constructs none — so this is
+    /// bookkeeping, not a seam the finalizer can reach.
+    pub gate: &'a Arc<SendGate>,
+}
+
+impl CleanupHarness<'_> {
+    /// Starts one finalizer as a runtime-owned cleanup run and returns its
+    /// registry entry.
+    ///
+    /// `scope` is the registration's anchor, kept on the entry like any
+    /// other run's placement. It is not a selection subject — a started
+    /// cleanup run is excluded from teardown selection by kind (RFC 0013
+    /// §3.1) — but it is what a diagnostic reads and what keeps the entry
+    /// uniform with the rest.
+    ///
+    /// The counter is fresh and stays at zero: a reservation is taken on a
+    /// send, and there is no send path here, so the entry's removal
+    /// condition reduces to "its exit was observed" (the accounting's rule 5
+    /// with `pending == 0` by construction).
+    pub fn start(
+        &mut self,
+        token: RunToken,
+        scope: ScopePath,
+        finalizer: BoxFuture<'static, ()>,
+    ) -> RunEntry {
+        let abort = spawn_contained(self.join_set, self.task_index, token, None, finalizer);
+
+        RunEntry {
+            token,
+            kind: RunKind::Cleanup,
+            scope,
+            phase: Phase::Running,
+            revoked: false,
+            exited: false,
+            counter: Arc::new(PendingCounter::default()),
+            gate: Arc::clone(self.gate),
             abort,
         }
     }
@@ -294,6 +396,18 @@ mod tests {
             gauge_trace(&RunKind::Keyed(CommandId::new("load"))).is_empty(),
             "the keyed gauge is count-based and published by the registry, so \
              starting a keyed run emits nothing here"
+        );
+    }
+
+    // INV-RC8's accounting half: a cleanup run counts toward no gauge at
+    // all — not the subscription one, not the unkeyed-command one, and not
+    // the registry's keyed count, which it never enters because its kind is
+    // not `Keyed`.
+    #[test]
+    fn a_cleanup_run_counts_toward_no_gauge() {
+        assert!(
+            gauge_trace(&RunKind::Cleanup).is_empty(),
+            "a cleanup run is none of the three producer kinds the schema counts"
         );
     }
 }

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -48,6 +48,15 @@ pub enum RunKind {
     /// barrier and only its quiescence can mark subscriptions dirty
     /// (RFC 0014 §5.1, §5.2).
     Sub(SubscriptionId),
+    /// A cleanup finalizer started by a teardown's application point.
+    ///
+    /// Runtime-owned like every other run — one entry, one join set, one
+    /// abort, one settle — and excluded from four things by its kind: it
+    /// counts toward no gauge (RFC 0006 §5.2's successor note), joins no
+    /// admission barrier and defers nothing (RFC 0014 INV-RC12 (a)), marks
+    /// no subscription dirt (§5.2), and is not selected by a later teardown
+    /// (RFC 0013 §3.1: a cleanup run already started is not selected).
+    Cleanup,
 }
 
 /// Lifecycle phase.
@@ -172,12 +181,25 @@ const fn stop_effect(exited: bool, phase: Phase) -> StopEffect {
 ///
 /// A complete-prefix comparison from the path root over structural segment
 /// equality: a path equal to the prefix is selected, and shorter, reordered,
-/// subset, and deeper-position paths are not. The run's *kind* and its local
-/// key are not arguments, which is how "uniform across every run kind" and
-/// "local keys never participate in selection" are structural here rather
-/// than asserted per kind.
+/// subset, and deeper-position paths are not. The run's local key is not an
+/// argument, which is how "local keys never participate in selection" is
+/// structural here rather than asserted per kind.
 fn selected_by(scope: &ScopePath, prefix: &ScopePath) -> bool {
     scope.starts_with(prefix)
+}
+
+/// Whether a run of this kind is a teardown *subject* at all.
+///
+/// The three producer kinds are, uniformly — that is INV-ST1's "across every
+/// run kind", and it is why the path predicate above takes no kind. A
+/// cleanup run that has already started is not: RFC 0013 §3.1 excludes it by
+/// name, and the reason is that a finalizer started by a teardown is itself a
+/// run under that very prefix, so a selection that read the kind out would
+/// have the application point stopping the work it had just begun — and a
+/// *second* application would stop a first application's still-running
+/// finalizer, which is exactly the re-entrance INV-ST5's idempotence denies.
+const fn selectable_by_teardown(kind: &RunKind) -> bool {
+    !matches!(kind, RunKind::Cleanup)
 }
 
 /// One run's authoritative record.
@@ -330,10 +352,13 @@ impl ScopeRegistry {
     ///
     /// Tombstones are selected like any other entry: a run that finished
     /// with output still queued is exactly the case INV-ST4 names, and
-    /// revoking it is what retracts that output.
+    /// revoking it is what retracts that output. Cleanup runs are the one
+    /// exclusion, and it is by kind rather than by path
+    /// ([`selectable_by_teardown`]).
     pub fn select_prefix(&self, prefix: &ScopePath) -> Vec<RunToken> {
         self.entries
             .values()
+            .filter(|entry| selectable_by_teardown(&entry.kind))
             .filter(|entry| selected_by(&entry.scope, prefix))
             .map(|entry| entry.token)
             .collect()
@@ -522,6 +547,9 @@ mod tests {
 
     use std::hash::{Hash, Hasher};
 
+    use crate::subscription::Subscription;
+    use crate::subscription::mock::MockSource;
+
     fn path(segments: &[&'static str]) -> ScopePath {
         // Root-first storage: the *last* `prefixed` call names the outermost
         // segment, so the slice reads root-first when applied in reverse.
@@ -685,6 +713,23 @@ mod tests {
         assert!(
             !selected_by(&first, &second),
             "selection compares structural values, not hashes"
+        );
+    }
+
+    // RFC 0013 §3.1's one exclusion by kind: the three producer kinds are
+    // teardown subjects uniformly, a started cleanup run is not.
+    #[test]
+    fn every_producer_kind_is_a_teardown_subject_and_a_cleanup_run_is_not() {
+        assert!(selectable_by_teardown(&RunKind::Keyed(CommandId::new(
+            "worker"
+        ))));
+        assert!(selectable_by_teardown(&RunKind::Anon));
+        assert!(selectable_by_teardown(&RunKind::Sub(
+            Subscription::new(MockSource::<u8>::new()).id().clone()
+        )));
+        assert!(
+            !selectable_by_teardown(&RunKind::Cleanup),
+            "a finalizer a teardown started is a run under that very prefix"
         );
     }
 

--- a/src/kernel/teardown.rs
+++ b/src/kernel/teardown.rs
@@ -12,7 +12,9 @@
 //!    (RFC 0014 INV-RC5, INV-RC6);
 //! 3. **requests a stop** for each, through the registry's single stop
 //!    transition, which is also what cancel, supersession, and termination
-//!    use.
+//!    use;
+//! 4. **consumes and starts** the prefix's unfired cleanup registrations
+//!    (RFC 0014 §4.4, RFC 0013 §5).
 //!
 //! Teardown applies in the cancel phase, before every spawn of the same
 //! command, and commutes with explicit cancels. It is total and idempotent:
@@ -44,27 +46,38 @@ impl<P: Program> Kernel<P> {
     /// takes a transition that is defined for it, and a second application
     /// re-revokes an already-revoked set with no further effect.
     ///
-    /// Selection is read whole before any stop is issued. Today that is not
-    /// load-bearing — the stop transition changes only revocation and phase,
-    /// neither of which the scope-path predicate reads, so the selected set
-    /// is invariant under the loop. It becomes load-bearing with the cleanup
-    /// hooks: a finalizer started by this very application is a run under
-    /// this very prefix, and RFC 0013 §3.1 excludes already-started cleanup
-    /// runs from selection.
+    /// **Step 4 — the prefix's unfired cleanup registrations are consumed
+    /// and started**, at this same point: the head of the
+    /// stop-requested→quiesced interval RFC 0013 §1.2 places the cleanup
+    /// window in, so a finalizer runs *concurrently* with the quiescence of
+    /// the runs this application just stopped rather than after it. Nothing
+    /// here awaits a run, and nothing here awaits a finalizer.
+    ///
+    /// Consumption is removal, which is what makes the hook at-most-once and
+    /// the second application of a prefix re-fire nothing (INV-RC8,
+    /// RFC 0013 INV-ST5) — and it is the *whole* mechanism, so there is no
+    /// fired-flag for a later path to read wrongly.
+    ///
+    /// Selection is read whole before any stop is issued, and the stops are
+    /// issued before any finalizer starts. Both orders are load-bearing. A
+    /// finalizer started here is a run under this very prefix, so a
+    /// selection taken afterwards would include it; RFC 0013 §3.1 excludes
+    /// already-started cleanup runs, and the registry carries that exclusion
+    /// by kind so it holds for a *later* teardown of the same prefix too,
+    /// not only for this one.
     ///
     /// No dirt is marked here. A teardown-stopped subscription run marks
     /// subscriptions dirty when it *quiesces*, not when it is stopped
     /// (RFC 0014 §5.2), and that observation belongs to the pass's exit
-    /// reflection stage.
+    /// reflection stage. A cleanup run's own quiescence marks none at all,
+    /// whichever way it ends.
     pub(super) fn apply_teardown(&mut self, prefix: &ScopePath) {
         for token in self.registry.select_prefix(prefix) {
             self.registry.stop_request(token);
         }
 
-        // The prefix's unfired cleanup registrations are consumed and
-        // started here (RFC 0014 §4.4, INV-RC8). The ledger that holds them
-        // lands with the cleanup run kind; until then a teardown has none to
-        // consume, and there is deliberately no partial half of the hook
-        // contract in the meantime.
+        for registration in self.cleanups.take_under(prefix) {
+            self.start_cleanup(registration);
+        }
     }
 }

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -25,6 +25,7 @@
 
 pub mod adapter;
 pub mod collection;
+pub mod combinator;
 
 use ratatui::Frame;
 

--- a/src/reducer.rs
+++ b/src/reducer.rs
@@ -24,6 +24,7 @@
 )]
 
 pub mod adapter;
+pub mod collection;
 
 use ratatui::Frame;
 

--- a/src/reducer/collection.rs
+++ b/src/reducer/collection.rs
@@ -41,12 +41,16 @@
 //! A journal entry is drained by the next `reduce` the boundary runs, so a
 //! mutation made *outside* one is still owed its teardown — and will get it
 //! at the first message that reaches the boundary. That is right for a
-//! removal and wrong for construction, where no instance ever ran. Build
-//! initial state with [`Keyed::from_iter`] (or a collected literal) and with
-//! [`Slot::present`] into an empty slot, both of which record nothing;
-//! reserve `insert` over an occupied key, `remove`, `present` over an
-//! occupied slot, and `dismiss` for `reduce`, where the boundary drains what
-//! they record in the same update.
+//! removal and wrong for construction, where no instance ever ran.
+//!
+//! Only the four removal shapes record anything, so only they are affected.
+//! [`Keyed::from_iter`], a collected literal, [`Keyed::insert`] into an
+//! absent key, and [`Slot::present`] into an empty slot record nothing and
+//! are as safe outside a `reduce` as inside one — growing a collection
+//! during `Program::init` is fine. What belongs inside a `reduce` is the
+//! four that do record: `insert` over an occupied key, `present` over an
+//! occupied slot, `remove`, and `dismiss`, whose entries the boundary drains
+//! in the same update.
 
 use std::hash::Hash;
 use std::mem;
@@ -185,9 +189,10 @@ impl<K: ScopeValue, V> FromIterator<(K, V)> for Keyed<K, V> {
     /// existed as an entry in this iterator never ran anything: nothing was
     /// spawned under its key, nothing declared, nothing to tear down. A
     /// teardown emitted for it would name a prefix no run was ever placed
-    /// under. This is why building initial state is a `from_iter` or a
-    /// literal rather than a sequence of `insert` calls — see the type's
-    /// note on mutation outside `reduce`.
+    /// under. That makes this — and a sequence of [`insert`](Keyed::insert)
+    /// calls into absent keys, which record nothing either — the ways to
+    /// build initial state; see the module note on mutating outside a
+    /// `reduce`.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(pairs: I) -> Self {
         let mut collection = Self::new();
         for (key, value) in pairs {

--- a/src/reducer/collection.rs
+++ b/src/reducer/collection.rs
@@ -1,0 +1,459 @@
+//! The collections a combinator boundary composes over, and the removal
+//! journals that make their teardowns complete.
+//!
+//! [`Keyed`] holds one child state per key and [`Slot`] holds at most one.
+//! Both record **removals** rather than exposing their contents for a
+//! diff — that difference is the whole contract here (RFC 0014 INV-RC3).
+//!
+//! # Why a journal and not a diff
+//!
+//! A combinator that compared the collection before and after an update
+//! would see nothing at all in the one case that matters: remove key `k` and
+//! re-insert `k` in the same update, and the before/after states are equal
+//! while the *instance* under `k` is a different one. The old instance's
+//! runs would then never be torn down — RFC 0014 §11's *diff-based removal
+//! detection* adversary, which passes every single-removal test. A journal
+//! records the removal when it happens, so the same-update reinsertion still
+//! yields the old instance's teardown and the new instance's fresh spawns.
+//!
+//! # The four removal shapes
+//!
+//! INV-RC3 quantifies over exactly four, and each records one entry:
+//!
+//! | shape | method |
+//! | --- | --- |
+//! | explicit removal by key | [`Keyed::remove`] |
+//! | explicit dismissal | [`Slot::dismiss`] |
+//! | replacement over an occupied key | [`Keyed::insert`] |
+//! | replacement over an occupied slot | [`Slot::present`] |
+//!
+//! The two replacement shapes are removals because that is what replacement
+//! *means* here: the old instance is torn down and the new one starts fresh
+//! (RFC 0014 §2.5). Insertion into an absent key and presentation into an
+//! empty slot record nothing — there was no instance to remove.
+//!
+//! Draining is the combinator's, not the application's: the two `drain_*`
+//! methods are crate-private, so an application can neither consume a
+//! pending removal before the boundary sees it nor manufacture one.
+
+use std::hash::Hash;
+use std::mem;
+
+/// The values a composition boundary may be segmented by.
+///
+/// This is RFC 0005's segment-value contract restated as a bound, and it
+/// carries no invariant of its own: `Eq + Hash` are what structural segment
+/// identity is defined over, `Send + Sync + 'static` are what erasure into a
+/// [`StructuralKey`](crate::structural_key::StructuralKey) requires, and
+/// `Clone` is what lets one boundary apply its segment to several carriers
+/// and to several updates.
+///
+/// The blanket implementation below is the whole of it: nothing opts in, and
+/// no type that satisfies the bound can be excluded.
+pub trait ScopeValue: PartialEq + Eq + Hash + Clone + Send + Sync + 'static {}
+
+impl<T> ScopeValue for T where T: PartialEq + Eq + Hash + Clone + Send + Sync + 'static {}
+
+/// A keyed collection of child states, with a removal journal.
+///
+/// Iteration is insertion order and lookup is a scan. Which structure this
+/// is stays mechanism; what is not mechanism is that the order is
+/// *deterministic*, because the commands and subscription declarations a
+/// boundary derives from a walk of this collection are observed in it
+/// (RFC 0014 INV-RC14).
+pub struct Keyed<K: ScopeValue, V> {
+    rows: Vec<(K, V)>,
+    /// Keys whose instance was removed since the last drain, in removal
+    /// order. One entry per removal, so a remove-and-reinsert-and-remove
+    /// within one update records two.
+    removals: Vec<K>,
+}
+
+impl<K: ScopeValue, V> Keyed<K, V> {
+    /// An empty collection.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            rows: Vec::new(),
+            removals: Vec::new(),
+        }
+    }
+
+    /// Inserts `value` under `key`, returning the instance it replaced.
+    ///
+    /// Replacing an occupied key **records a removal**: the old instance is
+    /// torn down and the new one starts fresh (RFC 0014 §2.5). The position
+    /// in the iteration order is the old instance's, so a replacement does
+    /// not reorder the collection.
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        if let Some(row) = self.rows.iter_mut().find(|(held, _)| *held == key) {
+            self.removals.push(key);
+            return Some(mem::replace(&mut row.1, value));
+        }
+        self.rows.push((key, value));
+        None
+    }
+
+    /// Removes the instance under `key`, recording the removal.
+    ///
+    /// Removing an absent key records nothing: there is no instance whose
+    /// runs would need tearing down.
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        let position = self.rows.iter().position(|(held, _)| held == key)?;
+        self.removals.push(key.clone());
+        Some(self.rows.remove(position).1)
+    }
+
+    /// The instance under `key`.
+    pub fn get(&self, key: &K) -> Option<&V> {
+        self.rows
+            .iter()
+            .find(|(held, _)| held == key)
+            .map(|(_, value)| value)
+    }
+
+    /// The instance under `key`, mutably.
+    pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.rows
+            .iter_mut()
+            .find(|(held, _)| held == key)
+            .map(|(_, value)| value)
+    }
+
+    /// Whether `key` holds an instance.
+    pub fn contains_key(&self, key: &K) -> bool {
+        self.get(key).is_some()
+    }
+
+    /// How many instances the collection holds.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether the collection is empty.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// The instances, in insertion order.
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&K, &V)> {
+        self.rows.iter().map(|(key, value)| (key, value))
+    }
+
+    /// The keys, in insertion order.
+    pub fn keys(&self) -> impl ExactSizeIterator<Item = &K> {
+        self.rows.iter().map(|(key, _)| key)
+    }
+
+    /// Takes the recorded removals, in removal order.
+    ///
+    /// Crate-private: the boundary drains this once per `reduce` it runs and
+    /// turns each entry into one teardown (RFC 0014 INV-RC3). An application
+    /// draining it would be able to lose a removal the boundary has not seen
+    /// yet, which is the completeness the invariant is about.
+    pub(crate) fn drain_removals(&mut self) -> Vec<K> {
+        mem::take(&mut self.removals)
+    }
+}
+
+impl<K: ScopeValue, V> Default for Keyed<K, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K: ScopeValue, V> FromIterator<(K, V)> for Keyed<K, V> {
+    /// Builds a collection from `(key, value)` pairs, recording a removal for
+    /// each duplicate key the input replaces — the same rule
+    /// [`insert`](Keyed::insert) applies, because it is the same operation.
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(pairs: I) -> Self {
+        let mut collection = Self::new();
+        for (key, value) in pairs {
+            collection.insert(key, value);
+        }
+        collection
+    }
+}
+
+/// At most one child state, with a dismissal journal.
+///
+/// The one-instance counterpart of [`Keyed`]: what a modal, a detail pane,
+/// or any other optionally-present child lives in.
+pub struct Slot<S> {
+    value: Option<S>,
+    /// How many instances have been removed since the last drain. A count
+    /// rather than a list because a dismissed instance has no key — what a
+    /// boundary derives from each entry is one teardown of its own segment.
+    dismissals: usize,
+}
+
+impl<S> Slot<S> {
+    /// An empty slot.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self {
+            value: None,
+            dismissals: 0,
+        }
+    }
+
+    /// Puts `value` in the slot, returning the instance it replaced.
+    ///
+    /// Presenting over an occupied slot **records a removal**, for the reason
+    /// [`Keyed::insert`] does: replacement is a teardown of the old instance
+    /// and a fresh start for the new one.
+    pub const fn present(&mut self, value: S) -> Option<S> {
+        let replaced = self.value.replace(value);
+        if replaced.is_some() {
+            self.dismissals += 1;
+        }
+        replaced
+    }
+
+    /// Empties the slot, recording the removal.
+    ///
+    /// Dismissing an empty slot records nothing.
+    pub const fn dismiss(&mut self) -> Option<S> {
+        let dismissed = self.value.take();
+        if dismissed.is_some() {
+            self.dismissals += 1;
+        }
+        dismissed
+    }
+
+    /// The instance, if the slot holds one.
+    pub const fn get(&self) -> Option<&S> {
+        self.value.as_ref()
+    }
+
+    /// The instance, mutably.
+    pub const fn get_mut(&mut self) -> Option<&mut S> {
+        self.value.as_mut()
+    }
+
+    /// Whether the slot holds an instance.
+    #[must_use]
+    pub const fn is_present(&self) -> bool {
+        self.value.is_some()
+    }
+
+    /// Takes the recorded dismissals.
+    ///
+    /// Crate-private for the reason [`Keyed::drain_removals`] is.
+    pub(crate) const fn drain_dismissals(&mut self) -> usize {
+        mem::replace(&mut self.dismissals, 0)
+    }
+}
+
+impl<S> Default for Slot<S> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The four removal shapes of INV-RC3, one test each.
+
+    #[test]
+    fn removing_a_key_records_the_removal() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.drain_removals();
+
+        assert_eq!(rows.remove(&"a"), Some(1));
+
+        assert_eq!(rows.drain_removals(), vec!["a"]);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn dismissing_an_occupied_slot_records_the_removal() {
+        let mut slot: Slot<u8> = Slot::empty();
+        slot.present(1);
+        slot.drain_dismissals();
+
+        assert_eq!(slot.dismiss(), Some(1));
+
+        assert_eq!(slot.drain_dismissals(), 1);
+        assert!(!slot.is_present());
+    }
+
+    #[test]
+    fn inserting_over_an_occupied_key_records_the_removal() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.drain_removals();
+
+        assert_eq!(rows.insert("a", 2), Some(1));
+
+        assert_eq!(
+            rows.drain_removals(),
+            vec!["a"],
+            "replacement tears the old instance down and starts the new one fresh"
+        );
+        assert_eq!(rows.get(&"a"), Some(&2));
+    }
+
+    #[test]
+    fn presenting_over_an_occupied_slot_records_the_removal() {
+        let mut slot: Slot<u8> = Slot::empty();
+        slot.present(1);
+        slot.drain_dismissals();
+
+        assert_eq!(slot.present(2), Some(1));
+
+        assert_eq!(slot.drain_dismissals(), 1);
+        assert_eq!(slot.get(), Some(&2));
+    }
+
+    // The two shapes that are *not* removals: there was no instance.
+
+    #[test]
+    fn a_first_insertion_and_a_first_presentation_record_nothing() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        let mut slot: Slot<u8> = Slot::empty();
+
+        assert_eq!(rows.insert("a", 1), None);
+        assert_eq!(slot.present(1), None);
+
+        assert!(rows.drain_removals().is_empty());
+        assert_eq!(slot.drain_dismissals(), 0);
+    }
+
+    #[test]
+    fn removing_an_absent_key_and_dismissing_an_empty_slot_record_nothing() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        let mut slot: Slot<u8> = Slot::empty();
+
+        assert_eq!(rows.remove(&"missing"), None);
+        assert_eq!(slot.dismiss(), None);
+
+        assert!(rows.drain_removals().is_empty());
+        assert_eq!(slot.drain_dismissals(), 0);
+    }
+
+    // RFC 0014 §11's *diff-based removal detection* adversary, at the
+    // collection level: the state before and after is identical, and the
+    // journal is what still reports that an instance was removed.
+    #[test]
+    fn a_same_update_remove_and_reinsert_leaves_no_state_difference_but_a_recorded_removal() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.drain_removals();
+        let before: Vec<(&str, u8)> = rows.iter().map(|(key, value)| (*key, *value)).collect();
+
+        rows.remove(&"a");
+        rows.insert("a", 1);
+
+        let after: Vec<(&str, u8)> = rows.iter().map(|(key, value)| (*key, *value)).collect();
+        assert_eq!(before, after, "no diff distinguishes the two instances");
+        assert_eq!(
+            rows.drain_removals(),
+            vec!["a"],
+            "the journal records the removal a diff cannot see"
+        );
+    }
+
+    #[test]
+    fn every_removal_in_one_update_is_recorded_in_order() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.insert("b", 2);
+        rows.drain_removals();
+
+        rows.remove(&"b");
+        rows.insert("a", 9);
+        rows.insert("b", 8);
+
+        assert_eq!(
+            rows.drain_removals(),
+            vec!["b", "a"],
+            "one entry per removal, in removal order"
+        );
+    }
+
+    #[test]
+    fn a_drain_leaves_the_journal_empty() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        let mut slot: Slot<u8> = Slot::empty();
+        rows.insert("a", 1);
+        slot.present(1);
+        rows.remove(&"a");
+        slot.dismiss();
+
+        assert_eq!(rows.drain_removals().len(), 1);
+        assert_eq!(slot.drain_dismissals(), 1);
+        assert!(
+            rows.drain_removals().is_empty(),
+            "a removal is reported to exactly one drain"
+        );
+        assert_eq!(slot.drain_dismissals(), 0);
+    }
+
+    // Iteration order is insertion order, and a replacement keeps the
+    // replaced instance's position — what a boundary's walk of the
+    // collection is observed in (INV-RC14).
+    #[test]
+    fn iteration_is_insertion_order_and_replacement_keeps_its_position() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.insert("b", 2);
+        rows.insert("c", 3);
+        rows.insert("a", 9);
+
+        assert_eq!(
+            rows.keys().copied().collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn removal_closes_the_gap_it_leaves() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+        rows.insert("b", 2);
+        rows.insert("c", 3);
+
+        rows.remove(&"b");
+
+        assert_eq!(rows.keys().copied().collect::<Vec<_>>(), vec!["a", "c"]);
+        assert_eq!(rows.len(), 2);
+        assert!(!rows.contains_key(&"b"));
+    }
+
+    #[test]
+    fn collecting_duplicate_keys_records_each_replacement() {
+        let mut rows: Keyed<&str, u8> = [("a", 1), ("b", 2), ("a", 3)].into_iter().collect();
+
+        assert_eq!(rows.get(&"a"), Some(&3));
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows.drain_removals(), vec!["a"]);
+    }
+
+    #[test]
+    fn a_row_is_reachable_mutably_and_a_missing_one_is_not() {
+        let mut rows: Keyed<&str, u8> = Keyed::new();
+        rows.insert("a", 1);
+
+        *rows.get_mut(&"a").expect("the row is present") = 7;
+
+        assert_eq!(rows.get(&"a"), Some(&7));
+        assert!(rows.get_mut(&"missing").is_none());
+    }
+
+    #[test]
+    fn a_slot_is_reachable_mutably_and_an_empty_one_is_not() {
+        let mut slot: Slot<u8> = Slot::empty();
+
+        assert!(slot.get_mut().is_none());
+        slot.present(1);
+        *slot.get_mut().expect("the slot is occupied") = 7;
+
+        assert_eq!(slot.get(), Some(&7));
+    }
+}

--- a/src/reducer/collection.rs
+++ b/src/reducer/collection.rs
@@ -32,6 +32,17 @@
 //! (RFC 0014 §2.5). Insertion into an absent key and presentation into an
 //! empty slot record nothing — there was no instance to remove.
 //!
+//! **Four shapes is the whole surface, and that is deliberate.** There is no
+//! `retain`, no `clear`, no `drain`, no `IndexMut`, and no `&mut` iterator:
+//! removing several rows is several [`Keyed::remove`] calls, which is the
+//! only thing that keeps INV-RC3's "every removal shape" exhaustive by
+//! construction rather than by review. Any bulk operation added later
+//! **must record one journal entry per instance it removes** — a `retain`
+//! that quietly kept the surviving rows and dropped the rest would leak
+//! every dropped row's runs, which is §11's diff-based adversary arriving
+//! through a convenience method. The same goes for any accessor that hands
+//! out mutable access to the backing sequence.
+//!
 //! Draining is the combinator's, not the application's: the two `drain_*`
 //! methods are crate-private, so an application can neither consume a
 //! pending removal before the boundary sees it nor manufacture one.
@@ -66,9 +77,13 @@ use std::mem;
 ///
 /// The blanket implementation below is the whole of it: nothing opts in, and
 /// no type that satisfies the bound can be excluded.
-pub trait ScopeValue: PartialEq + Eq + Hash + Clone + Send + Sync + 'static {}
+///
+/// RFC 0014 §2.5's block writes `PartialEq + Eq + …`, which `Eq: PartialEq`
+/// makes redundant; the bound is written here without it, and the RFC's
+/// wording is synced when §2.5's surface is made public at the switch.
+pub trait ScopeValue: Eq + Hash + Clone + Send + Sync + 'static {}
 
-impl<T> ScopeValue for T where T: PartialEq + Eq + Hash + Clone + Send + Sync + 'static {}
+impl<T> ScopeValue for T where T: Eq + Hash + Clone + Send + Sync + 'static {}
 
 /// A keyed collection of child states, with a removal journal.
 ///

--- a/src/reducer/collection.rs
+++ b/src/reducer/collection.rs
@@ -35,6 +35,18 @@
 //! Draining is the combinator's, not the application's: the two `drain_*`
 //! methods are crate-private, so an application can neither consume a
 //! pending removal before the boundary sees it nor manufacture one.
+//!
+//! # Mutating outside a `reduce`
+//!
+//! A journal entry is drained by the next `reduce` the boundary runs, so a
+//! mutation made *outside* one is still owed its teardown — and will get it
+//! at the first message that reaches the boundary. That is right for a
+//! removal and wrong for construction, where no instance ever ran. Build
+//! initial state with [`Keyed::from_iter`] (or a collected literal) and with
+//! [`Slot::present`] into an empty slot, both of which record nothing;
+//! reserve `insert` over an occupied key, `remove`, `present` over an
+//! occupied slot, and `dismiss` for `reduce`, where the boundary drains what
+//! they record in the same update.
 
 use std::hash::Hash;
 use std::mem;
@@ -165,13 +177,25 @@ impl<K: ScopeValue, V> Default for Keyed<K, V> {
 }
 
 impl<K: ScopeValue, V> FromIterator<(K, V)> for Keyed<K, V> {
-    /// Builds a collection from `(key, value)` pairs, recording a removal for
-    /// each duplicate key the input replaces — the same rule
-    /// [`insert`](Keyed::insert) applies, because it is the same operation.
+    /// Builds a collection from `(key, value)` pairs, recording **no**
+    /// removal — a duplicate key in the input included.
+    ///
+    /// Construction is not replacement. What the journal records is that an
+    /// *instance* left the collection, and an instance that only ever
+    /// existed as an entry in this iterator never ran anything: nothing was
+    /// spawned under its key, nothing declared, nothing to tear down. A
+    /// teardown emitted for it would name a prefix no run was ever placed
+    /// under. This is why building initial state is a `from_iter` or a
+    /// literal rather than a sequence of `insert` calls — see the type's
+    /// note on mutation outside `reduce`.
     fn from_iter<I: IntoIterator<Item = (K, V)>>(pairs: I) -> Self {
         let mut collection = Self::new();
         for (key, value) in pairs {
-            collection.insert(key, value);
+            if let Some(row) = collection.rows.iter_mut().find(|(held, _)| *held == key) {
+                row.1 = value;
+            } else {
+                collection.rows.push((key, value));
+            }
         }
         collection
     }
@@ -426,13 +450,19 @@ mod tests {
         assert!(!rows.contains_key(&"b"));
     }
 
+    // Construction is not replacement: an instance that only ever existed as
+    // an entry in the input iterator never ran anything, so a teardown for
+    // it would name a prefix no run was placed under.
     #[test]
-    fn collecting_duplicate_keys_records_each_replacement() {
+    fn collecting_duplicate_keys_records_no_removal() {
         let mut rows: Keyed<&str, u8> = [("a", 1), ("b", 2), ("a", 3)].into_iter().collect();
 
         assert_eq!(rows.get(&"a"), Some(&3));
         assert_eq!(rows.len(), 2);
-        assert_eq!(rows.drain_removals(), vec!["a"]);
+        assert!(
+            rows.drain_removals().is_empty(),
+            "nothing had run under the key the later pair replaced"
+        );
     }
 
     #[test]

--- a/src/reducer/combinator.rs
+++ b/src/reducer/combinator.rs
@@ -56,6 +56,20 @@
 //! [`Command::merging_teardowns`]'s aggregation, the lowering to runtime
 //! parts — is transformation and stays free.
 //!
+//! # The mutation run against the merge rows
+//!
+//! "A boundary adds nothing but identity carriers" is a claim about what is
+//! *absent* from the returned command, so the rows that hold it were checked
+//! by mutation rather than by reading. Restoring the fold to a
+//! [`Command::batch`] — the shape this module used before — leaves 53 rows
+//! passing and fails exactly two:
+//! `a_removing_boundary_preserves_the_update_s_redraw_directive` (the
+//! batch's directive fold hands a `without_redraw` update a redraw back) and
+//! `a_removing_boundary_reports_no_discarded_child_key` (the batch warns
+//! about a spawn key the boundary merely passed through). Nothing else
+//! moves, which is the record that those two rows are what stands between
+//! this contract and its regression.
+//!
 //! [`Subscription::scoped`]: crate::subscription::Subscription::scoped
 
 // The projection and mapping parameters are written exactly as RFC 0014

--- a/src/reducer/combinator.rs
+++ b/src/reducer/combinator.rs
@@ -20,6 +20,26 @@
 //!   (INV-RC3). Only [`ForEach`] and [`Presented`] have a journal to drain;
 //!   [`Scoped`] has none, because it composes a single child in place and
 //!   there is no collection at its boundary for an instance to leave.
+//!
+//! # A boundary drains only when its own `reduce` runs
+//!
+//! In a stack, a message an *outer* boundary claims is routed to that
+//! boundary's child, and the boundaries below it — its parent chain — do not
+//! run at all. Their journals are therefore not drained by that message.
+//!
+//! For an entry a boundary recorded **itself**, this is invisible: only a
+//! boundary's parent branch can record (a child is handed a projection and
+//! cannot reach the collection), and that branch is the one that drains, in
+//! the same call. It is observable only for an entry recorded outside a
+//! `reduce`, which the [`collection`](super::collection) module's note tells
+//! an application not to do. Such an entry stays owed until the next message
+//! that reaches its boundary, and is paid in full then — nothing is lost,
+//! but the teardown is deferred.
+//!
+//! `an_outer_claim_leaves_an_inner_boundary_s_pending_removal_undrained` is
+//! the row, and it is the wall a future INV-RC3 extension would meet: making
+//! the timing unconditional means draining every boundary in the stack per
+//! message, which is a different contract from the one §2.5 states.
 //! - **Routes typed messages**: `extract` either claims a message for the
 //!   child or hands it back to the parent, and a message addressed to a key
 //!   or slot with no instance is routed to nothing and discarded.
@@ -82,6 +102,8 @@
     clippy::type_complexity,
     reason = "RFC 0014 §2.5 fixes these signatures verbatim; an alias would hide the contract"
 )]
+
+use std::iter;
 
 use ratatui::Frame;
 
@@ -231,7 +253,7 @@ impl<R: Reducer + Sized> ReducerExt for R {}
 /// by INV-ST5's idempotence, and the alternative — collapsing them — would
 /// make the merge depend on a comparison of prefixes the boundary has no
 /// reason to perform.
-fn merge<Msg, Seg>(command: Command<Msg>, removed: Vec<Seg>) -> Command<Msg>
+fn merge<Msg, Seg>(command: Command<Msg>, removed: impl IntoIterator<Item = Seg>) -> Command<Msg>
 where
     Msg: Send + 'static,
     Seg: ScopeValue,
@@ -323,16 +345,21 @@ where
 
     /// Routes the message to its row, then drains the journal.
     ///
-    /// The drain runs on **both** branches, because either can remove a row:
-    /// the parent's `update` is where an application closes a pane, and a
-    /// row's own update could in principle reach the collection through the
-    /// state it was handed. Draining once per reduce is what makes the
-    /// journal complete rather than dependent on which branch ran.
+    /// **Only the parent branch can record**, and the drain still runs on
+    /// both. A row is handed the projected `&mut C::State` and nothing else,
+    /// so a child cannot reach the collection its state lives in; the
+    /// parent's `update` is the only place a row is removed *during* a
+    /// reduce, and that branch drains what it just recorded. What the drain
+    /// on the child branch is for is an entry recorded **before** this
+    /// reduce — by a mutation outside one, which the module note on
+    /// [`collection`](super::collection) discourages but nothing prevents.
+    /// Such an entry is owed its teardown whichever branch the next message
+    /// takes, and draining once per reduce is what pays it.
     ///
     /// A message addressed to a key the collection does not hold reaches no
     /// reducer and is discarded (RFC 0014 §2.5's routing boundary). The
-    /// journal is still drained: a removal recorded by an earlier operation
-    /// is owed its teardown whatever this message turned out to address.
+    /// journal is drained on that path too, for the same reason —
+    /// `a_pending_removal_survives_a_discarded_message` is its row.
     fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
         let command = match (self.extract)(message) {
             Ok((key, claimed)) => {
@@ -399,10 +426,16 @@ where
     /// a message for an absent key is.
     ///
     /// The drain runs on both branches, as [`ForEach`]'s does and for the
-    /// same reason. What differs is the segment: a dismissed occupant has no
-    /// key of its own, so each recorded dismissal yields a teardown of this
-    /// boundary's own `seg` — which is exactly where the occupant's runs
-    /// were placed.
+    /// same reason: only the parent branch can record — an occupant is
+    /// handed the projected `&mut C::State` and cannot reach the slot it
+    /// sits in — while an entry recorded before this reduce is owed its
+    /// teardown on whichever branch the next message takes.
+    ///
+    /// What differs is the segment: a dismissed occupant has no key of its
+    /// own, so each recorded dismissal yields a teardown of this boundary's
+    /// own `seg` — which is exactly where the occupant's runs were placed.
+    /// The segment is cloned per recorded dismissal and not at all when
+    /// there are none, which is what the lazy repetition below is for.
     fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
         let command = match (self.extract)(message) {
             Ok(claimed) => {
@@ -419,7 +452,10 @@ where
             Err(unclaimed) => self.parent.reduce(state, unclaimed),
         };
         let dismissals = (self.slot_mut)(state).drain_dismissals();
-        merge(command, vec![self.seg.clone(); dismissals])
+        merge(
+            command,
+            iter::repeat_with(|| self.seg.clone()).take(dismissals),
+        )
     }
 
     /// The parent's declarations, then the occupant's if there is one.
@@ -1053,6 +1089,45 @@ mod tests {
         let parts = lowered(&stack, &mut state, Message::Modal(ChildMessage::Carriers));
 
         assert!(parts.spawns.is_empty());
+    }
+
+    // A boundary drains only when its own `reduce` runs, and in a stack an
+    // outer boundary that claims a message routes it to its child — so the
+    // boundaries in its parent chain do not run and do not drain. Here the
+    // outermost boundary is the `presented` slot and the `for_each` sits
+    // below it: a `Modal(..)` message is claimed by the slot and never
+    // reaches the collection's boundary.
+    //
+    // Only an entry recorded *outside* a `reduce` can be observed this way,
+    // because an entry a boundary recorded itself was recorded on its parent
+    // branch, which is the branch that drains. Nothing is lost — the next
+    // message that reaches the boundary pays it in full — and that deferral
+    // is the wall a future INV-RC3 extension would meet.
+    #[test]
+    fn an_outer_claim_leaves_an_inner_boundary_s_pending_removal_undrained() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.modal.present(ChildState::new(true));
+        state.rows.insert("row-a", ChildState::new(true));
+        // The mutation the collection module tells an application not to
+        // make outside a `reduce`, which is the only way to have an entry
+        // pending when a reduce begins.
+        state.rows.remove(&"row-a");
+
+        let claimed_by_the_slot = lowered(&stack, &mut state, Message::Modal(ChildMessage::Quiet));
+
+        assert!(
+            claimed_by_the_slot.teardowns.is_empty(),
+            "the collection's boundary did not run, so it drained nothing"
+        );
+
+        let reaching_the_collection = lowered(&stack, &mut state, Message::Idle);
+
+        assert_eq!(
+            reaching_the_collection.teardowns,
+            vec![path(&["row-a"])],
+            "and the first message that reaches it pays the entry in full"
+        );
     }
 
     // A removal recorded before a message addressed to a *different*,

--- a/src/reducer/combinator.rs
+++ b/src/reducer/combinator.rs
@@ -17,10 +17,19 @@
 //!   `.scoped(...)` and can neither omit nor double-apply one (INV-RC2).
 //! - **Drains its removal journal** after the reduce it ran, merging one
 //!   [`Command::teardown`] per recorded removal into the returned command
-//!   (INV-RC3).
+//!   (INV-RC3). Only [`ForEach`] and [`Presented`] have a journal to drain;
+//!   [`Scoped`] has none, because it composes a single child in place and
+//!   there is no collection at its boundary for an instance to leave.
 //! - **Routes typed messages**: `extract` either claims a message for the
 //!   child or hands it back to the parent, and a message addressed to a key
 //!   or slot with no instance is routed to nothing and discarded.
+//!
+//! A boundary adds **identity carriers and nothing else**. It does not
+//! touch the returned command's runtime directives — a `without_redraw`
+//! update stays a `without_redraw` update through a boundary that removed a
+//! row — and it adds no effect, no cancel id, and no registration of its
+//! own. [`merge`] is where that is enforced, and its doc says why the fold
+//! is not a [`Command::batch`].
 //!
 //! # Read/write projection pairs
 //!
@@ -38,13 +47,14 @@
 //! # One teardown surface (RFC 0013 R8)
 //!
 //! Every teardown this module produces is a call to the public
-//! [`Command::teardown`] constructor, in exactly one place —
-//! [`teardowns_for`], which the three journal drains share. There is no
-//! internal twin that builds a teardown entry from a raw prefix, and no
-//! other route below the public surface originates one. What the boundaries
-//! do to an *already-originated* teardown — `scoped`'s prefix
-//! qualification, `batch`'s aggregation, the lowering to runtime parts — is
-//! transformation and stays free.
+//! [`Command::teardown`] constructor, in exactly one place — [`merge`],
+//! which the **two** journal drains share ([`ForEach`] and [`Presented`];
+//! [`Scoped`] has no journal). There is no internal twin that builds a
+//! teardown entry from a raw prefix, and no other route below the public
+//! surface originates one. What the boundaries do to an
+//! *already-originated* teardown — `scoped`'s prefix qualification,
+//! [`Command::merging_teardowns`]'s aggregation, the lowering to runtime
+//! parts — is transformation and stays free.
 //!
 //! [`Subscription::scoped`]: crate::subscription::Subscription::scoped
 
@@ -58,8 +68,6 @@
     clippy::type_complexity,
     reason = "RFC 0014 §2.5 fixes these signatures verbatim; an alias would hide the contract"
 )]
-
-use std::iter;
 
 use ratatui::Frame;
 
@@ -176,14 +184,32 @@ pub trait ReducerExt: Reducer + Sized {
 
 impl<R: Reducer + Sized> ReducerExt for R {}
 
-/// One teardown per recorded removal, as the merge a journal drain returns.
+/// Merges one teardown per recorded removal into the command a boundary's
+/// reduce produced.
 ///
 /// **The one origination site in this module** (RFC 0013 R8): every teardown
 /// a combinator produces is built here, by a call to the public
 /// [`Command::teardown`] constructor, from a segment value the application
 /// itself supplied as a key or as the boundary's `seg`. No raw prefix path
 /// is constructed anywhere in this module, and no other function here builds
-/// a teardown.
+/// a teardown. What happens to an originated teardown afterwards —
+/// [`Command::merging_teardowns`] folding its entry onto the returned
+/// command — is aggregation, which §7.2's review leaves free.
+///
+/// **The fold is not a [`Command::batch`]**, and that is a contract point
+/// rather than a shortcut. A boundary adds identity carriers to what its
+/// child or its parent returned and nothing else (RFC 0014 §2.5); batching
+/// would add two things more. It folds the redraw directive across
+/// children, so an update that returned [`Command::without_redraw`] would
+/// silently regain its redraw the moment a row was removed in it. And it
+/// warns about a child spawn key — a diagnostic addressed to an application
+/// that keyed a batch, fired here for a command the boundary is only
+/// passing through. Both are observable differences a boundary is not
+/// entitled to make.
+///
+/// The phase order does not depend on the fold: the lowering applies every
+/// cancel-phase entry of a command before every spawn of it, however the
+/// entries got onto it (RFC 0014 §3.4).
 ///
 /// One entry, one teardown — so a remove-and-reinsert-and-remove within a
 /// single update yields two, which is what "one teardown for the removed
@@ -191,33 +217,15 @@ impl<R: Reducer + Sized> ReducerExt for R {}
 /// by INV-ST5's idempotence, and the alternative — collapsing them — would
 /// make the merge depend on a comparison of prefixes the boundary has no
 /// reason to perform.
-fn teardowns_for<Msg, Seg>(removed: Vec<Seg>) -> impl Iterator<Item = Command<Msg>>
-where
-    Msg: Send + 'static,
-    Seg: ScopeValue,
-{
-    removed.into_iter().map(Command::teardown)
-}
-
-/// Merges a boundary's teardowns into the command its reduce produced.
-///
-/// The teardowns come first, which reads as "the removals apply, then this
-/// update's own work" — though the phase order does not depend on it: the
-/// lowering applies every cancel-phase entry of a command before every spawn
-/// of it, whatever order the batch put them in (RFC 0014 §3.4).
-///
-/// With nothing removed the command is returned untouched rather than
-/// wrapped in a one-child batch, so a boundary that removed nothing is not
-/// observable in the command it returns.
 fn merge<Msg, Seg>(command: Command<Msg>, removed: Vec<Seg>) -> Command<Msg>
 where
     Msg: Send + 'static,
     Seg: ScopeValue,
 {
-    if removed.is_empty() {
-        return command;
-    }
-    Command::batch(teardowns_for(removed).chain(iter::once(command)))
+    removed
+        .into_iter()
+        .map(Command::teardown)
+        .fold(command, Command::merging_teardowns)
 }
 
 /// One child under a fixed segment ([`ReducerExt::scope`]).
@@ -245,6 +253,14 @@ where
     /// A message the child does not claim goes to the parent, whose command
     /// is *not* qualified: it is the parent's own command at the parent's
     /// own level, and this boundary is not one it crossed.
+    ///
+    /// **No journal drain here, and none is missing.** A journal records
+    /// that an *instance* left a collection, and this boundary has no
+    /// collection: it composes one child in place, whose state is a
+    /// projection of the parent's that is always there. There is no removal
+    /// for it to observe and therefore no teardown for it to originate — the
+    /// two boundaries that do hold collections ([`ForEach`], [`Presented`])
+    /// are where INV-RC3 lives.
     fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
         match (self.extract)(message) {
             Ok(claimed) => {
@@ -367,6 +383,12 @@ where
     ///
     /// A claimed message reaching an empty slot is discarded, for the reason
     /// a message for an absent key is.
+    ///
+    /// The drain runs on both branches, as [`ForEach`]'s does and for the
+    /// same reason. What differs is the segment: a dismissed occupant has no
+    /// key of its own, so each recorded dismissal yields a teardown of this
+    /// boundary's own `seg` — which is exactly where the occupant's runs
+    /// were placed.
     fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
         let command = match (self.extract)(message) {
             Ok(claimed) => {
@@ -450,6 +472,7 @@ mod tests {
     use crate::command::{CommandId, KernelParts};
     use crate::structural_key::ScopePath;
     use crate::subscription::mock::MockSource;
+    use crate::test_support::TraceRecorder;
 
     // A child that answers each of its messages with a command carrying one
     // of every identity-bearing carrier, so a boundary's qualification can
@@ -531,6 +554,9 @@ mod tests {
         Present,
         /// Handled by the root, returning its own keyed command.
         RootWork,
+        /// Handled by the root, returning a command that opts out of the
+        /// redraw.
+        Silent,
         /// Handled by the root, returning nothing.
         Idle,
     }
@@ -585,6 +611,7 @@ mod tests {
                 Message::RootWork => {
                     Command::stream(stream::pending()).cancellable(CommandId::new("root"))
                 }
+                Message::Silent => Command::none().without_redraw(),
                 _ => Command::none(),
             }
         }
@@ -655,6 +682,65 @@ mod tests {
             |state: &mut RootState| &mut state.modal,
             modal_extract,
             Message::Modal,
+        )
+    }
+
+    /// A reducer one level above [`stack`]: its state holds the whole inner
+    /// state and its message wraps the inner message, so `scope` can compose
+    /// the entire combinator stack as one child.
+    struct Outer;
+
+    struct OuterState {
+        inner: RootState,
+    }
+
+    impl OuterState {
+        fn new() -> Self {
+            Self {
+                inner: RootState::new(),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum OuterMessage {
+        /// Claimed by the outer boundary and handed to the inner stack.
+        Inner(Message),
+        /// Handled by `Outer` itself, so the outer `extract` has both
+        /// answers to give.
+        Own,
+    }
+
+    impl Reducer for Outer {
+        type State = OuterState;
+        type Message = OuterMessage;
+
+        fn reduce(&self, _state: &mut OuterState, message: OuterMessage) -> Command<OuterMessage> {
+            assert_eq!(
+                message,
+                OuterMessage::Own,
+                "the outer boundary claims everything else before it gets here"
+            );
+            Command::none()
+        }
+    }
+
+    fn outer_extract(message: OuterMessage) -> Result<Message, OuterMessage> {
+        match message {
+            OuterMessage::Inner(inner) => Ok(inner),
+            other @ OuterMessage::Own => Err(other),
+        }
+    }
+
+    /// The whole of [`stack`] composed as the child of one more boundary.
+    fn nested() -> impl Reducer<State = OuterState, Message = OuterMessage> {
+        Outer.scope(
+            stack(),
+            "outer",
+            |state: &OuterState| &state.inner,
+            |state: &mut OuterState| &mut state.inner,
+            outer_extract,
+            OuterMessage::Inner,
         )
     }
 
@@ -774,10 +860,11 @@ mod tests {
         assert_eq!(spawn_scopes(&right), vec![path(&["right"]); 2]);
     }
 
-    // INV-RC2 through a *nested* stack: a `for_each` row's child is reached
+    // INV-RC2 at a collection boundary: a `for_each` row's child is reached
     // under the row key, and a teardown the child itself returned is
-    // qualified by that key too — so the qualification composes rather than
-    // stopping at the outermost boundary.
+    // qualified by that key too — so a carrier the child had already
+    // scoped is re-anchored rather than left alone. (Two boundaries stacked
+    // over one another are the separate row below.)
     #[test]
     fn a_row_s_child_is_qualified_by_its_key() {
         let stack = stack();
@@ -1039,6 +1126,132 @@ mod tests {
         state.left.subscribed = false;
 
         assert_eq!(stack.subscriptions(&state).len(), 2);
+    }
+
+    // A boundary adds identity carriers and **nothing else**. Two rows, one
+    // per thing merging through `Command::batch` used to add.
+
+    // The child-key diagnostic is the application's, addressed to code that
+    // keyed a batch. A boundary merging a removal into a keyed command is
+    // not that code, and must not make it look like it is. The second half
+    // is the control: the same recorder still sees an application's own
+    // keyed batch child, so the zero above is this path's silence rather
+    // than a silenced diagnostic.
+    #[test]
+    fn a_removing_boundary_reports_no_discarded_child_key() {
+        let recorder = TraceRecorder::new().with_target("tears::command");
+        let _guard = recorder.set_default();
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        state.rows.remove(&"row-a");
+
+        let before = recorder.event_count();
+        let parts = lowered(&stack, &mut state, Message::RootWork);
+        let after_boundary = recorder.event_count();
+        drop(Command::batch([
+            Command::message(Message::Idle).cancellable(CommandId::new("child"))
+        ]));
+
+        assert_eq!(
+            parts.teardowns,
+            vec![path(&["row-a"])],
+            "the removal was merged into the update's own keyed command"
+        );
+        assert_eq!(
+            after_boundary - before,
+            0,
+            "and merging it warned about nothing"
+        );
+        assert_eq!(
+            recorder.event_count() - after_boundary,
+            1,
+            "while an application's own keyed batch child still reports"
+        );
+    }
+
+    // The redraw directive is the update's own (RFC 0002's separation). A
+    // boundary that merged through `batch` would fold it against a
+    // teardown's default and hand a `without_redraw` update a redraw it
+    // declined.
+    #[test]
+    fn a_removing_boundary_preserves_the_update_s_redraw_directive() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        state.rows.remove(&"row-a");
+
+        let parts = lowered(&stack, &mut state, Message::Silent);
+
+        assert_eq!(parts.teardowns, vec![path(&["row-a"])]);
+        assert!(
+            !parts.redraw,
+            "the update opted out, and removing a row is not a boundary's licence to opt back in"
+        );
+    }
+
+    #[test]
+    fn a_removing_boundary_leaves_an_ordinary_update_redrawing() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Close("row-a"));
+
+        assert_eq!(parts.teardowns, vec![path(&["row-a"])]);
+        assert!(parts.redraw, "the update's own default is untouched too");
+    }
+
+    // Two boundaries stacked over one another: the outer `scope` composes a
+    // whole `for_each` stack as its child. Every carrier the inner boundary
+    // qualified with a row key is re-anchored under the outer segment, so a
+    // run lands at `["outer", "row-b"]` and the inner stack's own journal
+    // teardown at `["outer", "row-a"]` — the qualification composes down the
+    // stack rather than stopping at the boundary that applied it.
+    #[test]
+    fn two_stacked_boundaries_compose_their_segments() {
+        let nested = nested();
+        let mut state = OuterState::new();
+        state.inner.rows.insert("row-a", ChildState::new(true));
+        state.inner.rows.insert("row-b", ChildState::new(true));
+
+        let parts = nested
+            .reduce(
+                &mut state,
+                OuterMessage::Inner(Message::Row("row-b", ChildMessage::Carriers)),
+            )
+            .into_runtime_parts()
+            .into_kernel_parts();
+
+        assert_eq!(
+            parts
+                .spawns
+                .iter()
+                .map(|spawn| spawn.scope.clone())
+                .collect::<Vec<_>>(),
+            vec![path(&["outer", "row-b"]); 2],
+            "the inner boundary placed the runs under the row key, the outer under its segment"
+        );
+        assert_eq!(parts.teardowns, vec![path(&["outer", "row-b", "inner"])]);
+        assert_eq!(
+            parts
+                .cleanups
+                .iter()
+                .map(|registration| registration.scope.clone())
+                .collect::<Vec<_>>(),
+            vec![path(&["outer", "row-b"])]
+        );
+
+        let parts = nested
+            .reduce(&mut state, OuterMessage::Inner(Message::Close("row-a")))
+            .into_runtime_parts()
+            .into_kernel_parts();
+
+        assert_eq!(
+            parts.teardowns,
+            vec![path(&["outer", "row-a"])],
+            "the inner stack's journal teardown is re-anchored by the outer boundary too"
+        );
     }
 
     // `into_program` closes the stack, and the closed value's reducer half

--- a/src/reducer/combinator.rs
+++ b/src/reducer/combinator.rs
@@ -1,0 +1,1060 @@
+//! The composition combinators: [`ReducerExt`] and the four types it builds.
+//!
+//! A combinator is a [`Reducer`] wrapping a parent reducer and one child
+//! reducer, together with the projections and message mappings that connect
+//! them. Because every combinator implements
+//! `Reducer<State = Self::State, Message = Self::Message>` for its
+//! *parent's* associated types, stacks nest: each call adds one boundary and
+//! the result is still a reducer over the root's state and message.
+//!
+//! # What a boundary does (RFC 0014 §2.5)
+//!
+//! - **Qualifies every identity-bearing carrier** of the child's returned
+//!   command — spawn keys, explicit cancel ids, teardown prefixes, cleanup
+//!   registrations — and the child's subscription declarations, with the
+//!   boundary's segment. That is one [`Command::scoped`] call and one
+//!   [`Subscription::scoped`] call per boundary; user code writes no
+//!   `.scoped(...)` and can neither omit nor double-apply one (INV-RC2).
+//! - **Drains its removal journal** after the reduce it ran, merging one
+//!   [`Command::teardown`] per recorded removal into the returned command
+//!   (INV-RC3).
+//! - **Routes typed messages**: `extract` either claims a message for the
+//!   child or hands it back to the parent, and a message addressed to a key
+//!   or slot with no instance is routed to nothing and discarded.
+//!
+//! # Read/write projection pairs
+//!
+//! Each boundary takes its projection as a pair, because the two `Reducer`
+//! methods borrow the parent differently: `reduce` needs the mutable
+//! projection and `subscriptions` the shared one. A combinator holding only
+//! the mutable accessor could not aggregate its child's declarations from
+//! the `&Self::State` `subscriptions` gives it — it would have to fabricate
+//! an aliasing mutable borrow or drop the child's subscriptions, and
+//! INV-RC2's aggregation would be unimplementable. Both are projections of
+//! state the caller already holds, so RFC 0012 INV-SE6's purity is
+//! untouched. Two `fn` items per boundary is the whole cost; no lens trait
+//! is introduced and none is needed.
+//!
+//! # One teardown surface (RFC 0013 R8)
+//!
+//! Every teardown this module produces is a call to the public
+//! [`Command::teardown`] constructor, in exactly one place —
+//! [`teardowns_for`], which the three journal drains share. There is no
+//! internal twin that builds a teardown entry from a raw prefix, and no
+//! other route below the public surface originates one. What the boundaries
+//! do to an *already-originated* teardown — `scoped`'s prefix
+//! qualification, `batch`'s aggregation, the lowering to runtime parts — is
+//! transformation and stays free.
+//!
+//! [`Subscription::scoped`]: crate::subscription::Subscription::scoped
+
+// The projection and mapping parameters are written exactly as RFC 0014
+// §2.5 states them. Factoring `fn(Self::Message) -> Result<C::Message,
+// Self::Message>` behind an alias would hide the two things the contract is
+// about — that a boundary takes a read/write projection *pair*, and that
+// `extract` either claims a message or hands it back — behind a name, and
+// the signatures are the surface the invariant quantifies over.
+#![expect(
+    clippy::type_complexity,
+    reason = "RFC 0014 §2.5 fixes these signatures verbatim; an alias would hide the contract"
+)]
+
+use std::iter;
+
+use ratatui::Frame;
+
+use crate::command::Command;
+use crate::subscription::Subscription;
+
+use super::collection::{Keyed, ScopeValue, Slot};
+use super::{Program, Reducer};
+
+/// The composition combinators, on every [`Reducer`].
+pub trait ReducerExt: Reducer + Sized {
+    /// Composes one child under a fixed segment.
+    ///
+    /// `state`/`state_mut` project the child's state out of the parent's,
+    /// `extract` claims the messages that belong to the child, and `embed`
+    /// lifts the child's messages back into the parent's.
+    fn scope<Seg, C>(
+        self,
+        child: C,
+        seg: Seg,
+        state: fn(&Self::State) -> &C::State,
+        state_mut: fn(&mut Self::State) -> &mut C::State,
+        extract: fn(Self::Message) -> Result<C::Message, Self::Message>,
+        embed: fn(C::Message) -> Self::Message,
+    ) -> Scoped<Self, C, Seg>
+    where
+        C: Reducer,
+        Seg: ScopeValue,
+    {
+        Scoped {
+            parent: self,
+            child,
+            seg,
+            state,
+            state_mut,
+            extract,
+            embed,
+        }
+    }
+
+    /// Composes one child per row of a [`Keyed`] collection, each under its
+    /// own key as segment.
+    ///
+    /// `extract` names the row a message is addressed to; a message for a
+    /// key the collection does not hold is discarded.
+    fn for_each<C, K>(
+        self,
+        child: C,
+        rows: fn(&Self::State) -> &Keyed<K, C::State>,
+        rows_mut: fn(&mut Self::State) -> &mut Keyed<K, C::State>,
+        extract: fn(Self::Message) -> Result<(K, C::Message), Self::Message>,
+        embed: fn(K, C::Message) -> Self::Message,
+    ) -> ForEach<Self, C, K>
+    where
+        C: Reducer,
+        K: ScopeValue,
+    {
+        ForEach {
+            parent: self,
+            child,
+            rows,
+            rows_mut,
+            extract,
+            embed,
+        }
+    }
+
+    /// Composes one optionally-present child held in a [`Slot`], under a
+    /// fixed segment.
+    ///
+    /// A message the slot's occupant would have claimed is discarded while
+    /// the slot is empty.
+    fn presented<C, Seg>(
+        self,
+        child: C,
+        seg: Seg,
+        slot: fn(&Self::State) -> &Slot<C::State>,
+        slot_mut: fn(&mut Self::State) -> &mut Slot<C::State>,
+        extract: fn(Self::Message) -> Result<C::Message, Self::Message>,
+        embed: fn(C::Message) -> Self::Message,
+    ) -> Presented<Self, C, Seg>
+    where
+        C: Reducer,
+        Seg: ScopeValue,
+    {
+        Presented {
+            parent: self,
+            child,
+            seg,
+            slot,
+            slot_mut,
+            extract,
+            embed,
+        }
+    }
+
+    /// Closes a combinator stack into a runnable [`Program`].
+    ///
+    /// The root `init` and the root `view` are the two things a stack has no
+    /// place for: composition is over state transitions and declarations,
+    /// and rendering is root-level by design (RFC 0014 §2.1).
+    fn into_program<Flags>(
+        self,
+        init: fn(Flags) -> (Self::State, Command<Self::Message>),
+        view: fn(&Self::State, &mut Frame<'_>),
+    ) -> IntoProgram<Self, Flags> {
+        IntoProgram {
+            reducer: self,
+            init,
+            view,
+        }
+    }
+}
+
+impl<R: Reducer + Sized> ReducerExt for R {}
+
+/// One teardown per recorded removal, as the merge a journal drain returns.
+///
+/// **The one origination site in this module** (RFC 0013 R8): every teardown
+/// a combinator produces is built here, by a call to the public
+/// [`Command::teardown`] constructor, from a segment value the application
+/// itself supplied as a key or as the boundary's `seg`. No raw prefix path
+/// is constructed anywhere in this module, and no other function here builds
+/// a teardown.
+///
+/// One entry, one teardown — so a remove-and-reinsert-and-remove within a
+/// single update yields two, which is what "one teardown for the removed
+/// instance" means when two instances were removed. Repetition is harmless
+/// by INV-ST5's idempotence, and the alternative — collapsing them — would
+/// make the merge depend on a comparison of prefixes the boundary has no
+/// reason to perform.
+fn teardowns_for<Msg, Seg>(removed: Vec<Seg>) -> impl Iterator<Item = Command<Msg>>
+where
+    Msg: Send + 'static,
+    Seg: ScopeValue,
+{
+    removed.into_iter().map(Command::teardown)
+}
+
+/// Merges a boundary's teardowns into the command its reduce produced.
+///
+/// The teardowns come first, which reads as "the removals apply, then this
+/// update's own work" — though the phase order does not depend on it: the
+/// lowering applies every cancel-phase entry of a command before every spawn
+/// of it, whatever order the batch put them in (RFC 0014 §3.4).
+///
+/// With nothing removed the command is returned untouched rather than
+/// wrapped in a one-child batch, so a boundary that removed nothing is not
+/// observable in the command it returns.
+fn merge<Msg, Seg>(command: Command<Msg>, removed: Vec<Seg>) -> Command<Msg>
+where
+    Msg: Send + 'static,
+    Seg: ScopeValue,
+{
+    if removed.is_empty() {
+        return command;
+    }
+    Command::batch(teardowns_for(removed).chain(iter::once(command)))
+}
+
+/// One child under a fixed segment ([`ReducerExt::scope`]).
+pub struct Scoped<P: Reducer, C: Reducer, Seg> {
+    parent: P,
+    child: C,
+    seg: Seg,
+    state: fn(&P::State) -> &C::State,
+    state_mut: fn(&mut P::State) -> &mut C::State,
+    extract: fn(P::Message) -> Result<C::Message, P::Message>,
+    embed: fn(C::Message) -> P::Message,
+}
+
+impl<P, C, Seg> Reducer for Scoped<P, C, Seg>
+where
+    P: Reducer,
+    C: Reducer,
+    Seg: ScopeValue,
+{
+    type State = P::State;
+    type Message = P::Message;
+
+    /// Routes the message, and qualifies whatever the child returned.
+    ///
+    /// A message the child does not claim goes to the parent, whose command
+    /// is *not* qualified: it is the parent's own command at the parent's
+    /// own level, and this boundary is not one it crossed.
+    fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
+        match (self.extract)(message) {
+            Ok(claimed) => {
+                let embed = self.embed;
+                self.child
+                    .reduce((self.state_mut)(state), claimed)
+                    .map(embed)
+                    .scoped(self.seg.clone())
+            }
+            Err(unclaimed) => self.parent.reduce(state, unclaimed),
+        }
+    }
+
+    /// The parent's declarations, then the child's under this boundary.
+    fn subscriptions(&self, state: &P::State) -> Vec<Subscription<P::Message>> {
+        let mut declared = self.parent.subscriptions(state);
+        let embed = self.embed;
+        declared.extend(
+            self.child
+                .subscriptions((self.state)(state))
+                .into_iter()
+                .map(|declaration| declaration.map(embed).scoped(self.seg.clone())),
+        );
+        declared
+    }
+}
+
+/// One child per row of a [`Keyed`] collection ([`ReducerExt::for_each`]).
+pub struct ForEach<P: Reducer, C: Reducer, K: ScopeValue> {
+    parent: P,
+    child: C,
+    rows: fn(&P::State) -> &Keyed<K, C::State>,
+    rows_mut: fn(&mut P::State) -> &mut Keyed<K, C::State>,
+    extract: fn(P::Message) -> Result<(K, C::Message), P::Message>,
+    embed: fn(K, C::Message) -> P::Message,
+}
+
+impl<P, C, K> Reducer for ForEach<P, C, K>
+where
+    P: Reducer,
+    C: Reducer,
+    K: ScopeValue,
+{
+    type State = P::State;
+    type Message = P::Message;
+
+    /// Routes the message to its row, then drains the journal.
+    ///
+    /// The drain runs on **both** branches, because either can remove a row:
+    /// the parent's `update` is where an application closes a pane, and a
+    /// row's own update could in principle reach the collection through the
+    /// state it was handed. Draining once per reduce is what makes the
+    /// journal complete rather than dependent on which branch ran.
+    ///
+    /// A message addressed to a key the collection does not hold reaches no
+    /// reducer and is discarded (RFC 0014 §2.5's routing boundary). The
+    /// journal is still drained: a removal recorded by an earlier operation
+    /// is owed its teardown whatever this message turned out to address.
+    fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
+        let command = match (self.extract)(message) {
+            Ok((key, claimed)) => {
+                let embed = self.embed;
+                let addressed = key.clone();
+                (self.rows_mut)(state)
+                    .get_mut(&key)
+                    .map_or_else(Command::none, |row| {
+                        self.child
+                            .reduce(row, claimed)
+                            .map(move |message| embed(addressed.clone(), message))
+                            .scoped(key)
+                    })
+            }
+            Err(unclaimed) => self.parent.reduce(state, unclaimed),
+        };
+        merge(command, (self.rows_mut)(state).drain_removals())
+    }
+
+    /// The parent's declarations, then each row's under its own key.
+    fn subscriptions(&self, state: &P::State) -> Vec<Subscription<P::Message>> {
+        let mut declared = self.parent.subscriptions(state);
+        let embed = self.embed;
+        for (key, row) in (self.rows)(state).iter() {
+            declared.extend(
+                self.child
+                    .subscriptions(row)
+                    .into_iter()
+                    .map(|declaration| {
+                        let addressed = key.clone();
+                        declaration
+                            .map(move |message| embed(addressed.clone(), message))
+                            .scoped(key.clone())
+                    }),
+            );
+        }
+        declared
+    }
+}
+
+/// One optionally-present child ([`ReducerExt::presented`]).
+pub struct Presented<P: Reducer, C: Reducer, Seg> {
+    parent: P,
+    child: C,
+    seg: Seg,
+    slot: fn(&P::State) -> &Slot<C::State>,
+    slot_mut: fn(&mut P::State) -> &mut Slot<C::State>,
+    extract: fn(P::Message) -> Result<C::Message, P::Message>,
+    embed: fn(C::Message) -> P::Message,
+}
+
+impl<P, C, Seg> Reducer for Presented<P, C, Seg>
+where
+    P: Reducer,
+    C: Reducer,
+    Seg: ScopeValue,
+{
+    type State = P::State;
+    type Message = P::Message;
+
+    /// Routes the message to the occupant, then drains the journal.
+    ///
+    /// A claimed message reaching an empty slot is discarded, for the reason
+    /// a message for an absent key is.
+    fn reduce(&self, state: &mut P::State, message: P::Message) -> Command<P::Message> {
+        let command = match (self.extract)(message) {
+            Ok(claimed) => {
+                let embed = self.embed;
+                (self.slot_mut)(state)
+                    .get_mut()
+                    .map_or_else(Command::none, |occupant| {
+                        self.child
+                            .reduce(occupant, claimed)
+                            .map(embed)
+                            .scoped(self.seg.clone())
+                    })
+            }
+            Err(unclaimed) => self.parent.reduce(state, unclaimed),
+        };
+        let dismissals = (self.slot_mut)(state).drain_dismissals();
+        merge(command, vec![self.seg.clone(); dismissals])
+    }
+
+    /// The parent's declarations, then the occupant's if there is one.
+    fn subscriptions(&self, state: &P::State) -> Vec<Subscription<P::Message>> {
+        let mut declared = self.parent.subscriptions(state);
+        let embed = self.embed;
+        if let Some(occupant) = (self.slot)(state).get() {
+            declared.extend(
+                self.child
+                    .subscriptions(occupant)
+                    .into_iter()
+                    .map(|declaration| declaration.map(embed).scoped(self.seg.clone())),
+            );
+        }
+        declared
+    }
+}
+
+/// A closed combinator stack ([`ReducerExt::into_program`]).
+///
+/// Its `Reducer` half is the stack's, delegated verbatim: the same `reduce`
+/// and the same `subscriptions` a composed stack has when it is not closed,
+/// so closing a stack adds no execution path of its own. What it adds is the
+/// two root-level functions a [`Program`] needs.
+pub struct IntoProgram<R: Reducer, Flags> {
+    reducer: R,
+    init: fn(Flags) -> (R::State, Command<R::Message>),
+    view: fn(&R::State, &mut Frame<'_>),
+}
+
+impl<R: Reducer, Flags> Reducer for IntoProgram<R, Flags> {
+    type State = R::State;
+    type Message = R::Message;
+
+    fn reduce(&self, state: &mut R::State, message: R::Message) -> Command<R::Message> {
+        self.reducer.reduce(state, message)
+    }
+
+    fn subscriptions(&self, state: &R::State) -> Vec<Subscription<R::Message>> {
+        self.reducer.subscriptions(state)
+    }
+}
+
+impl<R: Reducer, Flags> Program for IntoProgram<R, Flags> {
+    type Flags = Flags;
+
+    fn init(&self, flags: Flags) -> (R::State, Command<R::Message>) {
+        (self.init)(flags)
+    }
+
+    fn view(&self, state: &R::State, frame: &mut Frame<'_>) {
+        (self.view)(state, frame);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::collections::HashSet;
+
+    use futures::stream;
+
+    use crate::command::{CommandId, KernelParts};
+    use crate::structural_key::ScopePath;
+    use crate::subscription::mock::MockSource;
+
+    // A child that answers each of its messages with a command carrying one
+    // of every identity-bearing carrier, so a boundary's qualification can
+    // be read off all four at once.
+    #[derive(Clone, Copy)]
+    struct Child;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum ChildMessage {
+        /// Return a keyed effect, an explicit cancel, a teardown, and a
+        /// registration, all under the child's own local ids.
+        Carriers,
+        /// Return nothing.
+        Quiet,
+    }
+
+    struct ChildState {
+        /// Whether this child declares its source.
+        subscribed: bool,
+        /// What the child recorded being asked to do.
+        seen: Vec<ChildMessage>,
+    }
+
+    impl ChildState {
+        const fn new(subscribed: bool) -> Self {
+            Self {
+                subscribed,
+                seen: Vec::new(),
+            }
+        }
+    }
+
+    impl Reducer for Child {
+        type State = ChildState;
+        type Message = ChildMessage;
+
+        fn reduce(&self, state: &mut ChildState, message: ChildMessage) -> Command<ChildMessage> {
+            state.seen.push(message.clone());
+            match message {
+                ChildMessage::Quiet => Command::none(),
+                ChildMessage::Carriers => Command::batch([
+                    Command::stream(stream::pending()).cancellable(CommandId::new("work")),
+                    Command::stream(stream::pending()),
+                    Command::cancel(CommandId::new("other")),
+                    Command::teardown("inner"),
+                    Command::on_teardown(async {}),
+                ]),
+            }
+        }
+
+        fn subscriptions(&self, state: &ChildState) -> Vec<Subscription<ChildMessage>> {
+            if state.subscribed {
+                vec![Subscription::new(MockSource::<ChildMessage>::new())]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    enum Message {
+        /// Addressed to the `scope` boundary's child.
+        Left(ChildMessage),
+        /// Addressed to the second `scope` boundary's child.
+        Right(ChildMessage),
+        /// Addressed to one row of the collection.
+        Row(&'static str, ChildMessage),
+        /// Addressed to the slot's occupant.
+        Modal(ChildMessage),
+        /// Handled by the root: removes one row.
+        Close(&'static str),
+        /// Handled by the root: replaces one row's instance.
+        Replace(&'static str),
+        /// Handled by the root: removes and re-inserts one row.
+        Recreate(&'static str),
+        /// Handled by the root: dismisses the slot.
+        Dismiss,
+        /// Handled by the root: presents a fresh instance in the slot.
+        Present,
+        /// Handled by the root, returning its own keyed command.
+        RootWork,
+        /// Handled by the root, returning nothing.
+        Idle,
+    }
+
+    struct RootState {
+        left: ChildState,
+        right: ChildState,
+        rows: Keyed<&'static str, ChildState>,
+        modal: Slot<ChildState>,
+    }
+
+    impl RootState {
+        fn new() -> Self {
+            Self {
+                left: ChildState::new(true),
+                right: ChildState::new(true),
+                rows: Keyed::new(),
+                modal: Slot::empty(),
+            }
+        }
+    }
+
+    struct Root;
+
+    impl Reducer for Root {
+        type State = RootState;
+        type Message = Message;
+
+        fn reduce(&self, state: &mut RootState, message: Message) -> Command<Message> {
+            match message {
+                Message::Close(key) => {
+                    state.rows.remove(&key);
+                    Command::none()
+                }
+                Message::Replace(key) => {
+                    state.rows.insert(key, ChildState::new(true));
+                    Command::none()
+                }
+                Message::Recreate(key) => {
+                    state.rows.remove(&key);
+                    state.rows.insert(key, ChildState::new(true));
+                    Command::none()
+                }
+                Message::Dismiss => {
+                    state.modal.dismiss();
+                    Command::none()
+                }
+                Message::Present => {
+                    state.modal.present(ChildState::new(true));
+                    Command::none()
+                }
+                Message::RootWork => {
+                    Command::stream(stream::pending()).cancellable(CommandId::new("root"))
+                }
+                _ => Command::none(),
+            }
+        }
+
+        fn subscriptions(&self, _state: &RootState) -> Vec<Subscription<Message>> {
+            vec![Subscription::new(MockSource::<Message>::new())]
+        }
+    }
+
+    fn left_extract(message: Message) -> Result<ChildMessage, Message> {
+        match message {
+            Message::Left(child) => Ok(child),
+            other => Err(other),
+        }
+    }
+
+    fn right_extract(message: Message) -> Result<ChildMessage, Message> {
+        match message {
+            Message::Right(child) => Ok(child),
+            other => Err(other),
+        }
+    }
+
+    fn row_extract(message: Message) -> Result<(&'static str, ChildMessage), Message> {
+        match message {
+            Message::Row(key, child) => Ok((key, child)),
+            other => Err(other),
+        }
+    }
+
+    fn modal_extract(message: Message) -> Result<ChildMessage, Message> {
+        match message {
+            Message::Modal(child) => Ok(child),
+            other => Err(other),
+        }
+    }
+
+    /// The stack every row below reduces through: two sibling `scope`
+    /// boundaries, a `for_each` over the collection, and a `presented` slot.
+    fn stack() -> impl Reducer<State = RootState, Message = Message> {
+        Root.scope(
+            Child,
+            "left",
+            |state: &RootState| &state.left,
+            |state: &mut RootState| &mut state.left,
+            left_extract,
+            Message::Left,
+        )
+        .scope(
+            Child,
+            "right",
+            |state: &RootState| &state.right,
+            |state: &mut RootState| &mut state.right,
+            right_extract,
+            Message::Right,
+        )
+        .for_each(
+            Child,
+            |state: &RootState| &state.rows,
+            |state: &mut RootState| &mut state.rows,
+            row_extract,
+            Message::Row,
+        )
+        .presented(
+            Child,
+            "modal",
+            |state: &RootState| &state.modal,
+            |state: &mut RootState| &mut state.modal,
+            modal_extract,
+            Message::Modal,
+        )
+    }
+
+    fn path(segments: &[&'static str]) -> ScopePath {
+        // Root-first storage: the last `prefixed` call names the outermost
+        // segment, so the slice reads root-first when applied in reverse.
+        segments
+            .iter()
+            .rev()
+            .fold(ScopePath::empty(), |acc, segment| acc.prefixed(*segment))
+    }
+
+    /// One reduce, lowered the way the kernel reads it.
+    fn lowered(
+        reducer: &impl Reducer<State = RootState, Message = Message>,
+        state: &mut RootState,
+        message: Message,
+    ) -> KernelParts<Message> {
+        reducer
+            .reduce(state, message)
+            .into_runtime_parts()
+            .into_kernel_parts()
+    }
+
+    /// The id `CommandId::new(local)` becomes under `boundary`, built the
+    /// way an application would build it — `Command::scoped` is the only
+    /// route to a qualified id from outside the command module, which is
+    /// what makes this an independent expectation rather than a restatement
+    /// of the combinator's own call.
+    fn qualified(local: &'static str, boundary: &'static str) -> CommandId {
+        Command::<Message>::cancel(CommandId::new(local))
+            .scoped(boundary)
+            .into_runtime_parts()
+            .into_kernel_parts()
+            .cancels
+            .into_iter()
+            .next()
+            .expect("the command carries the one cancel id it was built with")
+    }
+
+    fn spawn_scopes(parts: &KernelParts<Message>) -> Vec<ScopePath> {
+        parts
+            .spawns
+            .iter()
+            .map(|spawn| spawn.scope.clone())
+            .collect()
+    }
+
+    fn cleanup_scopes(parts: &KernelParts<Message>) -> Vec<ScopePath> {
+        parts
+            .cleanups
+            .iter()
+            .map(|registration| registration.scope.clone())
+            .collect()
+    }
+
+    // INV-RC2: a boundary qualifies **every** identity-bearing carrier of
+    // the child's returned command — the spawn key, the anonymous carrier's
+    // placement scope, the explicit cancel id, the teardown prefix, and the
+    // cleanup registration — with its segment, and nothing else.
+    #[test]
+    fn a_boundary_qualifies_every_carrier_of_its_child_s_command() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let parts = lowered(&stack, &mut state, Message::Left(ChildMessage::Carriers));
+
+        assert_eq!(
+            spawn_scopes(&parts),
+            vec![path(&["left"]), path(&["left"])],
+            "the keyed carrier and the anonymous one are both placed under the boundary"
+        );
+        assert_eq!(
+            parts.spawns[0]
+                .key
+                .as_ref()
+                .expect("the first carrier is keyed")
+                .id,
+            qualified("work", "left"),
+            "the spawn key is qualified"
+        );
+        assert_eq!(
+            parts.cancels,
+            vec![qualified("other", "left")],
+            "and so is the explicit cancel id"
+        );
+        assert_eq!(
+            parts.teardowns,
+            vec![path(&["left", "inner"])],
+            "and the teardown prefix, with the boundary's segment at the root"
+        );
+        assert_eq!(
+            cleanup_scopes(&parts),
+            vec![path(&["left"])],
+            "and the cleanup registration's anchor"
+        );
+    }
+
+    // INV-RC2's sibling clause: equal local ids under sibling scopes never
+    // alias. The two boundaries hand the *same* child the same message, and
+    // every carrier comes back distinct.
+    #[test]
+    fn equal_local_ids_under_sibling_boundaries_do_not_alias() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let left = lowered(&stack, &mut state, Message::Left(ChildMessage::Carriers));
+        let right = lowered(&stack, &mut state, Message::Right(ChildMessage::Carriers));
+
+        assert_ne!(
+            left.spawns[0].key.as_ref().expect("keyed").id,
+            right.spawns[0].key.as_ref().expect("keyed").id
+        );
+        assert_ne!(left.cancels, right.cancels);
+        assert_ne!(left.teardowns, right.teardowns);
+        assert_ne!(cleanup_scopes(&left), cleanup_scopes(&right));
+        assert_eq!(spawn_scopes(&right), vec![path(&["right"]); 2]);
+    }
+
+    // INV-RC2 through a *nested* stack: a `for_each` row's child is reached
+    // under the row key, and a teardown the child itself returned is
+    // qualified by that key too — so the qualification composes rather than
+    // stopping at the outermost boundary.
+    #[test]
+    fn a_row_s_child_is_qualified_by_its_key() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        state.rows.insert("row-b", ChildState::new(true));
+
+        let parts = lowered(
+            &stack,
+            &mut state,
+            Message::Row("row-b", ChildMessage::Carriers),
+        );
+
+        assert_eq!(spawn_scopes(&parts), vec![path(&["row-b"]); 2]);
+        assert_eq!(parts.teardowns, vec![path(&["row-b", "inner"])]);
+        assert_eq!(cleanup_scopes(&parts), vec![path(&["row-b"])]);
+        assert_eq!(
+            state.rows.get(&"row-a").expect("row-a is held").seen,
+            Vec::new(),
+            "the sibling row was not reduced"
+        );
+    }
+
+    // The parent's own command crosses no boundary and is left alone.
+    #[test]
+    fn a_message_the_children_do_not_claim_reaches_the_root_unqualified() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let parts = lowered(&stack, &mut state, Message::RootWork);
+
+        assert_eq!(spawn_scopes(&parts), vec![ScopePath::empty()]);
+        assert_eq!(
+            parts.spawns[0].key.as_ref().expect("keyed").id,
+            CommandId::new("root")
+        );
+    }
+
+    // INV-RC3, the four removal shapes, each read as the teardown the
+    // boundary merged into that update's command.
+    #[test]
+    fn removing_a_row_yields_that_row_s_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Close("row-a"));
+
+        assert_eq!(parts.teardowns, vec![path(&["row-a"])]);
+    }
+
+    #[test]
+    fn replacing_a_row_yields_the_old_instance_s_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Replace("row-a"));
+
+        assert_eq!(parts.teardowns, vec![path(&["row-a"])]);
+    }
+
+    #[test]
+    fn dismissing_the_slot_yields_the_boundary_s_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.modal.present(ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Dismiss);
+
+        assert_eq!(parts.teardowns, vec![path(&["modal"])]);
+    }
+
+    #[test]
+    fn presenting_over_an_occupied_slot_yields_the_old_occupant_s_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.modal.present(ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Present);
+
+        assert_eq!(parts.teardowns, vec![path(&["modal"])]);
+    }
+
+    #[test]
+    fn an_update_that_removes_nothing_yields_no_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let parts = lowered(&stack, &mut state, Message::Idle);
+
+        assert!(parts.teardowns.is_empty());
+        assert!(parts.spawns.is_empty());
+    }
+
+    // RFC 0014 §11's *diff-based removal detection* adversary at the
+    // boundary: the collection is identical before and after, and the
+    // teardown is still emitted — so the old instance's runs are torn down
+    // and the new instance is a fresh occupant of the same key.
+    #[test]
+    fn a_same_update_remove_and_reinsert_still_yields_the_old_instance_s_teardown() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+
+        let parts = lowered(&stack, &mut state, Message::Recreate("row-a"));
+
+        assert_eq!(
+            parts.teardowns,
+            vec![path(&["row-a"])],
+            "a diff of the collection would report no change at all"
+        );
+        assert!(state.rows.contains_key(&"row-a"), "and the key is occupied");
+    }
+
+    // A boundary's teardown merges *with* the update's own command rather
+    // than replacing it — the removal and the parent's work travel in one
+    // command, which is what lets the same dispatch apply the cancel phase
+    // before the spawn (RFC 0013 R4).
+    #[test]
+    fn a_removal_and_the_update_s_own_command_travel_together() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.modal.present(ChildState::new(true));
+
+        // One message that both dismisses the slot and, through the root,
+        // starts work: `Dismiss` returns `Command::none()`, so the row below
+        // uses the slot boundary over a root command instead.
+        let parts = lowered(&stack, &mut state, Message::Dismiss);
+        assert_eq!(parts.teardowns, vec![path(&["modal"])]);
+
+        state.modal.present(ChildState::new(true));
+        state.rows.insert("row-a", ChildState::new(true));
+        state.rows.remove(&"row-a");
+        let parts = lowered(&stack, &mut state, Message::RootWork);
+
+        assert_eq!(
+            parts.teardowns,
+            vec![path(&["row-a"])],
+            "the pending removal is drained by the next reduce whichever branch it took"
+        );
+        assert_eq!(
+            parts.spawns.len(),
+            1,
+            "and the root's own spawn is in the same command"
+        );
+    }
+
+    // RFC 0014 §2.5's routing boundary: a message addressed to a key the
+    // collection does not hold reaches no reducer and is discarded.
+    #[test]
+    fn a_message_for_an_absent_key_is_discarded() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let parts = lowered(
+            &stack,
+            &mut state,
+            Message::Row("missing", ChildMessage::Carriers),
+        );
+
+        assert!(parts.spawns.is_empty(), "no child ran");
+        assert!(parts.teardowns.is_empty());
+        assert!(parts.cleanups.is_empty());
+    }
+
+    #[test]
+    fn a_message_for_an_empty_slot_is_discarded() {
+        let stack = stack();
+        let mut state = RootState::new();
+
+        let parts = lowered(&stack, &mut state, Message::Modal(ChildMessage::Carriers));
+
+        assert!(parts.spawns.is_empty());
+    }
+
+    // A removal recorded before a message addressed to a *different*,
+    // now-absent key is still owed its teardown: the drain does not depend
+    // on the branch the message took.
+    #[test]
+    fn a_pending_removal_survives_a_discarded_message() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        state.rows.remove(&"row-a");
+
+        let parts = lowered(
+            &stack,
+            &mut state,
+            Message::Row("missing", ChildMessage::Quiet),
+        );
+
+        assert_eq!(parts.teardowns, vec![path(&["row-a"])]);
+    }
+
+    // INV-RC2's subscription half: the child's declarations are aggregated
+    // through the boundary's **shared** projection and qualified with the
+    // same segment, so two sibling boundaries declaring the same source do
+    // not alias.
+    #[test]
+    fn child_declarations_are_aggregated_and_qualified_per_boundary() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        state.modal.present(ChildState::new(true));
+
+        let declared = stack.subscriptions(&state);
+        let ids: Vec<_> = declared.iter().map(|sub| sub.id().clone()).collect();
+
+        assert_eq!(
+            ids.len(),
+            5,
+            "the root's own, the two sibling boundaries', the row's, and the slot occupant's"
+        );
+        let unique: HashSet<_> = ids.iter().collect();
+        assert_eq!(
+            unique.len(),
+            5,
+            "every one of them is a distinct identity: {ids:?}"
+        );
+    }
+
+    #[test]
+    fn a_row_removed_from_the_collection_declares_nothing() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.rows.insert("row-a", ChildState::new(true));
+        let with_row = stack.subscriptions(&state).len();
+
+        state.rows.remove(&"row-a");
+
+        assert_eq!(
+            stack.subscriptions(&state).len(),
+            with_row - 1,
+            "a removed row's declarations leave the declared set"
+        );
+    }
+
+    #[test]
+    fn an_empty_slot_declares_nothing() {
+        let stack = stack();
+        let state = RootState::new();
+
+        let declared = stack.subscriptions(&state);
+
+        assert_eq!(
+            declared.len(),
+            3,
+            "the root's own and the two sibling boundaries', with no occupant to add one"
+        );
+    }
+
+    // A child that declares nothing contributes nothing, so aggregation is
+    // not a fixed-arity fold over boundaries.
+    #[test]
+    fn a_child_declaring_nothing_contributes_nothing() {
+        let stack = stack();
+        let mut state = RootState::new();
+        state.left.subscribed = false;
+
+        assert_eq!(stack.subscriptions(&state).len(), 2);
+    }
+
+    // `into_program` closes the stack, and the closed value's reducer half
+    // is the stack's own — same routing, same qualification.
+    #[test]
+    fn a_closed_stack_reduces_exactly_as_the_stack_does() {
+        let program = stack().into_program(
+            |()| (RootState::new(), Command::none()),
+            |_state: &RootState, _frame: &mut Frame<'_>| {},
+        );
+        let (mut state, init) = program.init(());
+        assert!(init.is_none(), "the root init is the one it was given");
+
+        let parts = lowered(&program, &mut state, Message::Left(ChildMessage::Carriers));
+
+        assert_eq!(parts.teardowns, vec![path(&["left", "inner"])]);
+        assert_eq!(cleanup_scopes(&parts), vec![path(&["left"])]);
+    }
+}

--- a/src/testing/driver.rs
+++ b/src/testing/driver.rs
@@ -1061,6 +1061,17 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
             EntryKind::Keyed(id) => RunKind::Keyed(id),
             EntryKind::Sub(id) => RunKind::Subscription(id),
             EntryKind::Anon => RunKind::Anonymous,
+            // A cleanup run is none of the three kinds a name carries, and
+            // the kernel never reports one here: `started` is appended by
+            // the producer spawn path only, and a finalizer takes the
+            // cleanup path beside it (RFC 0008 §9.4, RFC 0014 §4.4). A test
+            // observes a finalizer through its own instrumentation and a
+            // bounded settle, which is what §9.6 says a run presenting no
+            // send-intent is observed by.
+            EntryKind::Cleanup => unreachable!(
+                "a cleanup run is not reported as started: it presents no send-intent and makes \
+                 no ledger record, so there is nothing for a RunName to name (RFC 0008 §9.4)"
+            ),
         };
         let name = RunName {
             driver: self.id,

--- a/src/testing/driver.rs
+++ b/src/testing/driver.rs
@@ -1028,7 +1028,15 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
         outcome: Result<(), B::Error>,
         started: Vec<StartedRun>,
     ) -> StepReport<B::Error> {
-        let started = started.into_iter().map(|run| self.mint(run)).collect();
+        // `filter_map`, because a run the driver has no name for is one it
+        // does not report: naming is per producer kind (RFC 0008 §9.4), and
+        // a cleanup run is none of them. Filtering here rather than
+        // asserting inside `mint` keeps a future routing mistake a missing
+        // entry rather than a panic.
+        let started = started
+            .into_iter()
+            .filter_map(|run| self.mint(run))
+            .collect();
         let terminated = match outcome {
             Err(error) => Some(Err(error)),
             Ok(()) if self.kernel.terminating() => Some(Ok(Exit::Quit)),
@@ -1047,31 +1055,31 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
     }
 
     /// Mints the name for one run a step started, from the kind the kernel
-    /// recorded at the start rather than from bookkeeping read back after.
+    /// recorded at the start rather than from bookkeeping read back after —
+    /// or `None` for a run there is no name for.
     ///
-    /// Reading it back would be a lookup that can fail for a reason the test
-    /// has no part in: a run whose exit a pass has already reflected has no
-    /// entry left, and bootstrap can reach exactly that state for an init
-    /// effect that finishes before its continuation pass. Nothing about the
-    /// name is chosen here either way — the kind is still the kernel's, just
-    /// taken at the moment it was true.
-    fn mint(&mut self, started: StartedRun) -> RunName {
+    /// Reading the kind back would be a lookup that can fail for a reason
+    /// the test has no part in: a run whose exit a pass has already
+    /// reflected has no entry left, and bootstrap can reach exactly that
+    /// state for an init effect that finishes before its continuation pass.
+    /// Nothing about the name is chosen here either way — the kind is still
+    /// the kernel's, just taken at the moment it was true.
+    ///
+    /// A cleanup run is the `None`: it is none of the three kinds a
+    /// [`RunName`] carries (RFC 0008 §9.4), it presents no send-intent to
+    /// grant and makes no ledger record to tag, so there is nothing for a
+    /// name to do. How a test observes one is its own instrumentation and a
+    /// bounded [`settle`](Self::settle), which is what §9.6 says a run
+    /// presenting no send-intent is observed by. Returning `None` rather
+    /// than asserting keeps the mapping total: a kind this driver has no
+    /// name for is one it does not report.
+    fn mint(&mut self, started: StartedRun) -> Option<RunName> {
         let StartedRun { token, kind } = started;
         let kind = match kind {
             EntryKind::Keyed(id) => RunKind::Keyed(id),
             EntryKind::Sub(id) => RunKind::Subscription(id),
             EntryKind::Anon => RunKind::Anonymous,
-            // A cleanup run is none of the three kinds a name carries, and
-            // the kernel never reports one here: `started` is appended by
-            // the producer spawn path only, and a finalizer takes the
-            // cleanup path beside it (RFC 0008 §9.4, RFC 0014 §4.4). A test
-            // observes a finalizer through its own instrumentation and a
-            // bounded settle, which is what §9.6 says a run presenting no
-            // send-intent is observed by.
-            EntryKind::Cleanup => unreachable!(
-                "a cleanup run is not reported as started: it presents no send-intent and makes \
-                 no ledger record, so there is nothing for a RunName to name (RFC 0008 §9.4)"
-            ),
+            EntryKind::Cleanup => return None,
         };
         let name = RunName {
             driver: self.id,
@@ -1079,7 +1087,7 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
             kind,
         };
         self.names.insert(token, name.clone());
-        name
+        Some(name)
     }
 
     /// Resolves the kernel-side records of a ledger to the names a test
@@ -1769,7 +1777,9 @@ mod tests {
             "and the bookkeeping no longer does: a mint that read it back would find nothing"
         );
 
-        let name = driver.mint(started.into_iter().next().expect("the one entry"));
+        let name = driver
+            .mint(started.into_iter().next().expect("the one entry"))
+            .expect("an anonymous run is one of the three kinds a name carries");
         assert_eq!(
             name.kind(),
             RunKind::Anonymous,

--- a/src/testing/driver.rs
+++ b/src/testing/driver.rs
@@ -1096,6 +1096,15 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
         sends
             .into_iter()
             .map(|send| SendRecord {
+                // Total because the two sets coincide: every run that can
+                // reach a ledger is a run this driver named. `mint` names
+                // the three producer kinds and returns `None` for the
+                // fourth, and the fourth cannot record — a cleanup run is
+                // constructed with no lane sender and no ingress at all
+                // (`kernel::producer::CleanupHarness`), which is also
+                // INV-RC8's no-output clause. Widening that harness — giving
+                // a cleanup run any send path — breaks this lookup, so the
+                // two have to move together.
                 run: self
                     .names
                     .get(&send.origin)


### PR DESCRIPTION
## Summary

Second scaffolding change of the kernel mainlining: **cleanup hooks
(RFC 0014 §4.4, INV-RC8) and the composition surface (RFC 0014 §2.5,
INV-RC2/RC3)** — `Command::on_teardown` and the cleanup ledger on the
kernel side; `ScopeValue`, `Keyed`/`Slot` with removal journals, and
`ReducerExt`'s `scope`/`for_each`/`presented`/`into_program` on the
reducer side. Everything is `pub(crate)`; production behavior and the
public API are unchanged (`tests/api_surface.rs` green, public API
diff empty), and the old runtime remains the production owner.

The combinator signatures are RFC 0014 §2.5's block verbatim — no
aliases, no reshaping — with one deliberate exception recorded in the
findings below (`ScopeValue`'s bound list).

## What lands

1. **Cleanup hooks.** Registration travels the command as its own
   carrier (qualified by `scoped` and the combinators — RFC 0005
   INV-18's coverage), arms in the spawn phase after the same
   command's cancel phase (§3.4's teardown-and-reregister rule), and
   starts when a teardown selects its scope. A cleanup run joins the
   kernel's one `JoinSet` but counts toward no gauge, neither joins
   nor triggers the admission barrier, marks no dirt, and has **no
   route back into the runtime**: its harness holds a join set, a
   task index, and the gate — no lane sender, no directive path. That
   absence is the no-output clause's structural review (INV-RC8),
   written at the construction site. Termination discards unfired
   registrations and cancels running finalizers, with no grace
   window.
2. **Collections with removal journals.** `Keyed` and `Slot` record
   *removals* — `remove`, `dismiss`, insert-over-occupied,
   present-over-occupied — never state diffs, so a same-update
   remove-and-reinsert still yields the old instance's teardown and a
   fresh successor in one command (INV-RC3). Building a collection
   (`from_iter`, literals) records nothing: an entry that only ever
   existed in an iterator never placed a run, so there is nothing to
   tear down.
3. **Combinators.** Each boundary qualifies every identity carrier of
   its child's returned command — spawn keys, cancel ids, teardown
   prefixes, cleanup registrations — and the child's subscription
   declarations, with its segment (INV-RC2); equal local ids under
   sibling boundaries never alias; stacks nest (a whole
   `for_each`/`presented` stack composed as another boundary's child
   is exercised end to end). Journal drains merge one teardown per
   removal into the update's own command **without constructing a
   batch**: the entries are appended to the command's teardown
   carrier directly, so a boundary adds identity carriers and
   nothing else — the update's redraw directive (including
   `without_redraw`) survives, and no spurious diagnostics fire.
   Origination stays one surface (RFC 0013 R8): `Command::teardown`
   is the only constructor of a teardown entry crate-wide.

## Evidence

- **Suite**: 687 lib tests under `--all-features` (+66 over `main`),
  all targets green, clippy `-D warnings` clean in debug and release,
  fmt clean, no sleeps/timers/clock reads, `#[ignore]` zero among
  additions. New and changed rows repeated ×10.
- **Counterexamples killed, with the mutation run** (applied,
  observed, reverted — an independent review pass re-ran them):
  - *diff-based removal detection*: a diff-equivalent journal fails
    the kernel recreate row on its **unkeyed-run** assertion (an
    unkeyed run has no identity to supersede, so only the journal's
    teardown reaches it) plus five unit rows; the fixed suite
    passes.
  - *batch-fold merge* (the shape the boundary drain deliberately
    avoids): restoring it fails exactly the two directive/diagnostic
    rows — `without_redraw` preserved, no false "child key ignored"
    warning (with an in-recorder control showing the zero is
    silence, not suppression).
  - *cancel-phase cleanup registration*: moving the registration to
    the cancel phase fails the three spawn-phase rows.
- **RFC 0013 §7.2's kernel rows** are all present, including the
  ST8 routing pair (a key-addressed message after a same-key
  remove-and-reinsert reaches the **new** instance's state; one for
  an absent key is discarded) and the final-update row (teardown and
  quit in one update; termination fires no hook). The final-update
  row reads the two RFC 0011 §4.4 postconditions through the
  driver's terminated report plus the bounded settle; the
  postconditions proper are owned by the existing termination row.
- **R8 one-surface review** re-verified by grep after the merge
  redesign: one origination site; `merging_teardowns` and `batch`
  extend already-originated entries.

## Deliberate exceptions

Two pre-existing test-code edits, both mechanical, no assertion
semantics changed: an exhaustiveness-forced match arm in a lowering
test helper (the new dispatch step variant), and an `.expect(...)`
where a test-surface constructor became `Option`-returning
(structural replacement of an `unreachable!`).

## Findings for the contract documents

1. **INV-RC12 (a)'s cleanup half cannot be behavioral.** A
   stop-requested cleanup run is not constructible outside
   termination — teardown selection excludes the kind, cancel and
   supersession address keyed slots, re-evaluation addresses
   subscription runs, and at termination no admission site remains.
   Verified independently by enumerating every stop-request call
   site. The reachable half (an in-flight cleanup run defers no
   admission) is behavioral here; the rest is carried structurally by
   the barrier predicate reading subscription runs only. RFC 0014
   §12 marks all of (a) behavioral — an enforcement-class amendment
   candidate for the RFC, not an implementation change.
2. **A boundary-merged teardown does not redraw; a hand-written
   `Command::teardown` does** (it inherits the default directive).
   Both are intended — directives belong to the update, and a
   boundary adds identity carriers only — but the sentence belongs in
   RFC 0014 §2.5 when this surface goes public at the switch.
3. **`ScopeValue` drops `PartialEq`**, which `Eq: PartialEq` makes
   redundant. RFC 0014 §2.5's block still writes it; a wording sync
   for the RFC when this surface goes public, not an implementation
   change.
4. `Keyed` iterates in insertion order off a linear scan —
   determinism is what the driving contract rides on; the O(n)
   lookup is stated mechanism (RFC 0013 §3.7) and joins the
   load-measurement list for the acceptance re-derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
