### PR TITLE
test(api-surface): name the features instead of `--all-features`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,10 @@ jobs:
       - name: Install nightly toolchain for rustdoc JSON
         run: rustup toolchain install nightly
       - uses: Swatinem/rust-cache@v2
+      # The test reads the feature set from `just --evaluate user_features`
+      # rather than restating it, so `just` has to be on PATH here even though
+      # this job runs no recipe.
+      - uses: taiki-e/install-action@just
       - name: Check public API surface
         run: cargo test --test api_surface -- --ignored
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,6 +81,13 @@ different mechanics from every other test in this repository:
 - Each test shells out to `cargo +nightly rustdoc`, so it needs a nightly
   toolchain installed (`rustup toolchain install nightly`) and takes several
   seconds per run.
+- It builds the surface with the features a dependant can enable, read at run
+  time from `just --evaluate user_features`, so `just` also has to be on PATH
+  (`cargo install just`). It does not use `--all-features`: that enables
+  `loom-core`, which removes code rather than adding it. As the code stands
+  the two sets produce the same surface, so nothing is lost either way; but an
+  item compiled out is one these rules never examine, so the check would pass
+  by looking at less.
 
 Both tests are `#[ignore]`d so `cargo test` stays fast and stable-only by
 default. Run them explicitly with:

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -4,10 +4,64 @@
 //! for why these require nightly and are `#[ignore]`d by default.
 
 use std::collections::{HashMap, HashSet};
+use std::process::Command;
 
 use public_api::PublicItem;
 use public_api::rustdoc_types::Id;
 use public_api::tokens::Token;
+
+/// The features a dependant can enable, read from the one place that declares
+/// them rather than restated here.
+///
+/// Not `--all-features`: that turns on `loom-core`, which *removes* code
+/// rather than adding it. The gate that would bite carries a `test`
+/// (`src/subscription.rs`), and rustdoc JSON builds the library without
+/// `cfg(test)`, so nothing is lost from the surface today — but that is a
+/// property of one gate's shape, not of the approach. A plain
+/// `#[cfg(not(feature = "loom-core"))]` compiles its item away whenever
+/// `loom-core` is on, so under `--all-features` it would not reach the
+/// surface at all, and the rules below cannot find a violation in an item
+/// that is not there: the check would pass by looking at less. Reading the
+/// set a dependant can actually enable keeps such an item in view.
+///
+/// `user_features` and not `build_features`: the public surface is what a
+/// dependant can reach, and everything `bench-internals` adds to it arrives
+/// through two `#[doc(hidden)]` re-exports in `src/lib.rs`; what they
+/// re-export sits under a `pub(crate)` module and is otherwise unreachable.
+/// `Cargo.toml` documents the feature as outside the API and not covered by
+/// semver.
+fn user_features() -> Vec<String> {
+    let output = Command::new("just")
+        .args(["--evaluate", "user_features"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect(
+            "failed to run `just --evaluate user_features`; install just with \
+             `cargo install just` (see docs/testing.md)",
+        );
+    assert!(
+        output.status.success(),
+        "`just --evaluate user_features` failed: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let evaluated = String::from_utf8(output.stdout)
+        .expect("`just --evaluate user_features` produced non-UTF-8 output");
+    // `just --evaluate <var>` prints the bare value and no trailing newline,
+    // but trim rather than depend on that.
+    let features: Vec<String> = evaluated
+        .trim()
+        .split(',')
+        .map(str::to_owned)
+        .filter(|feature| !feature.is_empty())
+        .collect();
+    assert!(
+        !features.is_empty(),
+        "`just --evaluate user_features` evaluated to nothing; the surface \
+         would be built with default features only",
+    );
+    features
+}
 
 fn build_public_api() -> public_api::PublicApi {
     let mut manifest_path = env!("CARGO_MANIFEST_DIR").to_owned();
@@ -16,7 +70,7 @@ fn build_public_api() -> public_api::PublicApi {
     let json_path = rustdoc_json::Builder::default()
         .toolchain("nightly")
         .manifest_path(manifest_path)
-        .all_features(true)
+        .features(user_features())
         .build()
         .expect(
             "failed to build rustdoc JSON; install a nightly toolchain with \
@@ -106,8 +160,10 @@ fn no_public_item_has_two_non_prelude_paths() {
     assert!(
         violations.is_empty(),
         "found public items reachable through more than one non-prelude path: {violations:?}\n\
-         Run `cargo +nightly public-api --all-features` to see the current surface and \
-         close the extra path per docs/api-guidelines.md \"Single Canonical Path\"."
+         Run `cargo +nightly public-api -ss --features \"$(just --evaluate user_features)\"` \
+         to see the same surface this test read (`-ss` drops the blanket and \
+         auto-trait impls this test also omits) and close the extra path per \
+         docs/api-guidelines.md \"Single Canonical Path\"."
     );
 }
 


### PR DESCRIPTION
## What

`tests/api_surface.rs` built its rustdoc JSON with `.all_features(true)`. It now names the same feature set the rest of the build names, read from `just --evaluate user_features`.

## Why

`--all-features` enables `loom-core`, which *removes* code rather than adding it — the reason #303 converted every other cargo invocation away from it. This test was the one it did not reach, and it is where seeing less does the most damage: the two rules it enforces cannot find a violation in an item they never see, so an item compiled out is not exempt from them, it is simply never examined.

## Measured impact today: none

Not argued — dumped both ways with a throwaway harness and diffed:

```
--all-features : 836 items
user_features  : 836 items
comm -23       : (empty)   # nothing lost by the change
comm -13       : (empty)   # nothing the guard is currently blind to
```

So this ships no change in signal. Two things happen to hold: the gate that would bite is `#[cfg(not(all(feature = "loom-core", test)))]` in `src/subscription.rs` and rustdoc JSON builds the library without `cfg(test)`; and `bench-internals` items do not appear in the surface under either set.

Both are properties of today's code, not of the approach. A plain `#[cfg(not(feature = "loom-core"))]` written later would be compiled away under `--all-features`, so its item would never reach the surface and the rules would keep passing without ever examining it. Reading the set a dependant enables keeps it in view. That is what this closes.

To be precise about the instrument: there is no recorded baseline to diff against. Both tests are structural invariants (single canonical path, prelude ⊆ root), so the failure this prevents is not "a change goes unreported" but "an item is never subjected to the rules".

## Feature set

`user_features`, not `build_features`: the public surface is what a dependant can reach, and everything `bench-internals` adds to it arrives through two `#[doc(hidden)]` re-exports in `src/lib.rs`; what they re-export sits under a `pub(crate)` module and is otherwise unreachable. `Cargo.toml` documents the feature as outside the API and not covered by semver.

Read from `just --evaluate user_features` rather than restated. That is the same single source the doctest recipes interpolate as `{{user_features}}` and that `ci.yml`'s `versions` job evaluates for `build_features` — neither neighbour runs this exact command, but each of them reads that one declaration instead of restating the list. That puts `just` on the test's runtime path, so:

- the `Public API Surface` job installs it (it runs no recipe, hence the comment saying why it is there)
- `docs/testing.md` lists it beside the nightly toolchain, since the test's panic message points readers there

## Verification

| check | result |
| --- | --- |
| `cargo test --test api_surface -- --ignored` | 2 passed |
| `just clippy` | clean |
| `just clippy-loom` | clean |
| `cargo fmt --check` | clean |
| `actionlint` | clean |
| `just` absent from `PATH` | panics with `failed to run just --evaluate user_features; install just with cargo install just (see docs/testing.md)` |
| `cargo +nightly public-api -ss --features "$(just --evaluate user_features)"` | 836 rows — matches what the test reads |

The `just`-absent row matters because the new dependency is on an external binary: `Command::output()` returns `Err(NotFound)` and nothing downstream runs, so the panic is whatever that `expect` says. It had to name the fix rather than surface a bare io error.

Closes #310
