### PR TITLE
refactor(kernel): build a fresh run entry through one constructor

### DIFF
--- a/src/kernel/bench_support.rs
+++ b/src/kernel/bench_support.rs
@@ -47,7 +47,7 @@ use super::Kernel;
 use super::accounting::PendingCounter;
 use super::cleanup::CleanupLedger;
 use super::lane::{GateMode, RunToken, SendGate};
-use super::registry::{Phase, RunEntry, RunKind, ScopeRegistry};
+use super::registry::{RunEntry, RunKind, ScopeRegistry};
 
 /// A command whose spawned run emits one **producer-originated** quit on the
 /// control lane and then ends (RFC 0014 §3.3).
@@ -199,17 +199,14 @@ impl RegistryScan {
                     RunKind::Sub(id)
                 }
             };
-            registry.insert(RunEntry {
-                token: index as RunToken + 1,
+            registry.insert(RunEntry::running(
+                index as RunToken + 1,
                 kind,
-                scope: run_scope(index),
-                phase: Phase::Running,
-                revoked: false,
-                exited: false,
-                counter: Arc::new(PendingCounter::default()),
-                gate: Arc::clone(&gate),
+                run_scope(index),
+                Arc::new(PendingCounter::default()),
+                Arc::clone(&gate),
                 abort,
-            });
+            ));
         }
         Self {
             registry,

--- a/src/kernel/producer.rs
+++ b/src/kernel/producer.rs
@@ -45,7 +45,7 @@ use crate::testing::driver::{AcceptanceRecorder, IntentRecorder};
 
 use super::accounting::PendingCounter;
 use super::lane::{ControlSender, DataSender, IngressHandle, RunToken, SendGate};
-use super::registry::{Phase, RunEntry, RunKind};
+use super::registry::{RunEntry, RunKind};
 
 /// What a producer body receives.
 pub struct EffectCtx<Msg> {
@@ -256,17 +256,7 @@ impl<Msg: Send + 'static> ProducerHarness<'_, Msg> {
         let run = body(EffectCtx { handle });
         let abort = spawn_contained(self.join_set, self.task_index, token, gauge, run);
 
-        RunEntry {
-            token,
-            kind,
-            scope,
-            phase: Phase::Running,
-            revoked: false,
-            exited: false,
-            counter,
-            gate,
-            abort,
-        }
+        RunEntry::running(token, kind, scope, counter, gate, abort)
     }
 }
 
@@ -328,17 +318,14 @@ impl CleanupHarness<'_> {
     ) -> RunEntry {
         let abort = spawn_contained(self.join_set, self.task_index, token, None, finalizer);
 
-        RunEntry {
+        RunEntry::running(
             token,
-            kind: RunKind::Cleanup,
+            RunKind::Cleanup,
             scope,
-            phase: Phase::Running,
-            revoked: false,
-            exited: false,
-            counter: Arc::new(PendingCounter::default()),
-            gate: Arc::clone(self.gate),
+            Arc::new(PendingCounter::default()),
+            Arc::clone(self.gate),
             abort,
-        }
+        )
     }
 }
 

--- a/src/kernel/registry.rs
+++ b/src/kernel/registry.rs
@@ -229,6 +229,43 @@ pub struct RunEntry {
 }
 
 impl RunEntry {
+    /// A freshly started run's entry: `Running`, unrevoked, unexited.
+    ///
+    /// Every construction site builds that one shape — the two spawn paths in
+    /// `producer`, the bench fixture, and this module's own unit row — because a
+    /// run is only ever recorded at its start; the other phases are reached by
+    /// transition, never by construction. The three state fields are therefore
+    /// not parameters: they are what "fresh" *means*, and nothing a spawn site
+    /// holds decides them. The remaining six are the run's identity and the
+    /// handles its spawn produced, which only the spawn site does hold.
+    ///
+    /// A convention its call sites keep, not a barrier: the fields stay `pub`
+    /// because the transitions and their readers are elsewhere — `pass` filters
+    /// on `phase`, `testing::driver` reads `exited` — so the literal remains
+    /// writable crate-wide and a site that skips this constructor still
+    /// compiles. What it buys is the one place a field addition has to be
+    /// taught the fresh shape.
+    pub const fn running(
+        token: RunToken,
+        kind: RunKind,
+        scope: ScopePath,
+        counter: Arc<PendingCounter>,
+        gate: Arc<SendGate>,
+        abort: AbortHandle,
+    ) -> Self {
+        Self {
+            token,
+            kind,
+            scope,
+            phase: Phase::Running,
+            revoked: false,
+            exited: false,
+            counter,
+            gate,
+            abort,
+        }
+    }
+
     /// Whether this entry participates in the uniform admission barrier: a
     /// stop-requested subscription run whose exit is unobserved (RFC 0014
     /// §5.1).
@@ -601,17 +638,14 @@ mod tests {
         let mut registry = ScopeRegistry::new(LoadObserver::new());
         let counter = Arc::new(PendingCounter::default());
         counter.reserve();
-        registry.insert(RunEntry {
-            token: 1,
-            kind: RunKind::Keyed(CommandId::new("worker")),
-            scope: ScopePath::empty(),
-            phase: Phase::Running,
-            revoked: false,
-            exited: false,
+        registry.insert(RunEntry::running(
+            1,
+            RunKind::Keyed(CommandId::new("worker")),
+            ScopePath::empty(),
             counter,
-            gate: Arc::new(SendGate::new(GateMode::Immediate)),
-            abort: tasks.spawn(pending::<()>()),
-        });
+            Arc::new(SendGate::new(GateMode::Immediate)),
+            tasks.spawn(pending::<()>()),
+        ));
         assert_eq!(recorder.current_u64("keyed_commands"), Some(1));
 
         assert!(!registry.on_dequeue(1), "an unrevoked origin delivers");


### PR DESCRIPTION
Closes #336.

## What

`RunEntry` (`src/kernel/registry.rs`) is a nine-field record with no constructor, built as a full struct literal at four sites:

- `src/kernel/producer.rs` — `ProducerHarness::start` and `CleanupHarness::start`
- `src/kernel/bench_support.rs` — `RegistryScan::with_runs`
- `src/kernel/registry.rs` — the registry unit row `an_exit_observed_after_the_drain_retires_the_entry`

Adding a field to the record breaks all four, including a test that has no interest in the new field.

## Why this shape

The four literals are identical, and not by coincidence: a run is only ever *recorded* at its start, and every other phase is reached by transition. `phase`, `revoked` and `exited` are therefore not per-site choices — they are what "fresh" means, and nothing a spawn site holds decides them — so `RunEntry::running(token, kind, scope, counter, gate, abort)` takes only the six the spawn site does hold and fills the three state fields itself.

It is a convention its call sites keep, not a barrier: the fields stay `pub` because `pass` filters on `phase` and `testing::driver` reads `exited`, so the literal remains writable crate-wide and a site that skips the constructor still compiles. What it buys is the one place a field addition has to be taught the fresh shape.

## Not in scope

The issue also notes the registry unit row hand-mints an `AbortHandle` via `JoinSet::spawn(pending())` because `bench_support`'s fixture is feature-gated out of `cfg(test)`. The constructor does not change that, and un-gating the fixture is a separate decision.

## Verification

- `just clippy` (`--all-targets`, `build_features`) clean — every target, including the `bench-internals` fixture, type-checks against the new signature.
- `just fmt-check` clean.
- Behaviour is unchanged by construction: the constructor's body is the same field-for-field initializer the four literals spelled.

### On `codecov/patch`

Red, and judged by content per `codecov.yml` (neither codecov status is a merge gate). All 5 missed diff lines are in `src/kernel/bench_support.rs`, which is 0% covered on both base and head: it is `bench-internals`-gated and reachable only from the benches, which the coverage job does not run. `registry.rs` reports every one of its 15 new lines hit and its miss count unchanged at 6; `producer.rs`'s is unchanged at 1. Absolute misses fall 614 → 612 and `codecov/project` reports +0.01%. The patch percentage drops because the diff *rewrites* lines in an already-uncoverable file, not because it adds untested code.