### PR TITLE
fix(package): anchor the include patterns to the crate root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,20 @@ readme = "README.md"
 keywords = ["tui", "tea", "elm-architecture", "ratatui", "framework"]
 categories = ["command-line-interface", "asynchronous"]
 rust-version = "1.88.0"
+# Anchored with a leading slash: an include pattern without one is a
+# gitignore-style glob that matches at any depth, so a bare "README.md"
+# also swept `docs/rfcs/README.md` and `scripts/README.md` into the
+# package. The four directory patterns already contain a slash and are
+# anchored for that reason.
 include = [
     "src/**/*",
     "examples/**/*",
     "tests/**/*",
     "benches/**/*",
-    "Cargo.toml",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
+    "/Cargo.toml",
+    "/LICENSE",
+    "/README.md",
+    "/CHANGELOG.md",
 ]
 
 [features]


### PR DESCRIPTION
Two files have been shipping to crates.io that nobody put on the list.

`include`'s entries are gitignore-style globs, and a pattern with no
slash in it matches at **any depth**. So `"README.md"` never meant "the
crate's README" — it meant every file named `README.md` in the tree:

```
README.md
docs/rfcs/README.md     <- swept in
scripts/README.md       <- swept in
```

The four directory patterns (`src/**/*` and friends) contain a slash and
are anchored for that reason, which is why they never had the problem.

## Before / after

`cargo package --list`, same commit, only `Cargo.toml` changed:

| | files | compressed |
| --- | ---: | ---: |
| before | 107 | 432.7 KiB |
| after | 105 | 428.8 KiB |

The diff between the two listings is exactly two lines:

```diff
- docs/rfcs/README.md
- scripts/README.md
```

Nothing else moves. The crate root's `README.md`, `LICENSE`,
`CHANGELOG.md`, `Cargo.toml` and `Cargo.lock` are all still there, and
the per-directory counts are unchanged: 74 under `src/`, 12 under
`tests/`, 9 under `examples/`, 3 under `benches/`, 7 at the root.

## Scope

`LICENSE`, `CHANGELOG.md` and `Cargo.toml` are anchored in the same
change even though neither of them is shipping anything extra today —
no nested file in the tree matches them. They are the same latent
defect, the anchoring is free, and the listing diff above is the
evidence that it changes nothing for them now.

## Verification

`cargo publish --dry-run` is clean at 105 files. It does emit
`warning: crate tears@0.10.2 already exists on crates.io index`, which
is expected: this branch sits on `main` at the current published
version, so the dry run is checking a version that is already out. The
version bump is a separate PR.

`cargo fmt --check`, `typos` and `git diff --check` are clean. No source
file changes, so the suite is unaffected — CI runs it anyway.
