### PR TITLE
chore(deps): move off the yanked chacha20 in the lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",


### PR DESCRIPTION
`cargo publish --dry-run` has been warning that the lockfile pins a
yanked release:

```
warning: package `chacha20 v0.10.1` in Cargo.lock is yanked in registry
`crates-io`, consider updating to a version that is not yanked
```

## How it got there, and how it is resolved

Nothing in this crate names `chacha20`. It arrives three levels down:

```
chacha20 v0.10.2
└── rand v0.10.2
    └── tungstenite v0.30.0
        └── tokio-tungstenite v0.30.0
            └── tears
```

`cargo update -p chacha20` resolves it directly — 0.10.1 → 0.10.2, a
patch release inside the requirement `rand` already states — so no
parent on that path had to move and no manifest constraint changed.
`Cargo.lock` is the only file touched, by one version line and one
checksum:

```diff
-version = "0.10.1"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+version = "0.10.2"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
```

No other package in the lockfile moved.

## Verification

`cargo publish --dry-run`: the yanked warning is gone, and the package
is unchanged at 106 files. It still reports `tears@0.10.2 already exists
on crates.io index`, which is expected on a branch cut from `main` at
the currently published version — the version bump is a separate change.

The dependency is on the WebSocket path, which the suite exercises, so
this is not taken on the lockfile diff alone: 641 tests passed / 0
failed / 2 ignored across lib, bins, tests and examples with all
features, plus 57 doctests and the 2 API-surface rows. `cargo clippy
--all-targets` is clean both with and without `--all-features` under
`-D warnings`, as is `cargo fmt --check`.
