### PR TITLE
ci(release): check the publish job got the toolchain it asked for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,12 @@ jobs:
   # pinned channel outranks whatever a job asks that action for, and asking
   # for `stable` while running the pin is the state this indirection replaces:
   # the toolchain the action installs is the one the job's components are
-  # added to and the one `Swatinem/rust-cache` keys off, so a job that named
-  # the wrong one installed its components somewhere it never built and cached
-  # under a key that did not describe the build.
+  # added to, while the pin is what builds, so a job that named the wrong one
+  # installed its components somewhere it never built. It could also move the
+  # `Swatinem/rust-cache` key, which hashes the version of every installed
+  # toolchain and so picks up the action updating the one it names — though
+  # not by making the key stop describing the build, since `rustc -vV` runs in
+  # the workspace and so reports the pin either way.
   #
   # One consequence worth recording, because it stays silent until it bites:
   # the action installs with `--profile minimal`, and it is now installing the
@@ -74,14 +77,18 @@ jobs:
           pinned=$(sed -ne 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)
           msrv=$(sed -ne 's/^rust-version = "\(.*\)"$/\1/p' Cargo.toml)
           features=$(just --evaluate build_features)
-          # The two `sed` reads need their guards: `sed` prints nothing and
-          # exits zero when it matches nothing, so an unreadable file would
-          # pass an empty string on. `just --evaluate` needs none for the
-          # equivalent case — it exits non-zero for a name it does not know,
-          # and this step has no `shell:`, so the default `bash -e` aborts at
-          # the assignment. Its guard is forward defence only: it fires for a
-          # variable that exists and evaluates empty, which `build_features`
-          # cannot do today because it is a concatenation.
+          # Each read needs a guard for the one empty result its command
+          # reports as success: `sed` prints nothing and exits zero for a file
+          # it can read that holds no matching line, and `just --evaluate`
+          # exits zero for a variable that exists and evaluates empty. The
+          # failures they do report need no guard — `sed` for a file it cannot
+          # read, `just` for a name it does not know, both non-zero — because
+          # this step has no `shell:`, so the default `bash -e` aborts at the
+          # assignment before any guard runs. None of the three can fire
+          # against the files as they stand; they are here for the edits that
+          # would change that, and the `sed` guards are the likelier pair,
+          # being tied to the layout of two files that get edited whenever
+          # the pin or the MSRV moves.
           test -n "$pinned" || { echo "no channel in rust-toolchain.toml" >&2; exit 1; }
           test -n "$msrv" || { echo "no rust-version in Cargo.toml" >&2; exit 1; }
           test -n "$features" || { echo "build_features is empty" >&2; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,61 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.versions.outputs.pinned }}
+      # Assert on `rustup default`, which is the level the action writes to
+      # and so the level that records whether it did. `dtolnay/rust-toolchain`
+      # installs the toolchain and runs `rustup default` on it — and that step
+      # carries `continue-on-error: true`, so it can fail without failing the
+      # job. `rust-toolchain.toml` outranks `rustup default`, so this job
+      # builds with the pin either way; what the default records is whether
+      # the action did what it was asked.
+      #
+      # That is why the assertion reads `rustup default`. The
+      # `rustup show active-toolchain` above it is there to name the winner in
+      # the log when the assertion fails — not a second check, though it is
+      # not inert either: the step has no `shell:`, so it runs under `bash -e`
+      # like every other line, and anything that makes rustup itself fail
+      # fails the step there. Comparing `rustup show active-toolchain` here
+      # would be comparing `rust-toolchain.toml` with itself: no directory
+      # override is set here, so the file decides, and `PINNED` is read from that
+      # same file. `ci.yml` says as much of the one leg where it has the same
+      # shape, and asserts the active toolchain only in the two jobs that set
+      # `RUSTUP_TOOLCHAIN` — an independent second source this job does not
+      # have. The eight jobs that install a toolchain without that second
+      # source assert nothing.
+      #
+      # What the default catches is both ways the action can fail to select
+      # the pin and say nothing: its `rustup default` step failing under the
+      # `continue-on-error`, and the `toolchain:` above naming something
+      # other than the pin — the state #302 replaced, when the channel lived
+      # in the action ref rather than in an input.
+      #
+      # Neither stops the build. `rust-toolchain.toml` outranks the default,
+      # and a pin the action did not install rustup installs on first use.
+      # They differ in what else they cost.
+      #
+      # The first costs nothing else. The action's install step carries no
+      # `continue-on-error`, so by the time its `rustup default` can fail the
+      # pin is installed already, at the profile the action asked for; the
+      # toolchains present and the cache key are what a healthy run has. All
+      # that is lost is the record that the action ran — which is what makes
+      # it worth asserting, not any damage it does.
+      #
+      # The second is quieter rather than harmless, and `ci.yml` records both
+      # halves. A pin that arrives by auto-install carries the `profile`
+      # named in `rust-toolchain.toml` rather than the action's
+      # `--profile minimal`. And the action updates whichever toolchain it
+      # names — the runner ships `stable` already — while
+      # `Swatinem/rust-cache` hashes the version of every installed toolchain
+      # into its key. The job publishes correctly throughout, while its
+      # `toolchain:` input has stopped naming the pin.
+      - name: Verify the toolchain the action selected
+        env:
+          PINNED: ${{ steps.versions.outputs.pinned }}
+        run: |
+          rustup show active-toolchain
+          default=$(rustup default)
+          echo "$default"
+          [[ $default == "${PINNED}-"* ]]
       - uses: Swatinem/rust-cache@v2
 
       - name: Check package


### PR DESCRIPTION
## What

Adds one step to `release.yml`: after installing the pinned channel, assert that `rustup default` names it.

```yaml
- name: Verify the toolchain the action selected
  env:
    PINNED: ${{ steps.versions.outputs.pinned }}
  run: |
    rustup show active-toolchain
    default=$(rustup default)
    echo "$default"
    [[ $default == "${PINNED}-"* ]]
```

## Why `rustup default` and not the active toolchain

`dtolnay/rust-toolchain` selects by running `rustup default`, and [that step carries `continue-on-error: true`](https://github.com/dtolnay/rust-toolchain/blob/6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772/action.yml#L97-L100) — it can fail without failing the job. The `toolchain:` input can also come to name something other than the pin — the state #302 replaced, when the channel lived in the action ref rather than in an input.

Neither goes wrong loudly, because `rust-toolchain.toml` outranks `rustup default`: the build uses the pin regardless.

What they change is quieter. An earlier revision of this PR claimed the job's components and its `Swatinem/rust-cache` key would attach to "a toolchain nothing built with" — that does not hold: this job declares no `components:`, and `rust-cache` builds its key from `rustc -vV` plus a version reading for every installed toolchain ([`src/config.ts#L392-L410`](https://github.com/Swatinem/rust-cache/blob/6323deb102c322ba6fcbdcafc7e3dddab59af2b6/src/config.ts#L392-L410)), where `rustc -vV` runs in the workspace and so resolves through `rust-toolchain.toml` to the pin, the toolchain that did build.

The two modes differ in what else they cost, and the comment now says so separately rather than crediting both with both.

**The action's `rustup default` step failing costs nothing else.** Its install step carries no `continue-on-error` ([`action.yml#L91-L100`](https://github.com/dtolnay/rust-toolchain/blob/6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772/action.yml#L91-L100)), so by the time `rustup default` can fail the pin is installed already, at the profile the action asked for. Toolchains present and cache key match a healthy run. What is lost is the record that the action ran — which is the reason to assert on it, not damage it does.

**The `toolchain:` input naming something else is quieter rather than harmless,** and [`ci.yml` already records both halves](https://github.com/akiomik/tears/blob/e54cd55fb0f091b3e3f093e33c83d22e8e3222aa/.github/workflows/ci.yml#L27-L40): a pin arriving by rustup auto-install carries the `profile` named in `rust-toolchain.toml` rather than `--profile minimal`; and the action updates whichever toolchain it names, while `rust-cache` hashes the version of every installed toolchain into its key. So the job keeps publishing correctly while its `toolchain:` input has stopped meaning anything — which is the state this asserts against. `rustup default` is the narrowest reading that distinguishes it.

Asserting `rustup show active-toolchain` instead — which is what the first draft of this PR did — is comparing `rust-toolchain.toml` with itself: no override is set in this job, so the file decides the active toolchain, and `PINNED` is `sed`-read from that same file.

## Verification

This working tree is in the failing state — `rustup default` names a different toolchain than the pin, which is what the job looks like if the action never applied:

```
$ rustup default
stable-aarch64-apple-darwin (default)
$ rustup show active-toolchain
1.97.0-aarch64-apple-darwin (overridden by '.../rust-toolchain.toml')
```

Against that state:

| assertion | result |
| --- | --- |
| `[[ $active == "1.97.0-"* ]]` (first draft) | **passes** — blind to it |
| `[[ $default == "1.97.0-"* ]]` (this PR) | **fails**, exit 1 |

And it passes when the action has done its job (`1.97.0-… (default)`).

A second commit corrects two `ci.yml` comments this work disproved, and touches only `ci.yml`, so it can be reverted on its own. One says a job naming the wrong toolchain "cached under a key that did not describe the build" — the key did describe it, for the reason above; naming the wrong one could still *move* the key, since it hashes every installed toolchain's version and the action updates the one it names, but that is a different fault from the one claimed, and the components half of the sentence is right and stays. The other says an unreadable `rust-toolchain.toml` "would pass an empty string on" and the `test -n` guards catch it — they never run, because `sed` exits non-zero and `bash -e` aborts at the assignment. Each guard covers the one empty result its command reports as *success*: a readable file with no matching line for `sed`, and a variable that exists and evaluates empty for `just --evaluate`. Both measured.

`actionlint` is clean. CI does not exercise `release.yml` — it triggers on tag push only — so this step's first real run is the next release, same as the code it guards.

## Why now

```
last Release run:      2026-07-26  (v0.10.2)
release.yml rewritten: 2026-08-27  (#302)
```

The workflow has not run since #302 rewrote this part of it, so its first execution is whenever the next tag lands. Per the maintainer's call: leaving the gap open risks it sitting unnoticed until an unscheduled release, which outweighs the risk of editing a workflow shortly before its first use. This is one additive step, no change to existing logic, no new file.

## What this leaves open in #308

Two things, and the second is worse than when the issue was filed:

1. **Both of #308's stated purposes are still open.** #308 gives the assertion two — a `sed` read returning something unexpected, and rustup's precedence changing again. Neither is closed. A precedence flip changes nothing observable, because since #302 both candidates resolve to the pin, so no assertion in this shape can see it. And `PINNED` is both what the action is told to install and what the comparison expects, so a `sed` read returning a wrong-but-installable channel makes the action install it, default to it, and the assertion pass; only the empty case is caught, by the pre-existing `test -n`.
2. **The duplication grew.** `ci.yml` already carries this idiom twice; this makes a third copy, alongside the `sed` snippet that already exists in both workflows. #308's option 2 — a composite action — is the one that closes both halves. That introduces a new mechanism into the path about to be used for the first time, which is the wrong trade this close to a release, but it is the fix and the issue stays open for it.

Refs #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
