### PR TITLE
ci(release): assert the publish job is standing on the pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,17 +18,17 @@ jobs:
   # than restating it.
   #
   # Why the indirection: `dtolnay/rust-toolchain` selects a toolchain with
-  # `rustup default` only, and rustup's precedence is `RUSTUP_TOOLCHAIN` >
-  # directory override > `rust-toolchain.toml` > `rustup default`. So the
-  # pinned channel outranks whatever a job asks that action for, and asking
-  # for `stable` while running the pin is the state this indirection replaces:
-  # the toolchain the action installs is the one the job's components are
-  # added to, while the pin is what builds, so a job that named the wrong one
-  # installed its components somewhere it never built. It could also move the
-  # `Swatinem/rust-cache` key, which hashes the version of every installed
-  # toolchain and so picks up the action updating the one it names — though
-  # not by making the key stop describing the build, since `rustc -vV` runs in
-  # the workspace and so reports the pin either way.
+  # `rustup default` only, and rustup's precedence is a `+toolchain` argument >
+  # `RUSTUP_TOOLCHAIN` > directory override > `rust-toolchain.toml` >
+  # `rustup default`. So the pinned channel outranks whatever a job asks that
+  # action for, and asking for `stable` while running the pin is the state this
+  # indirection replaces: the toolchain the action installs is the one the
+  # job's components are added to, while the pin is what builds, so a job that
+  # named the wrong one installed its components somewhere it never built. It
+  # could also move the `Swatinem/rust-cache` key, which hashes the version of
+  # every installed toolchain and so picks up the action updating the one it
+  # names — though not by making the key stop describing the build, since
+  # `rustc -vV` runs in the workspace and so reports the pin either way.
   #
   # One consequence worth recording, because it stays silent until it bites:
   # the action installs with `--profile minimal`, and it is now installing the
@@ -184,8 +184,8 @@ jobs:
         rust: [pinned, beta]
     runs-on: ${{ matrix.os }}
     # The leg's toolchain, named once and actually in force: `RUSTUP_TOOLCHAIN`
-    # is the only thing that outranks `rust-toolchain.toml`, which is what makes
-    # the `beta` leg beta.
+    # outranks `rust-toolchain.toml`, which is what makes the `beta` leg beta.
+    # A directory override outranks the file too, but nothing here sets one.
     env:
       RUSTUP_TOOLCHAIN: ${{ matrix.rust == 'pinned' && needs.versions.outputs.pinned || matrix.rust }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,64 +29,103 @@ jobs:
           pinned=$(sed -ne 's/^channel = "\(.*\)"$/\1/p' rust-toolchain.toml)
           test -n "$pinned" || { echo "no channel in rust-toolchain.toml" >&2; exit 1; }
           echo "pinned=$pinned" >> "$GITHUB_OUTPUT"
+          # Also as `RUSTUP_TOOLCHAIN`, which outranks both
+          # `rust-toolchain.toml` and the directory override that also
+          # outranks it. Only a `+toolchain` argument beats it, and nothing
+          # here passes one to cargo. `ci.yml` sets this from job `env:`
+          # because its read is a separate job; this read is a step in the
+          # job that uses it, so it travels through `GITHUB_ENV`. Same effect
+          # from the next step on.
+          echo "RUSTUP_TOOLCHAIN=$pinned" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ steps.versions.outputs.pinned }}
-      # Assert on `rustup default`, which is the level the action writes to
-      # and so the level that records whether it did. `dtolnay/rust-toolchain`
-      # installs the toolchain and runs `rustup default` on it — and that step
-      # carries `continue-on-error: true`, so it can fail without failing the
-      # job. `rust-toolchain.toml` outranks `rustup default`, so this job
-      # builds with the pin either way; what the default records is whether
-      # the action did what it was asked.
+      # Two readings, because the job can go wrong in two places and neither
+      # reading sees the other's failure.
       #
-      # That is why the assertion reads `rustup default`. The
-      # `rustup show active-toolchain` above it is there to name the winner in
-      # the log when the assertion fails — not a second check, though it is
-      # not inert either: the step has no `shell:`, so it runs under `bash -e`
-      # like every other line, and anything that makes rustup itself fail
-      # fails the step there. Comparing `rustup show active-toolchain` here
-      # would be comparing `rust-toolchain.toml` with itself: no directory
-      # override is set here, so the file decides, and `PINNED` is read from that
-      # same file. `ci.yml` says as much of the one leg where it has the same
-      # shape, and asserts the active toolchain only in the two jobs that set
-      # `RUSTUP_TOOLCHAIN` — an independent second source this job does not
-      # have. The eight jobs that install a toolchain without that second
-      # source assert nothing.
+      # The active toolchain is what `cargo publish` below will run under, and
+      # that is the highest-consequence cargo invocation in the repository.
+      # Asserting it mirrors what `ci.yml` does in the two jobs that set
+      # `RUSTUP_TOOLCHAIN`. Setting that variable is the substantive half of
+      # this, and it is prevention rather than evidence. Before it, two things
+      # named the pin — the file, and the `rustup default` the action sets —
+      # so in a healthy run any order between them still landed on the pin;
+      # what was unguarded is the run where the action's `rustup default`
+      # silently fails under its `continue-on-error` and the file is the only
+      # thing left holding the release on the pin. Now the pin is named above
+      # every level that decides what `cargo publish` runs under, so that is
+      # no longer a position the job can be argued into.
       #
-      # What the default catches is both ways the action can fail to select
-      # the pin and say nothing: its `rustup default` step failing under the
-      # `continue-on-error`, and the `toolchain:` above naming something
-      # other than the pin — the state #302 replaced, when the channel lived
-      # in the action ref rather than in an input.
+      # `ci.yml`'s disclaimer applies here too, and this is the pinned-leg
+      # shape it applies to: the env var and the file carry the same string by
+      # construction, so the assertion passes whichever of them wins. Against
+      # the precedence question it is therefore weaker than comparing the file
+      # against itself would be: it adds one more level that has to be off the
+      # pin before the comparison can fail. The file and the action's
+      # `rustup default` both name it, so removing the file alone already fell
+      # through to a `rustup default` that answers correctly; now the export
+      # has to be lost as well. It does add one case of its own: if the export
+      # never happens the comparison matches against a bare `-` and the step
+      # fails, even though the file still has the pin in force. What it is for
+      # is saying the pin is in force rather than assuming it.
       #
-      # Neither stops the build. `rust-toolchain.toml` outranks the default,
-      # and a pin the action did not install rustup installs on first use.
-      # They differ in what else they cost.
+      # `rustup default` is a separate question — whether the action did what
+      # it was asked. `dtolnay/rust-toolchain` selects by running
+      # `rustup default`, and that step carries `continue-on-error: true`, so
+      # it can fail without failing the job; `RUSTUP_TOOLCHAIN` now outranks
+      # the result either way, so the failure is silent by construction. What
+      # `rustup default` reports does not consult `RUSTUP_TOOLCHAIN`, so this
+      # reading survives the export above.
       #
-      # The first costs nothing else. The action's install step carries no
-      # `continue-on-error`, so by the time its `rustup default` can fail the
-      # pin is installed already, at the profile the action asked for; the
-      # toolchains present and the cache key are what a healthy run has. All
-      # that is lost is the record that the action ran — which is what makes
-      # it worth asserting, not any damage it does.
+      # What it catches is both ways the action can fail to select the pin:
+      # that step failing under the `continue-on-error`, and the `toolchain:`
+      # input naming something other than the pin — the state #302 replaced,
+      # when the channel lived in the action ref. Neither stops the build, and
+      # they differ in what else they cost. The first costs nothing else: the
+      # install step carries no `continue-on-error`, so by the time
+      # `rustup default` can fail the pin is installed already, at the profile
+      # the action asked for. The second is quieter rather than harmless: the
+      # action updates whichever toolchain it names, and `Swatinem/rust-cache`
+      # hashes the version of every installed toolchain into its key, so the
+      # key can move for a change that did not touch the build — only if the
+      # update finds a newer version, as `ci.yml` hedges it too.
       #
-      # The second is quieter rather than harmless, and `ci.yml` records both
-      # halves. A pin that arrives by auto-install carries the `profile`
-      # named in `rust-toolchain.toml` rather than the action's
-      # `--profile minimal`. And the action updates whichever toolchain it
-      # names — the runner ships `stable` already — while
-      # `Swatinem/rust-cache` hashes the version of every installed toolchain
-      # into its key. The job publishes correctly throughout, while its
-      # `toolchain:` input has stopped naming the pin.
-      - name: Verify the toolchain the action selected
-        env:
-          PINNED: ${{ steps.versions.outputs.pinned }}
+      # `ci.yml` records a second cost there — a pin arriving by auto-install
+      # carrying `rust-toolchain.toml`'s `profile` rather than the action's
+      # `--profile minimal` — and the export above removes it rather than
+      # moving it. The file stops being the override, so such an install takes
+      # rustup's settings profile, and the runner image installs rustup with
+      # `--profile=minimal`; the pin arrives with what the action would have
+      # given it. That half of the cost is `ci.yml`'s, not this file's.
+      #
+      # What neither reading catches: both compare against a value read by the
+      # same `sed`, so a read returning a wrong-but-installable channel is
+      # installed, defaulted to, put in `RUSTUP_TOOLCHAIN` and asserted
+      # against itself. #308's other option does not close that either — a
+      # composite action shared with `ci.yml` still reads once and compares
+      # against that read; what it closes is the two copies drifting apart,
+      # the duplication half the issue names. Catching a wrong read means
+      # making the read itself stricter, which is neither option as the issue
+      # states them.
+      #
+      # Each comparison carries its own `exit` rather than leaning on
+      # `bash -e`, because errexit does not catch every failing command here:
+      # a `[[ ]]` that fails does not trip it on bash 3.2, which is what a
+      # contributor reproducing this on macOS runs, though `false` and `test`
+      # on the same shell do trip it. The two `ci.yml` assertions are single
+      # trailing comparisons, so they are exit status rather than errexit and
+      # are unaffected. Prefix comparisons rather than `grep`, whose pattern
+      # would read the dots in a version as any-character.
+      - name: Verify the toolchain
         run: |
-          rustup show active-toolchain
+          active=$(rustup show active-toolchain)
+          echo "$active"
+          [[ $active == "${RUSTUP_TOOLCHAIN}-"* ]] \
+            || { echo "active toolchain is not the pin ${RUSTUP_TOOLCHAIN}" >&2; exit 1; }
           default=$(rustup default)
           echo "$default"
-          [[ $default == "${PINNED}-"* ]]
+          [[ $default == "${RUSTUP_TOOLCHAIN}-"* ]] \
+            || { echo "the action did not default to the pin ${RUSTUP_TOOLCHAIN}" >&2; exit 1; }
       - uses: Swatinem/rust-cache@v2
 
       - name: Check package


### PR DESCRIPTION
## What

#308's **option 1 only**: `release.yml` now asserts the toolchain the publish job ended up on, mirroring `ci.yml`. Option 1 "closes the consequence half and leaves the duplication", and that is what this does.

The **first** commit corrects `ci.yml`'s account of rustup precedence, which this work disproved. It comes first so that no commit on this branch is self-contradictory, and so the `release.yml` commit — which reasons from that stack — can be reverted on its own without restoring a statement this PR proves false:

- "`RUSTUP_TOOLCHAIN` is the only thing that outranks `rust-toolchain.toml`" is false; a directory override does too.
- The precedence stack omitted its top level: a `+toolchain` argument outranks `RUSTUP_TOOLCHAIN`.

`release.yml` now reasons about where `RUSTUP_TOOLCHAIN` sits, so the levels above it have to be stated correctly.

## `RUSTUP_TOOLCHAIN` is prevention, not evidence

Setting it is the substantive half of this change, and it is worth being exact about which half it is — an earlier revision of this PR had the reasoning backwards.

It does **not** make the assertion evidential. Its value is `sed`-read from the same `rust-toolchain.toml`, so the comparison is still against a string of the job's own making — the limitation #311 recorded. Against the precedence question it is *weaker* than a bare assertion: it adds one more level that has to be off the pin before the comparison can fail. Before the export, the file and the action's `rustup default` both named the pin, so losing the file alone fell through to a default that still answered correctly; now the export has to be lost as well. It is not strictly weaker, because it adds one case of its own — if the export never happens, the comparison matches a bare `-` and the step fails even though the file still has the pin in force. `ci.yml`'s own comment calls this shape "a consistency check rather than evidence", and it is the shape this job has — the pinned leg, not the beta leg where the two candidates differ.

What it changes is the job's **exposure**:

- **Before**: two things named the pin — the file, and the `rustup default` the action sets. A healthy run landed on the pin under any order between them. The unguarded run is the one where the action's `rustup default` fails silently under its `continue-on-error`, leaving the file as the only thing holding the release on the pin. That is not yet #308's failure — the pin still publishes — but it is the precondition for it: one mechanism away, with nothing saying so.
- **After**: the pin is named above every level that decides what `cargo publish` runs under, so that position no longer exists. A reordering below it cannot move the release off the pin. (`+toolchain` outranks `RUSTUP_TOOLCHAIN`, and `dtolnay/rust-toolchain` uses it internally for its own `rustc +<tc>` reads — but nothing here passes one to cargo.)

The assertion's job is then to say the pin is in force rather than assume it, of the highest-consequence cargo invocation in the repository — and to fail closed if `RUSTUP_TOOLCHAIN` is never exported, which leaves the comparison matching against a bare `-`.

`ci.yml` sets it from job `env:` because its read is a separate job; this read is a step in the job that uses it, so it goes through `GITHUB_ENV`. The `beta` legs already prove the ordering works when the named toolchain is not yet installed at the point the variable is set.

`rustup default` stays asserted beside it — a different question (did the action do what it was asked), and `RUSTUP_TOOLCHAIN` does not change what it reports, so the two readings stay independent.

## Each comparison carries its own `exit`

Not styling. A bare `[[ ]]` that fails **does not trip `errexit` on bash 3.2**, which is what a contributor reproducing this on macOS runs. Measured:

```
bash 3.2.57:  bash -e -c '[[ a == b ]]; true'  ->  exit 0
bash 5.3.15:  bash -e -c '[[ a == b ]]; true'  ->  exit 1
```

The runner is ubuntu-only, so the plain form would have worked there — but the first of two assertions would have been decorative anywhere else. Only a *trailing* comparison is safe without an explicit exit, which is what both `ci.yml` assertions are; they are unaffected and untouched.

## Verification

Simulated against every reachable state, on bash 3.2 (the version that ignores errexit here, so this is the harder case):

| state | exit | message |
| --- | --- | --- |
| healthy | 0 | — |
| action's `rustup default` silently failed | 1 | `the action did not default to the pin 1.97.0` |
| `RUSTUP_TOOLCHAIN` never set | 1 | `active toolchain is not the pin` |
| pin not in force | 1 | `active toolchain is not the pin 1.97.0` |
| `toolchain:` regressed to a literal | 1 | `the action did not default to the pin 1.97.0` |

`actionlint` clean. `release.yml` triggers on tag push only, so CI does not exercise it; its first real run is the next release, same as the code it guards.

## What this leaves open

The self-comparison, and the duplication. Both readings check a value from the same `sed`, so a read returning a wrong-but-installable channel is installed, defaulted to, exported to `RUSTUP_TOOLCHAIN` and then asserted against itself; only the empty case is caught, by the pre-existing `test -n`.

Option 2 does not close that either, and an earlier revision of this PR said it did. A composite action shared with `ci.yml` still reads once and compares against that read — what it closes is the two copies drifting apart, which is the "duplication" half the issue names. Catching a wrong read means making the read stricter, which is neither option as written. The issue stays open for the duplication.

Refs #308
