### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-29
+
 > Upgrading from 0.10.x? The
 > [migration guide](docs/migrations/0.10-to-0.11.md) triages the entries below
 > into the ones the compiler reports, the ones that change behaviour with the
@@ -104,7 +106,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The 100µs window that used to cap a batch is gone with the wall-clock reads
   it needed. A batch is finite under every configuration; this control only
-  replaces the default count.
+  replaces the default count. An application that left it unset to mean
+  "drain everything ready" pins the size it wants instead:
+
+  ```rust
+  // Before: unset meant an uncapped batch.
+  let config = RuntimeConfig::new();
+
+  // After: unset means the kernel's own cap; name one to override it.
+  let config = RuntimeConfig::new()
+      .batch_max_messages(NonZeroUsize::new(4096).expect("non-zero"));
+  ```
 
 - **Breaking:** effect constructors return `EffectCommand<Msg>`, and
   `cancellable` / `cancellable_with` move onto it
@@ -158,6 +170,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy. `batch` also takes anything convertible into a command, so a batch
   of carriers needs no conversion and a mixed one converts its carriers.
 
+  ```rust
+  // Before: the child key was discarded with a warning, and the batch ran
+  // one unkeyed run; cancelling `id` cancelled nothing.
+  Command::batch([fetch.cancellable(id), poll.cancellable(other)])
+
+  // After: two independently keyed runs. Drop the modifier from a child
+  // that was never meant to be cancellable on its own.
+  Command::batch([fetch.cancellable(id), poll.into()])
+  ```
+
 - **Breaking:** a quit returned from `update` is applied synchronously
 
   It no longer travels a channel, so no later input, cancel, or arbitration
@@ -174,6 +196,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   An application that wants "deliver this, then quit" returns the quit from
   the `update` that observes the final message. That order is now pinned by
   construction rather than by channel timing.
+
+  ```rust
+  // Before: the quit rode the effect stream, so `Saved` might arrive first
+  // — or not, depending on arbitration.
+  fn update(&mut self, msg: Message) -> Command<Message> {
+      match msg {
+          Message::Save => Command::batch([save(), Command::quit()]),
+          Message::Saved => Command::none(),
+      }
+  }
+
+  // After: quit from the update that sees the last message you care about.
+  fn update(&mut self, msg: Message) -> Command<Message> {
+      match msg {
+          Message::Save => save().into(),
+          Message::Saved => Command::quit(),
+      }
+  }
+  ```
 
 - **Breaking:** a producer-originated quit no longer orders against its own
   run's earlier output
@@ -194,6 +235,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pull incidentally provided — a keyed command's output waiting behind ready
   shared input, leaving a window to cancel it — is gone with it.
 
+  There is no code change to make: nothing named the precedence. What needs
+  revisiting is a design that leaned on the window — cancel at the point you
+  decide to, rather than relying on a producer's output waiting its turn.
+
 - **Breaking:** `TestStore::receive_quit` observes a quit applied at a
   dispatch, and an applied quit is terminal before it is observed
 
@@ -210,6 +255,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   A producer-originated quit still travels as output and is still asserted the
   same way.
+
+  ```rust
+  // Before: the quit had to be the next deliverable item, so a message the
+  // same command produced had to be received first.
+  store.send(Message::Save);
+  store.receive(Message::Saved);
+  store.receive_quit();
+
+  // After: the quit applied at the dispatch, and the store is terminal from
+  // that moment — observe it, and do not expect to drain anything after.
+  store.send(Message::Save);
+  store.receive_quit();
+  ```
 
 - **Breaking:** `TestStore` runs cleanup hooks, and exhaustiveness gained two
   leak classes
@@ -236,6 +294,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renamed telemetry field breaks dashboards and alert rules silently, off the
   compiler's path. `"shared"` and `"keyed"` retire with the channels they
   named, and `shared_pending` now reads as the data lane's residual occupancy.
+
+  The migration is consumer-side and the compiler will not find it: a query
+  or alert rule that groups by `channel`, or that matches `"shared"` or
+  `"keyed"`, now matches nothing. Drop the grouping, or match `"data"`.
 
 - **Breaking:** `RuntimeConfig` is `Clone` but no longer `Copy`; with the
   `Default` derive added above, the full set is now `Clone`, `Debug`,
@@ -338,6 +400,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   builds, where nothing can be contained. A contained panic's report is
   written on the alternate screen in raw mode, so applications that want it
   readable should point their panic reporter at a file or log target
+
+- The published crate no longer carries two files that were never meant to be
+  in it. `docs/rfcs/README.md` and `scripts/README.md` shipped in every
+  release that used the current `include` list, because an include pattern
+  without a slash is a glob that matches at any depth — so `"README.md"`
+  matched those two alongside the crate's own. The four file patterns are
+  anchored to the crate root now, which takes the package from 107 files to
+  105 and changes nothing else: `README.md`, `LICENSE`, `CHANGELOG.md`,
+  `Cargo.toml` and every source, test, example and bench file are where they
+  were
 
 ## [0.10.2] - 2026-07-26
 
@@ -1144,7 +1216,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive API documentation with examples
 - Counter example demonstrating timer and keyboard input
 
-[unreleased]: https://github.com/akiomik/tears/compare/v0.10.2...HEAD
+[unreleased]: https://github.com/akiomik/tears/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/akiomik/tears/releases/tag/v0.11.0
 [0.10.2]: https://github.com/akiomik/tears/releases/tag/v0.10.2
 [0.10.1]: https://github.com/akiomik/tears/releases/tag/v0.10.1
 [0.10.0]: https://github.com/akiomik/tears/releases/tag/v0.10.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "tears"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "color-eyre",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tears"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2024"
 authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
 description = "A simple and elegant framework for building TUI applications using The Elm Architecture (TEA)"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tears = "0.10"
+tears = "0.11"
 ratatui = "0.30"
 crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Cuts `[Unreleased]` to `[0.11.0]`, bumps `Cargo.toml`/`Cargo.lock`, and
moves the README's install snippet to `0.11`. Same shape as the last
three releases.

This is the composition release: the runtime core is replaced, so the
breaking list is long, but the public entry point for an `Application`
is unchanged — `Runtime::<App>::new(flags)` still returns a runtime
whose `run` has the same signature and the same result contract.

## Highlights

**A reducer-first kernel.** `Reducer` and `Program` are the unit the
runtime drives, with combinators — `scope`, `for_each`, `presented`,
`into_program` — that qualify a child's identities with the boundary's
segment, so equal local IDs under sibling scopes never alias.
`ProgramRuntime<P>` runs one. `Application` is a single-feature adapter
over the same kernel, not a second runtime: one delivery path, one
lifecycle, one identity model.

**`EffectCommand<Msg>`.** Effect constructors return a carrier that
holds exactly one effect, and the keying modifiers live there. That
makes `Command::batch([..]).cancellable(id)` — one spawn key reaching
several carriers — not constructible rather than diagnosed at runtime.

**`tears::testing::TestDriver`.** Drives the production kernel a pass at
a time: the same construction path, the same tasks, the same lanes, with
the driving difference confined to naming which armed source begins a
pass and releasing one producer send at a time through a grant
handshake. `ParkProbe` scripts the park boundary.

**A smaller `RuntimeConfig`.** Two fields: `data_lane_capacity` and
`batch_max_messages`. Frame pacing is gone — render cadence is bounded
by the pass, so there is no rate left to configure — and with one data
lane there are no per-command channels for a second capacity to size.

**`Command::teardown` / `on_teardown`.** Tear down every run placed
under a scope prefix, and register a finalizer that runs when one is.

## Breaking changes

Thirteen entries, each with its migration in the CHANGELOG. In short:

- `FrameRate` and the second parameter of `Runtime::new` are gone.
- `RuntimeConfig::app_channel_capacity` → `data_lane_capacity` with no
  alias; `keyed_channel_capacity` removed; `new` takes no arguments;
  unset `batch_max_messages` now means the kernel's cap, not uncapped.
- Effect constructors return `EffectCommand<Msg>`; keying a batch or a
  `quit` no longer compiles.
- `Command::batch` honours each child's spawn key.
- A quit returned from `update` applies synchronously at its dispatch; a
  producer-originated quit takes a control lane and no longer orders
  against its own run's earlier output.
- Shared-first delivery precedence and per-command backpressure
  isolation are not preserved.
- `TestStore` gains cleanup-hook execution and two leak classes;
  `receive_quit` observes a quit applied at a dispatch.
- The capacity-wait event's `channel` field takes one value, `"data"`.
- `RuntimeConfig` is no longer `Copy`.

Two of these have no code to change and say so: the delivery-precedence
loss is a design consideration, and the telemetry field change is
consumer-side, where the compiler will not find it.

## For review

**The stage-3 driver's enums ship exhaustive, deliberately.**
`WakeSource`, `RunKind`, `Confirmed`, `Lane` and `StepReport` carry no
`#[non_exhaustive]`. That is not an oversight: RFC 0008 §9.3 states each
of them as a closed set — `WakeSource` is exactly the sources INV-RC16
arms, `Confirmed`'s two arms are stated as disjoint and exhaustive, and
a test matching on them is supposed to fail to compile if the set ever
changes, which is the property the driver exists to give. Adding
`#[non_exhaustive]` later is itself a breaking change, so this is the
decision that has to be made now rather than deferred.

**Migration examples.** Six breaking entries carried prose but no
worked example; they now have one, or an explicit statement that no code
change exists. Four already had Before/After blocks and are unchanged.

**Packaging.** `cargo publish --dry-run` is clean — 107 files, 1.7 MiB
(432.7 KiB compressed), no warnings. Two files arrive that no one asked
for: `docs/rfcs/README.md` and `scripts/README.md`, swept in because
`include`'s `"README.md"` is an unanchored gitignore-style pattern that
matches at any depth. Pre-existing, unchanged from 0.10.2, and left
alone here so the release carries no packaging change.

## Verification

635 tests passed / 0 failed / 2 ignored across lib, bins, tests and
examples with all features; 50 doctests passed. `cargo clippy
--all-targets` clean both with and without `--all-features` under
`-D warnings`; `cargo fmt --check`, `cargo doc --no-deps --all-features`
and `typos` clean.
