### PR TITLE
docs(changelog): drop the non-conforming group and attach before/after blocks to their entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,14 +240,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `RuntimeConfig` is `Clone` but no longer `Copy`; with the
   `Default` derive added above, the full set is now `Clone`, `Debug`,
   `Default`, `Eq`, `PartialEq` (RFC 0007 §2.1)
-  - The type is the aggregation point for future runtime knobs, so a `Copy`
-    config would turn the first non-`Copy` field added later into a breaking
-    derive removal deferred onto whoever adds it; taking the removal now, while
-    the config is small, keeps that growth non-breaking
-  - The consuming setters now move the configuration, so discarding a setter's
-    return value and then using the original is a compile error rather than a
-    silent stale read
-  - Code that relied on the implicit copy adds an explicit `clone()`
+
+  The type is the aggregation point for future runtime knobs, so a `Copy`
+  config would turn the first non-`Copy` field added later into a breaking
+  derive removal deferred onto whoever adds it; taking the removal now, while
+  the config is small, keeps that growth non-breaking. The consuming setters
+  now move the configuration, so discarding a setter's return value and then
+  using the original is a compile error rather than a silent stale read, and
+  code that relied on the implicit copy adds an explicit `clone()`.
 
   Before:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -986,8 +986,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: `Command::single()` has been removed
-  - Use `Command::message()` instead for sending messages immediately
+  - Use `Command::message()` instead for sending messages immediately; this is
+    a mechanical replacement with identical functionality
   - This change aligns with iced v0.14.0 design principles while maintaining tears' self-messaging feature
+
+  Before:
+
+  ```rust
+  Command::single(Message::Refresh)
+  ```
+
+  After:
+
+  ```rust
+  Command::message(Message::Refresh)
+  ```
+
 - Simplified `Runtime` internals by removing `Instance` wrapper
   - `Runtime` now directly holds the application instead of wrapping it in `Instance<App>`
   - Eliminates unnecessary indirection (`.inner`) throughout the codebase
@@ -1003,23 +1017,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `tokio` from 1.48.0 to 1.49.0
 - Upgraded `tokio-stream` from 0.1.17 to 0.1.18
 - Upgraded `tokio-util` from 0.7.17 to 0.7.18
-
-### Migration Guide (v0.5.0 → v0.6.0)
-
-#### Command API Changes
-
-Replace all uses of `Command::single()` with `Command::message()`:
-
-```rust
-// Before (v0.5.0)
-Command::single(Message::Refresh)
-
-// After (v0.6.0)
-Command::message(Message::Refresh)
-```
-
-This is a mechanical replacement with identical functionality.
-The new name better clarifies the intent and reserves more generic verbs (`send`, `dispatch`, `emit`) for potential future features.
 
 ## [0.5.0] - 2026-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,7 +453,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Duplicate desired subscriptions still keep the first declaration and now
     emit a warning under the `tears::subscription` tracing target
 
-  Before:
+  Before, computing the digest by hand in `id()`:
 
   ```rust
   impl SubscriptionSource for WatchSource {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -986,9 +986,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING**: `Command::single()` has been removed
-  - Use `Command::message()` instead for sending messages immediately; this is
-    a mechanical replacement with identical functionality
-  - This change aligns with iced v0.14.0 design principles while maintaining tears' self-messaging feature
+
+  Use `Command::message()` instead for sending messages immediately. It is a
+  mechanical replacement with identical functionality, and aligns with iced
+  v0.14.0 design principles while maintaining tears' self-messaging feature.
 
   Before:
 


### PR DESCRIPTION
## What

Four structural fixes to `CHANGELOG.md`.

1. Removes `### Migration Guide (v0.5.0 → v0.6.0)` from the 0.6.0 section, folding its before/after into the `Command::single()` entry under `### Changed`.
2. Attaches that entry's `Before:`/`After:` blocks to the sentence they demonstrate, by folding its two sub-bullets into prose.
3. Does the same for `RuntimeConfig`'s `Copy`-removal entry under `[Unreleased]`, whose three sub-bullets sat between the entry and its snippets.
4. Gives 0.10.0's "Subscription identity is now structural and collision-safe" a lead-in on its `Before:` block naming what it shows, so it no longer reads as demonstrating the last of the five sub-bullets above it.

No information is dropped. Two sentences from the removed section do not survive verbatim — "Replace all uses of `Command::single()` with `Command::message()`:" and the one about reserving `send`/`dispatch`/`emit` — but what they said is carried: the first is what the snippet pair now shows directly, and the second is already recorded under `### Added` for the same release, in different words ("More explicit than `single` and reserves `send`/`dispatch`/`emit` for future extensions").

## Why

**The removed group is not one Keep a Changelog defines.** The spec has six: Added, Changed, Deprecated, Removed, Fixed, Security. `### Migration Guide (v0.5.0 → v0.6.0)` was a seventh, and the only non-conforming heading in the file. After this change every `###` is one of the six.

That section was also near-duplicate of what surrounded it: its before/after restated the `Command::single()` removal recorded two groups above, and its closing sentence restated a point `### Added` already made. What it carried that the entry did not — the snippet and "mechanical replacement with identical functionality" — is folded into the entry itself.

**A before/after block belongs to the sentence above it.** Markdown renders these blocks against whatever immediately precedes them, so a sub-bullet in between silently reattaches them: the 0.6.0 snippets read as demonstrating "This change aligns with iced v0.14.0 design principles", `RuntimeConfig`'s as demonstrating "code that relied on the implicit copy adds an explicit `clone()`", and 0.10.0's as demonstrating a warning under the `tears::subscription` target. None is what the snippet shows. The `[Unreleased]` entries that got this right — frame rate, `app_channel_capacity` — flow from prose straight into the block, so that shape is the file's own convention rather than an imported one.

Two of the three are fixed by folding, one is not. Folding suits sub-bullets carrying rationale. 0.10.0's five enumerate distinct API changes, where a checklist is the right shape, so that one gets a lead-in instead — matching its `After,` side, which already had one.

## Why fold rather than extract to `docs/migrations/`

Keep a Changelog constrains the group headings, not what an entry contains, and `[Unreleased]` already carries before/after blocks inside its entries. The conforming shape already existed in this file; 0.6.0 was the one release still using the older one.

Extracting instead would trade one debt for another. A `docs/migrations/` holding a six-line mechanical rename next to a full behavioural triage has no legible criterion, and it implies a standing promise that every breaking release gets a guide. `single` → `message` is precisely the case that does not need one: the compiler names every call site. `docs/migrations/README.md` (added in #296) records that criterion.

## Verification

- Every `###` heading checked against the six Keep a Changelog groups; none non-conforming remains.
- The whole file scanned for bare `Before:`/`After:` blocks hanging off a sub-bullet rather than off the entry. The first version of that scan reported clean while missing item 4: it walked back only to the nearest non-blank line and required a `- ` prefix, which a sub-bullet spanning two lines does not have on its last line. Walking back to the owning bullet finds all three; re-run after the fixes, it is clean.
- `typos` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)