### PR TITLE
test(observability): read gauge current values by seq, not by arrival

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,6 +143,21 @@ use trace_recorder::TraceRecorder;
 keeps unused tracing code out of integration-test targets that do not assert
 tracing output.
 
+Read a gauge's *current value* through `current_u64`, never through
+`u64_values(...).last()`: the gauge contract orders events by `seq`, not by
+arrival. The accessor assumes one runtime instance per recorder and
+panics otherwise; a deliberately multi-instance test partitions by
+`runtime_id` itself, the way `src/runtime/load.rs`'s contract rows do.
+The rule covers the gauge snapshot's fields — the ones whose events carry
+a `seq`. Other unsigned-integer fields on the same target (`pulled`,
+`updated`, `shared_pending`, `wait_us`) are per-event readings with no
+current value to take; `current_u64` returns `None` for them, so keep those
+on `u64_values`.
+
+The INV-LC7 producer-gauge census in `tests/common/gauges.rs` is included
+with the same `#[path]` mechanism as the recorder above; see its module
+docs for the include prerequisite.
+
 Prefer filtering the recorder to the event being asserted, for example with
 `.with_target("tears::runtime")` and `.with_level(tracing::Level::DEBUG)`.
 Avoid ad hoc subscribers that filter by returning `false` from `enabled()`:

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1270,8 +1270,8 @@ mod tests {
         assert_eq!(kernel.owned_task_count(), 0);
         assert_eq!(kernel.registry().len(), 0, "the bookkeeping is cleared");
         assert_eq!(
-            recorder.u64_values("unkeyed_commands").last(),
-            Some(&0),
+            recorder.current_u64("unkeyed_commands"),
+            Some(0),
             "the producer gauge fell with the task the settle drained"
         );
     }

--- a/src/kernel/conformance/observability.rs
+++ b/src/kernel/conformance/observability.rs
@@ -240,18 +240,18 @@ fn the_gauge_kind_counts_map_onto_the_kernel_s_run_kinds() {
     driver.boot();
 
     assert_eq!(
-        recorder.u64_values("unkeyed_commands").last(),
-        Some(&1),
+        recorder.current_u64("unkeyed_commands"),
+        Some(1),
         "the anonymous run"
     );
     assert_eq!(
-        recorder.u64_values("keyed_commands").last(),
-        Some(&1),
+        recorder.current_u64("keyed_commands"),
+        Some(1),
         "the keyed run"
     );
     assert_eq!(
-        recorder.u64_values("subscriptions").last(),
-        Some(&1),
+        recorder.current_u64("subscriptions"),
+        Some(1),
         "and the subscription run"
     );
 }
@@ -281,11 +281,16 @@ fn a_cleanup_run_counts_in_no_gauge_field() {
         config().batch_max_messages(cap(1)),
     );
     let trigger = driver.boot().started[0].clone();
-    let kinds = |field: &str| recorder.u64_values(field).last().copied();
-    let (anonymous, keyed, subscriptions) = (
-        kinds("unkeyed_commands"),
-        kinds("keyed_commands"),
-        kinds("subscriptions"),
+    assert_eq!(
+        (
+            recorder.current_u64("unkeyed_commands"),
+            recorder.current_u64("keyed_commands"),
+            recorder.current_u64("subscriptions"),
+        ),
+        (Some(1), Some(0), Some(0)),
+        "the baseline is a measured reading, not a silenced instrument, checked before the \
+         teardown so a fixture or schema change reports here rather than as a cleanup-run \
+         regression at the closing comparison"
     );
 
     accept(&mut driver, trigger);
@@ -296,11 +301,11 @@ fn a_cleanup_run_counts_in_no_gauge_field() {
 
     assert_eq!(
         (
-            kinds("unkeyed_commands"),
-            kinds("keyed_commands"),
-            kinds("subscriptions")
+            recorder.current_u64("unkeyed_commands"),
+            recorder.current_u64("keyed_commands"),
+            recorder.current_u64("subscriptions")
         ),
-        (anonymous, keyed, subscriptions),
+        (Some(1), Some(0), Some(0)),
         "the teardown started a cleanup run and no gauge field moved for it"
     );
 }

--- a/src/kernel/conformance/quit.rs
+++ b/src/kernel/conformance/quit.rs
@@ -421,10 +421,10 @@ fn a_quit_buffered_before_its_origin_s_revocation_is_discarded() {
 // not a stage probe — so this row stays pass-unit driven like the rest.
 #[test]
 fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running() {
+    const KEYED_GAUGE: &str = "keyed_commands";
     let recorder = TraceRecorder::new().with_target("tears::runtime::load");
     let _subscriber = recorder.set_default();
-    let gauge = || recorder.u64_values("keyed_commands");
-    let keyed = || gauge().last().copied();
+    let keyed = || recorder.current_u64(KEYED_GAUGE);
 
     let (handshake, gate) = MidBatchHandshake::new();
     let reclaimed = handshake.reclaimed();
@@ -499,7 +499,7 @@ fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running()
          is what leaves the drain below two passes"
     );
 
-    let events_at_retirement = gauge().len();
+    let readings_at_retirement = recorder.u64_values(KEYED_GAUGE).len();
     for _ in 0..2 {
         let stepped = driver
             .step_pass(WakeSource::Data)
@@ -509,12 +509,12 @@ fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running()
             "and the kernel stays running while the backlog drains"
         );
     }
+    let readings = recorder.u64_values(KEYED_GAUGE);
+    let recorded_since = &readings[readings_at_retirement..];
     assert!(
-        gauge()[events_at_retirement..]
-            .iter()
-            .all(|&keyed_count| keyed_count == 0),
-        "the retirement holds through the drain: every gauge event the trailing passes \
-         recorded still counts zero keyed runs"
+        recorded_since.iter().all(|&count| count == 0),
+        "the retirement holds through the drain: no reading recorded after it counts a keyed \
+         run — a claim about the arrival-order log, whose suffix is {recorded_since:?}"
     );
     assert_eq!(
         journal.reduced(),

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -356,9 +356,9 @@ mod tests {
             "blocked rose while the send waited: {blocked:?}"
         );
         assert_eq!(
-            blocked.last(),
-            Some(&0),
-            "blocked fell once the send was accepted: {blocked:?}"
+            recorder.current_u64("blocked"),
+            Some(0),
+            "blocked fell once the send was accepted (arrival-order log: {blocked:?})"
         );
     }
 
@@ -421,9 +421,9 @@ mod tests {
             "blocked rose while the send waited: {blocked_values:?}"
         );
         assert_eq!(
-            blocked_values.last(),
-            Some(&0),
-            "aborting the blocked send lowered blocked: {blocked_values:?}"
+            recorder.current_u64("blocked"),
+            Some(0),
+            "aborting the blocked send lowered blocked (arrival-order log: {blocked_values:?})"
         );
         assert!(
             recorder.str_values("channel").is_empty(),

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -250,6 +250,14 @@ impl GaugeSnapshot {
     /// `tracing::event_enabled!` gate, or the gate goes stale — silently
     /// skipping (or failing to skip) dispatch for events it no longer
     /// describes.
+    ///
+    /// The field names emitted here are also read back *by name* by the
+    /// test recorders' `current_u64` (`seq`/`runtime_id` as the snapshot
+    /// markers), by the integration census's `PRODUCER_GAUGES`, and by the
+    /// bench subscriber's `LoadVisitor` in `benches/kernel_load.rs` — the
+    /// one consumer that degrades *silently* on a rename, its unmatched
+    /// names falling into a catch-all arm; this emitter is their source of
+    /// truth.
     fn dispatch(self) {
         tracing::debug!(
             target: "tears::runtime::load",

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
 use tracing::callsite::rebuild_interest_cache;
 use tracing::field::{Field, Visit};
@@ -20,6 +20,18 @@ use tracing::{Dispatch, Event, Level, Metadata, Subscriber};
 static REGISTRY_LOCK: Mutex<()> = Mutex::new(());
 static INTEREST_KEEPER: OnceLock<Dispatch> = OnceLock::new();
 
+/// Takes the registry lock, recovering from poisoning: any panicking test
+/// unwinds through [`TraceRecorderGuard`]'s drop while holding nothing but
+/// this lock's discipline, and a panic inside another holder's critical
+/// section must not abort the binary via a panic-while-panicking there.
+/// The lock only serializes callsite-interest cache rebuilds, and the next
+/// acquisition rebuilds the full cache, so a poisoned generation carries
+/// no corrupt state. Every acquisition goes through here so none can
+/// regress to an `.expect`.
+fn registry_lock() -> MutexGuard<'static, ()> {
+    REGISTRY_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
 /// A cache-safe tracing subscriber for tests that need to count events or
 /// inspect simple event fields.
 ///
@@ -36,12 +48,17 @@ pub struct TraceRecorder {
 struct TraceRecorderState {
     events: AtomicUsize,
     bool_fields: Mutex<HashMap<String, Vec<bool>>>,
-    u64_fields: Mutex<HashMap<String, Vec<u64>>>,
     str_fields: Mutex<HashMap<String, Vec<String>>>,
     // The sorted field-name set of each matching event, in arrival order, so a
-    // test can assert which fields co-occur on a single event (the per-field
-    // maps above flatten across events and cannot).
+    // test can assert which fields co-occur on a single event — across all
+    // field types at once: the bool/str maps above flatten across events, and
+    // the u64 event log below keeps per-event grouping for its own type only.
     field_sets: Mutex<Vec<Vec<String>>>,
+    // Each event's unsigned-integer fields kept together, in arrival order —
+    // the single u64 source of truth: `u64_values` flattens it per field, and
+    // `current_u64` pairs a value with the `seq` recorded on its own event,
+    // which a flattened per-field map could not.
+    u64_events: Mutex<Vec<Vec<(String, u64)>>>,
 }
 
 #[derive(Clone, Default)]
@@ -94,12 +111,91 @@ impl TraceRecorder {
     #[must_use]
     pub fn u64_values(&self, field: &str) -> Vec<u64> {
         self.state
-            .u64_fields
+            .u64_events
             .lock()
-            .expect("trace recorder u64 field log mutex should not be poisoned")
-            .get(field)
-            .cloned()
-            .unwrap_or_default()
+            .expect("trace recorder u64 event log mutex should not be poisoned")
+            .iter()
+            .flat_map(|event| {
+                // Every occurrence, not `field_value`'s first: the flattened
+                // log must not collapse a field a callsite recorded twice.
+                field_values(event, field)
+            })
+            .collect()
+    }
+
+    /// Returns the current value of a gauge field, read the way the gauge
+    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
+    /// the greatest-`seq` event that records `field`. Arrival order is
+    /// never consulted among distinct `seq` values, so the read stays
+    /// correct even if dispatch order diverges from `seq` order; a `seq`
+    /// tie — impossible for a real runtime, whose `seq` strictly increases —
+    /// resolves to the first-arriving match. An event carrying `field`
+    /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
+    /// is ignored; `None` when no event carries all three. The marker
+    /// names come from `GaugeSnapshot::dispatch` (`src/runtime/load.rs`),
+    /// the schema's single emitter and their source of truth.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the matched events span more than one `runtime_id`,
+    /// since `seq` is comparable only within one runtime instance. An
+    /// event is matched when it carries `seq`, `runtime_id`, and the
+    /// queried field; every snapshot carries every count, so only an
+    /// instance that emits no snapshot at all stays outside the scan. The
+    /// panic message carries the remedies.
+    #[must_use]
+    #[track_caller]
+    #[expect(
+        clippy::panic,
+        reason = "a cross-instance read is test misuse, reported with the observed ids"
+    )]
+    pub fn current_u64(&self, field: &str) -> Option<u64> {
+        let events = self
+            .state
+            .u64_events
+            .lock()
+            .expect("trace recorder u64 event log mutex should not be poisoned");
+        let mut runtime_id: Option<u64> = None;
+        let mut clash: Option<(u64, u64)> = None;
+        let mut current: Option<(u64, u64)> = None;
+        for event in events.iter() {
+            // `seq` first: the target's non-snapshot events (the batch and
+            // capacity-wait families) fail that lookup, so they skip the
+            // other two scans.
+            let Some(seq) = field_value(event, "seq") else {
+                continue;
+            };
+            let (Some(value), Some(id)) =
+                (field_value(event, field), field_value(event, "runtime_id"))
+            else {
+                continue;
+            };
+            match runtime_id {
+                None => runtime_id = Some(id),
+                Some(seen) if seen != id => {
+                    clash = Some((seen, id));
+                    break;
+                }
+                Some(_) => {}
+            }
+            if current.is_none_or(|(greatest, _)| seq > greatest) {
+                current = Some((seq, value));
+            }
+        }
+        // Released before the panic below, so a failing guard reports its
+        // own message rather than poisoning the log for every later read.
+        drop(events);
+        if let Some((first, second)) = clash {
+            panic!(
+                "current_u64({field:?}) matched gauge events from at least two runtime \
+                 instances ({first} and {second}); `seq` is comparable only within one. \
+                 Restructure to observe one runtime per recorder (test-helper observers, \
+                 like `channel`'s throwaway, also count), read `u64_values` and partition \
+                 by `runtime_id` yourself, or — if the script minted no second observer — \
+                 treat it as a one-instance-per-run regression"
+            );
+        }
+        current.map(|(_, value)| value)
     }
 
     /// Returns all string values recorded for the named event field.
@@ -137,9 +233,7 @@ pub fn set_default_subscriber<S>(subscriber: S) -> TraceRecorderGuard
 where
     S: Subscriber + Send + Sync + 'static,
 {
-    let _registry = REGISTRY_LOCK
-        .lock()
-        .expect("trace recorder registry mutex should not be poisoned");
+    let _registry = registry_lock();
     ensure_interest_keeper();
     let guard = set_default(subscriber);
     rebuild_interest_cache();
@@ -182,9 +276,7 @@ impl Subscriber for InterestKeeper {
 
 impl Drop for TraceRecorderGuard {
     fn drop(&mut self) {
-        let _registry = REGISTRY_LOCK
-            .lock()
-            .expect("trace recorder registry mutex should not be poisoned");
+        let _registry = registry_lock();
         drop(self.guard.take());
         rebuild_interest_cache();
     }
@@ -197,6 +289,27 @@ impl EventFilter {
             .is_none_or(|target| metadata.target() == target)
             && self.level.is_none_or(|level| *metadata.level() == level)
     }
+}
+
+/// Every value the event recorded under `name`, in record order — the one
+/// place the name match is spelled, so `field_value` and `u64_values`
+/// cannot disagree about which events carry a field.
+fn field_values<'event>(
+    event: &'event [(String, u64)],
+    name: &'event str,
+) -> impl Iterator<Item = u64> + 'event {
+    event
+        .iter()
+        .filter(move |(field_name, _)| field_name == name)
+        .map(|(_, value)| *value)
+}
+
+/// The named unsigned-integer field of one recorded event — the *first*
+/// occurrence when a callsite records the name twice. `u64_values` keeps
+/// every occurrence; this is for the snapshot fields (`seq`,
+/// `runtime_id`, and the gauges), which a snapshot carries once each.
+fn field_value(event: &[(String, u64)], name: &str) -> Option<u64> {
+    field_values(event, name).next()
 }
 
 impl Subscriber for TraceRecorder {
@@ -245,14 +358,11 @@ impl Subscriber for TraceRecorder {
             }
         }
         if !visitor.u64s.is_empty() {
-            let mut fields = self
-                .state
-                .u64_fields
+            self.state
+                .u64_events
                 .lock()
-                .expect("trace recorder u64 field log mutex should not be poisoned");
-            for (field, value) in visitor.u64s {
-                fields.entry(field).or_default().push(value);
-            }
+                .expect("trace recorder u64 event log mutex should not be poisoned")
+                .push(visitor.u64s);
         }
         if !visitor.strs.is_empty() {
             let mut fields = self
@@ -334,5 +444,50 @@ mod tests {
             1,
             "recorder should observe an event even if the callsite was first registered on a non-recorder thread"
         );
+    }
+
+    #[test]
+    fn current_u64_reads_by_seq_not_by_arrival() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 2u64, gauge = 5u64, "later snapshot, early arrival");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 1u64, gauge = 9u64, "earlier snapshot, late arrival");
+        tracing::trace!(target: TARGET, gauge = 7u64, "no seq: not a snapshot");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 3u64, other = 1u64, "snapshot without the field");
+        tracing::trace!(target: TARGET, seq = 9u64, gauge = 1u64, "no runtime_id: not a snapshot either");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 2u64, gauge = 8u64, "a seq tie: the first arrival keeps the read");
+
+        assert_eq!(
+            recorder.current_u64("gauge"),
+            Some(5),
+            "the greatest-seq event carrying the field wins — whatever arrived last, whatever \
+             lacks a runtime_id, and whichever of a seq tie arrived later"
+        );
+        assert_eq!(
+            recorder.u64_values("gauge"),
+            vec![5, 9, 7, 1, 8],
+            "while the flattened view keeps every value in arrival order — the last is exactly \
+             where the arrival-order read differs"
+        );
+        assert_eq!(recorder.current_u64("absent"), None);
+    }
+
+    // Pinned here and not in the tests/ mirror: one copy suffices for the
+    // contract, and mirroring would add a deliberate panic to every
+    // including binary for no new coverage of the same source. No
+    // `hook_guard`: this row swaps no hook, and a recording hook's defence
+    // against deliberate panics is its thread-name filter
+    // (docs/testing.md, "Process-Global Panic Hook Tests").
+    #[test]
+    #[should_panic(expected = "matched gauge events from at least two runtime instances")]
+    fn current_u64_refuses_a_cross_instance_read() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, runtime_id = 1u64, seq = 1u64, gauge = 3u64, "one instance");
+        tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 9u64, gauge = 0u64, "another");
+
+        let _ = recorder.current_u64("gauge");
     }
 }

--- a/tests/common/gauges.rs
+++ b/tests/common/gauges.rs
@@ -1,0 +1,114 @@
+//! The INV-LC7 producer-gauge census, shared via `#[path]` so every
+//! integration target that reads the gauges reads one definition of the
+//! field set and one meaning of "settled" — a producer gauge added here
+//! reaches every census at once instead of leaving a copy waiting on the
+//! old set.
+//!
+//! An including target must also declare the recorder at its crate root,
+//! spelled exactly `#[path = "common/trace_recorder.rs"] mod
+//! trace_recorder;` — this module resolves the type through that name.
+//! Every item here is used by every including target, deliberately: an
+//! item only one target needs (`no_producer_gauge_event_fired` lives in
+//! `lifecycle.rs` for this reason) stays with its caller.
+
+use crate::trace_recorder::TraceRecorder;
+
+/// The settling producer gauges RFC 0011 INV-LC7 reads — three of RFC 0006
+/// §4.4's four counts. `blocked`, the fourth, rides the same snapshot but
+/// belongs to the bounded-send layer rather than to run lifecycle, so the
+/// settle census does not hold it to a terminal reading. The names' code
+/// source of truth is `GaugeSnapshot::dispatch` in `src/runtime/load.rs`,
+/// the schema's single emitter.
+pub const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
+
+/// Whether every producer gauge has reached its terminal reading.
+///
+/// A gauge whose producer the row actually starts (`expected_active`) must
+/// currently read zero: `None` is not a settled gauge but a silenced
+/// instrument — no gauge event fired at all, or none carried the `seq` the
+/// current-value read requires — and accepting it there would let a
+/// mutation that stops or de-schemas the emission satisfy INV-LC7 on
+/// iteration zero. Gauges outside the set take the weaker reading: `None`
+/// stays acceptable, and — since every gauge event carries all the counts
+/// at once — a fired event still holds them to `Some(0)`; the set names
+/// which gauges must have *risen*, not which are exempt from settling.
+///
+/// Written as a plain loop rather than an iterator chain so the
+/// `#[track_caller]` chain holds: a closure would break it, and
+/// `current_u64`'s cross-instance panic would then name this file instead
+/// of the caller. The chain propagates one frame — a row calling directly
+/// is named; a shared helper in between becomes the named frame itself.
+///
+/// An empty `expected_active` makes every branch tolerant: that is a
+/// no-producers reading, not an INV-LC7 check — rows that start no
+/// producer assert on the raw event log instead.
+///
+/// # Panics
+///
+/// Inherits `current_u64`'s single-runtime guard: a recorder that observed
+/// gauge events from more than one runtime instance panics here rather
+/// than settling on a cross-instance reading.
+#[track_caller]
+pub fn producer_gauges_are_zero(recorder: &TraceRecorder, expected_active: &[&str]) -> bool {
+    assert!(
+        expected_active
+            .iter()
+            .all(|field| PRODUCER_GAUGES.contains(field)),
+        "an expected-active name outside the census silently weakens every gauge to the \
+         tolerant branch: {expected_active:?}"
+    );
+    for field in PRODUCER_GAUGES {
+        let current = recorder.current_u64(field);
+        let settled = if expected_active.contains(&field) {
+            current == Some(0)
+        } else {
+            matches!(current, None | Some(0))
+        };
+        if !settled {
+            return false;
+        }
+    }
+    true
+}
+
+/// Each gauge beside its current value and its arrival-order log — the
+/// census's one diagnostic shape, interpolated by both settle asserts so a
+/// change to it reaches every failure message at once. No `#[track_caller]`:
+/// the `.map` closure would break the chain anyway, and every count rides
+/// one snapshot, so a clash here would already have fired on the census's
+/// first read.
+#[must_use]
+pub fn producer_gauge_report(
+    recorder: &TraceRecorder,
+) -> [(&'static str, Option<u64>, Vec<u64>); PRODUCER_GAUGES.len()] {
+    PRODUCER_GAUGES.map(|field| {
+        (
+            field,
+            recorder.current_u64(field),
+            recorder.u64_values(field),
+        )
+    })
+}
+
+// Compiled per including target, so this row runs once per binary — the
+// deliberate cost of each target pinning the census it links against.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The strict/tolerant split is the census's whole contract: an active
+    // gauge with no events is a silenced instrument, not a settled one,
+    // while a gauge the row never raises may legitimately have none.
+    #[test]
+    fn an_active_gauge_with_no_events_is_not_settled() {
+        let recorder = TraceRecorder::new();
+        assert!(
+            !producer_gauges_are_zero(&recorder, &["subscriptions"]),
+            "an expected-active gauge must have fired to count as settled"
+        );
+        assert!(
+            producer_gauges_are_zero(&recorder, &[]),
+            "a gauge the row never raises settles on no events at all"
+        );
+    }
+}

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
 use tracing::callsite::rebuild_interest_cache;
 use tracing::field::{Field, Visit};
@@ -31,6 +31,18 @@ use tracing::{Dispatch, Event, Level, Metadata, Subscriber};
 static REGISTRY_LOCK: Mutex<()> = Mutex::new(());
 static INTEREST_KEEPER: OnceLock<Dispatch> = OnceLock::new();
 
+/// Takes the registry lock, recovering from poisoning: any panicking test
+/// unwinds through [`TraceRecorderGuard`]'s drop while holding nothing but
+/// this lock's discipline, and a panic inside another holder's critical
+/// section must not abort the binary via a panic-while-panicking there.
+/// The lock only serializes callsite-interest cache rebuilds, and the next
+/// acquisition rebuilds the full cache, so a poisoned generation carries
+/// no corrupt state. Every acquisition goes through here so none can
+/// regress to an `.expect`.
+fn registry_lock() -> MutexGuard<'static, ()> {
+    REGISTRY_LOCK.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
 /// A cache-safe tracing subscriber for tests that need to count events or
 /// inspect simple event fields.
 ///
@@ -47,12 +59,17 @@ pub struct TraceRecorder {
 struct TraceRecorderState {
     events: AtomicUsize,
     bool_fields: Mutex<HashMap<String, Vec<bool>>>,
-    u64_fields: Mutex<HashMap<String, Vec<u64>>>,
     str_fields: Mutex<HashMap<String, Vec<String>>>,
     // The sorted field-name set of each matching event, in arrival order, so a
-    // test can assert which fields co-occur on a single event (the per-field
-    // maps above flatten across events and cannot).
+    // test can assert which fields co-occur on a single event — across all
+    // field types at once: the bool/str maps above flatten across events, and
+    // the u64 event log below keeps per-event grouping for its own type only.
     field_sets: Mutex<Vec<Vec<String>>>,
+    // Each event's unsigned-integer fields kept together, in arrival order —
+    // the single u64 source of truth: `u64_values` flattens it per field, and
+    // `current_u64` pairs a value with the `seq` recorded on its own event,
+    // which a flattened per-field map could not.
+    u64_events: Mutex<Vec<Vec<(String, u64)>>>,
 }
 
 #[derive(Clone, Default)]
@@ -94,9 +111,7 @@ impl TraceRecorder {
     /// Installs this recorder as the default subscriber for the current thread.
     #[must_use]
     pub fn set_default(&self) -> TraceRecorderGuard {
-        let _registry = REGISTRY_LOCK
-            .lock()
-            .expect("trace recorder registry mutex should not be poisoned");
+        let _registry = registry_lock();
         ensure_interest_keeper();
         let guard = set_default(self.clone());
         rebuild_interest_cache();
@@ -126,12 +141,91 @@ impl TraceRecorder {
     #[must_use]
     pub fn u64_values(&self, field: &str) -> Vec<u64> {
         self.state
-            .u64_fields
+            .u64_events
             .lock()
-            .expect("trace recorder u64 field log mutex should not be poisoned")
-            .get(field)
-            .cloned()
-            .unwrap_or_default()
+            .expect("trace recorder u64 event log mutex should not be poisoned")
+            .iter()
+            .flat_map(|event| {
+                // Every occurrence, not `field_value`'s first: the flattened
+                // log must not collapse a field a callsite recorded twice.
+                field_values(event, field)
+            })
+            .collect()
+    }
+
+    /// Returns the current value of a gauge field, read the way the gauge
+    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
+    /// the greatest-`seq` event that records `field`. Arrival order is
+    /// never consulted among distinct `seq` values, so the read stays
+    /// correct even if dispatch order diverges from `seq` order; a `seq`
+    /// tie — impossible for a real runtime, whose `seq` strictly increases —
+    /// resolves to the first-arriving match. An event carrying `field`
+    /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
+    /// is ignored; `None` when no event carries all three. The marker
+    /// names come from `GaugeSnapshot::dispatch` (`src/runtime/load.rs`),
+    /// the schema's single emitter and their source of truth.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the matched events span more than one `runtime_id`,
+    /// since `seq` is comparable only within one runtime instance. An
+    /// event is matched when it carries `seq`, `runtime_id`, and the
+    /// queried field; every snapshot carries every count, so only an
+    /// instance that emits no snapshot at all stays outside the scan. The
+    /// panic message carries the remedies.
+    #[must_use]
+    #[track_caller]
+    #[expect(
+        clippy::panic,
+        reason = "a cross-instance read is test misuse, reported with the observed ids"
+    )]
+    pub fn current_u64(&self, field: &str) -> Option<u64> {
+        let events = self
+            .state
+            .u64_events
+            .lock()
+            .expect("trace recorder u64 event log mutex should not be poisoned");
+        let mut runtime_id: Option<u64> = None;
+        let mut clash: Option<(u64, u64)> = None;
+        let mut current: Option<(u64, u64)> = None;
+        for event in events.iter() {
+            // `seq` first: the target's non-snapshot events (the batch and
+            // capacity-wait families) fail that lookup, so they skip the
+            // other two scans.
+            let Some(seq) = field_value(event, "seq") else {
+                continue;
+            };
+            let (Some(value), Some(id)) =
+                (field_value(event, field), field_value(event, "runtime_id"))
+            else {
+                continue;
+            };
+            match runtime_id {
+                None => runtime_id = Some(id),
+                Some(seen) if seen != id => {
+                    clash = Some((seen, id));
+                    break;
+                }
+                Some(_) => {}
+            }
+            if current.is_none_or(|(greatest, _)| seq > greatest) {
+                current = Some((seq, value));
+            }
+        }
+        // Released before the panic below, so a failing guard reports its
+        // own message rather than poisoning the log for every later read.
+        drop(events);
+        if let Some((first, second)) = clash {
+            panic!(
+                "current_u64({field:?}) matched gauge events from at least two runtime \
+                 instances ({first} and {second}); `seq` is comparable only within one. \
+                 Restructure to observe one runtime per recorder (test-helper observers, \
+                 like `channel`'s throwaway, also count), read `u64_values` and partition \
+                 by `runtime_id` yourself, or — if the script minted no second observer — \
+                 treat it as a one-instance-per-run regression"
+            );
+        }
+        current.map(|(_, value)| value)
     }
 
     /// Returns all string values recorded for the named event field.
@@ -194,9 +288,7 @@ impl Subscriber for InterestKeeper {
 
 impl Drop for TraceRecorderGuard {
     fn drop(&mut self) {
-        let _registry = REGISTRY_LOCK
-            .lock()
-            .expect("trace recorder registry mutex should not be poisoned");
+        let _registry = registry_lock();
         drop(self.guard.take());
         rebuild_interest_cache();
     }
@@ -209,6 +301,27 @@ impl EventFilter {
             .is_none_or(|target| metadata.target() == target)
             && self.level.is_none_or(|level| *metadata.level() == level)
     }
+}
+
+/// Every value the event recorded under `name`, in record order — the one
+/// place the name match is spelled, so `field_value` and `u64_values`
+/// cannot disagree about which events carry a field.
+fn field_values<'event>(
+    event: &'event [(String, u64)],
+    name: &'event str,
+) -> impl Iterator<Item = u64> + 'event {
+    event
+        .iter()
+        .filter(move |(field_name, _)| field_name == name)
+        .map(|(_, value)| *value)
+}
+
+/// The named unsigned-integer field of one recorded event — the *first*
+/// occurrence when a callsite records the name twice. `u64_values` keeps
+/// every occurrence; this is for the snapshot fields (`seq`,
+/// `runtime_id`, and the gauges), which a snapshot carries once each.
+fn field_value(event: &[(String, u64)], name: &str) -> Option<u64> {
+    field_values(event, name).next()
 }
 
 impl Subscriber for TraceRecorder {
@@ -257,14 +370,11 @@ impl Subscriber for TraceRecorder {
             }
         }
         if !visitor.u64s.is_empty() {
-            let mut fields = self
-                .state
-                .u64_fields
+            self.state
+                .u64_events
                 .lock()
-                .expect("trace recorder u64 field log mutex should not be poisoned");
-            for (field, value) in visitor.u64s {
-                fields.entry(field).or_default().push(value);
-            }
+                .expect("trace recorder u64 event log mutex should not be poisoned")
+                .push(visitor.u64s);
         }
         if !visitor.strs.is_empty() {
             let mut fields = self
@@ -316,5 +426,46 @@ impl Visit for FieldVisitor {
 
     fn record_debug(&mut self, field: &Field, _value: &dyn Debug) {
         self.names.push(field.name().to_owned());
+    }
+}
+
+// Mirrored from the src copy so each integration target that includes this
+// helper also pins its own copy's `current_u64` semantics — the two files
+// are duplicated by policy and drift silently otherwise. The src copy's
+// cross-instance `#[should_panic]` row is *not* mirrored: one copy pins
+// the guard's contract, and running it per target would add a deliberate
+// panic to every including binary for no new coverage of the same
+// source.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TARGET: &str = "tears::tests::common::trace_recorder";
+
+    #[test]
+    fn current_u64_reads_by_seq_not_by_arrival() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 2u64, gauge = 5u64, "later snapshot, early arrival");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 1u64, gauge = 9u64, "earlier snapshot, late arrival");
+        tracing::trace!(target: TARGET, gauge = 7u64, "no seq: not a snapshot");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 3u64, other = 1u64, "snapshot without the field");
+        tracing::trace!(target: TARGET, seq = 9u64, gauge = 1u64, "no runtime_id: not a snapshot either");
+        tracing::trace!(target: TARGET, runtime_id = 4u64, seq = 2u64, gauge = 8u64, "a seq tie: the first arrival keeps the read");
+
+        assert_eq!(
+            recorder.current_u64("gauge"),
+            Some(5),
+            "the greatest-seq event carrying the field wins — whatever arrived last, whatever \
+             lacks a runtime_id, and whichever of a seq tie arrived later"
+        );
+        assert_eq!(
+            recorder.u64_values("gauge"),
+            vec![5, 9, 7, 1, 8],
+            "while the flattened view keeps every value in arrival order — the last is exactly \
+             where the arrival-order read differs"
+        );
+        assert_eq!(recorder.current_u64("absent"), None);
     }
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -16,6 +16,8 @@
 //! can anchor on.
 
 mod common;
+#[path = "common/gauges.rs"]
+mod gauges;
 #[path = "common/panic_hook.rs"]
 mod panic_hook;
 #[path = "common/trace_recorder.rs"]
@@ -32,6 +34,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use color_eyre::eyre::Result;
 use futures::FutureExt;
 use futures::stream::{self, StreamExt};
+use gauges::{PRODUCER_GAUGES, producer_gauge_report, producer_gauges_are_zero};
 use ratatui::Terminal;
 use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
 use ratatui::buffer::Cell;
@@ -99,29 +102,14 @@ impl Drop for DropFlag {
     }
 }
 
-/// The producer gauges RFC 0006 §4.4 defines and RFC 0011 INV-LC7 reads.
-const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
-
-/// Whether every producer gauge has reached its terminal reading.
+/// Whether no producer gauge event has fired at all — the complement census
+/// for rows whose application starts no producer. Local to this target, its
+/// only caller, so the shared census module carries no per-target dead code.
 ///
-/// A gauge whose producer the row actually starts (`expected_active`) must read
-/// zero: "no event ever" is not a settled gauge but a silenced instrument, and
-/// accepting `None` there would let a mutation that stops the emission
-/// altogether — a renamed target or field, a lowered level, an emission moved
-/// off the teardown path — satisfy INV-LC7 on iteration zero. A gauge the row
-/// never raises has no event of its own to wait for, so `None` and a trailing
-/// zero both count for it.
-fn producer_gauges_are_zero(recorder: &TraceRecorder, expected_active: &[&str]) -> bool {
-    PRODUCER_GAUGES.iter().all(|field| {
-        let last = recorder.u64_values(field).last().copied();
-        if expected_active.contains(field) {
-            last == Some(0)
-        } else {
-            matches!(last, None | Some(0))
-        }
-    })
-}
-
+/// Deliberately read off the raw event log (`u64_values`) rather than
+/// through `current_u64`: "no event ever" is a claim about the log itself,
+/// so a gauge event that somehow lost its `seq` must still count as fired
+/// here even though the current-value read would ignore it.
 fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
     PRODUCER_GAUGES
         .iter()
@@ -206,10 +194,8 @@ async fn assert_two_stage_postconditions(
 
     assert!(
         producer_gauges_are_zero(recorder, expected_active),
-        "every producer gauge must settle to zero: subscriptions={:?} unkeyed={:?} keyed={:?}",
-        recorder.u64_values("subscriptions"),
-        recorder.u64_values("unkeyed_commands"),
-        recorder.u64_values("keyed_commands"),
+        "every producer gauge must settle to zero (held active: {expected_active:?}): {:?}",
+        producer_gauge_report(recorder),
     );
     for (name, flag) in dismantled {
         assert!(

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -6,6 +6,8 @@
 //! at their narrower deterministic layers in `src/runtime`.
 
 mod common;
+#[path = "common/gauges.rs"]
+mod gauges;
 #[path = "common/trace_recorder.rs"]
 mod trace_recorder;
 
@@ -13,6 +15,7 @@ use std::future::pending;
 use std::num::NonZeroU64;
 
 use color_eyre::eyre::Result;
+use gauges::{PRODUCER_GAUGES, producer_gauge_report, producer_gauges_are_zero};
 use ratatui::Frame;
 use tears::command::CommandId;
 use tears::prelude::*;
@@ -86,15 +89,14 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
     // fixed wait would make this assertion flake on a scheduler change. The cap
     // only bounds a pathological hang; the loop exits the moment they settle.
     for _ in 0..1_000 {
-        let settled = recorder.u64_values("subscriptions").last() == Some(&0)
-            && recorder.u64_values("unkeyed_commands").last() == Some(&0)
-            && recorder.u64_values("keyed_commands").last() == Some(&0);
-        if settled {
+        if producer_gauges_are_zero(&recorder, &PRODUCER_GAUGES) {
             break;
         }
         yield_now().await;
     }
-
+    // The rise assertions come first so a total-emission outage reports as
+    // "never rose" rather than as a settle failure; the census assert then
+    // carries the whole fall claim with its per-field diagnostic.
     let subscriptions = recorder.u64_values("subscriptions");
     let unkeyed = recorder.u64_values("unkeyed_commands");
     let keyed = recorder.u64_values("keyed_commands");
@@ -112,20 +114,10 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
         "starting a keyed command must raise the keyed_commands gauge: {keyed:?}"
     );
 
-    assert_eq!(
-        subscriptions.last(),
-        Some(&0),
-        "the subscriptions gauge must fall back to zero: {subscriptions:?}"
-    );
-    assert_eq!(
-        unkeyed.last(),
-        Some(&0),
-        "the unkeyed_commands gauge must fall back to zero: {unkeyed:?}"
-    );
-    assert_eq!(
-        keyed.last(),
-        Some(&0),
-        "the keyed_commands gauge must fall back to zero: {keyed:?}"
+    assert!(
+        producer_gauges_are_zero(&recorder, &PRODUCER_GAUGES),
+        "every producer gauge must settle to zero: {:?}",
+        producer_gauge_report(&recorder),
     );
 
     // INV-L13: every gauge event a real run emits carries the emitting


### PR DESCRIPTION
## Summary

Closes #317.

The load module's gauge contract (`src/runtime/load.rs`, "Ordering") states that a gauge's current value is the value on the greatest-`seq` event, and that arrival order matching `seq` order is an implementation coincidence — "no consumer may rely on it". Every test-side "current value" read did rely on it: `u64_values(field).last()` across five files.

## The change

Both `TraceRecorder` copies (intentionally duplicated per `docs/testing.md`) keep each event's unsigned-integer fields together as the single u64 source of truth — `u64_values` flattens it per field, keeping every occurrence of a repeated name, while a `field_value` helper reads the once-per-snapshot fields — and expose one new accessor:

- `current_u64(field)`: the value on the greatest-`seq` event that records `field`, in one streaming pass with no allocation. An event lacking `seq`, the field, or `runtime_id` is not a gauge snapshot and is ignored; the marker names are anchored to `GaugeSnapshot::dispatch`, the schema's single emitter, in both directions. The read panics on the second distinct `runtime_id` among the matched events, from the caller's line (`#[track_caller]`), lock released first, with a message naming the three readings of the failure (multi-runtime by design, a helper's throwaway observer, or a one-instance-per-run regression). A `#[should_panic]` row pins the guard in the src copy; it takes no `hook_guard` — the row swaps no hook, and per `docs/testing.md` a recording hook's defence against deliberate panics is its thread-name filter. `TraceRecorderGuard`'s registry lock recovers from poisoning (any panicking test unwinds through its drop; an `.expect` there could abort the binary mid-unwind).

Every current-value read migrates; event-log assertions stay on `u64_values` with interpolated vectors labeled as the arrival-order log. The cleanup-run conformance row asserts its measured baseline literally before and after, so a de-schema'd emission cannot pass it as `None == None`. The `quit.rs` post-drain check asserts the post-retirement suffix is all zero and prints that suffix.

The INV-LC7 census lives in `tests/common/gauges.rs` with no dead code and no blanket `allow`: `PRODUCER_GAUGES` (with the grounds for excluding `blocked`, and its source-of-truth anchor) and `producer_gauges_are_zero` — a plain loop so `#[track_caller]` reaches the calling row (one frame; a shared helper in between becomes the named frame), with an `assert!` (release-safe) that `expected_active` names are in the census — plus a shared `producer_gauge_report` diagnostic; `no_producer_gauge_event_fired` stays in `lifecycle.rs` with its only caller. A census unit test pins the strict/tolerant split; both settle asserts share the report; `tests/observability.rs` orders rise assertions before its census assert.

## Declined from review, with grounds

- A `current_u64_by_runtime` partition API, a combined one-pass census, a per-event accessor, and a `Readings` newtype: the enforcement rows in `src/runtime/load.rs` must hand-roll the partition; scan costs are instrumented noise (every suite recorder holds under 50 events; settle loops exit in 0–2 iterations); each is an architecture change beyond this migration.
- Reverting `current_u64`'s streaming fold to collect-then-process, and the cleanup row's literal baseline to captured locals: both shapes were prescribed by review (the fold by the maintainer's own pass, for its zero allocation and early abort; the literals for readability at the assert site) and the counter-proposals are reversals, not defects.
- A rise-half census helper, shared settle-bound constant, and empty-`expected_active` rejection: latent (no fourth gauge exists; the bound predates this PR; the empty census is documented and pinned as the no-producers reading).

## Performance note

`u64_values` moves from one map lookup to a linear scan and `current_u64` is a second scan; instrumentation across the whole suite showed no recorder ever accumulates 50 events and both settle loops exit within 2 iterations, while the emit path got cheaper (one push, no per-field hashing). A future high-volume row would want a revisit.

## Testing

Full test suite (lib + all integration targets), `just clippy` (the CI recipe), and `cargo fmt --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)