### PR TITLE
ci: stop a failing matrix leg cancelling its neighbours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,18 +137,34 @@ jobs:
     name: Test
     needs: versions
     strategy:
-      # A leg that fails must not cancel its neighbours, now that `beta` can
-      # fail on its own. Until this branch both legs ran the pin, so the only
-      # failures possible were ones every leg shared; a real `beta` picks up
-      # an upstream regression that none of the `pinned` legs have, and with
-      # the default `fail-fast` that cancels them — including all three
-      # required contexts, on a tree with nothing wrong in it, until upstream
-      # is fixed. Observed here already: on run 33041812710 one leg failed for
-      # an unrelated infrastructure reason and took the other five with it.
+      # A leg that fails must not cancel its neighbours. Under the default
+      # `fail-fast`, one failing leg cancels the rest of the matrix, and three
+      # of these six are required contexts — so any single failure leaves a
+      # merge blocked on checks that never ran and can therefore only ever
+      # report `cancelled`.
       #
-      # `cancelled` at least blocks rather than passes, so the default is not
-      # unsafe — it is just far heavier than what it buys, which is a few
-      # runner-minutes.
+      # Whether that clears depends on why the leg failed, and both cases are
+      # real. A transient failure clears on a re-run: that has happened here,
+      # an `actions/checkout` fault on one runner cancelling the other five,
+      # then a re-run turning all six green with nothing else changed. A
+      # deterministic one does not — a `beta` leg tracking an upstream
+      # regression fails the same way and cancels the same neighbours every
+      # time, and the `beta` legs are not required, so they would be holding
+      # up a merge they have no standing to block.
+      #
+      # The cost of not cancelling is the survivors' runtime: the six legs
+      # total a median of 580s over the last 25 runs, so five of them running
+      # on rather than being cancelled is most of that. It buys back a merge
+      # that would otherwise be blocked on a tree with nothing wrong in it,
+      # which is the better side of the trade.
+      #
+      # Runner *time*, not money — this repository is public, so GitHub-hosted
+      # runners are free and its runs report zero billable milliseconds. What
+      # is actually spent is occupancy and queue latency.
+      #
+      # `cancelled` blocks rather than passes, so the default was never
+      # fail-open. This is a question of which failure costs less, not of
+      # safety.
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,19 @@ jobs:
     name: Test
     needs: versions
     strategy:
+      # A leg that fails must not cancel its neighbours, now that `beta` can
+      # fail on its own. Until this branch both legs ran the pin, so the only
+      # failures possible were ones every leg shared; a real `beta` picks up
+      # an upstream regression that none of the `pinned` legs have, and with
+      # the default `fail-fast` that cancels them — including all three
+      # required contexts, on a tree with nothing wrong in it, until upstream
+      # is fixed. Observed here already: on run 33041812710 one leg failed for
+      # an unrelated infrastructure reason and took the other five with it.
+      #
+      # `cancelled` at least blocks rather than passes, so the default is not
+      # unsafe — it is just far heavier than what it buys, which is a few
+      # runner-minutes.
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # `pinned` is the channel a contributor's checkout selects, so this leg

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,8 +89,8 @@ default. Run them explicitly with:
 cargo test --test api_surface -- --ignored
 ```
 
-CI runs this as its own step with a nightly toolchain installed, separate
-from the test matrix.
+CI runs this in its own job, `Public API Surface`, with a nightly toolchain
+installed, separate from the test matrix.
 
 ## Do Not Use Sleep For Synchronization
 


### PR DESCRIPTION
## What

Two things that were written for #302 and did not reach it. Both are corrected from what was reviewed there — see "Corrections" below.

- `fail-fast: false` on the `test` matrix
- `docs/testing.md` naming the check the API-surface job posts

## Why `fail-fast: false`

Under the default, one failing leg cancels the rest of the matrix. Three of these six legs are required contexts, so any single failure leaves a merge blocked on checks that never ran and can therefore only ever report `cancelled`. `fail-fast: false` lets each leg report its own result.

Whether a cancellation clears depends on why the leg failed, and both cases are real:

- **transient** — clears on a re-run. Run 33041812710 is the demonstration: at attempt 1 a `Set up job` failure (`Failed to load actions/checkout/v7/action.yml` on one runner) cancelled the other five legs; attempt 2 turned all six green at the same head sha with nothing fixed anywhere.
- **deterministic** — does not clear. This is where the `beta` leg matters, now that #302 made it real: it fails the same way every attempt and cancels the same neighbours each time. The `beta` legs are not required contexts, so they would be holding up a merge they have no standing to block.

The run is quoted from `gh api repos/akiomik/tears/actions/runs/33041812710/attempts/1/jobs`; in the web UI it is [attempt 1](https://github.com/akiomik/tears/actions/runs/33041812710/attempts/1). The bare run id resolves to attempt 2, which shows six successes. Its legs are named `stable`, because it predates #302's rename:

```
failure    Test (macos-latest, beta)
cancelled  Test (macos-latest, stable)
cancelled  Test (ubuntu-latest, beta)
cancelled  Test (ubuntu-latest, stable)
cancelled  Test (windows-latest, beta)
cancelled  Test (windows-latest, stable)
```

## What it costs

Not cancelling spends the survivors' runtime. The six legs total a median of **580s** across the last 25 runs (range 428–1047s; this branch's own run is 562s), so five of them running on rather than being cancelled is most of that.

It is runner *time*, not money: this repository is public, so GitHub-hosted runners are free and every run reports zero billable milliseconds. What is spent is occupancy and queue latency, against a merge that would otherwise be blocked on a healthy tree.

`cancelled` blocks rather than passes, so the default was never fail-open. This is about which failure costs less, not about safety.

## Why the doc line

`api-surface` is the YAML key; the job's `name:` is `Public API Surface`, and that is the check-run a reader sees. The original line called it a step, which was wrong in a different way.

## Corrections to what #302 reviewed

A code review of this branch found the justification, not the change, to be substantially wrong. Recorded because the errors are the same class this repository keeps catching:

1. The run transcript was **re-labelled**: the three cancelled legs were quoted as `pinned`, and the run has them as `stable`. Not an omitted condition — an altered one.
2. The premise was backwards. It argued the hazard opened when `beta` became real; the run cited three lines later is from before the split and shows a single leg failing alone, so unshared failures were always possible.
3. "until upstream is fixed" was wrong for the cited case, where a plain re-run recovered it.
4. The cost was wrong twice — first "a few runner-minutes" unmeasured, then "roughly 70 billable minutes", which is a bill never issued: the repo is public, so runners are free. The 950s behind it was also a cold-cache outlier against a 580s median.
5. "this branch" and "observed here" referred to #302 and to #304's branch respectively, and resolve to nothing once merged.
6. This body previously cited commit `d643dee` as evidence; it returns 422, having only ever existed on a detached `HEAD`.

## Why they missed #302

They were committed on a detached `HEAD`, so `git push origin ci/pin-toolchain-per-job` pushed a branch ref that had not moved — a no-op that exited zero. #302 merged as `e33f7a8` without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
