### PR TITLE
test(kernel): pin the removal condition's exit-observation half

### DIFF
--- a/src/kernel/conformance.rs
+++ b/src/kernel/conformance.rs
@@ -98,8 +98,10 @@
 //! than the scripted reducer; [`admission`] carries RFC 0012's admission
 //! suite — INV-SE1, INV-SE2, INV-SE3's immediate half, and INV-SE4's
 //! mandated supersession sequence — which is INV-RC12's first clause; and
-//! [`observability`] carries the batch event's kernel reading and INV-RC15's
-//! behavioural neighbour (RFC 0014 §9 row 9).
+//! [`observability`] carries the batch event's kernel reading, INV-RC15's
+//! behavioural neighbour (RFC 0014 §9 row 9), and the removal condition's
+//! exit-observation half on the gauge surface (its dequeue-site mirror is
+//! in [`quit`]).
 //!
 //! [`lifecycle`] additionally carries the rows of RFC 0011's suite that the
 //! four series above do not, which is the rest of INV-RC11; its own module

--- a/src/kernel/conformance/delivery.rs
+++ b/src/kernel/conformance/delivery.rs
@@ -193,7 +193,7 @@ fn a_revoked_run_s_buffered_message_and_quit_are_both_retracted() {
 #[test]
 fn a_naturally_finished_run_s_buffered_output_is_still_delivered() {
     let done = Beacon::default();
-    let (mut driver, journal) = driver(Script::new(finishing_effect(vec![9], done.clone())));
+    let (mut driver, journal) = driver(Script::new(finishing_effect([9], done.clone())));
     let run = driver.boot().started[0].clone();
 
     accept(&mut driver, run);
@@ -221,7 +221,7 @@ fn a_revoked_run_s_exit_lands_before_its_buffered_item_is_filtered() {
     let (mut driver, journal) = driver_with(
         Script::new(Command::batch([
             parking_effect([1]),
-            finishing_effect(vec![10], reclaimed.clone()).cancellable(worker.clone()),
+            finishing_effect([10], reclaimed.clone()).cancellable(worker.clone()),
         ]))
         .replying([Command::cancel(worker)]),
         config().batch_max_messages(cap(1)),

--- a/src/kernel/conformance/observability.rs
+++ b/src/kernel/conformance/observability.rs
@@ -1,5 +1,6 @@
-//! The observability seam: the batch event's kernel reading and INV-RC15's
-//! behavioural neighbour (RFC 0014 §9 row 9, RFC 0006 §4.4's INV-L13
+//! The observability seam: the batch event's kernel reading, INV-RC15's
+//! behavioural neighbour, and the removal condition's exit-observation half
+//! on the gauge surface (RFC 0014 §9 row 9, RFC 0006 §4.4's INV-L13
 //! schema).
 //!
 //! **What is read here is a production surface, not a driver one.** These
@@ -16,15 +17,21 @@
 //! `shared_pending`, and `channel` by name, and one of them asserts the
 //! batch event's field set entire — a renamed field is the silent break
 //! that row exists to prevent.
+//!
+//! One run-accounting row also lives here (registry rules 5 and 6, not an
+//! INV-LC cell): the removal condition's exit-observation half, asserted on
+//! the `keyed_commands` gauge it moves — extending the gauge readings this
+//! file already takes at admission (the boot triple) and at teardown (the
+//! cleanup row) to retirement. Its dequeue-site mirror is in `quit.rs`.
 
-use crate::command::{Command, CommandId};
+use crate::command::{CancelPolicy, Command, CommandId};
 use crate::kernel::arbiter::WakeSource;
 use crate::test_support::TraceRecorder;
-use crate::testing::driver::{Confirmed, RunKind};
+use crate::testing::driver::{Confirmed, NotReady, RunKind, RunName};
 
 use super::support::{
-    Beacon, Feed, ProbeSource, Script, TEST_TURNS, accept, cap, config, driver, driver_with,
-    marking_effect, parking_effect,
+    Beacon, Feed, Latch, ProbeSource, Script, TEST_TURNS, accept, cap, config, driver, driver_with,
+    marking_effect, outliving_effect, parking_effect, silent_effect,
 };
 
 /// The one target the whole schema lives on (RFC 0006 §4.4).
@@ -307,6 +314,138 @@ fn a_cleanup_run_counts_in_no_gauge_field() {
         ),
         (Some(1), Some(0), Some(0)),
         "the teardown started a cleanup run and no gauge field moved for it"
+    );
+}
+
+// The removal condition's exit-observation half, on the gauge surface. A
+// keyed run whose committed envelope is dequeued while it still runs is an
+// *emptied entry* — count at zero, run still living — which is the state
+// opposite to a `Draining` tombstone (there, the run has exited and output
+// is still pending): the dequeue's own removal check finds the run
+// unexited and keeps the entry. What retires it is the run's natural
+// finish — the pass that reflects the exit applies the same removal
+// condition, and with the count already at zero it is the only site left
+// that can. A registry that dropped that half would hold a finished keyed
+// run's entry and its gauge reading until termination's `clear`, with
+// nothing in steady state ever able to retire it. The gauge counts keyed
+// *entries*, tombstones included, so what it names is retirement, not slot
+// occupancy; in this row the two never part (the run is never revoked),
+// and the slot claim is carried by the tail's admission rather than by the
+// count (RFC 0003 §6.1). Read on the same production surface as the rest
+// of the file (RFC 0006 §4.4 as RFC 0014 §9 row 9 amends it); the
+// registry-level core of the same composition is a unit row on
+// `ScopeRegistry` itself, and the dequeue-site half is `quit.rs`'s — the
+// module header holds the pairing. This row's tail pins the behavioral
+// consequence — a same-identity keep-in-flight successor admitted rather
+// than suppressed.
+#[test]
+fn a_natural_finish_retires_the_emptied_entry_at_its_exit_observation() {
+    let recorder = TraceRecorder::new().with_target(TARGET);
+    let _subscriber = recorder.set_default();
+    let keyed = || recorder.current_u64("keyed_commands");
+    let worker = CommandId::new("worker");
+    let release = Latch::default();
+    let done = Beacon::default();
+    let (mut driver, journal) = driver(
+        Script::new(Command::batch([
+            parking_effect([1]),
+            outliving_effect([7], release.clone(), done.clone()).cancellable(worker.clone()),
+        ]))
+        .replying([
+            // Reply to message 7, the keyed run's own send: nothing.
+            Command::none(),
+            // Reply to message 1, the trigger's post-retirement send: the
+            // successor. Keep-in-flight, so an *occupied* slot would
+            // suppress it — the admission at the tail then discriminates a
+            // freed slot from a leaked occupant, which the default replace
+            // policy could not, since it admits against either.
+            silent_effect()
+                .cancellable_with(worker.clone(), CancelPolicy::KeepInFlight)
+                .into(),
+        ]),
+    );
+    let report = driver.boot();
+    let (trigger, run) = (report.started[0].clone(), report.started[1].clone());
+    assert_eq!(
+        run.kind(),
+        RunKind::Keyed(worker.clone()),
+        "the premise: the second started run is the keyed one this row drives"
+    );
+    assert_eq!(keyed(), Some(1), "the keyed run is in the bookkeeping");
+
+    accept(&mut driver, run.clone());
+    // The ordering premise, checked kernel-side the way `delivery.rs`'s
+    // tombstone row checks its own: no exit is observable before the
+    // dequeue — the finish is still latched — so this row cannot silently
+    // degenerate into the tombstone case.
+    assert_eq!(
+        driver.step_pass(WakeSource::ProducerExit).err(),
+        Some(NotReady),
+        "no exit precedes the dequeue: the keyed run still holds its latch"
+    );
+    driver
+        .step_pass(WakeSource::Data)
+        .expect("the committed send is in the lane");
+    assert_eq!(journal.reduced(), vec![7], "the envelope was delivered");
+    assert_eq!(
+        keyed(),
+        Some(1),
+        "emptied is not retired: the dequeue found the run still living and kept its entry"
+    );
+
+    // The run ends only now, so the exit observation lands strictly after
+    // the dequeue — the ordering that leaves the exit-side removal check as
+    // the only possible retirement site. Its exit is the only one this
+    // script can produce at this point: the trigger parks forever and the
+    // successor is not yet spawned.
+    release.open();
+    driver.settle(TEST_TURNS, || done.marked());
+    assert_eq!(
+        keyed(),
+        Some(1),
+        "the run's own end moves no gauge: retirement is the registry's, applied at a pass, \
+         never a task-side effect of finishing"
+    );
+    let stepped = driver
+        .step_pass(WakeSource::ProducerExit)
+        .expect("the finished run's exit is observable");
+    assert!(
+        stepped.terminated.is_none(),
+        "a keyed run's natural finish terminates nothing"
+    );
+    assert_eq!(
+        keyed(),
+        Some(0),
+        "the exit observation retired the emptied entry: the removal condition's other half"
+    );
+
+    // The behavioral half of the same claim: retirement freed the identity
+    // slot, not just the count. Under the successor's keep-in-flight policy
+    // a leaked occupant would suppress it, so its admission as a run of its
+    // own is what pins the slot as genuinely free.
+    accept(&mut driver, trigger);
+    let stepped = driver
+        .step_pass(WakeSource::Data)
+        .expect("the trigger's send is in the lane");
+    assert_eq!(
+        stepped
+            .started
+            .iter()
+            .map(RunName::kind)
+            .collect::<Vec<_>>(),
+        vec![RunKind::Keyed(worker)],
+        "the same-identity successor started as a keyed run of its own: {:?}",
+        stepped.started
+    );
+    assert_ne!(
+        stepped.started[0], run,
+        "and it is a fresh run, not the retired one re-reported"
+    );
+    assert_eq!(journal.reduced(), vec![7, 1], "the trigger was delivered");
+    assert_eq!(
+        keyed(),
+        Some(1),
+        "and its admission put the count back on the books"
     );
 }
 

--- a/src/kernel/conformance/quit.rs
+++ b/src/kernel/conformance/quit.rs
@@ -414,6 +414,10 @@ fn a_quit_buffered_before_its_origin_s_revocation_is_discarded() {
 // scripted to stay **running**: the retirement here is the steady-state
 // rule's, not the quiescent postcondition's.
 //
+// The exit-observation half of the same removal condition — a natural
+// finish retiring an emptied, still-unexited entry — is pinned by its
+// mirror row in `observability.rs`.
+//
 // The observation is the `keyed_commands` gauge, which the registry
 // publishes at its single membership mutation point. That is a production
 // observability surface (RFC 0006 §4.4 as RFC 0014 §9 row 9 amends it), read

--- a/src/kernel/conformance/support.rs
+++ b/src/kernel/conformance/support.rs
@@ -1420,13 +1420,45 @@ where
 /// An effect that sends each of `messages`, marks `done`, and then ends —
 /// a run whose natural finish is observable from the application side, so a
 /// `settle` predicate can wait for it.
-pub fn finishing_effect(messages: Vec<u8>, done: Beacon) -> EffectCommand<u8> {
-    Command::stream(
-        stream::iter(messages).chain(stream::unfold(Some(done), |state| async move {
-            state?.mark();
-            None::<(u8, Option<Beacon>)>
-        })),
-    )
+///
+/// [`outliving_effect`] with the latch already open: one finish tail, one
+/// place its caveats live — the mark-before-observable-exit fact documented
+/// there binds this fixture's callers identically.
+pub fn finishing_effect<I>(messages: I, done: Beacon) -> EffectCommand<u8>
+where
+    I: IntoIterator<Item = u8>,
+    I::IntoIter: Send + 'static,
+{
+    let release = Latch::default();
+    release.open();
+    outliving_effect(messages, release, done)
+}
+
+/// An effect that sends each of `messages`, holds at `release`, then marks
+/// `done` and ends — [`finishing_effect`] with its finish pinned behind the
+/// test's own latch, for rows that need the run still living while its
+/// output is committed and dequeued, and its natural finish strictly after.
+///
+/// Two facts a caller's script leans on. The mark lands on the effect's
+/// final poll, strictly *before* the run's exit is observable on the join
+/// set — settling on `done` and then stepping a pass is deterministic only
+/// on the current-thread driver, where that poll, the stream's end, and
+/// the task's completion land together; the multi-worker series must use
+/// [`step_when_ready`] instead. And `release` frees exactly one waiter
+/// ([`Latch::open`] banks a single permit), so one latch serves one run.
+pub fn outliving_effect<I>(messages: I, release: Latch, done: Beacon) -> EffectCommand<u8>
+where
+    I: IntoIterator<Item = u8>,
+    I::IntoIter: Send + 'static,
+{
+    Command::stream(stream::iter(messages).chain(stream::unfold(
+        (release, done),
+        |(release, done)| async move {
+            release.wait().await;
+            done.mark();
+            None
+        },
+    )))
 }
 
 /// A producer-originated quit: the run emits one quit on the control lane

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -545,10 +545,15 @@ impl Drop for ScopeRegistry {
 mod tests {
     use super::*;
 
+    use std::future::pending;
     use std::hash::{Hash, Hasher};
 
+    use tokio::task::JoinSet;
+
+    use crate::kernel::GateMode;
     use crate::subscription::Subscription;
     use crate::subscription::mock::MockSource;
+    use crate::test_support::TraceRecorder;
 
     fn path(segments: &[&'static str]) -> ScopePath {
         // Root-first storage: the *last* `prefixed` call names the outermost
@@ -577,6 +582,59 @@ mod tests {
         assert!(
             !removal_rule(true, true, 0),
             "a poisoned counter never satisfies the removal condition"
+        );
+    }
+
+    // The rule's two application sites composed, which the rows above read
+    // one cell at a time: a dequeue that empties the count keeps an unexited
+    // entry, and the exit observation then applies the same rule and retires
+    // it. The kernel-level mirror is `conformance::observability`'s
+    // natural-finish row; this is its two-call registry core.
+    #[tokio::test]
+    async fn an_exit_observed_after_the_drain_retires_the_entry() {
+        // The gauge is read alongside membership so the keyed-count half of
+        // retire is pinned here too, not only by `publish_keyed_gauge`'s
+        // debug assertion, which a release build compiles out.
+        let recorder = TraceRecorder::new().with_target("tears::runtime::load");
+        let _subscriber = recorder.set_default();
+        let mut tasks = JoinSet::new();
+        let mut registry = ScopeRegistry::new(LoadObserver::new());
+        let counter = Arc::new(PendingCounter::default());
+        counter.reserve();
+        registry.insert(RunEntry {
+            token: 1,
+            kind: RunKind::Keyed(CommandId::new("worker")),
+            scope: ScopePath::empty(),
+            phase: Phase::Running,
+            revoked: false,
+            exited: false,
+            counter,
+            gate: Arc::new(SendGate::new(GateMode::Immediate)),
+            abort: tasks.spawn(pending::<()>()),
+        });
+        assert_eq!(recorder.current_u64("keyed_commands"), Some(1));
+
+        assert!(!registry.on_dequeue(1), "an unrevoked origin delivers");
+        let kept = registry
+            .get(1)
+            .expect("drained but unexited: the entry is kept");
+        assert_eq!(
+            kept.counter.value(),
+            0,
+            "the premise: the dequeue emptied the count"
+        );
+        assert_eq!(kept.phase, Phase::Running, "still living, not a tombstone");
+        assert!(!kept.exited, "the dequeue observed no exit");
+
+        let observed = registry
+            .on_exit(1)
+            .expect("the entry is still known at its exit");
+        assert!(!observed.stopped, "a natural finish, not a stop");
+        assert_eq!(registry.len(), 0, "and the exit observation retires it");
+        assert_eq!(
+            recorder.current_u64("keyed_commands"),
+            Some(0),
+            "with the keyed count retired alongside the entry"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #316.

**Stacked on #318** (it reads the gauge through `current_u64`); the base retargets to `main` when #318 merges.

The registry retires an entry at whichever site completes the removal condition (`exited && counter == 0`) second: the dequeue that takes the count to zero (`on_dequeue`), or the stage-1 exit observation (`on_exit`).

## What was actually uncovered (corrects #316's premise)

#316 was filed on the claim that no test reaches the `on_exit` retire at all. Review of this PR disproved that by full-suite mutation: deleting the retire inside `on_exit` fails 9 pre-existing rows plus this PR's rows. A correcting comment is on #316. What no test constructed before this PR is narrower: the **emptied-entry ordering** — an envelope dequeued while its run still lives, the entry kept with its count at zero (the state opposite to a `Draining` tombstone, whose run has exited with output still pending), and the later exit observation as the only site left that can retire it — together with its `keyed_commands` gauge consequence and the behavioral meaning of the freed slot.

## The change

Two pins of the same composition, plus the maps that index them:

**A conformance row** in `observability.rs` — whose gauge family already reads admission (the boot triple) and teardown (the cleanup row); the file header and `conformance.rs`'s series index both name the new subject, and the dequeue-site mirror stays in `quit.rs`. Every premise the row leans on is checked rather than narrated:

1. The started run's kind is asserted before it is driven, and a kernel-side `NotReady` probe (delivery.rs's shape) pins that no exit is observable before the dequeue — the row cannot silently degenerate into the tombstone case.
2. The gauge still reads 1 across the reap settle — retirement is the registry's, applied at a pass — and falls to 0 exactly at the exit-reflecting pass, which terminates nothing.
3. The tail pins the behavioral half with a **keep-in-flight** successor under the same `CommandId`: its admission as a keyed run of its own — kinds vector and run-identity freshness both asserted, with the started list in the failure message — discriminates a freed slot from a leaked occupant, which the default replace policy could not. The gauge counts keyed *entries* (tombstones included), so the slot claim rides the admission, not the count; the row comment states this.

**A registry unit row** on `ScopeRegistry` itself — the two-call core (`on_dequeue` keeps the unexited entry, `on_exit` retires it), sitting where the removal rule lives, so a regression localizes to two lines instead of a scripted kernel row.

The ordering is the script's own, not the scheduler's: the new `outliving_effect` fixture is `finishing_effect` with its finish pinned behind a `Latch`, generic over its messages like its siblings; its doc states the two facts callers lean on — the mark lands strictly before the exit is observable (current-thread only; the multi-worker series must use `step_when_ready`), and the latch banks a single permit.

## Verification

- Mutation 1 (deleting `on_exit`'s retire): fails the registry unit row, the conformance row, and the 9 incidental rows.
- Mutation 2 (retire frees the count but leaks the entry): fails the keep-in-flight tail; independently re-verified in review — with the successor switched back to the default policy, the mutant passes, confirming KeepInFlight is load-bearing.
- Full suite (544 lib tests + integration), `just clippy` (the CI recipe), `cargo fmt --check` all clean; the row is deterministic across 40/40 review runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Recreated against `main` after #318 merged and auto-closed the stacked predecessor #319 (its base branch was deleted). Same branch and head._