### PR TITLE
test(observability): share the census's rise half and its settle bound

### DIFF
--- a/tests/common/gauges.rs
+++ b/tests/common/gauges.rs
@@ -1,8 +1,9 @@
 //! The INV-LC7 producer-gauge census, shared via `#[path]` so every
 //! integration target that reads the gauges reads one definition of the
-//! field set and one meaning of "settled" — a producer gauge added here
-//! reaches every census at once instead of leaving a copy waiting on the
-//! old set.
+//! field set, one meaning of "rose", one meaning of "settled", and one
+//! bound on how long settling may take — a producer gauge added here
+//! reaches every census at once, on both halves, instead of leaving a copy
+//! waiting on the old set.
 //!
 //! An including target must also declare the recorder at its crate root,
 //! spelled exactly `#[path = "common/trace_recorder.rs"] mod
@@ -20,6 +21,81 @@ use crate::trace_recorder::TraceRecorder;
 /// source of truth is `GaugeSnapshot::dispatch` in `src/runtime/load.rs`,
 /// the schema's single emitter.
 pub const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
+
+/// How many settle steps a census may take before it reports the quiescent
+/// postcondition as unmet.
+///
+/// This counts executor drains, not intervals, so host load cannot consume it.
+/// One step is one `yield_now`, and under the `current_thread` scheduler that
+/// is a complete drain of the run queue: the caller's waker goes on the
+/// deferred list, so `block_on` keeps popping tasks until the queue is empty
+/// before it wakes the deferred wakers and polls the caller again. The
+/// teardown needs exactly one such drain — aborting a task leaves it queued
+/// and cancelled, and running it drops the future — so the bound carries three
+/// orders of magnitude of margin over the mechanism it waits on.
+///
+/// A step must not advance the paused clock, which rules out a
+/// `sleep`/`timeout` bound however appealing "settled or never will" sounds as
+/// a formulation. Advancing virtual time hands a producer that the teardown
+/// failed to cancel a second way to stop — its own timer firing into the
+/// channel whose receiver the teardown dropped — and the rows this bounds
+/// exist to catch exactly that failure. `yield_now` reschedules through the
+/// deferred list, which keeps the scheduler off the parking path and therefore
+/// keeps the clock still.
+pub const SETTLE_STEPS: usize = 1_000;
+
+/// Asserts every gauge named in `expected_active` rose while the row's
+/// producers ran.
+///
+/// The census's positive half, and what makes its settle half witness
+/// anything: every gauge event carries all the counts at once, so a gauge that
+/// never rose still reads `Some(0)` on some other producer's event and settles
+/// on iteration zero. Naming the risen gauges is what separates "wound down"
+/// from "never started". Taking the set as an argument is what keeps this half
+/// following [`PRODUCER_GAUGES`] — a gauge added there is rise-checked
+/// wherever the caller passes the whole census, instead of leaving a
+/// hand-unrolled copy asserting the old set.
+///
+/// "Rose" is any reading above zero rather than a reading of exactly one. The
+/// two agree for a counter that moves by one per producer and emits on every
+/// move, so they can only differ where an emission was lost — and there the
+/// exact-value form fails for the wrong reason, reporting a gauge that plainly
+/// ran as one that never started. How many producers ran is a different claim,
+/// left to the rows that make it.
+///
+/// Guarded on census membership like [`producer_gauges_are_zero`], and for
+/// a reason particular to this direction: `u64_values` reads a field name
+/// off the whole `tears::runtime::load` target, and every gauge event also
+/// carries `seq` and `runtime_id` — both above zero by construction. A name
+/// that misses the census does not read empty and fail; it can read one of
+/// those and *pass*, asserting that the ordering counter rose. The guard is
+/// what keeps this half unable to satisfy itself on a non-gauge.
+///
+/// Written as a plain loop rather than an iterator chain for the same
+/// `#[track_caller]` reason as [`producer_gauges_are_zero`].
+///
+/// # Panics
+///
+/// If any name is outside [`PRODUCER_GAUGES`], or any named gauge has no
+/// reading above zero.
+#[track_caller]
+pub fn producer_gauges_rose(recorder: &TraceRecorder, expected_active: &[&str]) {
+    assert!(
+        expected_active
+            .iter()
+            .all(|field| PRODUCER_GAUGES.contains(field)),
+        "a rise assertion on a name outside the census can pass on an unrelated load field: \
+         {expected_active:?}"
+    );
+    for field in expected_active {
+        let values = recorder.u64_values(field);
+        assert!(
+            values.iter().any(|&value| value > 0),
+            "the {field} gauge must have risen while this row's producers ran, \
+             or its fall to zero witnesses nothing: {values:?}"
+        );
+    }
+}
 
 /// Whether every producer gauge has reached its terminal reading.
 ///

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -34,7 +34,10 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use color_eyre::eyre::Result;
 use futures::FutureExt;
 use futures::stream::{self, StreamExt};
-use gauges::{PRODUCER_GAUGES, producer_gauge_report, producer_gauges_are_zero};
+use gauges::{
+    PRODUCER_GAUGES, SETTLE_STEPS, producer_gauge_report, producer_gauges_are_zero,
+    producer_gauges_rose,
+};
 use ratatui::Terminal;
 use ratatui::backend::{Backend, ClearType, TestBackend, WindowSize};
 use ratatui::buffer::Cell;
@@ -116,27 +119,6 @@ fn no_producer_gauge_event_fired(recorder: &TraceRecorder) -> bool {
         .all(|field| recorder.u64_values(field).is_empty())
 }
 
-/// How many settle steps [`assert_two_stage_postconditions`] may take before it
-/// reports the quiescent postcondition as unmet.
-///
-/// This counts executor drains, not intervals, so host load cannot consume it.
-/// One step is one `yield_now`, and under the `current_thread` scheduler that is
-/// a complete drain of the run queue: the caller's waker goes on the deferred
-/// list, so `block_on` keeps popping tasks until the queue is empty before it
-/// wakes the deferred wakers and polls the caller again. The teardown needs
-/// exactly one such drain — aborting a task leaves it queued and cancelled, and
-/// running it drops the future — so the bound carries three orders of magnitude
-/// of margin over the mechanism it waits on.
-///
-/// A step must not advance the paused clock, which rules out a
-/// `sleep`/`timeout` bound however appealing "settled or never will" sounds as a
-/// formulation. Advancing virtual time hands a producer that the teardown failed
-/// to cancel a second way to stop — its own timer firing into the channel whose
-/// receiver the teardown dropped — and these rows exist to catch exactly that
-/// failure. `yield_now` reschedules through the deferred list, which keeps the
-/// scheduler off the parking path and therefore keeps the clock still.
-const SETTLE_STEPS: usize = 1_000;
-
 /// INV-LC7's bounded settle loop, doubling as INV-LC6's re-checked
 /// no-further-transition assertion.
 ///
@@ -167,14 +149,7 @@ async fn assert_two_stage_postconditions(
     expected_active: &[&str],
     dismantled: &[(&str, &Arc<AtomicBool>)],
 ) {
-    for field in expected_active {
-        let values = recorder.u64_values(field);
-        assert!(
-            values.iter().any(|&value| value > 0),
-            "the {field} gauge must have risen while this row's producer ran, \
-             or its fall to zero witnesses nothing: {values:?}"
-        );
-    }
+    producer_gauges_rose(recorder, expected_active);
 
     for _ in 0..SETTLE_STEPS {
         assert_eq!(

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -15,7 +15,10 @@ use std::future::pending;
 use std::num::NonZeroU64;
 
 use color_eyre::eyre::Result;
-use gauges::{PRODUCER_GAUGES, producer_gauge_report, producer_gauges_are_zero};
+use gauges::{
+    PRODUCER_GAUGES, SETTLE_STEPS, producer_gauge_report, producer_gauges_are_zero,
+    producer_gauges_rose,
+};
 use ratatui::Frame;
 use tears::command::CommandId;
 use tears::prelude::*;
@@ -88,31 +91,17 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
     // number of passes — that count is a tokio cooperative-budget detail, so a
     // fixed wait would make this assertion flake on a scheduler change. The cap
     // only bounds a pathological hang; the loop exits the moment they settle.
-    for _ in 0..1_000 {
+    for _ in 0..SETTLE_STEPS {
         if producer_gauges_are_zero(&recorder, &PRODUCER_GAUGES) {
             break;
         }
         yield_now().await;
     }
-    // The rise assertions come first so a total-emission outage reports as
+    // The rise assertion comes first so a total-emission outage reports as
     // "never rose" rather than as a settle failure; the census assert then
-    // carries the whole fall claim with its per-field diagnostic.
-    let subscriptions = recorder.u64_values("subscriptions");
-    let unkeyed = recorder.u64_values("unkeyed_commands");
-    let keyed = recorder.u64_values("keyed_commands");
-
-    assert!(
-        subscriptions.contains(&1),
-        "starting a subscription must raise the subscriptions gauge: {subscriptions:?}"
-    );
-    assert!(
-        unkeyed.contains(&1),
-        "starting an unkeyed command must raise the unkeyed_commands gauge: {unkeyed:?}"
-    );
-    assert!(
-        keyed.contains(&1),
-        "starting a keyed command must raise the keyed_commands gauge: {keyed:?}"
-    );
+    // carries the whole fall claim with its per-field diagnostic. Both halves
+    // take the whole census, so a gauge added to it is held to both here.
+    producer_gauges_rose(&recorder, &PRODUCER_GAUGES);
 
     assert!(
         producer_gauges_are_zero(&recorder, &PRODUCER_GAUGES),


### PR DESCRIPTION
Closes #335.

## What

The INV-LC7 producer-gauge census (`tests/common/gauges.rs`) shared its field set (`PRODUCER_GAUGES`) and its settle predicate (`producer_gauges_are_zero`), but not the two pieces on either side of them. This adds `producer_gauges_rose` and moves `SETTLE_STEPS` into the census, so both including targets — `tests/lifecycle.rs` and `tests/observability.rs` — read one definition of each.

## The rise half was the live gap

`observability.rs` asserted three literal `contains(&1)` calls; `lifecycle.rs` looped over `expected_active` with `any(> 0)`. A gauge added to `PRODUCER_GAUGES` was therefore settle-checked automatically and rise-checked **nowhere** in `observability.rs` — and since every gauge event carries all the counts at once, a never-rising gauge reads `Some(0)` on some other producer's event and clears even the strict settle branch. That is exactly the silenced-instrument vacuity the census exists to prevent.

Reproduced by adding RFC 0006 §4.4's fourth count `blocked` to `PRODUCER_GAUGES` (it rides the same snapshot and stays at zero over this run):

- **Before:** `producer_gauges_rise_and_fall_over_a_run` **passes**, with `blocked` reading `[0, 0, 0, 0, 0, 0]`.
- **After:** the row **fails** — `the blocked gauge must have risen while this row's producers ran, or its fall to zero witnesses nothing: [0, 0, 0, 0, 0, 0]` — and `#[track_caller]` names `tests/observability.rs:104`, the caller, not the helper.

`producer_gauges_rose` takes the set as an argument, so both halves follow `PRODUCER_GAUGES` together.

## The membership guard

`producer_gauges_rose` carries the same census-membership assert as `producer_gauges_are_zero`, and the rise direction needs it more. `u64_values` reads a field name off the whole `tears::runtime::load` target, where every gauge event also carries `seq` and `runtime_id` — both above zero by construction. So a name that misses the census does *not* read empty and fail; it can read one of those and **pass**, asserting that the ordering counter rose. Verified: without the guard `producer_gauges_rose(&recorder, &["seq"])` passes on an empty recorder's target; with it, it panics naming the census.

## On "rose"

The two copies disagreed: `contains(&1)` fails a gauge that jumped straight to 2, `any(> 0)` does not. Settled toward `any(> 0)`. The forms agree for a counter that moves by one per producer and emits on every move, so they can differ only where an emission was lost — and there the exact-value form fails for the wrong reason, reporting a gauge that plainly ran as one that never started. How many producers ran is a different claim, made by the unit-layer rows that pin exact gauge traces (`an_anonymous_run_raises_and_lowers_the_unkeyed_command_gauge` and its siblings in `src/kernel/producer.rs`).

## The settle bound

`observability.rs` spelled a bare `0..1_000` against `lifecycle.rs`'s `SETTLE_STEPS`, whose comment carries the load-bearing rationale: the bound counts executor drains rather than time, because a `sleep`/`timeout` bound would advance the paused clock and hand an uncancelled producer a second way to stop — masking the exact teardown bug these rows catch. The bare literal carried none of that. The constant moves to the census beside its rationale.

## Not taken from the issue

Rejecting an empty `expected_active` in `producer_gauges_are_zero`. The census's own unit row (`an_active_gauge_with_no_events_is_not_settled`) passes `&[]` deliberately, to pin the tolerant branch a no-producers reading needs, so an assert there would fail a row that documents the behaviour.

## Verification

- `just clippy` (`--all-targets`, `build_features`) clean, `just fmt-check` clean.
- `cargo test --test lifecycle --test observability`: 15 + 3 passed, 0 failed.
- The `blocked` mutation above, run in both directions.
- The `seq` guard probe above, run in both directions.