### PR TITLE
test(kernel): settle on the retirement instead of reading it flat

### DIFF
--- a/src/kernel/conformance/admission.rs
+++ b/src/kernel/conformance/admission.rs
@@ -381,6 +381,9 @@ fn the_mandated_supersession_window_never_invokes_the_superseded_spawner() {
     // re-evaluates against the then-current state.
     gate.open();
     driver.settle(THREADED_TURNS, || first.quiescences() > 0);
+    // Deterministic because A's quiescence is the only observable this
+    // script can produce: the trigger parks forever, and B and C are
+    // silent, never-ending sources (`step_when_ready`'s preconditions).
     step_when_ready(&mut driver, WakeSource::ProducerExit, THREADED_TURNS);
 
     assert_eq!(

--- a/src/kernel/conformance/quit.rs
+++ b/src/kernel/conformance/quit.rs
@@ -35,7 +35,7 @@ use crate::testing::driver::{Confirmed, NotReady};
 use super::support::{
     Call, MidBatchHandshake, Script, THREADED_TURNS, accept, accept_within, cap, config, driver,
     driver_with, gated_quitting_effect, parking_effect, quitting_effect, silent_effect,
-    threaded_driver_with,
+    step_when_ready, threaded_driver_with,
 };
 
 // --- the synchronous route ------------------------------------------------
@@ -423,6 +423,8 @@ fn a_quit_buffered_before_its_origin_s_revocation_is_discarded() {
 fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running() {
     let recorder = TraceRecorder::new().with_target("tears::runtime::load");
     let _subscriber = recorder.set_default();
+    let gauge = || recorder.u64_values("keyed_commands");
+    let keyed = || gauge().last().copied();
 
     let (handshake, gate) = MidBatchHandshake::new();
     let reclaimed = handshake.reclaimed();
@@ -439,11 +441,7 @@ fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running()
     );
     let report = driver.boot();
     let (feed, quitter) = (report.started[0].clone(), report.started[1].clone());
-    assert_eq!(
-        recorder.u64_values("keyed_commands").last(),
-        Some(&1),
-        "the keyed run is in the bookkeeping"
-    );
+    assert_eq!(keyed(), Some(1), "the keyed run is in the bookkeeping");
 
     for _ in 0..4 {
         accept_within(&mut driver, feed.clone(), THREADED_TURNS);
@@ -461,26 +459,62 @@ fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running()
 
     driver.settle(THREADED_TURNS, || reclaimed.marked());
     assert_eq!(
-        recorder.u64_values("keyed_commands").last(),
-        Some(&1),
+        keyed(),
+        Some(1),
         "the entry outlives its own task: the quit it committed is still in the control lane"
     );
 
-    for _ in 0..3 {
+    // The task is reclaimed, but its exit is a separate fact: it reaches the
+    // registry only through a pass's first stage, and no pass has run since
+    // the teardown's abort — so the exit is still on the join set. Reflect
+    // it now, on a stated bound: left to land during the drain below, a
+    // slow reap could outrun every stage-1 drain (#307's flake), leaving
+    // the removal condition half-met and the row reading the un-retired
+    // count. Reflected here, the retirement lands at the discarding dequeue
+    // of this same pass — the steady-state site the header names — on every
+    // run.
+    //
+    // Deterministic only because the quitter's is the sole exit this
+    // script can produce (`step_when_ready`'s preconditions): the feed
+    // parks forever and is root-scoped (the teardown does not select it),
+    // and the torn-down scope registers no cleanup. A run added to this
+    // row that can exit — or the feed moved into the "quit" scope — would
+    // let readiness arrive with the quitter still unreaped and break this
+    // step.
+    let stepped = step_when_ready(&mut driver, WakeSource::ProducerExit, THREADED_TURNS);
+    assert!(
+        stepped.terminated.is_none(),
+        "the discarded quit terminates nothing, so the kernel is still running"
+    );
+    assert_eq!(
+        keyed(),
+        Some(0),
+        "the discarding dequeue took the last committed item off the count, and the tombstone \
+         retired on the steady-state rule rather than at a settle"
+    );
+    assert_eq!(
+        journal.reduced(),
+        vec![5, 6],
+        "and the same pass still drained the data lane — exactly one item under the cap, which \
+         is what leaves the drain below two passes"
+    );
+
+    let events_at_retirement = gauge().len();
+    for _ in 0..2 {
         let stepped = driver
             .step_pass(WakeSource::Data)
             .expect("the feed's backlog is still ready");
         assert!(
             stepped.terminated.is_none(),
-            "the discarded quit terminates nothing, so the kernel is still running"
+            "and the kernel stays running while the backlog drains"
         );
     }
-
-    assert_eq!(
-        recorder.u64_values("keyed_commands").last(),
-        Some(&0),
-        "the discarding dequeue took the last committed item off the count, and the tombstone \
-         retired on the steady-state rule rather than at a settle"
+    assert!(
+        gauge()[events_at_retirement..]
+            .iter()
+            .all(|&keyed_count| keyed_count == 0),
+        "the retirement holds through the drain: every gauge event the trailing passes \
+         recorded still counts zero keyed runs"
     );
     assert_eq!(
         journal.reduced(),

--- a/src/kernel/conformance/support.rs
+++ b/src/kernel/conformance/support.rs
@@ -1294,9 +1294,27 @@ pub fn accept<P: Program, B: Backend>(driver: &mut TestDriver<P, B>, run: RunNam
 /// driver's own budgeted waiting primitive, so nothing here reaches past the
 /// published surface.
 ///
+/// # Preconditions
+///
+/// With [`WakeSource::ProducerExit`], readiness is satisfied by *any*
+/// observable exit or quiescence, not one the caller has in mind — the
+/// report carries no run identity to check against. A call is
+/// deterministic only when the script has exactly one exit-capable run
+/// outstanding; with more, the step can be admitted by the wrong one while
+/// the awaited run is still unreaped, and the caller's next read is back
+/// on worker timing. State the census at the call site.
+///
+/// The retry path also inherits [`TestDriver::settle`]'s misuse condition:
+/// do not call with a grant outstanding, banked or not. An attempt that
+/// finds the source already ready returns without settling, so the misuse
+/// would surface only on the runs that wait — a timing-dependent panic,
+/// the class this helper exists to remove.
+///
 /// # Panics
 ///
-/// Panics when `max_turns` is spent with the source still not ready.
+/// Panics when `max_turns` is spent with the source still not ready, and —
+/// through the retry path's [`TestDriver::settle`] — when called while a
+/// grant is outstanding.
 ///
 /// [`TestDriver::settle`]: crate::testing::driver::TestDriver::settle
 #[expect(


### PR DESCRIPTION
## Summary

Fixes #307.

`a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running` ended by reading the `keyed_commands` gauge immediately after its last `step_pass` and could find the entry still in place — about once in 320 runs with the row alone under 16 concurrent processes (evidence table in #307).

## The mechanism (differs from the issue's diagnosis)

#307 read the flake as an observation race: the retirement had happened, its emit just hadn't been seen. It is the retirement itself that is pending. The removal condition needs `exited && counter == 0`; the discarding dequeue supplies only the zero, and `exited` is set solely by a pass's stage-1 join drain. When the aborted quitter has not been reaped by the loop's last pass, no stage has observed the exit, so the still-`Stopping` entry legitimately stands.

That also rules out the issue's proposed fix: `driver.settle` spends executor turns, no turn runs a stage, so no number of turns can set `exited` — a settle on the gauge would replay the same flake as a bound-exhaustion panic.

## The change

The row now reflects the exit deterministically instead of hoping the loop's passes catch it. No pass runs between the teardown's abort and the reclamation settle, so the quitter's exit — the only exit this script can produce, a premise the comment states as load-bearing (the feed parks forever and is root-scoped; the torn-down scope registers no cleanup) — is still on the join set on every run. One bounded pass begun by `WakeSource::ProducerExit` consumes it: its first stage turns the entry into a `Draining` tombstone with the committed quit still pending, and the same pass's control drain then discards that quit, so the decrement and the retirement land at the dequeue — the site the row documents — on every run rather than on a worker-reap-dependent subset.

Supporting adjustments from review:

- `step_when_ready` gains a `# Preconditions` section: with `WakeSource::ProducerExit` the wait is satisfied by *any* observable exit, so a call is deterministic only under a one-exit-capable-run census, which each call site now states (the other caller, in `admission.rs`, gained its one-line premise note). The doc also names the no-grant-outstanding condition the retry path inherits from `TestDriver::settle`.
- The journal is pinned to `[5, 6]` right after the hoisted pass, the file's own convention for capped passes, so a broken cap premise fails at the pass that broke it rather than as a mismatch at the end.
- That pass delivers one of the feed's items under `cap(1)`, so the trailing drain shrinks from three passes to two; each trailing pass still asserts `terminated.is_none()`, and every gauge event recorded during the drain is asserted to still count zero keyed runs — a suffix check that witnesses a re-admission or gauge flap without coupling to unrelated gauge fields or event counts.
- The gauge reads go through `gauge()`/`keyed()` closures, so the field name is spelled once and a rename cannot leave a dead-field read passing vacuously.

An earlier revision guarded the extra pass behind a gauge check after the loop; review showed the rare branch would validate a different retirement site (`on_exit`) than the row documents and could fail through the helper's generic bound-exhaustion panic, so the unconditional, hoisted form replaced it.

Review also surfaced two pre-existing suite-wide items, filed rather than expanded into this row: #316 (no test reaches retirement at the `on_exit` site) and #317 (gauge reads rely on arrival order with no recorder accessor).

## Testing

- Full `--lib` suite (540 tests) passes; `cargo clippy --all-targets` and `cargo fmt --check` are clean.
- The hoisted form was validated across review rounds at 200×/300×/400× serial and 360× under 6-way contention, plus 50× locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)