### PR TITLE
docs(migrations): add the 0.10.x to 0.11.0 migration guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,20 @@ jobs:
       # identical, as the bench job above does.
       - name: Run doc tests
         run: just test-doc
+      # The `include` entry for the migration guide is the only thing keeping
+      # `include_str!` resolvable in a published crate, and nothing else
+      # checks it: `cargo publish`'s verification is a `cargo build`, which
+      # drops the `cfg(doctest)` item before the macro runs. Package, extract
+      # and run the doctests against the extracted tree, which is what a
+      # consumer of the published crate gets.
+      - name: Run doc tests against the packaged crate
+        run: |
+          cargo package --no-verify
+          pkg=$(cargo metadata --no-deps --format-version 1 \
+                | jq -r '.packages[0] | "\(.name)-\(.version)"')
+          tar xzf "target/package/${pkg}.crate" -C target/package
+          cd "target/package/${pkg}"
+          cargo test --doc --features http,ws,native-tls
 
   msrv:
     name: MSRV (1.88.0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,16 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@just
       # The `test` job passes explicit target flags, which suppress the
       # implicit doctest run; `doc` builds docs without `cfg(doctest)`, and
       # `coverage` omits `--doctests`. Without this job nothing compiles the
       # examples in rustdoc comments or in the `cfg(doctest)`-included
       # migration guide, so an API rename could break every snippet and leave
-      # CI green.
+      # CI green. Invoked via `just` so the local and CI invocations are
+      # identical, as the bench job below does.
       - name: Run doc tests
-        run: cargo test --doc --all-features
+        run: just test-doc
 
   msrv:
     name: MSRV (1.88.0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,20 +147,12 @@ jobs:
       # identical, as the bench job above does.
       - name: Run doc tests
         run: just test-doc
-      # The `include` entry for the migration guide is the only thing keeping
-      # `include_str!` resolvable in a published crate, and nothing else
-      # checks it: `cargo publish`'s verification is a `cargo build`, which
-      # drops the `cfg(doctest)` item before the macro runs. Package, extract
-      # and run the doctests against the extracted tree, which is what a
-      # consumer of the published crate gets.
+      # Guards the `include` entry that keeps `include_str!` resolvable once
+      # published; the recipe explains why nothing else catches it. Invoked
+      # via `just` so the local and CI invocations are identical, and so the
+      # feature list lives in one place rather than being restated here.
       - name: Run doc tests against the packaged crate
-        run: |
-          cargo package --no-verify
-          pkg=$(cargo metadata --no-deps --format-version 1 \
-                | jq -r '.packages[0] | "\(.name)-\(.version)"')
-          tar xzf "target/package/${pkg}.crate" -C target/package
-          cd "target/package/${pkg}"
-          cargo test --doc --features http,ws,native-tls
+        run: just test-doc-packaged
 
   msrv:
     name: MSRV (1.88.0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
       # examples in rustdoc comments or in the `cfg(doctest)`-included
       # migration guide, so an API rename could break every snippet and leave
       # CI green. Invoked via `just` so the local and CI invocations are
-      # identical, as the bench job below does.
+      # identical, as the bench job above does.
       - name: Run doc tests
         run: just test-doc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,22 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  doctest:
+    name: Doc Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # The `test` job passes explicit target flags, which suppress the
+      # implicit doctest run; `doc` builds docs without `cfg(doctest)`, and
+      # `coverage` omits `--doctests`. Without this job nothing compiles the
+      # examples in rustdoc comments or in the `cfg(doctest)`-included
+      # migration guide, so an API rename could break every snippet and leave
+      # CI green.
+      - name: Run doc tests
+        run: cargo test --doc --all-features
+
   msrv:
     name: MSRV (1.88.0)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,9 +200,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A quit returned from `update` no longer travels as output, so `receive_quit`
   no longer requires it to be the next deliverable item, and a message the
   same command produced is not a failure there. In exchange the store stops
-  accepting work after that dispatch: `send`, `advance`, `receive` and
-  `receive_matching` fail from the moment the quit applies, which is what "no
-  later input can intervene" means on the test side. An applied quit that no
+  accepting work after that dispatch: `send`, `advance`, `receive`,
+  `receive_matching` and a second `receive_quit` fail from the moment the quit
+  applies, which is what "no later input can intervene" means on the test
+  side. Observation is unaffected — `state`, `redraw_requested` and
+  `subscription_ids` stay callable, and `finish` still passes. An applied quit that no
   `receive_quit` observed now fails `finish` and the drop check, with the same
   standing as output that was never received.
 
@@ -280,6 +282,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that constructs a runtime without running it, or that observes an init
   effect's side effects before `run()`, can tell the difference (RFC 0011 §3.4,
   INV-LC3)
+
+- **Breaking:** `run()` waits for every runtime-owned task to finish before it
+  returns
+
+  Termination used to abort: subscriptions were cancelled, command tasks were
+  aborted, and `run()` returned without waiting for either. It now joins the
+  task set to completion after the loop ends.
+
+  A producer that does not finish promptly once cancelled — a
+  `Command::perform` future or a subscription stream doing blocking work
+  between await points, an `on_teardown` finalizer waiting on something that
+  never arrives — was previously abandoned and is now waited for, so quitting
+  blocks on it. A task that never yields never lets `run()` return, and the
+  symptom is a hang at exit rather than an error.
+
+- **Breaking:** a quit carried by the init command ends bootstrap before any
+  frame renders and before any subscription source starts
+
+  The runtime terminates during the init dispatch, deterministically. Under
+  the previous contract subscriptions were initialized unconditionally before
+  the loop began and the quit arbitrated afterwards, so sources started and a
+  frame could render first — that outcome was one legal result of bootstrap
+  arbitration, and it is now settled the other way (RFC 0014 §6.2, amending
+  RFC 0011)
 
 - A new or restarted subscription is admitted only after every previously
   stopped subscription task has quiesced. A re-evaluation that removes or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> Upgrading from 0.10.x? The
+> [migration guide](docs/migrations/0.10-to-0.11.md) triages the entries below
+> into the ones the compiler reports, the ones that change behaviour with the
+> build still green, and the properties that no configuration restores.
+
 ### Added
 
 - `ProgramRuntime<P>` — the entry point for a `Program`, which is what a stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,8 +107,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cancellable` / `cancellable_with` move onto it
 
   `Command::perform`, `future`, `stream`, `run`, `message`, `retry` and
-  `retry_if` keep their names and return one effect carrier. The two keying
-  modifiers exist on that type alone, so keying a batch — one key reaching
+  `retry_if` keep their names and return one effect carrier, as does
+  `subscription::http::Mutation::mutate` under the `http` feature. The two
+  keying modifiers exist on that type alone, so keying a batch — one key reaching
   several carriers, a shape with no meaning to lower — no longer builds, and
   neither does keying `Command::quit()`, which names no run. `map`, `scoped`,
   `timeout` and `without_redraw` exist on both types and return their own, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,8 +235,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiler's path. `"shared"` and `"keyed"` retire with the channels they
   named, and `shared_pending` now reads as the data lane's residual occupancy.
 
-- **Breaking:** `RuntimeConfig` is `Clone` but no longer `Copy`; `Debug`, `Eq`,
-  and `PartialEq` remain (RFC 0007 §2.1)
+- **Breaking:** `RuntimeConfig` is `Clone` but no longer `Copy`; with the
+  `Default` derive added above, the full set is now `Clone`, `Debug`,
+  `Default`, `Eq`, `PartialEq` (RFC 0007 §2.1)
   - The type is the aggregation point for future runtime knobs, so a `Copy`
     config would turn the first non-`Copy` field added later into a breaking
     derive removal deferred onto whoever adds it; taking the removal now, while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (RFC 0008 §9)
 - `Command::teardown` and `Command::on_teardown`: tear down every run placed
   under a scope prefix, and register a finalizer that runs when one is
+- `RuntimeConfig` now derives `Default`, so `RuntimeConfig::default()` is
+  available beside `RuntimeConfig::new()`; both leave every control unset
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that need the kernel itself rather than the non-executing store beside it
   (RFC 0008 §9)
 - `Command::teardown` and `Command::on_teardown`: tear down every run placed
-  under a scope prefix, and register a finalizer that runs when one is
+  under a scope prefix, and register a finalizer that runs when a teardown
+  selects that scope
 - `RuntimeConfig` now derives `Default`, so `RuntimeConfig::default()` is
   available beside `RuntimeConfig::new()`; both leave every control unset
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,15 @@ include = [
     "examples/**/*",
     "tests/**/*",
     "benches/**/*",
-    # `src/lib.rs` pulls the migration guide in with `include_str!` under
+    # `src/lib.rs` pulls this guide in with `include_str!` under
     # `cfg(doctest)`. `cargo publish` verifies with `cargo build`, which drops
-    # the item before the macro runs, so leaving this out breaks
-    # `cargo test --doc` in the published crate and nowhere earlier.
-    "docs/migrations/**/*",
+    # the item before the macro runs, so leaving it out breaks
+    # `cargo test --doc` in the published crate and nowhere earlier; the
+    # `doctest` job packages and extracts the crate to catch that.
+    # Named file by file rather than `docs/migrations/**/*`, which would also
+    # ship `docs/migrations/README.md` — a maintainer policy index, not crate
+    # content.
+    "/docs/migrations/0.10-to-0.11.md",
     "/Cargo.toml",
     "/LICENSE",
     "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,18 @@ rust-version = "1.88.0"
 # Anchored with a leading slash: an include pattern without one is a
 # gitignore-style glob that matches at any depth, so a bare "README.md"
 # also swept `docs/rfcs/README.md` and `scripts/README.md` into the
-# package. The four directory patterns already contain a slash and are
+# package. The five directory patterns already contain a slash and are
 # anchored for that reason.
 include = [
     "src/**/*",
     "examples/**/*",
     "tests/**/*",
     "benches/**/*",
+    # `src/lib.rs` pulls the migration guide in with `include_str!` under
+    # `cfg(doctest)`. `cargo publish` verifies with `cargo build`, which drops
+    # the item before the macro runs, so leaving this out breaks
+    # `cargo test --doc` in the published crate and nowhere earlier.
+    "docs/migrations/**/*",
     "/Cargo.toml",
     "/LICENSE",
     "/README.md",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 # Anchored with a leading slash: an include pattern without one is a
 # gitignore-style glob that matches at any depth, so a bare "README.md"
 # also swept `docs/rfcs/README.md` and `scripts/README.md` into the
-# package. The five directory patterns already contain a slash and are
+# package. The four directory patterns already contain a slash and are
 # anchored for that reason.
 include = [
     "src/**/*",

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -35,7 +35,7 @@ Read the section if the condition holds.
 | [2.5 Batch keys](#25-commandbatch-honours-the-spawn-key-on-each-child) | You put keyed commands inside `Command::batch` |
 | [2.6 Batch cap](#26-batch_max_messages-unset-now-means-the-kernels-cap) | You leave `batch_max_messages` unset and depend on batch size |
 | [2.7 Init command](#27-constructing-a-runtime-no-longer-starts-the-init-command) | You construct a `Runtime` without running it |
-| [2.8 Subscription admission](#28-a-restarted-subscription-waits-for-the-old-task-to-quiesce) | You restart subscriptions that hold exclusive resources |
+| [2.8 Subscription admission](#28-subscription-admission-waits-on-any-stopping-subscription) | Your declared subscription set ever changes — the wait is runtime-wide, not per ID |
 | [2.9 Panic hook](#29-install_panic_hook-no-longer-restores-the-terminal-for-contained-panics) | You call `install_panic_hook` |
 | [3.1 Gauges](#31-gauge-events-must-be-partitioned-by-runtime_id) | You consume `tears::runtime::load` gauge events |
 | [3.2 Capacity waits](#32-the-capacity-wait-channel-field-takes-one-value) | You filter capacity-wait events on `channel` |
@@ -98,10 +98,11 @@ No alias is kept for the old name: it would misstate what it bounds.
 `RuntimeConfig` also drops `Copy` (`Clone`, `Debug`, `Eq` and `PartialEq`
 remain). The type is the aggregation point for future runtime knobs, so
 keeping `Copy` would turn the first non-`Copy` field added later into a
-breaking derive removal deferred onto whoever adds it. The practical effect
-is that the consuming setters now move the configuration, so discarding a
-setter's return value and then using the original is a compile error rather
-than a silent stale read.
+breaking derive removal deferred onto whoever adds it. The practical effect is
+narrow: the setters were already `#[must_use]` in 0.10.x, so discarding a
+setter's return value and using the original was already a warning. Losing
+`Copy` promotes it to a compile error, because the setter now moves the
+configuration rather than copying it.
 
 Before:
 
@@ -148,7 +149,9 @@ let unbounded = config;
 
 `Command::perform`, `future`, `stream`, `run`, `message`, `retry` and
 `retry_if` keep their names and now return `EffectCommand<Msg>` — one effect
-carrier. `cancellable` and `cancellable_with` exist **on that type alone**.
+carrier. With the `http` feature, `Mutation::mutate` returns
+`EffectCommand<Result<O, QueryError>>` for the same reason. `cancellable` and
+`cancellable_with` exist **on that type alone**.
 `map`, `scoped`, `timeout` and `without_redraw` exist on both types and
 return their own, so every modifier ordering that built before still builds.
 
@@ -270,9 +273,17 @@ leaving a window to cancel it — is gone with it. Code that cancelled a keyed
 command on a terminal event and *expected* the in-flight output to be
 suppressed may now see that output delivered.
 
-RFC 0003's explicit cancellation semantics are unchanged: a cancel still
-suppresses output that has not yet been admitted. What is gone is the extra
-window that ordering happened to grant.
+Cancellation itself did not weaken — it strengthened. From the point a
+revocation applies, *none* of that run's output is delivered, whether it was
+buffered on the lane beforehand or sent afterwards (RFC 0014 INV-RC5). So a
+cancel that runs still retracts output already sitting on the lane; there is
+no need for defensive handling of stale messages from a cancelled run,
+because they do not arrive.
+
+What is gone is only the extra *opportunity* to cancel that the old ordering
+handed out for free — the pull order no longer holds a keyed result back
+behind ready shared input, so an `update` that would have cancelled during
+that gap may simply never run.
 
 ### 2.3 A quit returned from `update` applies synchronously
 
@@ -371,21 +382,33 @@ running it, or that observes an init effect's side effects before `run()`,
 can tell the difference — which in practice means tests that built a runtime
 to assert on a side effect without driving it.
 
-### 2.8 A restarted subscription waits for the old task to quiesce
+### 2.8 Subscription admission waits on any stopping subscription
 
 A re-evaluation that removes or replaces a subscription requests its task's
-cancellation and **waits for that task to finish** before starting the
-replacement, so a source holding an exclusive resource — a socket, a file
-lock — is never live twice under one ID (RFC 0012 §4).
+cancellation and **waits for that task to finish** before admitting anything,
+so a source holding an exclusive resource — a socket, a file lock — is never
+live twice under one ID (RFC 0012 §4).
 
-Re-evaluations with no outstanding stopped task admit immediately as before:
-pure additions, restarts of already-finished subscriptions, and continuing
-subscriptions are all unaffected.
+**The wait is runtime-wide, not per ID.** While any stop-requested
+subscription anywhere has not yet quiesced, *every* admission is deferred —
+including subscriptions unrelated to the one being stopped. So the reach is
+wider than "you restart subscriptions":
 
-This is a fix, not a regression, but it changes timing: a restart now takes as
-long as the old source takes to drop. A source that ignores cancellation and
-blocks will delay its own replacement, where before it would have been
-shadowed by it.
+- Dropping subscription `A` and adding an unrelated `B` in the same
+  re-evaluation delays `B` until `A`'s task has finished. A pure addition is
+  unaffected only when nothing else is stopping at the time.
+- One source that is slow to honour cancellation therefore delays the start of
+  every other source, not just its own replacement.
+
+Re-evaluations with no stop outstanding anywhere admit immediately, as before:
+restarts of already-finished subscriptions and continuing subscriptions are
+unaffected.
+
+This is a fix, not a regression — it is what makes the exclusive-resource
+guarantee hold — but it changes timing, and the timing it changes is not
+confined to the subscription that caused it. If you have a source that ignores
+cancellation and blocks, it is now on the critical path for every subscription
+start in the runtime.
 
 Subscription re-evaluation also gained a message-independent trigger. The
 quiescence of a task stopped by a steady-state cause — an ID leaving the

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -353,6 +353,13 @@ change to yours: putting an `Action::Quit` into a carrier that a run is
 spawned for requires `Command::actions`, which is crate-visible under `test`
 and the bench-only feature and was not public in 0.10.x either.
 
+One wrapper does escape the crate — `producer_quit`, re-exported at the crate
+root under the `bench-internals` feature. It is `#[doc(hidden)]`, exists for
+the load harness's own measurements, and carries no semver guarantee, so
+enabling that feature puts you outside the public API rather than inside the
+reach of this change. If you have enabled it, this section is about you and
+the rest of this guide's assumptions are not.
+
 The public constructors cannot express it. `Command::stream` and
 `Command::run` both lower through `stream.map(Action::Message)`, so every item
 a spawned run emits is a message. `Command::quit()` builds the immediate-quit

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -95,8 +95,10 @@ Three changes land together.
 
 No alias is kept for the old name: it would misstate what it bounds.
 
-`RuntimeConfig` also drops `Copy` (`Clone`, `Debug`, `Eq` and `PartialEq`
-remain). The type is the aggregation point for future runtime knobs, so
+`RuntimeConfig` also drops `Copy` and gains `Default`, so the full derive set
+is now `Clone, Debug, Default, Eq, PartialEq` and `RuntimeConfig::default()`
+is available alongside `RuntimeConfig::new()` — the two are equivalent, both
+leaving every control unset. The type is the aggregation point for future runtime knobs, so
 keeping `Copy` would turn the first non-`Copy` field added later into a
 breaking derive removal deferred onto whoever adds it. The practical effect is
 narrow: the setters were already `#[must_use]` in 0.10.x, so discarding a
@@ -171,14 +173,23 @@ After:
 ```rust
 # use tears::prelude::*;
 # use tears::command::CommandId;
+# use ratatui::Frame;
 # #[derive(Debug)]
 # enum Message { Loaded(()) }
 # async fn fetch() {}
-fn update(msg: Message) -> Command<Message> {
+# struct MyApp;
+# impl Application for MyApp {
+#     type Message = Message;
+#     type Flags = ();
+#     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+#     fn view(&self, _: &mut Frame<'_>) {}
+#     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+fn update(&mut self, msg: Message) -> Command<Message> {
     Command::perform(fetch(), Message::Loaded)
         .cancellable(CommandId::new("load"))
         .into()
 }
+# }
 ```
 
 Two shapes the compiler reports less obviously.
@@ -273,17 +284,22 @@ leaving a window to cancel it — is gone with it. Code that cancelled a keyed
 command on a terminal event and *expected* the in-flight output to be
 suppressed may now see that output delivered.
 
-Cancellation itself did not weaken — it strengthened. From the point a
-revocation applies, *none* of that run's output is delivered, whether it was
-buffered on the lane beforehand or sent afterwards (RFC 0014 INV-RC5). So a
-cancel that runs still retracts output already sitting on the lane; there is
-no need for defensive handling of stale messages from a cancelled run,
-because they do not arrive.
+A cancel that *does* apply is as strong as before — stronger, in fact: from
+the point a revocation applies, none of that run's output is delivered,
+whether it was buffered on the lane beforehand or sent afterwards (RFC 0014
+INV-RC5). Nothing about the effect of a cancel changed.
 
-What is gone is only the extra *opportunity* to cancel that the old ordering
-handed out for free — the pull order no longer holds a keyed result back
-behind ready shared input, so an `update` that would have cancelled during
-that gap may simply never run.
+What changed is the *chance to issue one*. The pull order no longer holds a
+keyed result back behind ready shared input, so an `update` that would have
+cancelled during that gap may simply never run — the result is delivered
+first, and the cancel is decided afterwards, on a screen the result has
+already changed.
+
+**So keep the guard.** If an `update` handling a keyed result asks "is this
+still the request I want?" — a generation counter, a comparison against the
+currently selected item — that check is now doing more work than it was in
+0.10.x, not less. The strictness of `INV-RC5` covers output from a run that
+was cancelled in time; it says nothing about a run nobody got to cancel.
 
 ### 2.3 A quit returned from `update` applies synchronously
 
@@ -332,15 +348,24 @@ that observes it returns the quit:
 
 ```rust
 # use tears::prelude::*;
+# use ratatui::Frame;
 # #[derive(Debug)]
 # enum Message { Saved }
-fn update(msg: Message) -> Command<Message> {
+# struct MyApp;
+# impl Application for MyApp {
+#     type Message = Message;
+#     type Flags = ();
+#     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+#     fn view(&self, _: &mut Frame<'_>) {}
+#     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+fn update(&mut self, msg: Message) -> Command<Message> {
     match msg {
         // Observing `Saved` is what decides to terminate, so nothing can
         // terminate before `Saved` has been handled.
         Message::Saved => Command::quit(),
     }
 }
+# }
 ```
 
 ### 2.5 `Command::batch` honours the spawn key on each child
@@ -353,7 +378,10 @@ If your code batched keyed commands and *relied* on the keys being dropped —
 most likely without knowing it, since the warning was the only signal — those
 commands are now cancellable and subject to same-id policy. Two same-key
 children in one batch apply in declaration order as two consecutive
-dispatches, the second replacing the first under its own policy.
+dispatches, and which one survives is the second one's policy:
+`CancelInFlight` — what `cancellable` uses — stops the first and starts the
+second, while `KeepInFlight` discards the second and leaves the first
+running.
 
 The 0.10.x warning was a `tracing` event emitted by `Command::batch` when it
 folded the key away, on the `tears::command` target — a runtime event, not a

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -31,7 +31,7 @@ Read the section if the condition holds.
 | [2.1 One lane](#21-one-lane-per-key-isolation-is-gone) | You set a channel capacity, or run keyed commands concurrently |
 | [2.2 Delivery order](#22-shared-first-delivery-precedence-is-gone) | You relied on cancelling a keyed command before its output landed |
 | [2.3 Synchronous quit](#23-a-quit-returned-from-update-applies-synchronously) | You return `Command::quit()` from `update` |
-| [2.4 Producer quit](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output) | An effect stream emits a message and then quits |
+| [2.4 Producer quit](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output) | Never — no public constructor reaches it; read it only to rule the changelog entry out |
 | [2.5 Batch keys](#25-commandbatch-honours-the-spawn-key-on-each-child) | You put keyed commands inside `Command::batch` |
 | [2.6 Batch cap](#26-batch_max_messages-unset-now-means-the-kernels-cap) | You leave `batch_max_messages` unset and depend on batch size |
 | [2.7 Init command](#27-constructing-a-runtime-no-longer-starts-the-init-command) | You construct a `Runtime` without running it |
@@ -287,39 +287,37 @@ Two consequences for existing code:
 - A quit can no longer be suppressed after the fact. There is no window in
   which a cancel could reach it, because there is no buffered quit to reach.
 
-This is stricter than before, so it rarely breaks code. It is listed here
-because it is the *replacement* for the guarantee removed in
-[2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output).
+This is stricter than before, so it rarely breaks code. It is also the only
+quit an application can return from `update`, and — together with
+[2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)
+— the only quit the public API can express at all.
 
 ### 2.4 A producer-originated quit no longer orders against its own output
 
-**This is the change most likely to break a working application silently.**
+**No application code can reach this.** It is listed so that the changelog
+entry beside it does not send you looking for a shape you cannot have written.
 
-A quit emitted by a running effect takes a dedicated control lane, drained
-before every batch and never bounded, while that run's messages take the data
-lane. A run emitting `[Message(Saved), Quit]` therefore **no longer
-guarantees that `Saved` reaches `update` before termination**.
+The changelog records that a quit emitted by a running effect now takes a
+dedicated control lane while that run's messages take the data lane, so a run
+emitting `[Message(Saved), Quit]` no longer guarantees `Saved` reaches
+`update` first. That is a real change to the kernel's contract. It is not a
+change to yours: putting an `Action::Quit` into a carrier that a run is
+spawned for requires `Command::actions`, which is crate-visible under `test`
+and the bench-only feature and was not public in 0.10.x either.
 
-In exchange the quit is backlog-independent — it is not queued behind a full
-lane — and stays revocable until applied: cancelling its run still suppresses
-it.
+The public constructors cannot express it. `Command::stream` and
+`Command::run` both lower through `stream.map(Action::Message)`, so every item
+a spawned run emits is a message. `Command::quit()` builds the immediate-quit
+carrier, which lowering applies synchronously at its dispatch and never spawns
+— it is [2.3](#23-a-quit-returned-from-update-applies-synchronously), not a
+producer quit. Batching the two does not combine them into one run either;
+each leaf is spawned as its own branch.
 
-To find out whether this reaches you, look for any effect stream that emits at
-least one message and then quits. A `Command::stream` or `Command::run` whose
-last act is a quit is the shape at risk.
-
-Before — the message was ordered ahead of the quit by the channel:
-
-```rust,ignore
-Command::run(|mut emit| async move {
-    save().await;
-    emit(Message::Saved).await;
-    emit(Message::Quit).await; // `Saved` was guaranteed to land first
-})
-```
-
-After — move the quit to the `update` that observes the final message. That
-order is now pinned by construction rather than by channel timing:
+So there is nothing to search for and nothing to migrate. What *is* worth
+knowing is the shape that expresses "deliver this, then quit", because it is
+the one the runtime recommends and it is now ordered by construction rather
+than by channel timing — the effect emits its final message, and the `update`
+that observes it returns the quit:
 
 ```rust
 # use tears::prelude::*;
@@ -327,8 +325,8 @@ order is now pinned by construction rather than by channel timing:
 # enum Message { Saved }
 fn update(msg: Message) -> Command<Message> {
     match msg {
-        // Observing `Saved` is what decides to terminate, so the quit cannot
-        // outrun it.
+        // Observing `Saved` is what decides to terminate, so nothing can
+        // terminate before `Saved` has been handled.
         Message::Saved => Command::quit(),
     }
 }
@@ -346,8 +344,13 @@ commands are now cancellable and subject to same-id policy. Two same-key
 children in one batch apply in declaration order as two consecutive
 dispatches, the second replacing the first under its own policy.
 
-Search your build logs from 0.10.x for the discarded-key warning: every site
-that produced it changes behavior here.
+The 0.10.x warning was a `tracing` event emitted by `Command::batch` when it
+folded the key away, on the `tears::command` target — a runtime event, not a
+build diagnostic, so it is your application's log that recorded it and never
+`cargo build`. If you kept those logs, every occurrence marks a site that
+changes behaviour here. If you did not, the equivalent is a source search: a
+`cancellable` or `cancellable_with` call on a command that is passed to
+`Command::batch`.
 
 ### 2.6 `batch_max_messages` unset now means the kernel's cap
 
@@ -456,11 +459,15 @@ A quit returned from `update` no longer travels as output, so `receive_quit`
 no longer requires it to be the next deliverable item, and a message the same
 command produced is not a failure there.
 
-In exchange the store stops accepting work after that dispatch: `send`,
-`advance`, `receive` and `receive_matching` fail from the moment the quit
-applies. That is what "no later input can intervene" means on the test side.
-Tests that asserted on state *after* an observed quit must move those
-assertions before it.
+In exchange the store stops being *driven* after that dispatch: `send`,
+`advance`, `receive`, `receive_matching` and a second `receive_quit` fail from
+the moment the quit applies. That is what "no later input can intervene" means
+on the test side.
+
+Observation is unaffected. `state`, `redraw_requested` and `subscription_ids`
+stay callable after an observed quit, and `finish` still passes, so assertions
+about the final state stay where they are. What must move — or go — is any
+call that drives the store further.
 
 An applied quit that no `receive_quit` observed now fails `finish` and the
 drop check, with the same standing as output that was never received.
@@ -509,12 +516,14 @@ Nothing here is required to upgrade.
 
 ## Not preserved, and not restorable
 
-Three properties are gone by construction. No configuration brings them back,
-so if your design depends on one, it needs a different shape rather than a
-different setting.
+Two properties an application could depend on are gone by construction. No
+configuration brings them back, so if your design depends on one, it needs a
+different shape rather than a different setting.
 
 - Per-key producer isolation ([2.1](#21-one-lane-per-key-isolation-is-gone)).
 - Shared-first delivery precedence, and the cancel window it granted
   ([2.2](#22-shared-first-delivery-precedence-is-gone)).
-- Ordering between a producer's own messages and its quit
-  ([2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)).
+
+A third — ordering between a producer's own messages and its quit — is also
+gone, but no public constructor could express the shape that depended on it
+([2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)).

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -28,19 +28,23 @@ Read the section if the condition holds.
 | [1.1 Frame rate](#11-the-frame-rate-is-gone) | Always — `Runtime::new` changed arity |
 | [1.2 `RuntimeConfig`](#12-runtimeconfig-renamed-narrowed-and-no-longer-copy) | You call `Runtime::with_config` |
 | [1.3 `EffectCommand`](#13-effect-constructors-return-effectcommand) | Always — every effect constructor changed its return type |
-| [2.1 One lane](#21-one-lane-per-key-isolation-is-gone) | You set a channel capacity, or run keyed commands concurrently |
+| [2.1 One lane](#21-one-lane-per-key-isolation-is-gone) | You run more than one producer at a time — the delivery-order half applies at the unbounded default too |
 | [2.2 Delivery order](#22-shared-first-delivery-precedence-is-gone) | You relied on cancelling a keyed command before its output landed |
 | [2.3 Synchronous quit](#23-a-quit-returned-from-update-applies-synchronously) | You return `Command::quit()` from `update` |
 | [2.4 Producer quit](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output) | Never — no public constructor reaches it; read it only to rule the changelog entry out |
 | [2.5 Batch keys](#25-commandbatch-honours-the-spawn-key-on-each-child) | You put keyed commands inside `Command::batch` |
-| [2.6 Batch cap](#26-batch_max_messages-unset-now-means-the-kernels-cap) | You leave `batch_max_messages` unset and depend on batch size |
-| [2.7 Init command](#27-constructing-a-runtime-no-longer-starts-the-init-command) | You construct a `Runtime` without running it |
+| [2.6 Batch cap](#26-batch_max_messages-unset-now-means-the-kernels-cap) | Input-to-render latency matters to you — whether or not you set `batch_max_messages` |
+| [2.7 Init](#27-constructing-a-runtime-no-longer-runs-applicationnew) | `Application::new` does anything besides build state, or you construct a `Runtime` without running it |
 | [2.8 Subscription admission](#28-subscription-admission-waits-on-any-stopping-subscription) | Your declared subscription set ever changes — the wait is runtime-wide, not per ID |
 | [2.9 Panic hook](#29-install_panic_hook-no-longer-restores-the-terminal-for-contained-panics) | You call `install_panic_hook` |
+| [2.10 Input priority](#210-terminal-input-is-no-longer-prioritized-over-producer-output) | You set `data_lane_capacity` — especially if you sized it for UI responsiveness |
+| [2.11 Shutdown join](#211-run-now-waits-for-every-runtime-owned-task-to-finish) | Any producer of yours can be slow to finish once cancelled |
+| [2.12 Init quit](#212-a-quit-from-the-init-command-ends-bootstrap-before-anything-starts) | `Application::new` can return a quit |
 | [3.1 Gauges](#31-gauge-events-must-be-partitioned-by-runtime_id) | You consume `tears::runtime::load` gauge events |
-| [3.2 Capacity waits](#32-the-capacity-wait-channel-field-takes-one-value) | You filter capacity-wait events on `channel` |
+| [3.2 `shared_pending`](#32-shared_pending-counts-a-different-thing) | You chart or alert on `shared_pending` — its name and event are unchanged, its meaning is not |
+| [3.3 Capacity waits](#33-the-capacity-wait-channel-field-takes-one-value) | You filter capacity-wait events on `channel` |
 | [4.1 `TestStore` quit](#41-receive_quit-observes-an-applied-quit-and-the-store-is-terminal-after-it) | You use `TestStore::receive_quit` |
-| [4.2 Cleanup hooks](#42-teststore-runs-cleanup-hooks-and-gained-two-leak-classes) | You register `Command::on_teardown` |
+| [4.2 Cleanup hooks](#42-cleanup-hooks-bring-two-new-exhaustiveness-failures) | You plan to adopt `Command::teardown` — not a migration item, the API is new |
 
 ---
 
@@ -253,25 +257,42 @@ carriers.
 
 ### 2.1 One lane: per-key isolation is gone
 
-All producer output — keyed command output, unkeyed command output,
-subscription output — travels **one lane**, tagged with the run that produced
-it. The private per-key channels are gone.
+Producer output — keyed command output, unkeyed command output, subscription
+output — travels **one lane**, tagged with the run that produced it. The
+private per-key channels are gone. (One output does not travel it: a
+producer-originated quit takes an unbounded control lane. See
+[2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)
+— no public constructor reaches it.)
 
-**This is a property loss worth stating plainly.** One key's backlog now
-delays admission for every other producer. The isolation the private channels
-gave — one command's full channel never delaying another's — is not
+**This is a property loss worth stating plainly.** The isolation the private
+channels gave — one command's output never delaying another's — is not
 preserved, and **no configuration restores it**.
 
-You are affected if a bounded `data_lane_capacity` is set *and* several
-producers can be in flight at once. Under an unbounded lane there is no
-admission wait to share, so the loss is not observable; under a bounded one, a
-slow consumer of one key's output now backs up every other producer behind
-it.
+It reaches you in two different ways, and only one of them depends on
+capacity:
+
+- **Delivery order, at any capacity — including the unbounded default.** In
+  0.10.x each keyed command had its own receiver and the pull point
+  multiplexed them round-robin, so one key emitting ten thousand items did not
+  push another key's single item behind them. Under one FIFO lane it does.
+  This is the reach that is easy to miss: leaving `data_lane_capacity` unset
+  does not opt out of it.
+- **Admission, under a bounded lane only.** With `data_lane_capacity` set, a
+  slow consumer of one key's output now backs every other producer up behind
+  it, where a full private channel used to delay only its own command.
 
 If you were relying on isolation to keep a latency-sensitive producer
 responsive under another's burst, the shape that survives is to stop
 generating the burst — bound it at the source (a `stream` that samples rather
 than forwards every item, a coalescing `update`), rather than at the channel.
+
+One bounded-mode hazard is worth naming because it has no lane-capacity fix:
+an application that spawns a command per processed message can, under
+overload, convert message backlog into *blocked-producer* backlog — blocked
+command tasks each holding one in-flight message — which no capacity bounds.
+The producer gauges make it visible (`blocked` on the
+`tears::runtime::load` gauge event). Restructure the effect flow rather than
+resizing the lane.
 
 ### 2.2 Shared-first delivery precedence is gone
 
@@ -394,44 +415,73 @@ changes behaviour here. If you did not, the equivalent is a source search: a
 ### 2.6 `batch_max_messages` unset now means the kernel's cap
 
 The 100µs window that used to cap a batch is gone, along with the wall-clock
-reads it needed. Left unset, `batch_max_messages` now means the kernel's own
-count cap rather than an uncapped batch. A batch is finite under every
-configuration; the control only replaces the default count.
+reads it needed. A batch is finite under every configuration; what bounds it
+is now a count and nothing else.
 
-To find out whether this reaches you: it only can if you left the control
-unset, since an explicit value meant a count cap before and means one now. The
-observable is the `pulled` field on the per-batch `tears::runtime::load` event
-— the count of inputs taken in one batch. Under 0.10.x that count was
-whatever arrived inside the time window; it is now bounded by the kernel's
-count. If you have `pulled` recorded from a 0.10.x run under representative
-load, compare its distribution; if it used to exceed the new bound, your
-batches are smaller and each one reaches `view` sooner. Setting
-`batch_max_messages` explicitly pins the count either way, and is the way to
-stop the default from moving under you again.
+**This reaches you whether or not you set the control, and in opposite
+directions.** In 0.10.x the window applied *unconditionally* and an explicit
+`batch_max_messages` was an additional cap inside it — a batch ended at
+whichever came first. Removing the window changes both cases:
 
-### 2.7 Constructing a `Runtime` no longer starts the init command
+- **Left unset:** the bound is now the kernel's own count cap, 1024 inputs,
+  where before it was however many arrived within 100µs. If your batches used
+  to hit the window, they are now larger — up to 1024 — and each one reaches
+  `view` later.
+- **Set explicitly:** your value is now the *only* bound. A configuration
+  whose per-input work exceeded 100µs used to end batches well short of the
+  value you set; it now drains up to it. Batches get **larger**, not smaller.
 
-The command `Application::new` returns is dispatched inside `run()`, ahead of
-the first subscription reconcile. A runtime that is constructed and never run
-spawns no task and runs no effect (RFC 0011 §3.4, INV-LC3).
+The observable is the `pulled` field on the per-batch `tears::runtime::load`
+event — the count of inputs taken in one batch, the opening input included.
+If you have `pulled` recorded from a 0.10.x run under representative load,
+compare its distribution against 1024 (or against your explicit value): where
+the old distribution sat below the bound, the window was what ended those
+batches, and those batches are the ones that grow.
+
+If input-to-render latency matters more to you than per-batch throughput, set
+`batch_max_messages` to a value near the old distribution's typical size
+rather than leaving it unset — 1024 is a finiteness guarantee, not a latency
+target.
+
+### 2.7 Constructing a `Runtime` no longer runs `Application::new`
+
+**More moved than the init command.** In 0.10.x `Runtime::new` and
+`with_config` called `Application::new(flags)` eagerly. They are now `const
+fn` that only store the flags; `Application::new` runs inside `run()`, and the
+command it returns is dispatched there too, ahead of the first subscription
+reconcile (RFC 0011 §3.4, INV-LC3).
+
+So everything in your `new` body moves to `run()`, not just the returned
+command's effect — registering a global, opening a handle, seeding a channel,
+consuming the `Flags` value, and any panic on invalid flags, which now
+surfaces from `run(...).await` rather than from the constructor.
 
 The order between the init command and the first reconcile is unchanged, and
-public signatures are untouched. Only code that constructs a runtime without
-running it, or that observes an init effect's side effects before `run()`,
-can tell the difference — which in practice means tests that built a runtime
-to assert on a side effect without driving it.
+public signatures are untouched. You are affected if anything observes those
+side effects between construction and `run()` — most often a test that builds
+a runtime to assert on one without driving it, but also production startup
+code that constructs the runtime early and awaits `run()` later.
+
+If the init command itself quits, see
+[2.12](#212-a-quit-from-the-init-command-ends-bootstrap-before-anything-starts).
 
 ### 2.8 Subscription admission waits on any stopping subscription
 
 A re-evaluation that removes or replaces a subscription requests its task's
-cancellation and **waits for that task to finish** before admitting anything,
-so a source holding an exclusive resource — a socket, a file lock — is never
-live twice under one ID (RFC 0012 §4).
+cancellation and **waits for that task to finish** before starting any
+subscription, so a source holding an exclusive resource — a socket, a file
+lock — is never live twice under one ID (RFC 0012 §4, INV-SE3).
 
-**The wait is runtime-wide, not per ID.** While any stop-requested
-subscription anywhere has not yet quiesced, *every* admission is deferred —
-including subscriptions unrelated to the one being stopped. So the reach is
-wider than "you restart subscriptions":
+The wait covers subscription starts only. Command spawns are not deferred by
+it, and neither is a stopped *command* run a subject of it: a scope teardown
+that selects both a command run and a subscription run defers admission behind
+the subscription run alone.
+
+**Within subscriptions, the wait is runtime-wide, not per ID.** While any
+stop-requested subscription anywhere has not yet quiesced — including one
+stopped by an *earlier* re-evaluation, or by a scope teardown — every
+subscription start is deferred, not just the replacement for the ID being
+stopped. So the reach is wider than "you restart subscriptions":
 
 - Dropping subscription `A` and adding an unrelated `B` in the same
   re-evaluation delays `B` until `A`'s task has finished. A pure addition is
@@ -450,20 +500,35 @@ cancellation and blocks, it is now on the critical path for every subscription
 start in the runtime.
 
 Subscription re-evaluation also gained a message-independent trigger. The
-quiescence of a task stopped by a steady-state cause — an ID leaving the
-declared set, a restart, or a scope teardown selecting the run — marks
-subscriptions dirty by itself, so the reconcile the admission wait deferred
-runs on the pass that observes the quiescence instead of waiting for the next
-message. A source that merely *finishes* marks nothing: it restarts at the
-next re-evaluation, as it did before (RFC 0012 §4.2, INV-SE5).
+quiescence of a task stopped by a steady-state cause — an ID removed or
+*replaced* out of the declared set by a re-evaluation, or selected by a scope
+teardown — marks subscriptions dirty by itself, so the reconcile the admission
+wait deferred runs on the pass that observes the quiescence instead of waiting
+for the next message (RFC 0012 §4.2, INV-SE5).
+
+A source that merely *finishes* still marks nothing itself — but that does not
+make it unaffected, because someone else's quiescence can now carry it. If
+source `A` finishes naturally while a stopped `B` is still quiescing, `B`'s
+quiescence dirties the next pass, and that re-evaluation restarts the
+still-declared `A` **with no message having been processed in between**. Under
+0.10.x `A` waited for the next message.
+
+So a one-shot source with an external side effect — a fetch that runs once per
+declared key — can now re-fire earlier, and in an application whose declared
+set changes often (so something is usually quiescing) noticeably more often.
+If re-running it is not harmless, carry the "already done" state in your model
+rather than relying on the source not being re-declared.
 
 ### 2.9 `install_panic_hook` no longer restores the terminal for contained panics
 
-A panic inside a runtime-owned producer task — an unkeyed command task, a
-keyed command task, or a subscription forwarder — is caught by the runtime and
-leaves the application running (RFC 0011 §5, INV-LC8). The hook now delegates
-to the previously installed hook without leaving raw mode or the alternate
-screen, and the still-running application keeps drawing.
+A panic inside a runtime-owned task — an unkeyed command task, a keyed command
+task, a subscription forwarder, **or a `Command::on_teardown` finalizer** — is
+caught by the runtime and leaves the application running (RFC 0011 §5,
+INV-LC8). The hook now delegates to the previously installed hook without
+leaving raw mode or the alternate screen, and the still-running application
+keeps drawing. A finalizer is spawned by the same contained path as the three
+producer kinds, so a panic in one is contained exactly like theirs — it
+neither restores the terminal nor ends the application.
 
 Panics on the application's own driving path — `update`, `view`,
 `subscriptions`, a subscription's source constructor — still restore the
@@ -473,39 +538,120 @@ where nothing can be contained.
 **A contained panic's report is written on the alternate screen in raw mode.**
 If you want it readable, point your panic reporter at a file or log target.
 
+### 2.10 Terminal input is no longer prioritized over producer output
+
+In 0.10.x terminal input reached `update` through the shared channel, whose
+capacity no keyed output consumed, and shared-first pull put it ahead of every
+ready keyed result. On this kernel input is subscription output like any
+other: same lane, same capacity, same FIFO (RFC 0014 §3.2).
+
+This is stated separately from
+[2.1](#21-one-lane-per-key-isolation-is-gone) and
+[2.2](#22-shared-first-delivery-precedence-is-gone) because its subject is the
+user-facing input path rather than a delivery order between producers. It
+reaches you if you set `data_lane_capacity`: a keystroke's admission can now
+queue behind keyed command output that a full lane is holding, so **the
+interactivity a bounded configuration buys is not what it was**. No
+configuration restores it, and the per-command routing advice the old property
+carried — put liveness-critical output in an unkeyed command — has no
+successor.
+
+If you sized a bounded lane specifically to keep the UI responsive under load,
+that reasoning no longer holds and the configuration deserves re-deriving
+rather than carrying over.
+
+### 2.11 `run()` now waits for every runtime-owned task to finish
+
+Termination used to abort: `run()` cancelled subscriptions, aborted command
+tasks and returned. It now joins — after the loop ends, the runtime drains its
+task set to completion before `run()` resolves.
+
+You are affected if any producer can fail to finish promptly once cancelled: a
+`Command::perform` future or a subscription stream doing blocking work between
+await points, or an `on_teardown` finalizer waiting on something that never
+arrives. Under 0.10.x such a task was abandoned and quitting returned anyway;
+now **quitting waits for it**, and a task that never yields never lets `run()`
+return.
+
+To find out whether this reaches you, look for producers that do blocking work
+without an await point and for anything holding a resource across cancellation.
+The fix is the ordinary one — make the work cancellation-aware, or move
+blocking work onto a blocking-safe task — and it is worth doing before the
+upgrade rather than after, because the symptom is a hang at exit rather than an
+error.
+
+### 2.12 A quit from the init command ends bootstrap before anything starts
+
+If the command `Application::new` returns carries a quit — flag validation, a
+`--version`-style early exit — the runtime now terminates during the init
+dispatch: **no frame is rendered and no subscription source is started**.
+
+Under 0.10.x subscriptions were initialized unconditionally before the loop
+began, and the quit arbitrated afterwards, so sources started and a frame could
+render first. That outcome was one legal result of bootstrap arbitration then;
+it is now deterministic in the other direction (RFC 0014 §6.2, amending
+RFC 0011).
+
+You are affected if `Application::new` can return a quit and you relied on
+anything happening first — a farewell frame, a source that performed a side
+effect on start. Move that work to before the runtime is constructed, where it
+is ordinary code rather than a race you were winning.
+
 ---
 
 ## 3. Telemetry consumers
 
-Field names and the rest of the schema are unchanged, deliberately: a renamed
-telemetry field breaks dashboards and alert rules silently, off the compiler's
-path. Two semantic changes still need action.
+Field *names* are unchanged, deliberately: a renamed telemetry field breaks
+dashboards and alert rules silently, off the compiler's path. Three semantic
+changes still need action, and one of them is a field whose name and event are
+both unchanged.
 
 ### 3.1 Gauge events must be partitioned by `runtime_id`
 
-The `tears::runtime::load` producer-gauge event gained a `runtime_id` field —
+The `tears::runtime::load` producer-gauge event gained a `runtime_id` field:
 the emitting runtime instance's process-local identifier, never reused within
-the process — and the `seq` ordering counter added in 0.10.1 is now scoped per
-instance.
+the process.
+
+The `seq` counter it accompanies was **already** per-instance in 0.10.1 —
+what was missing was any way to tell which instance an event came from. So
+this is not a change in `seq`'s scope; it is the first release in which a
+multi-runtime consumer can read gauges correctly at all.
 
 The current value of each gauge is the value on the greatest-`seq` event
 **among events carrying that `runtime_id`**. A consumer partitions by
 `runtime_id` first and never reads gauge events in arrival order. Comparing
 `seq` across instances is meaningless.
 
-A 0.10.1 consumer that took the global maximum `seq` will read a wrong current
-value as soon as a second runtime instance exists in the process. If your
-process only ever builds one runtime, the reading is unchanged — but the
+If your process builds more than one runtime, your 0.10.x dashboard was
+already reading interleaved streams as one and was already wrong — upgrading
+does not break it, it makes it fixable, and the fix is to partition. If your
+process only ever builds one runtime, the reading is unchanged, but the
 partition is still worth adding, since nothing in the schema will tell you
 when that stops being true.
 
-The batch and capacity-wait events are unchanged and carry neither field.
+The batch and capacity-wait events carry neither field.
 
-### 3.2 The capacity-wait `channel` field takes one value
+### 3.2 `shared_pending` counts a different thing
+
+`shared_pending` is on the per-batch event, beside `pulled` and `updated`. Its
+name and its event are both unchanged, so nothing will draw your attention to
+it — but what it counts changed with the lanes.
+
+In 0.10.x it was the shared application channel's residual occupancy: input
+and unkeyed command output, with keyed command output in separate channels it
+did not see. It is now the *data lane's* residual occupancy, and that lane
+carries every producer's output — keyed included — plus terminal input.
+
+A panel labelled "input backlog" that charts `shared_pending` therefore
+silently changed meaning, and it will read higher than before on the same
+workload for a reason that is not a regression. Relabel it, or narrow what
+you conclude from it.
+
+### 3.3 The capacity-wait `channel` field takes one value
 
 `channel` is now always `"data"`. The values `"shared"` and `"keyed"` retire
-with the channels they named, and `shared_pending` now reads as the data
-lane's residual occupancy.
+with the channels they named. The event's other field, `wait_us`, is
+unchanged.
 
 Any dashboard panel or alert rule filtering on `channel == "keyed"` will
 silently match nothing. Drop the filter rather than repointing it: there is no
@@ -535,17 +681,27 @@ An applied quit that no `receive_quit` observed now fails `finish` and the
 drop check, with the same standing as output that was never received.
 
 A producer-originated quit still travels as output and is still asserted the
-same way.
+same way — but no application can produce one
+([2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)),
+so in practice every quit your tests observe is the applied kind above.
 
-### 4.2 `TestStore` runs cleanup hooks, and gained two leak classes
+### 4.2 Cleanup hooks bring two new exhaustiveness failures
 
-`Command::on_teardown` registrations reached the store and were dropped; they
-are now armed against their scope and run by the teardown that selects them,
-at most once. Exhaustiveness gained two leak classes:
+This is not a migration item: `Command::teardown` and `Command::on_teardown`
+are **new** in 0.11.0, so no 0.10.x test can have used them. It is here rather
+than in [§5](#5-new-surfaces-optional) because what they add to `TestStore` is
+two ways for a test to fail that no other feature produces, and they are worth
+knowing before you adopt the API rather than after.
+
+`on_teardown` registrations are armed against their scope and run by the
+teardown that selects them, at most once. Exhaustiveness counts two new leak
+classes:
 
 - **A registration still armed when the test ends** fails `finish` and the
   drop check, the way undelivered output does. Tear the scope down, or end
-  with a quit, which discards unfired hooks as termination does.
+  with a quit — which discards unfired hooks as termination does, provided you
+  then observe it with `receive_quit`, since an applied-but-unobserved quit
+  fails `finish` on its own ([4.1](#41-receive_quit-observes-an-applied-quit-and-the-store-is-terminal-after-it)).
 - **A finalizer that has not finished** fails them too. This one is
   recoverable rather than lost: the store holds the run and re-polls it at
   `advance` and at the checks, so a hook waiting on the controlled clock
@@ -566,9 +722,14 @@ Nothing here is required to upgrade.
   `into_program`), and the `Keyed` and `Slot` collections. `ProgramRuntime<P>`
   is the entry point a stack of these closes into, and `Runtime<App>` is that
   type with the `Application` adapter applied — both run the same kernel over
-  the same lanes.
+  the same lanes. `ProgramRuntime::run` resolves to `Exit`, also new at the
+  crate root, where the `Runtime<App>` facade's `run` keeps returning
+  `Result<(), _>`.
 - **`Command::teardown` and `Command::on_teardown`**: tear down every run
-  placed under a scope prefix, and register a finalizer that runs when one is.
+  placed under a scope prefix, and register a finalizer that runs when a
+  teardown selects that scope. See
+  [4.2](#42-cleanup-hooks-bring-two-new-exhaustiveness-failures) for what they
+  add to `TestStore`'s exhaustiveness checks.
 - **`tears::testing::TestDriver`**, the stage-3 driving layer (RFC 0008 §9).
   It drives the production kernel a pass at a time — the same construction
   path, the same runtime-owned tasks, the same lanes — with the driving
@@ -578,19 +739,25 @@ Nothing here is required to upgrade.
 
 ## Not preserved, and not restorable
 
-Three properties an application could depend on are gone by construction. No
-configuration brings them back, so if your design depends on one, it needs a
-different shape rather than a different setting.
+**Four** properties an application could depend on are gone by construction.
+No configuration brings them back, so if your design depends on one, it needs
+a different shape rather than a different setting.
 
-- Per-key producer isolation ([2.1](#21-one-lane-per-key-isolation-is-gone)).
-- Shared-first delivery precedence, and the cancel window it granted
-  ([2.2](#22-shared-first-delivery-precedence-is-gone)).
-- A ceiling on render frequency ([1.1](#11-the-frame-rate-is-gone)). Every pass
-  that leaves the view dirty draws, so a frame rate passed to *throttle*
-  drawing — a slow terminal, a session over SSH — has no replacement control.
-  The work to throttle has to move into the state that drives the view, so
-  that fewer passes leave it dirty.
+1. Per-key producer isolation — in delivery order at any capacity, and in
+   admission under a bounded lane
+   ([2.1](#21-one-lane-per-key-isolation-is-gone)).
+2. Shared-first delivery precedence, and the cancel window it granted
+   ([2.2](#22-shared-first-delivery-precedence-is-gone)).
+3. Priority for terminal input over producer output, and with it the
+   interactivity a bounded lane used to buy
+   ([2.10](#210-terminal-input-is-no-longer-prioritized-over-producer-output)).
+4. A ceiling on render frequency ([1.1](#11-the-frame-rate-is-gone)). Every
+   pass that leaves the view dirty draws, so a frame rate passed to *throttle*
+   drawing — a slow terminal, a session over SSH — has no replacement control.
+   The work to throttle has to move into the state that drives the view, so
+   that fewer passes leave it dirty.
 
-A third — ordering between a producer's own messages and its quit — is also
-gone, but no public constructor could express the shape that depended on it
+A fifth — ordering between a producer's own messages and its quit — is also
+gone, but it is listed apart because no public constructor could express the
+shape that depended on it
 ([2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)).

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -5,6 +5,11 @@ RFC 0014) and rebuilds lifecycle, subscription execution and scope teardown
 on top of it (RFC 0011, RFC 0012, RFC 0013). The public skeleton — the
 `Application` trait, `update`, `view`, `subscriptions` — is unchanged.
 
+This guide is the triage: which changes reach you, and how to tell. The
+[changelog](https://github.com/akiomik/tears/blob/main/CHANGELOG.md) is the
+record of what changed, with a before/after beside each entry; where this
+guide says "the changelog entry", that is where to look.
+
 The upgrade splits into three kinds of work, and they are not equally
 dangerous:
 

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -1,0 +1,520 @@
+# Migrating from 0.10.x to 0.11.0
+
+0.11.0 replaces the runtime's core with the reducer-first kernel (RFC 0010,
+RFC 0014) and rebuilds lifecycle, subscription execution and scope teardown
+on top of it (RFC 0011, RFC 0012, RFC 0013). The public skeleton — the
+`Application` trait, `update`, `view`, `subscriptions` — is unchanged.
+
+The upgrade splits into three kinds of work, and they are not equally
+dangerous:
+
+1. **Changes the compiler reports.** Renamed and removed items, and the new
+   effect carrier. Fix until it builds; the compiler names every site.
+2. **Changes the compiler cannot report.** Your code still builds, and it
+   behaves differently. These need reading, not fixing — each one below says
+   how to tell whether it reaches you.
+3. **Changes to test and telemetry consumers.** Failing tests with
+   non-obvious causes, and dashboards that read the wrong value in silence.
+
+Group 2 is where the real risk is. Work through it even if the build is
+already green.
+
+## Triage
+
+Read the section if the condition holds.
+
+| Section | Read it if |
+| --- | --- |
+| [1.1 Frame rate](#11-the-frame-rate-is-gone) | Always — `Runtime::new` changed arity |
+| [1.2 `RuntimeConfig`](#12-runtimeconfig-renamed-narrowed-and-no-longer-copy) | You call `Runtime::with_config` |
+| [1.3 `EffectCommand`](#13-effect-constructors-return-effectcommand) | Always — every effect constructor changed its return type |
+| [2.1 One lane](#21-one-lane-per-key-isolation-is-gone) | You set a channel capacity, or run keyed commands concurrently |
+| [2.2 Delivery order](#22-shared-first-delivery-precedence-is-gone) | You relied on cancelling a keyed command before its output landed |
+| [2.3 Synchronous quit](#23-a-quit-returned-from-update-applies-synchronously) | You return `Command::quit()` from `update` |
+| [2.4 Producer quit](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output) | An effect stream emits a message and then quits |
+| [2.5 Batch keys](#25-commandbatch-honours-the-spawn-key-on-each-child) | You put keyed commands inside `Command::batch` |
+| [2.6 Batch cap](#26-batch_max_messages-unset-now-means-the-kernels-cap) | You leave `batch_max_messages` unset and depend on batch size |
+| [2.7 Init command](#27-constructing-a-runtime-no-longer-starts-the-init-command) | You construct a `Runtime` without running it |
+| [2.8 Subscription admission](#28-a-restarted-subscription-waits-for-the-old-task-to-quiesce) | You restart subscriptions that hold exclusive resources |
+| [2.9 Panic hook](#29-install_panic_hook-no-longer-restores-the-terminal-for-contained-panics) | You call `install_panic_hook` |
+| [3.1 Gauges](#31-gauge-events-must-be-partitioned-by-runtime_id) | You consume `tears::runtime::load` gauge events |
+| [3.2 Capacity waits](#32-the-capacity-wait-channel-field-takes-one-value) | You filter capacity-wait events on `channel` |
+| [4.1 `TestStore` quit](#41-receive_quit-observes-an-applied-quit-and-the-store-is-terminal-after-it) | You use `TestStore::receive_quit` |
+| [4.2 Cleanup hooks](#42-teststore-runs-cleanup-hooks-and-gained-two-leak-classes) | You register `Command::on_teardown` |
+
+---
+
+## 1. Changes the compiler reports
+
+### 1.1 The frame rate is gone
+
+`FrameRate`, `FrameRateError` and `Runtime::new`'s second parameter are
+removed. Render cadence is bounded by the pass now: the loop renders when a
+pass leaves the view dirty and parks when it has no work, so there is no
+period left to configure.
+
+Before:
+
+```rust,ignore
+let frame_rate = FrameRate::new(NonZeroU32::new(60).expect("non-zero"))?;
+let runtime = Runtime::<MyApp>::new(flags, frame_rate);
+```
+
+After:
+
+```rust
+# use tears::prelude::*;
+# use ratatui::Frame;
+# struct MyApp;
+# enum Message {}
+# impl Application for MyApp {
+#     type Message = Message;
+#     type Flags = ();
+#     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+#     fn update(&mut self, _: Message) -> Command<Message> { Command::none() }
+#     fn view(&self, _: &mut Frame<'_>) {}
+#     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+# }
+let runtime = Runtime::<MyApp>::new(());
+```
+
+A frame rate you passed to keep an animation moving has no replacement knob,
+and needs none: a pass that leaves the view dirty draws. A frame rate you
+passed to *throttle* drawing has no replacement either — if you were using it
+that way, the work to throttle belongs in the state that drives the view.
+
+### 1.2 `RuntimeConfig`: renamed, narrowed, and no longer `Copy`
+
+Three changes land together.
+
+- `app_channel_capacity` is renamed `data_lane_capacity`.
+- `keyed_channel_capacity` is **removed** — there is no per-key channel left
+  to size (see [2.1](#21-one-lane-per-key-isolation-is-gone)).
+- `RuntimeConfig::new` takes no arguments, since the frame rate it used to
+  carry is gone.
+
+No alias is kept for the old name: it would misstate what it bounds.
+
+`RuntimeConfig` also drops `Copy` (`Clone`, `Debug`, `Eq` and `PartialEq`
+remain). The type is the aggregation point for future runtime knobs, so
+keeping `Copy` would turn the first non-`Copy` field added later into a
+breaking derive removal deferred onto whoever adds it. The practical effect
+is that the consuming setters now move the configuration, so discarding a
+setter's return value and then using the original is a compile error rather
+than a silent stale read.
+
+Before:
+
+```rust,ignore
+let config = RuntimeConfig::new(frame_rate)
+    .app_channel_capacity(NonZeroUsize::new(1024).expect("non-zero"))
+    .keyed_channel_capacity(NonZeroUsize::new(16).expect("non-zero"));
+let runtime = Runtime::<MyApp>::with_config(flags, config);
+```
+
+After:
+
+```rust
+# use std::num::NonZeroUsize;
+# use tears::prelude::*;
+# use tears::RuntimeConfig;
+# use ratatui::Frame;
+# struct MyApp;
+# enum Message {}
+# impl Application for MyApp {
+#     type Message = Message;
+#     type Flags = ();
+#     fn new(_: ()) -> (Self, Command<Message>) { (MyApp, Command::none()) }
+#     fn update(&mut self, _: Message) -> Command<Message> { Command::none() }
+#     fn view(&self, _: &mut Frame<'_>) {}
+#     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
+# }
+let config = RuntimeConfig::new().data_lane_capacity(NonZeroUsize::new(1024).expect("non-zero"));
+let runtime = Runtime::<MyApp>::with_config((), config);
+```
+
+If you kept a configuration around and reused it, add an explicit `clone()`:
+
+```rust
+# use std::num::NonZeroUsize;
+# use tears::RuntimeConfig;
+let config = RuntimeConfig::new();
+let bounded = config.clone().data_lane_capacity(NonZeroUsize::new(1024).expect("non-zero"));
+// `config` is still usable here.
+let unbounded = config;
+```
+
+### 1.3 Effect constructors return `EffectCommand`
+
+`Command::perform`, `future`, `stream`, `run`, `message`, `retry` and
+`retry_if` keep their names and now return `EffectCommand<Msg>` — one effect
+carrier. `cancellable` and `cancellable_with` exist **on that type alone**.
+`map`, `scoped`, `timeout` and `without_redraw` exist on both types and
+return their own, so every modifier ordering that built before still builds.
+
+A carrier converts into a `Command` and not back. Where a `Command` is
+required — an `update` returning one, a mixed `batch` — add `.into()`.
+
+Before:
+
+```rust,ignore
+fn update(&mut self, msg: Message) -> Command<Message> {
+    Command::perform(fetch(), Message::Loaded).cancellable(CommandId::new("load"))
+}
+```
+
+After:
+
+```rust
+# use tears::prelude::*;
+# use tears::command::CommandId;
+# #[derive(Debug)]
+# enum Message { Loaded(()) }
+# async fn fetch() {}
+fn update(msg: Message) -> Command<Message> {
+    Command::perform(fetch(), Message::Loaded)
+        .cancellable(CommandId::new("load"))
+        .into()
+}
+```
+
+Two shapes the compiler reports less obviously.
+
+**An empty batch no longer infers its item type.** `Command::batch(vec![])`
+fails with `E0283`; name the type:
+
+```rust
+# use tears::prelude::*;
+# enum Message {}
+let cmd = Command::batch(Vec::<Command<Message>>::new());
+```
+
+**`cancellable` is gone from commands that carry no effect.** A spawn key
+names a run, and `Command::none()`, `Command::cancel(id)` and
+`Command::quit()` start none. Keying a batch is gone for the same reason: one
+key reaching several carriers is a shape with no meaning to lower.
+
+```rust,compile_fail
+# use tears::prelude::*;
+# use tears::command::CommandId;
+# enum Message {}
+// `quit` names no run, so there is no spawn key to attach.
+let cmd: Command<Message> = Command::quit().cancellable(CommandId::new("bye"));
+```
+
+```rust,compile_fail
+# use tears::prelude::*;
+# use tears::command::CommandId;
+# #[derive(Debug)]
+# enum Message { Tick }
+// A batch names no single run either.
+let cmd: Command<Message> =
+    Command::batch(vec![Command::message(Message::Tick)]).cancellable(CommandId::new("load"));
+```
+
+A command that both cancels an id and starts keyed work under it is a `batch`
+of the two, with the key on the carrier:
+
+```rust
+# use tears::prelude::*;
+# use tears::command::CommandId;
+# #[derive(Debug)]
+# enum Message { Loaded(()) }
+# async fn fetch() {}
+let cmd: Command<Message> = Command::batch(vec![
+    Command::cancel(CommandId::new("load")),
+    Command::perform(fetch(), Message::Loaded)
+        .cancellable(CommandId::new("load"))
+        .into(),
+]);
+```
+
+`Command::batch` also takes anything convertible into a command, so a batch of
+carriers needs no conversion at all and a mixed one converts only its
+carriers.
+
+---
+
+## 2. Changes the compiler cannot report
+
+### 2.1 One lane: per-key isolation is gone
+
+All producer output — keyed command output, unkeyed command output,
+subscription output — travels **one lane**, tagged with the run that produced
+it. The private per-key channels are gone.
+
+**This is a property loss worth stating plainly.** One key's backlog now
+delays admission for every other producer. The isolation the private channels
+gave — one command's full channel never delaying another's — is not
+preserved, and **no configuration restores it**.
+
+You are affected if a bounded `data_lane_capacity` is set *and* several
+producers can be in flight at once. Under an unbounded lane there is no
+admission wait to share, so the loss is not observable; under a bounded one, a
+slow consumer of one key's output now backs up every other producer behind
+it.
+
+If you were relying on isolation to keep a latency-sensitive producer
+responsive under another's burst, the shape that survives is to stop
+generating the burst — bound it at the source (a `stream` that samples rather
+than forwards every item, a coalescing `update`), rather than at the channel.
+
+### 2.2 Shared-first delivery precedence is gone
+
+With one lane there is no second class of input to prefer. Delivery is FIFO
+over the lane.
+
+The broad cancel-opportunity property that shared-first pull incidentally
+provided — a keyed command's output waiting behind ready shared input,
+leaving a window to cancel it — is gone with it. Code that cancelled a keyed
+command on a terminal event and *expected* the in-flight output to be
+suppressed may now see that output delivered.
+
+RFC 0003's explicit cancellation semantics are unchanged: a cancel still
+suppresses output that has not yet been admitted. What is gone is the extra
+window that ordering happened to grant.
+
+### 2.3 A quit returned from `update` applies synchronously
+
+It no longer travels a channel, so no later input, cancel, or arbitration can
+intervene between the update that returned it and termination.
+
+Two consequences for existing code:
+
+- A quit returned in a `batch` applies at that dispatch's completion, and
+  siblings the same command spawned are torn down by termination rather than
+  skipped.
+- A quit can no longer be suppressed after the fact. There is no window in
+  which a cancel could reach it, because there is no buffered quit to reach.
+
+This is stricter than before, so it rarely breaks code. It is listed here
+because it is the *replacement* for the guarantee removed in
+[2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output).
+
+### 2.4 A producer-originated quit no longer orders against its own output
+
+**This is the change most likely to break a working application silently.**
+
+A quit emitted by a running effect takes a dedicated control lane, drained
+before every batch and never bounded, while that run's messages take the data
+lane. A run emitting `[Message(Saved), Quit]` therefore **no longer
+guarantees that `Saved` reaches `update` before termination**.
+
+In exchange the quit is backlog-independent — it is not queued behind a full
+lane — and stays revocable until applied: cancelling its run still suppresses
+it.
+
+To find out whether this reaches you, look for any effect stream that emits at
+least one message and then quits. A `Command::stream` or `Command::run` whose
+last act is a quit is the shape at risk.
+
+Before — the message was ordered ahead of the quit by the channel:
+
+```rust,ignore
+Command::run(|mut emit| async move {
+    save().await;
+    emit(Message::Saved).await;
+    emit(Message::Quit).await; // `Saved` was guaranteed to land first
+})
+```
+
+After — move the quit to the `update` that observes the final message. That
+order is now pinned by construction rather than by channel timing:
+
+```rust
+# use tears::prelude::*;
+# #[derive(Debug)]
+# enum Message { Saved }
+fn update(msg: Message) -> Command<Message> {
+    match msg {
+        // Observing `Saved` is what decides to terminate, so the quit cannot
+        // outrun it.
+        Message::Saved => Command::quit(),
+    }
+}
+```
+
+### 2.5 `Command::batch` honours the spawn key on each child
+
+A batched child's key used to be discarded with a warning. Each child now
+lowers to its own keyed entry, and the warning is gone with the fold it
+described.
+
+If your code batched keyed commands and *relied* on the keys being dropped —
+most likely without knowing it, since the warning was the only signal — those
+commands are now cancellable and subject to same-id policy. Two same-key
+children in one batch apply in declaration order as two consecutive
+dispatches, the second replacing the first under its own policy.
+
+Search your build logs from 0.10.x for the discarded-key warning: every site
+that produced it changes behavior here.
+
+### 2.6 `batch_max_messages` unset now means the kernel's cap
+
+The 100µs window that used to cap a batch is gone, along with the wall-clock
+reads it needed. Left unset, `batch_max_messages` now means the kernel's own
+count cap rather than an uncapped batch. A batch is finite under every
+configuration; the control only replaces the default count.
+
+### 2.7 Constructing a `Runtime` no longer starts the init command
+
+The command `Application::new` returns is dispatched inside `run()`, ahead of
+the first subscription reconcile. A runtime that is constructed and never run
+spawns no task and runs no effect (RFC 0011 §3.4, INV-LC3).
+
+The order between the init command and the first reconcile is unchanged, and
+public signatures are untouched. Only code that constructs a runtime without
+running it, or that observes an init effect's side effects before `run()`,
+can tell the difference — which in practice means tests that built a runtime
+to assert on a side effect without driving it.
+
+### 2.8 A restarted subscription waits for the old task to quiesce
+
+A re-evaluation that removes or replaces a subscription requests its task's
+cancellation and **waits for that task to finish** before starting the
+replacement, so a source holding an exclusive resource — a socket, a file
+lock — is never live twice under one ID (RFC 0012 §4).
+
+Re-evaluations with no outstanding stopped task admit immediately as before:
+pure additions, restarts of already-finished subscriptions, and continuing
+subscriptions are all unaffected.
+
+This is a fix, not a regression, but it changes timing: a restart now takes as
+long as the old source takes to drop. A source that ignores cancellation and
+blocks will delay its own replacement, where before it would have been
+shadowed by it.
+
+Subscription re-evaluation also gained a message-independent trigger. The
+quiescence of a task stopped by a steady-state cause — an ID leaving the
+declared set, a restart, or a scope teardown selecting the run — marks
+subscriptions dirty by itself, so the reconcile the admission wait deferred
+runs on the pass that observes the quiescence instead of waiting for the next
+message. A source that merely *finishes* marks nothing: it restarts at the
+next re-evaluation, as it did before (RFC 0012 §4.2, INV-SE5).
+
+### 2.9 `install_panic_hook` no longer restores the terminal for contained panics
+
+A panic inside a runtime-owned producer task — an unkeyed command task, a
+keyed command task, or a subscription forwarder — is caught by the runtime and
+leaves the application running (RFC 0011 §5, INV-LC8). The hook now delegates
+to the previously installed hook without leaving raw mode or the alternate
+screen, and the still-running application keeps drawing.
+
+Panics on the application's own driving path — `update`, `view`,
+`subscriptions`, a subscription's source constructor — still restore the
+terminal exactly as before, as do all panics under `panic = "abort"` builds,
+where nothing can be contained.
+
+**A contained panic's report is written on the alternate screen in raw mode.**
+If you want it readable, point your panic reporter at a file or log target.
+
+---
+
+## 3. Telemetry consumers
+
+Field names and the rest of the schema are unchanged, deliberately: a renamed
+telemetry field breaks dashboards and alert rules silently, off the compiler's
+path. Two semantic changes still need action.
+
+### 3.1 Gauge events must be partitioned by `runtime_id`
+
+The `tears::runtime::load` producer-gauge event gained a `runtime_id` field —
+the emitting runtime instance's process-local identifier, never reused within
+the process — and the `seq` ordering counter added in 0.10.1 is now scoped per
+instance.
+
+The current value of each gauge is the value on the greatest-`seq` event
+**among events carrying that `runtime_id`**. A consumer partitions by
+`runtime_id` first and never reads gauge events in arrival order. Comparing
+`seq` across instances is meaningless.
+
+A 0.10.1 consumer that took the global maximum `seq` will read a wrong current
+value as soon as a second runtime instance exists in the process. If your
+process only ever builds one runtime, the reading is unchanged — but the
+partition is still worth adding, since nothing in the schema will tell you
+when that stops being true.
+
+The batch and capacity-wait events are unchanged and carry neither field.
+
+### 3.2 The capacity-wait `channel` field takes one value
+
+`channel` is now always `"data"`. The values `"shared"` and `"keyed"` retire
+with the channels they named, and `shared_pending` now reads as the data
+lane's residual occupancy.
+
+Any dashboard panel or alert rule filtering on `channel == "keyed"` will
+silently match nothing. Drop the filter rather than repointing it: there is no
+second channel to distinguish.
+
+---
+
+## 4. `TestStore`
+
+### 4.1 `receive_quit` observes an applied quit, and the store is terminal after it
+
+A quit returned from `update` no longer travels as output, so `receive_quit`
+no longer requires it to be the next deliverable item, and a message the same
+command produced is not a failure there.
+
+In exchange the store stops accepting work after that dispatch: `send`,
+`advance`, `receive` and `receive_matching` fail from the moment the quit
+applies. That is what "no later input can intervene" means on the test side.
+Tests that asserted on state *after* an observed quit must move those
+assertions before it.
+
+An applied quit that no `receive_quit` observed now fails `finish` and the
+drop check, with the same standing as output that was never received.
+
+A producer-originated quit still travels as output and is still asserted the
+same way.
+
+### 4.2 `TestStore` runs cleanup hooks, and gained two leak classes
+
+`Command::on_teardown` registrations reached the store and were dropped; they
+are now armed against their scope and run by the teardown that selects them,
+at most once. Exhaustiveness gained two leak classes:
+
+- **A registration still armed when the test ends** fails `finish` and the
+  drop check, the way undelivered output does. Tear the scope down, or end
+  with a quit, which discards unfired hooks as termination does.
+- **A finalizer that has not finished** fails them too. This one is
+  recoverable rather than lost: the store holds the run and re-polls it at
+  `advance` and at the checks, so a hook waiting on the controlled clock
+  completes once `advance` reaches its deadline.
+
+Registrations must be scoped to be reachable. `Command::teardown` always
+prefixes at least one segment, so a root-anchored hook has no prefix that
+selects it — register it under the same scope as the runs it cleans up after.
+
+---
+
+## 5. New surfaces (optional)
+
+Nothing here is required to upgrade.
+
+- **The reducer-first core**, at `tears::reducer`: the `Reducer` and `Program`
+  traits, the `ReducerExt` combinators (`scope`, `for_each`, `presented`,
+  `into_program`), and the `Keyed` and `Slot` collections. `ProgramRuntime<P>`
+  is the entry point a stack of these closes into, and `Runtime<App>` is that
+  type with the `Application` adapter applied — both run the same kernel over
+  the same lanes.
+- **`Command::teardown` and `Command::on_teardown`**: tear down every run
+  placed under a scope prefix, and register a finalizer that runs when one is.
+- **`tears::testing::TestDriver`**, the stage-3 driving layer (RFC 0008 §9).
+  It drives the production kernel a pass at a time — the same construction
+  path, the same runtime-owned tasks, the same lanes — with the driving
+  difference confined to naming which armed source begins a pass and releasing
+  one producer send at a time through a grant handshake. Reach for it when a
+  test needs the kernel itself rather than the non-executing store beside it.
+
+## Not preserved, and not restorable
+
+Three properties are gone by construction. No configuration brings them back,
+so if your design depends on one, it needs a different shape rather than a
+different setting.
+
+- Per-key producer isolation ([2.1](#21-one-lane-per-key-isolation-is-gone)).
+- Shared-first delivery precedence, and the cancel window it granted
+  ([2.2](#22-shared-first-delivery-precedence-is-gone)).
+- Ordering between a producer's own messages and its quit
+  ([2.4](#24-a-producer-originated-quit-no-longer-orders-against-its-own-output)).

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -722,9 +722,10 @@ Nothing here is required to upgrade.
   `into_program`), and the `Keyed` and `Slot` collections. `ProgramRuntime<P>`
   is the entry point a stack of these closes into, and `Runtime<App>` is that
   type with the `Application` adapter applied — both run the same kernel over
-  the same lanes. `ProgramRuntime::run` resolves to `Exit`, also new at the
-  crate root, where the `Runtime<App>` facade's `run` keeps returning
-  `Result<(), _>`.
+  the same lanes. Both `run` methods return a `Result` over the backend's
+  error; they differ only in the success type — `ProgramRuntime::run` gives
+  `Result<Exit, B::Error>`, naming `Exit` (also new at the crate root), where
+  the `Runtime<App>` facade keeps `Result<(), B::Error>`.
 - **`Command::teardown` and `Command::on_teardown`**: tear down every run
   placed under a scope prefix, and register a finalizer that runs when a
   teardown selects that scope. See

--- a/docs/migrations/0.10-to-0.11.md
+++ b/docs/migrations/0.10-to-0.11.md
@@ -398,6 +398,17 @@ reads it needed. Left unset, `batch_max_messages` now means the kernel's own
 count cap rather than an uncapped batch. A batch is finite under every
 configuration; the control only replaces the default count.
 
+To find out whether this reaches you: it only can if you left the control
+unset, since an explicit value meant a count cap before and means one now. The
+observable is the `pulled` field on the per-batch `tears::runtime::load` event
+— the count of inputs taken in one batch. Under 0.10.x that count was
+whatever arrived inside the time window; it is now bounded by the kernel's
+count. If you have `pulled` recorded from a 0.10.x run under representative
+load, compare its distribution; if it used to exceed the new bound, your
+batches are smaller and each one reaches `view` sooner. Setting
+`batch_max_messages` explicitly pins the count either way, and is the way to
+stop the default from moving under you again.
+
 ### 2.7 Constructing a `Runtime` no longer starts the init command
 
 The command `Application::new` returns is dispatched inside `run()`, ahead of
@@ -567,13 +578,18 @@ Nothing here is required to upgrade.
 
 ## Not preserved, and not restorable
 
-Two properties an application could depend on are gone by construction. No
+Three properties an application could depend on are gone by construction. No
 configuration brings them back, so if your design depends on one, it needs a
 different shape rather than a different setting.
 
 - Per-key producer isolation ([2.1](#21-one-lane-per-key-isolation-is-gone)).
 - Shared-first delivery precedence, and the cancel window it granted
   ([2.2](#22-shared-first-delivery-precedence-is-gone)).
+- A ceiling on render frequency ([1.1](#11-the-frame-rate-is-gone)). Every pass
+  that leaves the view dirty draws, so a frame rate passed to *throttle*
+  drawing — a slow terminal, a session over SSH — has no replacement control.
+  The work to throttle has to move into the state that drives the view, so
+  that fewer passes leave it dirty.
 
 A third — ordering between a producer's own messages and its quit — is also
 gone, but no public constructor could express the shape that depended on it

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -40,6 +40,12 @@ which of these changes reaches me, and how do I tell?
 - The changelog keeps its per-entry before/after blocks. A guide links to the
   changelog rather than restating it, and holds only the triage, the detection
   steps, and the properties that are not restorable.
+- **Links out of a guide must be absolute.** A guide is `include_str!`-ed into
+  rustdoc, where it is rendered from `src/`, so a repo-relative path like
+  `../../CHANGELOG.md` resolves in neither docs.rs nor a local `cargo doc`.
+  Use the full `https://github.com/akiomik/tears/...` URL. (Anchors within the
+  guide are fine, and are checked by nothing — verify them when editing
+  headings.)
 
 ## Index
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -26,6 +26,14 @@ which of these changes reaches me, and how do I tell?
   snippets are compiled by `cargo test --doc` and cannot drift from the API.
   It adds no public module, so it can be deleted once the release it covers is
   far enough back.
+- **Adding a guide takes two edits, not one.** Besides the `include_str!` in
+  `src/lib.rs`, add the file to `include` in `Cargo.toml` — named
+  individually, so the maintainer-facing files here (this README) stay out of
+  the package. Miss it and nothing fails until someone runs `cargo test --doc`
+  against the *published* crate: `cargo publish` verifies with `cargo build`,
+  which drops the `cfg(doctest)` item before the macro runs. `just
+  test-doc-packaged` reproduces the published tree and is what the CI
+  `doctest` job runs; removing a guide means removing both edits.
 - "Before" snippets are marked `ignore`; they describe an API that is gone.
   Where "this no longer builds" is the point being taught, use `compile_fail`
   against the current API instead.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,40 @@
+# Migration guides
+
+Per-release upgrade guides for breaking changes that the compiler does not
+fully report.
+
+## When a release gets a guide
+
+A guide is warranted when a release's breaking changes include **behavior a
+caller must reason about but the compiler cannot name** — an ordering
+guarantee that no longer holds, a property that is gone and not restorable, a
+telemetry field whose meaning changed under a stable schema.
+
+A release whose breaking changes are entirely type-level does **not** get a
+guide. A renamed or removed item is already reported at every call site, and
+the [changelog](../../CHANGELOG.md) entry carries the before/after next to the
+change it belongs to. Adding a guide for those would split one story across
+two files and put the maintenance burden on the wrong one.
+
+The changelog is organised by *what changed*. A guide is organised by *what
+the reader must do*, and exists to answer a question the changelog cannot:
+which of these changes reaches me, and how do I tell?
+
+## Conventions
+
+- A guide is included into the crate under `#[cfg(doctest)]`, so its "after"
+  snippets are compiled by `cargo test --doc` and cannot drift from the API.
+  It adds no public module, so it can be deleted once the release it covers is
+  far enough back.
+- "Before" snippets are marked `ignore`; they describe an API that is gone.
+  Where "this no longer builds" is the point being taught, use `compile_fail`
+  against the current API instead.
+- The changelog keeps its per-entry before/after blocks. A guide links to the
+  changelog rather than restating it, and holds only the triage, the detection
+  steps, and the properties that are not restorable.
+
+## Index
+
+| Guide | Covers |
+| --- | --- |
+| [0.10.x → 0.11.0](0.10-to-0.11.md) | Reducer-first core: frame rate removal, one-lane delivery, `EffectCommand`, quit ordering |

--- a/justfile
+++ b/justfile
@@ -57,11 +57,32 @@ test-integration:
 # as the reason and re-measure before widening this list. See issue #298.
 #
 # The list is the feature set a user can actually enable, minus the two
-# build-only ones (`loom-core`, `bench-internals`).
+# build-only ones (`loom-core`, `bench-internals`). Single source for both
+# doctest recipes and for the CI job that calls them.
+doc_features := "http,ws,native-tls"
 
 # Run only doc tests
 test-doc:
-    cargo test --doc --features http,ws,native-tls
+    cargo test --doc --features {{doc_features}}
+
+# Guards the `include` entry that keeps `include_str!` resolvable once
+# published: `cargo publish`'s verification is a `cargo build`, which drops
+# the `cfg(doctest)` item before the macro runs, so a missing entry shows up
+# nowhere else. Packaging and extracting reproduces what a consumer gets.
+#
+# `--allow-dirty` so this is usable before committing, which is when a bad
+# `include` is cheapest to catch; CI checks out clean, so it changes nothing
+# there.
+
+# Run the doc tests against the packaged crate
+test-doc-packaged:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo package --no-verify --allow-dirty
+    pkg=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | "\(.name)-\(.version)"')
+    tar xzf "target/package/${pkg}.crate" -C target/package
+    cd "target/package/${pkg}"
+    cargo test --doc --features {{doc_features}}
 
 # Run loom concurrency model tests (scoped to the isolated core mirrors)
 test-loom:

--- a/justfile
+++ b/justfile
@@ -56,10 +56,12 @@ test-integration:
 # reproducible, the mechanism is not established, so treat the numbers above
 # as the reason and re-measure before widening this list. See issue #298.
 #
-# The list is the feature set a user can actually enable, minus the two
-# build-only ones (`loom-core`, `bench-internals`). Single source for both
-# doctest recipes and for the CI job that calls them.
-doc_features := "http,ws,native-tls"
+# The list is every feature a user can enable, minus the two build-only ones
+# (`loom-core`, `bench-internals`) — the three TLS backends included, since
+# they coexist and a doctest gated on one must not go uncompiled just because
+# another was picked here. Single source for both doctest recipes and for the
+# CI job that calls them; keep it exhaustive as features are added.
+doc_features := "http,ws,native-tls,rustls,rustls-tls-webpki-roots"
 
 # Run only doc tests
 test-doc:
@@ -72,16 +74,24 @@ test-doc:
 #
 # `--allow-dirty` so this is usable before committing, which is when a bad
 # `include` is cheapest to catch; CI checks out clean, so it changes nothing
-# there.
+# there. The extraction directory is removed first for the same reason: `tar`
+# unpacks over whatever is already there, so a file dropped from `include`
+# would survive from an earlier run and the check would pass locally while
+# failing on CI's clean checkout — which is the half of this recipe
+# `--allow-dirty` exists to serve. Requires `jq`.
 
 # Run the doc tests against the packaged crate
 test-doc-packaged:
     #!/usr/bin/env bash
     set -euo pipefail
+    meta=$(cargo metadata --no-deps --format-version 1)
+    pkg=$(jq -r '.packages[0] | "\(.name)-\(.version)"' <<<"$meta")
+    # Honours CARGO_TARGET_DIR / build.target-dir rather than assuming ./target.
+    out=$(jq -r '.target_directory' <<<"$meta")/package
     cargo package --no-verify --allow-dirty
-    pkg=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0] | "\(.name)-\(.version)"')
-    tar xzf "target/package/${pkg}.crate" -C target/package
-    cd "target/package/${pkg}"
+    rm -rf "${out:?}/${pkg}"
+    tar xzf "${out}/${pkg}.crate" -C "$out"
+    cd "${out}/${pkg}"
     cargo test --doc --features {{doc_features}}
 
 # Run loom concurrency model tests (scoped to the isolated core mirrors)

--- a/justfile
+++ b/justfile
@@ -41,14 +41,25 @@ test-unit:
 test-integration:
     cargo test --test '*'
 
+# Deliberately not `--all-features`. Measured, on rustc 1.97.0:
+#
+#     cargo test --doc                          61 tests
+#     cargo test --doc --features loom-core     60 tests   (both `Signal` ones gone)
+#     cargo test --doc --all-features           71 tests   (both `Signal` ones gone)
+#     cargo test --doc --features http,ws,native-tls
+#                                               73 tests   (superset of all above)
+#
+# Enabling `loom-core` drops `subscription::signal`'s two doctests. The
+# obvious reading — that rustdoc satisfies the `test` in that module's
+# `#[cfg(not(all(feature = "loom-core", test)))]` — is *not* the cause: no
+# rustdoc invocation in the run receives `--cfg test`. The effect is
+# reproducible, the mechanism is not established, so treat the numbers above
+# as the reason and re-measure before widening this list. See issue #298.
+#
+# The list is the feature set a user can actually enable, minus the two
+# build-only ones (`loom-core`, `bench-internals`).
+
 # Run only doc tests
-# Deliberately not `--all-features`: that enables `loom-core`, and
-# `subscription::signal` is `#[cfg(not(all(feature = "loom-core", test)))]`,
-# which rustdoc's doctest collection satisfies — so `--all-features` silently
-# drops the `Signal` examples. The list below is the feature set a user can
-# actually enable, minus the two build-only ones (`loom-core`,
-# `bench-internals`), and covers strictly more doctests than either default
-# features or `--all-features`.
 test-doc:
     cargo test --doc --features http,ws,native-tls
 
@@ -60,10 +71,12 @@ test-loom:
 bench:
     cargo bench
 
-# Run the load harness's smoke profiles (RFC 0007 §6 and RFC 0014 §13.5;
-# the CI Benchmarks profile). Latency-assertion-free: proves the harness
-# builds and the reduced rows terminate with their exact scripted sequences.
-# Acceptance numbers come from the full runs only, never from these.
+# RFC 0007 §6 and RFC 0014 §13.5; the CI Benchmarks profile.
+# Latency-assertion-free: proves the harness builds and the reduced rows
+# terminate with their exact scripted sequences. Acceptance numbers come from
+# the full runs only, never from these.
+
+# Run the load harness's smoke profiles
 bench-smoke:
     cargo bench --bench kernel_load --features bench-internals -- --self-test
     cargo bench --bench kernel_load --features bench-internals -- --smoke

--- a/justfile
+++ b/justfile
@@ -88,11 +88,37 @@ test-doc-packaged:
     pkg=$(jq -r '.packages[0] | "\(.name)-\(.version)"' <<<"$meta")
     # Honours CARGO_TARGET_DIR / build.target-dir rather than assuming ./target.
     out=$(jq -r '.target_directory' <<<"$meta")/package
+
+    # `doc_features` is written by hand, so check it still lists every feature
+    # a user can enable. Without this the invariant is only a comment, and a
+    # new feature gating a module with doctests would silently stop being
+    # compiled while this job stayed green — the failure mode the job exists
+    # to prevent.
+    # Excludes `default`, the two build-only features, and the implicit
+    # features cargo synthesises for optional dependencies (value is exactly
+    # `["dep:<same name>"]`) — those are not features a caller enables.
+    want=$(jq -r '[.packages[0].features | to_entries[]
+                   | select(.value != ["dep:" + .key])
+                   | .key
+                   | select(. != "default" and . != "loom-core" and . != "bench-internals")]
+                  | sort | join(",")' <<<"$meta")
+    have=$(tr ',' '\n' <<<'{{doc_features}}' | sort | paste -sd, -)
+    if [ "$want" != "$have" ]; then
+      echo "doc_features is stale: expected '$want', got '$have'" >&2
+      echo "Update doc_features in the justfile (see the notes above it)." >&2
+      exit 1
+    fi
+
     cargo package --no-verify --allow-dirty
     rm -rf "${out:?}/${pkg}"
     tar xzf "${out}/${pkg}.crate" -C "$out"
     cd "${out}/${pkg}"
-    cargo test --doc --features {{doc_features}}
+    # Build outside the repo: an in-place build here leaves a second, ~1 GB
+    # tree under `target/` that nothing reuses and CI's cache action would
+    # store.
+    nested=$(mktemp -d)
+    trap 'rm -rf "$nested"' EXIT
+    CARGO_TARGET_DIR="$nested" cargo test --doc --features {{doc_features}}
 
 # Run loom concurrency model tests (scoped to the isolated core mirrors)
 test-loom:

--- a/justfile
+++ b/justfile
@@ -5,8 +5,13 @@
 default:
     @just --list
 
-# Run all checks (fmt, clippy, test)
-check: fmt clippy test
+# `test` passes `--all-targets`, which suppresses the implicit doctest run, so
+# `test-doc` has to be listed separately here and in `pre-commit`; without it
+# nothing compiles the examples in rustdoc comments or in the
+# `cfg(doctest)`-included migration guide.
+
+# Run all checks (fmt, clippy, test, doc tests)
+check: fmt clippy test test-doc
 
 # Format code with rustfmt
 fmt:
@@ -109,7 +114,7 @@ outdated:
     cargo outdated
 
 # Run all pre-commit checks
-pre-commit: fmt-check clippy test
+pre-commit: fmt-check clippy test test-doc
 
 # Run quick checks (no tests)
 quick: fmt clippy

--- a/justfile
+++ b/justfile
@@ -38,7 +38,7 @@ test-integration:
 
 # Run only doc tests
 test-doc:
-    cargo test --doc
+    cargo test --doc --all-features
 
 # Run loom concurrency model tests (scoped to the isolated core mirrors)
 test-loom:

--- a/justfile
+++ b/justfile
@@ -43,11 +43,11 @@ test-integration:
 
 # Deliberately not `--all-features`. Measured, on rustc 1.97.0:
 #
-#     cargo test --doc                          61 tests
-#     cargo test --doc --features loom-core     60 tests   (both `Signal` ones gone)
-#     cargo test --doc --all-features           71 tests   (both `Signal` ones gone)
-#     cargo test --doc --features http,ws,native-tls
-#                                               73 tests   (superset of all above)
+#     cargo test --doc                       61 tests
+#     cargo test --doc --features loom-core  60 tests  (both `Signal` ones gone)
+#     cargo test --doc --all-features        71 tests  (both `Signal` ones gone)
+#     cargo test --doc --features <the value below>
+#                                            73 tests  (superset of all above)
 #
 # Enabling `loom-core` drops `subscription::signal`'s two doctests. The
 # obvious reading — that rustdoc satisfies the `test` in that module's
@@ -60,7 +60,9 @@ test-integration:
 # (`loom-core`, `bench-internals`) — the three TLS backends included, since
 # they coexist and a doctest gated on one must not go uncompiled just because
 # another was picked here. Single source for both doctest recipes and for the
-# CI job that calls them; keep it exhaustive as features are added.
+# CI job that calls them; `test-doc-packaged` fails if it drifts from
+# Cargo.toml's `[features]`, so the table above stays measured against this
+# exact value.
 doc_features := "http,ws,native-tls,rustls,rustls-tls-webpki-roots"
 
 # Run only doc tests
@@ -78,7 +80,8 @@ test-doc:
 # unpacks over whatever is already there, so a file dropped from `include`
 # would survive from an earlier run and the check would pass locally while
 # failing on CI's clean checkout — which is the half of this recipe
-# `--allow-dirty` exists to serve. Requires `jq`.
+# `--allow-dirty` exists to serve. Requires `jq` and Python 3.11+ (`tomllib`);
+# neither is needed by `just check`, which does not reach this recipe.
 
 # Run the doc tests against the packaged crate
 test-doc-packaged:
@@ -94,20 +97,24 @@ test-doc-packaged:
     # new feature gating a module with doctests would silently stop being
     # compiled while this job stayed green — the failure mode the job exists
     # to prevent.
-    # Excludes `default`, the two build-only features, and the implicit
-    # features cargo synthesises for optional dependencies (value is exactly
-    # `["dep:<same name>"]`) — those are not features a caller enables.
-    want=$(jq -r '[.packages[0].features | to_entries[]
-                   | select(.value != ["dep:" + .key])
-                   | .key
-                   | select(. != "default" and . != "loom-core" and . != "bench-internals")]
-                  | sort | join(",")' <<<"$meta")
-    have=$(tr ',' '\n' <<<'{{doc_features}}' | sort | paste -sd, -)
-    if [ "$want" != "$have" ]; then
-      echo "doc_features is stale: expected '$want', got '$have'" >&2
-      echo "Update doc_features in the justfile (see the notes above it)." >&2
-      exit 1
-    fi
+    #
+    # Read from Cargo.toml's `[features]` rather than `cargo metadata`, which
+    # reports cargo's synthesised optional-dependency features the same way it
+    # reports an explicitly declared `foo = ["dep:foo"]`. Filtering the
+    # synthesised ones out of metadata would therefore also drop an explicit
+    # declaration of that shape and let it go missing here.
+    python3 - '{{doc_features}}' <<'PY'
+    import pathlib, sys, tomllib
+
+    BUILD_ONLY = {"default", "loom-core", "bench-internals"}
+    have = {f for f in sys.argv[1].split(",") if f}
+    want = set(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["features"]) - BUILD_ONLY
+    if have != want:
+        print(f"doc_features is stale: expected '{','.join(sorted(want))}', "
+              f"got '{','.join(sorted(have))}'", file=sys.stderr)
+        print("Update doc_features in the justfile (see the notes above it).", file=sys.stderr)
+        raise SystemExit(1)
+    PY
 
     cargo package --no-verify --allow-dirty
     rm -rf "${out:?}/${pkg}"

--- a/justfile
+++ b/justfile
@@ -42,8 +42,15 @@ test-integration:
     cargo test --test '*'
 
 # Run only doc tests
+# Deliberately not `--all-features`: that enables `loom-core`, and
+# `subscription::signal` is `#[cfg(not(all(feature = "loom-core", test)))]`,
+# which rustdoc's doctest collection satisfies — so `--all-features` silently
+# drops the `Signal` examples. The list below is the feature set a user can
+# actually enable, minus the two build-only ones (`loom-core`,
+# `bench-internals`), and covers strictly more doctests than either default
+# features or `--all-features`.
 test-doc:
-    cargo test --doc --all-features
+    cargo test --doc --features http,ws,native-tls
 
 # Run loom concurrency model tests (scoped to the isolated core mirrors)
 test-loom:

--- a/justfile
+++ b/justfile
@@ -56,14 +56,20 @@ test-integration:
 # reproducible, the mechanism is not established, so treat the numbers above
 # as the reason and re-measure before widening this list. See issue #298.
 #
-# The list is every feature a user can enable, minus the two build-only ones
-# (`loom-core`, `bench-internals`) — the three TLS backends included, since
-# they coexist and a doctest gated on one must not go uncompiled just because
-# another was picked here. Single source for both doctest recipes and for the
-# CI job that calls them; `test-doc-packaged` fails if it drifts from
-# Cargo.toml's `[features]`, so the table above stays measured against this
-# exact value.
-doc_features := "http,ws,native-tls,rustls,rustls-tls-webpki-roots"
+# The list is every feature a dependant can name, minus the two build-only
+# ones (`loom-core`, `bench-internals`). All three TLS backends are here
+# because they coexist and a doctest gated on one must not go uncompiled
+# because another was picked. `dashmap`, `thiserror` and `tokio-tungstenite`
+# are here because `http` and `ws` reference those optional dependencies by
+# bare name rather than with `dep:`, so cargo synthesises a feature per
+# dependency and a dependant can enable them — switching those two to `dep:`
+# would remove them from the surface, but that is a feature-surface decision,
+# not a doctest one.
+#
+# Single source for both doctest recipes and for the CI job that calls them;
+# `test-doc-packaged` fails if it drifts, so the table above stays measured
+# against this exact value.
+doc_features := "dashmap,http,native-tls,rustls,rustls-tls-webpki-roots,thiserror,tokio-tungstenite,ws"
 
 # Run only doc tests
 test-doc:
@@ -80,8 +86,8 @@ test-doc:
 # unpacks over whatever is already there, so a file dropped from `include`
 # would survive from an earlier run and the check would pass locally while
 # failing on CI's clean checkout — which is the half of this recipe
-# `--allow-dirty` exists to serve. Requires `jq` and Python 3.11+ (`tomllib`);
-# neither is needed by `just check`, which does not reach this recipe.
+# `--allow-dirty` exists to serve. Requires `jq`, which `just check` does not
+# need since it does not reach this recipe.
 
 # Run the doc tests against the packaged crate
 test-doc-packaged:
@@ -98,23 +104,20 @@ test-doc-packaged:
     # compiled while this job stayed green — the failure mode the job exists
     # to prevent.
     #
-    # Read from Cargo.toml's `[features]` rather than `cargo metadata`, which
-    # reports cargo's synthesised optional-dependency features the same way it
-    # reports an explicitly declared `foo = ["dep:foo"]`. Filtering the
-    # synthesised ones out of metadata would therefore also drop an explicit
-    # declaration of that shape and let it go missing here.
-    python3 - '{{doc_features}}' <<'PY'
-    import pathlib, sys, tomllib
-
-    BUILD_ONLY = {"default", "loom-core", "bench-internals"}
-    have = {f for f in sys.argv[1].split(",") if f}
-    want = set(tomllib.loads(pathlib.Path("Cargo.toml").read_text())["features"]) - BUILD_ONLY
-    if have != want:
-        print(f"doc_features is stale: expected '{','.join(sorted(want))}', "
-              f"got '{','.join(sorted(have))}'", file=sys.stderr)
-        print("Update doc_features in the justfile (see the notes above it).", file=sys.stderr)
-        raise SystemExit(1)
-    PY
+    # `cargo metadata` reports explicit features and the ones cargo synthesises
+    # for optional dependencies identically, and that is fine here: both kinds
+    # can be named in a dependant's `features = [...]`, so both belong in the
+    # list. Nothing needs to tell them apart. Comparison and sorting happen
+    # inside jq so the two sides cannot disagree on collation.
+    jq -e --arg have '{{doc_features}}' '
+      ([.packages[0].features | keys[]
+        | select(. != "default" and . != "loom-core" and . != "bench-internals")]
+       | sort) as $want
+      | ($have | split(",") | map(select(length > 0)) | sort) as $got
+      | if $want == $got then true
+        else "doc_features is stale: expected \($want | join(",")), got \($got | join(","))"
+             | error
+        end' <<<"$meta" >/dev/null
 
     cargo package --no-verify --allow-dirty
     rm -rf "${out:?}/${pkg}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,10 +159,13 @@ pub use kernel::bench_support::{BenchKernel, CleanupLedgerScan, RegistryScan, pr
 
 // The 0.10.x → 0.11.0 migration guide, compiled only when collecting
 // doctests, so every "after" snippet in it is checked against the API it
-// tells callers to move to and the guide cannot rot silently. `cfg(doctest)`
-// keeps it off the public module tree: the guide is a transitional artifact
-// that should be deletable without touching the surface (docs/api-guidelines.md,
-// "Root Promotion Criteria").
+// tells callers to move to and the guide cannot rot silently. That check is
+// only as real as the job that runs it: the `test` job passes explicit target
+// flags, which suppress the implicit doctest run, so the `doctest` job in
+// .github/workflows/ci.yml is what makes this load-bearing. `cfg(doctest)`
+// keeps the item off the public module tree: the guide is a transitional
+// artifact that should be deletable without touching the surface
+// (docs/api-guidelines.md, "Root Promotion Criteria").
 #[cfg(doctest)]
 #[doc = include_str!("../docs/migrations/0.10-to-0.11.md")]
 pub struct MigrationGuide0_11;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,5 +157,15 @@ pub use runtime::load::LoadObserver;
 #[doc(hidden)]
 pub use kernel::bench_support::{BenchKernel, CleanupLedgerScan, RegistryScan, producer_quit};
 
+// The 0.10.x → 0.11.0 migration guide, compiled only when collecting
+// doctests, so every "after" snippet in it is checked against the API it
+// tells callers to move to and the guide cannot rot silently. `cfg(doctest)`
+// keeps it off the public module tree: the guide is a transitional artifact
+// that should be deletable without touching the surface (docs/api-guidelines.md,
+// "Root Promotion Criteria").
+#[cfg(doctest)]
+#[doc = include_str!("../docs/migrations/0.10-to-0.11.md")]
+pub struct MigrationGuide0_11;
+
 #[cfg(test)]
 mod test_support;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -52,9 +52,11 @@ tokio::task_local! {
 /// ```
 ///
 /// Panics the runtime contains are exempt from the restore. A panic inside a
-/// runtime-owned producer task — an unkeyed command task, a keyed command
-/// task, or a subscription forwarder — is caught by the runtime and does not
-/// terminate the application (RFC 0011 §5, INV-LC8): the event loop keeps
+/// runtime-owned task — an unkeyed command task, a keyed command task, a
+/// subscription forwarder, or a [`Command::on_teardown`](crate::Command::on_teardown)
+/// finalizer, which is spawned through the same contained path — is caught by
+/// the runtime and does
+/// not terminate the application (RFC 0011 §5, INV-LC8): the event loop keeps
 /// running and keeps drawing. Restoring the terminal for such a panic would
 /// drop a live UI out of raw mode and off the alternate screen, so the hook
 /// only delegates to the previous hook in that case.


### PR DESCRIPTION
## What

Adds `docs/migrations/0.10-to-0.11.md`, a migration guide for the reducer-first release, plus `docs/migrations/README.md` recording when a release earns one. The guide is included into the crate under `#[cfg(doctest)]` so its snippets are compiled by `cargo test --doc`, and `[Unreleased]` links to it.

## Why

The `[Unreleased]` entries already carry before/after blocks for four breaking changes: the frame rate removal, the `RuntimeConfig` renames, `EffectCommand`, and the `Copy` removal. All four are reported at every call site by the compiler.

The breaking changes with no before/after are the ones that leave the build green:

- per-key producer isolation is gone (§2.1)
- shared-first delivery precedence is gone, with the cancel window it granted (§2.2)
- `batch` now honours each child's spawn key (§2.5)
- `batch_max_messages` unset changed meaning (§2.6)
- constructing a `Runtime` no longer starts the init command (§2.7)
- a restarted subscription now waits for the old task to quiesce (§2.8)
- gauge events must now be partitioned by `runtime_id` before reading a current value (§3.1)

So the changes that need the most reading had the least written about them.

## Why a separate document

The changelog is ordered by what changed. A guide is ordered by what the reader must do, and answers a question the per-entry ordering cannot: which of these reaches me, and how do I tell?

Structure: a triage table keyed on "read this section if…", then the compiler-reported changes, then the silent behavioural ones each with a detection step, then telemetry and `TestStore`. It closes by naming the four properties an application could depend on that no configuration restores, plus a fifth listed apart because no public constructor could express the shape that depended on it.

The changelog keeps its per-entry before/after blocks. The guide holds only the triage, the detection steps, and the not-restorable list, so the two do not restate each other.

## §2.4 states a non-reach deliberately

The changelog records that a producer-originated quit no longer orders against its own run's earlier output. That is a real kernel contract change, but **no application can reach it**: `Command::stream` and `Command::run` both lower through `stream.map(Action::Message)` and can only emit messages, `Command::quit()` builds the immediate-quit carrier and never spawns, and the one constructor that can put an `Action::Quit` into a spawned run is `Command::actions` — crate-visible under `test` and the bench-only feature, and not public in 0.10.x either.

The section is kept rather than dropped so that a reader who meets the changelog entry can rule it out instead of hunting for a shape they could not have written. It carries the "deliver then quit" form, which is reachable and is the order the runtime recommends.

## Why `#[cfg(doctest)]`

Every "after" snippet is compiled by `cargo test --doc`, so the guide cannot drift from the API it points callers at. `cfg(doctest)` keeps it off the public module tree: the guide is transitional and should be deletable without touching the surface.

This required adding `docs/migrations/**/*` to `include`. `cargo publish` verifies with `cargo build`, which drops the `cfg(doctest)` item before `include_str!` runs — so without the include entry, the published crate would fail `cargo test --doc` and nothing earlier would have caught it.

The trade-off is that the guide does not render on docs.rs. Dropping the `cfg` attribute is all it takes to change that, if the docs.rs placement is worth a public item.

## Verification

- 12 code blocks: 7 "after" snippets pass, 3 "before" snippets are `ignore` (they describe an API that is gone), 2 are `compile_fail`.
- The two `compile_fail` blocks — keying a batch, and keying `Command::quit()` — were checked to fail on the `cancellable` call itself, by compiling the same snippets with only that call removed. Both compile, so neither block is passing on an unrelated error.
- Packaged the crate, extracted the tarball, and ran `cargo test --doc` inside it: the guide is present and its doctests run.
- All 16 internal anchors resolved against the generated heading slugs.
- `just fmt-check`, `just clippy` (`--all-targets --all-features -D warnings`), `just test-doc`, `just doc-build`, `cargo test --test api_surface -- --ignored` and `typos` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)