### PR TITLE
ci(codecov): stop the project status failing on measurement noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,20 +8,30 @@
 # the time, and the only remedy is to re-run a job until the measurement lands
 # on the higher value.
 #
-# `informational` keeps the number and the pull request comment and never
-# reports failure. That is what the operating policy already is — this check is
-# not required and its failures are judged by content — so the setting states
-# it rather than changing it.
+# A threshold rather than `informational`, which was the first thing tried
+# here. `informational` never reports failure, and that is more than this
+# needs: `project` is the only signal that watches *unchanged* code, because
+# `patch` reads the lines a diff adds and a pull request that deletes a test
+# covering something else adds none. Silencing it leaves nothing to notice
+# that, the `Code Coverage` job included — it uploads with
+# `fail_ci_if_error: false` and cannot fail on content.
 #
-# `patch` is left at its default, which makes it a report and not a gate:
-# the repository's ruleset requires neither codecov status, and the
-# `Code Coverage` job that feeds them uploads with `fail_ci_if_error: false`,
-# so it cannot fail on their content either. What `patch` keeps doing is
-# reporting on the lines a diff adds. On every commit in the range above it
-# read "Coverage not affected", which says only that those diffs added no
-# lines for it to measure.
+# 0.5% is chosen against the observed spread rather than against a target
+# regression size: the oscillation is 0.02–0.03 points, so this is more than
+# an order of magnitude above the noise it exists to absorb, while a real
+# decrease large enough to matter is not that small. Re-measure it if the
+# oscillation's cause is ever found and fixed, since the reason for any
+# tolerance at all goes with it.
+#
+# Neither codecov status is a merge gate, and that is deliberate rather than
+# an oversight: the repository's ruleset requires neither, so what a threshold
+# buys is a red mark a reviewer can judge by content — which is the operating
+# policy, and which needs something to judge. `patch` is left at its default
+# for the same reason, reporting on the lines a diff adds. On every commit in
+# the range above it read "Coverage not affected", which says only that those
+# diffs added no lines for it to measure.
 coverage:
   status:
     project:
       default:
-        informational: true
+        threshold: 0.5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Without this file Codecov applies its default `project` status, `target:
+# auto` with `threshold: 0%` — fail on any decrease at all. The measurement is
+# not stable to that resolution. On one branch, against one base, six commits
+# that changed no executable Rust landed on exactly two values, 95.61% and
+# 95.59%, and the check passed or failed accordingly; re-running the Code
+# Coverage job with nothing else changed has flipped a failure to a pass every
+# time it was tried. So a docs-only pull request fails this check about half
+# the time, and the only remedy is to re-run a job until the measurement lands
+# on the higher value.
+#
+# `informational` keeps the number and the pull request comment and never
+# reports failure. That is what the operating policy already is — this check is
+# not required and its failures are judged by content — so the setting states
+# it rather than changing it.
+#
+# `patch` is deliberately left at its default. It reports on the lines a diff
+# adds, so it has nothing to say about a diff that adds none: it read "Coverage
+# not affected" on every commit in the range above, including both failures.
+# Uncovered new lines are the part that has been accurate throughout, and it
+# stays a gate.
+coverage:
+  status:
+    project:
+      default:
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,11 +13,13 @@
 # not required and its failures are judged by content — so the setting states
 # it rather than changing it.
 #
-# `patch` is deliberately left at its default. It reports on the lines a diff
-# adds, so it has nothing to say about a diff that adds none: it read "Coverage
-# not affected" on every commit in the range above, including both failures.
-# Uncovered new lines are the part that has been accurate throughout, and it
-# stays a gate.
+# `patch` is left at its default, which makes it a report and not a gate:
+# the repository's ruleset requires neither codecov status, and the
+# `Code Coverage` job that feeds them uploads with `fail_ci_if_error: false`,
+# so it cannot fail on their content either. What `patch` keeps doing is
+# reporting on the lines a diff adds. On every commit in the range above it
+# read "Coverage not affected", which says only that those diffs added no
+# lines for it to measure.
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,13 +8,13 @@
 # the time, and the only remedy is to re-run a job until the measurement lands
 # on the higher value.
 #
-# A threshold rather than `informational`, which was the first thing tried
-# here. `informational` never reports failure, and that is more than this
-# needs: `project` is the only signal that watches *unchanged* code, because
-# `patch` reads the lines a diff adds and a pull request that deletes a test
-# covering something else adds none. Silencing it leaves nothing to notice
-# that, the `Code Coverage` job included — it uploads with
-# `fail_ci_if_error: false` and cannot fail on content.
+# A threshold rather than `informational`: `informational` never reports
+# failure, and that is more than this needs. `project` is the only signal that
+# watches *unchanged* code, because `patch` reads the lines a diff adds and a
+# pull request that deletes a test covering something else adds none.
+# Silencing it leaves nothing to notice that, the `Code Coverage` job
+# included — that job generates a report and uploads it, and nothing in it
+# reads the number back or fails on it.
 #
 # 0.5% is chosen against the observed spread rather than against a target
 # regression size: the oscillation is 0.02–0.03 points, so this is more than


### PR DESCRIPTION
## What

Adds `codecov.yml`, setting `coverage.status.project.default.threshold: 0.5%`.

## Why

There is no `codecov.yml` in the repo, so Codecov applies its default `project` status — `target: auto`, `threshold: 0%` — which fails on any decrease at all. The measurement is not stable to that resolution.

On `docs/migration-guide-0-11`, six commits against one base landed on exactly two values for the same executable code:

| commit | .rs changed | codecov/project |
| --- | --- | --- |
| 89c8a3b | 0 | **failure** 95.59% (-0.03%) |
| f878f57 | 0 | success 95.61% (+0.00%) |
| acbb974 | 0 | success 95.61% (+0.00%) |
| 7e5df44 | 1 (rustdoc only) | success 95.61% (+0.00%) |
| 80e9a7d | 0 | success 95.61% (+0.00%) |
| 8980d3c | 0 | **failure** 95.59% (-0.03%) |

Re-running the `Code Coverage` job on a failing commit has flipped it to the higher value each time it was tried, with nothing else changed. So a docs-only pull request fails this check about half the time, and the only remedy is to re-run a job.

## Why a threshold and not `informational`

`informational: true` was the first thing this PR did, and it silenced more than the noise. `project` is the only signal watching code a diff does not touch: `patch` reports on the lines a diff **adds**, so a pull request that deletes a test covering something else adds none and passes. The `Code Coverage` job cannot cover for it either — it generates a report and uploads it, and nothing in it reads the number back or fails on it. With `project` informational, nothing anywhere would notice that change.

0.5% is set against the observed spread rather than against a target regression size: the oscillation is 0.02–0.03 points, so the tolerance sits more than an order of magnitude above the noise it exists to absorb, while a decrease worth acting on is not that small. Worth re-measuring if the oscillation's cause is ever found and fixed, since the reason for any tolerance at all goes with it.

## What this is and is not

Neither codecov status is required by the repository's ruleset — the required contexts are `Format Check`, `Clippy`, `Documentation`, `Code Coverage` and the three `Test (…, stable)` legs. So this is a red mark a reviewer judges by content, not a merge gate. That is the operating policy, and the policy needs something to judge, which is the argument against turning the signal off.

`patch` is left at its default for the same reason. On every commit in the range above it read "Coverage not affected" — which says only that those diffs added no lines for it to measure.

## Verification

```
$ curl -X POST --data-binary @codecov.yml https://codecov.io/validate
Valid!
{"coverage":{"status":{"project":{"default":{"threshold":0.5}}}}}
```

Whether the setting takes effect on this PR itself or only once it is on the default branch is not something I have verified; the `codecov/project` check on this PR is the observation.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)
