### PR TITLE
test(observability): give the gauge field-name schema one source

### DIFF
--- a/benches/kernel_load.rs
+++ b/benches/kernel_load.rs
@@ -191,7 +191,9 @@ use futures::stream::{self, StreamExt};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use tears::prelude::*;
-use tears::{BenchKernel, BoxStream, RuntimeConfig, SubscriptionSource, producer_quit};
+use tears::{
+    BenchKernel, BoxStream, GAUGE_EVENT_FIELDS, RuntimeConfig, SubscriptionSource, producer_quit,
+};
 use tokio::runtime::{Builder, Runtime as TokioRuntime};
 use tokio::task::yield_now;
 use tokio::time::{MissedTickBehavior, interval, timeout};
@@ -1527,6 +1529,22 @@ impl Subscriber for LoadSubscriber {
         event.record(&mut visitor);
 
         if let (Some(runtime_id), Some(seq)) = (visitor.runtime_id, visitor.seq) {
+            // Both markers present means this is a gauge event, and INV-L13
+            // says a gauge event carries the whole field set. The guards on
+            // the three recording paths cover a count that arrived *wrong*;
+            // this covers one that did not arrive at all — dropped from the
+            // emitter, and from `GAUGE_EVENT_FIELDS` with it, so neither the
+            // schema guards nor the anchor row has anything left to compare.
+            // It is where `gauge_sum()`'s `unwrap_or(0)` stops being able to
+            // absorb the loss.
+            assert!(
+                visitor.subscriptions.is_some()
+                    && visitor.unkeyed_commands.is_some()
+                    && visitor.keyed_commands.is_some()
+                    && visitor.blocked.is_some(),
+                "a gauge event reached this subscriber without all four counts as unsigned \
+                 integers: {visitor:?}"
+            );
             let slot = TRIAL_METRICS
                 .lock()
                 .expect("trial metrics slot poisoned")
@@ -1570,7 +1588,7 @@ impl Subscriber for LoadSubscriber {
     fn exit(&self, _span: &Id) {}
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct LoadVisitor {
     runtime_id: Option<u64>,
     seq: Option<u64>,
@@ -1590,6 +1608,27 @@ impl LoadVisitor {
     }
 }
 
+/// Rejects a gauge-schema name arriving anywhere but `record_u64`.
+///
+/// The whole schema is unsigned integers, so a schema name reaching a
+/// different recording path is a gauge this visitor will silently read as
+/// absent — `gauge_sum()` under-reports, `LIVE_PRODUCERS` falls early, and
+/// `await_quiescence()` returns with producers still live, corrupting later
+/// rows' gauge readings with no failure signal. That is the same corruption
+/// the rename guard prevents, reached by a different route.
+///
+/// Costs nothing on the target's real traffic: the only non-schema names that
+/// arrive off `record_u64` are `tracing`'s own `message` and the
+/// capacity-wait event's `channel`.
+fn assert_off_schema(field: &Field) {
+    assert!(
+        !GAUGE_EVENT_FIELDS.contains(&field.name()),
+        "`{}` is in the gauge schema but did not arrive as an unsigned integer: the emitter's \
+         representation has drifted from what this visitor reads",
+        field.name()
+    );
+}
+
 impl Visit for LoadVisitor {
     fn record_u64(&mut self, field: &Field, value: u64) {
         match field.name() {
@@ -1599,17 +1638,47 @@ impl Visit for LoadVisitor {
             "unkeyed_commands" => self.unkeyed_commands = Some(value),
             "keyed_commands" => self.keyed_commands = Some(value),
             "blocked" => self.blocked = Some(value),
-            _ => {}
+            // The capacity-wait event's `wait_us` also arrives here, so an
+            // unmatched name is ordinary — unless it belongs to the gauge
+            // schema, which is the one way this arm goes wrong. (The batch
+            // event's `pulled`/`updated`/`shared_pending` never reach it:
+            // `batch` emits at `trace!` and `enabled` above takes `DEBUG`
+            // only.) A renamed gauge would land here, `gauge_sum()` would
+            // under-report it, and the harness would stop waiting for
+            // producers that are still live: the exact corruption of later
+            // rows' gauge readings that `await_quiescence` exists to prevent,
+            // with no failure signal. `GAUGE_EVENT_FIELDS` is kept in step
+            // with the emitter by a unit row, so consulting it here turns that
+            // silence into a panic.
+            //
+            // This closes the *rename* axis. The representation axis — a
+            // schema name that keeps its spelling but stops arriving as an
+            // unsigned integer — never reaches this arm at all, and is closed
+            // by the mirrored guards on `record_str` and `record_debug`.
+            other => assert!(
+                !GAUGE_EVENT_FIELDS.contains(&other),
+                "`{other}` is in the gauge schema but has no arm here: this visitor's \
+                 match has fallen behind `GAUGE_EVENT_FIELDS`"
+            ),
         }
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
         if field.name() == "channel" {
             self.channel = Some(value.to_owned());
+            return;
         }
+        assert_off_schema(field);
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn Debug) {}
+    // The sink every recording path that this visitor does not override falls
+    // into: `Visit`'s `record_i64`, `record_f64`, `record_bool` and the rest
+    // all default to `record_debug`. So this arm plus `record_str`'s is the
+    // whole of the representation axis — a schema field given a signed type,
+    // or emitted with `?`, arrives at one of the two.
+    fn record_debug(&mut self, field: &Field, _value: &dyn Debug) {
+        assert_off_schema(field);
+    }
 }
 
 struct Metrics {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,9 +145,12 @@ pub use subscription::core::{Subscription, SubscriptionId, SubscriptionSource};
 // is not part of the public API and carries no semver guarantees; do not
 // enable it for normal builds. `kernel::bench_support` is the same pattern
 // applied to the kernel's own internals.
+// `GAUGE_EVENT_FIELDS` rides the same gate for `benches/kernel_load.rs`: its
+// `LoadVisitor` matches the gauge schema by name, and reading the array back
+// is what turns a rename from a silent under-count into a bench failure.
 #[cfg(feature = "bench-internals")]
 #[doc(hidden)]
-pub use runtime::load::LoadObserver;
+pub use runtime::load::{GAUGE_EVENT_FIELDS, LoadObserver};
 // Bench-only re-exports for the kernel load-acceptance re-derivation
 // (RFC 0014 §13.5). `kernel` is `pub(crate)`, so `benches/kernel_load.rs` and
 // `benches/kernel_scan.rs` — separate crates that see the public API only —

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -228,6 +228,35 @@ impl Gauges {
     }
 }
 
+/// The producer-gauge event's field-name schema: the two snapshot markers
+/// followed by RFC 0006 §4.4's four counts.
+///
+/// The names are the contract, and they are matched *by name* by consumers
+/// that cannot see each other — the test recorders' `current_u64` markers,
+/// the integration census's `PRODUCER_GAUGES`, and the bench subscriber's
+/// `LoadVisitor`. `tracing`'s field names are macro syntax rather than
+/// values, so `GaugeSnapshot::dispatch` cannot be written in terms of this
+/// array; the binding is made by test instead. `gauge_event_carries_the_full_field_set`
+/// reads an emitted event's own field set and holds it to exactly this list,
+/// so a rename that reaches the emitter without reaching here fails at the
+/// anchor rather than at whichever consumer noticed first — or, in the bench
+/// visitor's case, at no consumer at all.
+///
+/// Exported under `bench-internals` for that visitor, which is the reason the
+/// anchor is worth having: an unmatched name there falls into a catch-all
+/// arm, `gauge_sum()` under-reports, and the harness stops waiting for
+/// producers that are still live — corrupting later rows' gauge readings with
+/// no failure signal.
+#[cfg(any(test, feature = "bench-internals"))]
+pub const GAUGE_EVENT_FIELDS: [&str; 6] = [
+    "runtime_id",
+    "seq",
+    "subscriptions",
+    "unkeyed_commands",
+    "keyed_commands",
+    "blocked",
+];
+
 /// One producer-gauge event's payload — the four counts, the emitting
 /// instance's `runtime_id`, and their ordering `seq` — captured under the lock
 /// and dispatched to `tracing` after the lock is released (RFC 0006 §4.4).
@@ -251,13 +280,11 @@ impl GaugeSnapshot {
     /// skipping (or failing to skip) dispatch for events it no longer
     /// describes.
     ///
-    /// The field names emitted here are also read back *by name* by the
-    /// test recorders' `current_u64` (`seq`/`runtime_id` as the snapshot
-    /// markers), by the integration census's `PRODUCER_GAUGES`, and by the
-    /// bench subscriber's `LoadVisitor` in `benches/kernel_load.rs` — the
-    /// one consumer that degrades *silently* on a rename, its unmatched
-    /// names falling into a catch-all arm; this emitter is their source of
-    /// truth.
+    /// The field names emitted here are read back *by name* downstream, so
+    /// they are a contract rather than a spelling. This is where they are
+    /// written; `GAUGE_EVENT_FIELDS` is where they are named as data, and
+    /// a rename must reach both — which is what
+    /// `gauge_event_carries_the_full_field_set` enforces.
     fn dispatch(self) {
         tracing::debug!(
             target: "tears::runtime::load",
@@ -576,6 +603,15 @@ mod tests {
     // ordering `seq` — so a subscriber reads a complete, attributable, ordered
     // snapshot from any one event. The per-field recorder views flatten across
     // events and cannot see this; the field-set view can.
+    //
+    // Doubles as `GAUGE_EVENT_FIELDS`'s anchor, and that is why the comparison
+    // is set *equality* rather than a containment check per name. Containment
+    // holds the emitter to the array; equality also holds the array to the
+    // emitter, which is the direction a by-name consumer depends on: a field
+    // added to the event and not to the array leaves the array describing a
+    // schema that no longer exists, and the bench visitor's catch-all guard
+    // reads the array. `message` is excluded because it is `tracing`'s own
+    // field for the event's literal text, not part of the gauge schema.
     #[test]
     fn gauge_event_carries_the_full_field_set() {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");
@@ -586,26 +622,35 @@ mod tests {
         observer.set_keyed_entries(2);
         drop(subscription);
 
+        let mut expected: Vec<&str> = GAUGE_EVENT_FIELDS.to_vec();
+        expected.sort_unstable();
+
+        // Selected by schema membership rather than by a literal name: a
+        // literal here would be a fourth copy of a name inside the very row
+        // that makes the array authoritative, and a coordinated rename would
+        // fail on "no events fired" instead of on the mismatch. Any event
+        // carrying at least one schema name is a candidate; the equality
+        // assert below is what decides whether it is a whole one.
         let gauge_events: Vec<_> = recorder
             .field_name_sets()
             .into_iter()
-            .filter(|fields| fields.iter().any(|name| name == "subscriptions"))
+            .filter(|fields| {
+                fields
+                    .iter()
+                    .any(|name| GAUGE_EVENT_FIELDS.contains(&name.as_str()))
+            })
             .collect();
         assert!(!gauge_events.is_empty(), "gauge events should have fired");
         for fields in gauge_events {
-            for required in [
-                "runtime_id",
-                "seq",
-                "subscriptions",
-                "unkeyed_commands",
-                "keyed_commands",
-                "blocked",
-            ] {
-                assert!(
-                    fields.iter().any(|name| name == required),
-                    "a gauge event is missing `{required}`: {fields:?}"
-                );
-            }
+            let schema: Vec<&str> = fields
+                .iter()
+                .map(String::as_str)
+                .filter(|name| *name != "message")
+                .collect();
+            assert_eq!(
+                schema, expected,
+                "a gauge event's field set must be exactly GAUGE_EVENT_FIELDS"
+            );
         }
     }
 

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -132,8 +132,11 @@ impl TraceRecorder {
     /// resolves to the first-arriving match. An event carrying `field`
     /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
     /// is ignored; `None` when no event carries all three. The marker
-    /// names come from `GaugeSnapshot::dispatch` (`src/runtime/load.rs`),
-    /// the schema's single emitter and their source of truth.
+    /// names must match `GAUGE_EVENT_FIELDS` (`src/runtime/load.rs`), the
+    /// schema's source of truth, which a unit row holds to what
+    /// `GaugeSnapshot::dispatch` actually emits. Nothing binds these two
+    /// literals to that array — a coordinated rename makes this return
+    /// `None`, and the census's strict branch is what refuses it.
     ///
     /// # Panics
     ///

--- a/tests/common/gauges.rs
+++ b/tests/common/gauges.rs
@@ -18,8 +18,11 @@ use crate::trace_recorder::TraceRecorder;
 /// §4.4's four counts. `blocked`, the fourth, rides the same snapshot but
 /// belongs to the bounded-send layer rather than to run lifecycle, so the
 /// settle census does not hold it to a terminal reading. The names' code
-/// source of truth is `GaugeSnapshot::dispatch` in `src/runtime/load.rs`,
-/// the schema's single emitter.
+/// source of truth is `GAUGE_EVENT_FIELDS` in `src/runtime/load.rs`, which
+/// a unit row holds to the schema its emitter actually writes. Nothing
+/// binds these three literals to that array, though: a coordinated rename
+/// leaves them stale, and what refuses it is the strict branch below —
+/// a renamed gauge reads `None`, which is not a settled gauge.
 pub const PRODUCER_GAUGES: [&str; 3] = ["subscriptions", "unkeyed_commands", "keyed_commands"];
 
 /// How many settle steps a census may take before it reports the quiescent

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -162,8 +162,11 @@ impl TraceRecorder {
     /// resolves to the first-arriving match. An event carrying `field`
     /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
     /// is ignored; `None` when no event carries all three. The marker
-    /// names come from `GaugeSnapshot::dispatch` (`src/runtime/load.rs`),
-    /// the schema's single emitter and their source of truth.
+    /// names must match `GAUGE_EVENT_FIELDS` (`src/runtime/load.rs`), the
+    /// schema's source of truth, which a unit row holds to what
+    /// `GaugeSnapshot::dispatch` actually emits. Nothing binds these two
+    /// literals to that array — a coordinated rename makes this return
+    /// `None`, and the census's strict branch is what refuses it.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Closes #333.

## The gap

The `tears::runtime::load` gauge event's field names are the contract, and they are matched **by name** by consumers that cannot see each other. Most fail loudly on a rename — `current_u64`'s `seq`/`runtime_id` markers, the integration census's `PRODUCER_GAUGES`, the field-set unit row.

`benches/kernel_load.rs`'s `LoadVisitor` did not. Its `record_u64` match ended in `_ => {}`, so a renamed count fell through: `gauge_sum()` under-reports, `LIVE_PRODUCERS` reaches zero early, and `await_quiescence()` returns before producers have quiesced — corrupting later rows' gauge readings, the exact failure its own comment forbids, **with no failure signal**. The bench runs in CI (`bench-smoke`).

## The anchor

`GAUGE_EVENT_FIELDS` (`src/runtime/load.rs`) names the schema as data, exported under the existing `bench-internals` `#[doc(hidden)]` gate.

`tracing`'s field names are macro syntax rather than values, so `GaugeSnapshot::dispatch` cannot be *written* in terms of the array. The binding is made by test instead: `gauge_event_carries_the_full_field_set` already read an emitted event's own field set, and now compares it to the array for **equality** rather than containment. Containment holds the emitter to the array; equality also holds the array to the emitter — the direction a by-name consumer depends on, since a field added to the event and not to the array leaves the array describing a schema that no longer exists. That row also selects gauge events by schema membership rather than by the literal `"subscriptions"`, so the row that makes the array authoritative does not keep a private copy of one of its entries.

## The guards

The corruption above has two routes, and only one of them is a rename. The visitor consults the array on all three of its recording paths:

- **`record_u64`'s catch-all** — the rename axis. A gauge name with no arm is a match that has fallen behind, and it panics. Unmatched names otherwise stay ordinary: the capacity-wait event's `wait_us` arrives here too.
- **`record_str` and `record_debug`** — the representation axis. Every other `Visit` method defaults into `record_debug`, so a schema name emitted with `?`, or given a signed type, lands on one of those two, and would otherwise be read as simply absent. This axis covers `seq` and `runtime_id`, which **no guard inside the gauge branch can reach** — losing either is precisely what skips that branch, leaving `LIVE_PRODUCERS` at its initial `0` so `await_quiescence()` returns on its first check.

The completeness assert in `event` then covers what neither does: a count dropped from the emitter *and* from the array together, where nothing is left to compare. It is where `gauge_sum()`'s `unwrap_or(0)` stops absorbing the loss.

## Verification

Each mutation run against the tree it is meant to catch:

| mutation | expected | result |
| --- | --- | --- |
| rename `blocked` in the emitter only | anchor row fails | `FAILED`, reporting both field sets |
| rename in the emitter **and** the array, visitor's arms left behind | rename guard fires | exit 101, `` `blocked_sends` is in the gauge schema but has no arm here `` |
| emit `blocked` as `?self.blocked`, name intact | anchor **passes** (names unchanged), representation guard fires | anchor `ok`; bench exit 101 |
| emit `seq` as `?self.seq` | representation guard fires | exit 101, `` `seq` … did not arrive as an unsigned integer `` |
| drop `blocked` from the emitter **and** the array | anchor **passes** (the two agree), completeness assert fires | anchor `ok`; bench exit 101, `…without all four counts…: LoadVisitor { …, blocked: None, … }` |
| unmutated | smoke passes, no guard fires on the target's own events | `just bench-smoke` exit 0, no panics |

Rows 3–5 are why the three guards are not redundant: the anchor cannot see value-representation drift (`field_name_sets()` compares names), row 4 is the case the gauge branch is structurally blind to, and row 5 is the case where emitter and array agree so no comparison is left.

Also run: `just clippy` (`--all-targets`, `build_features`) clean, `just fmt-check` clean, `cargo test --lib` 589 passed, `cargo test --test lifecycle --test observability` 15 + 3 passed, `RUSTDOCFLAGS=-D warnings cargo doc` clean with `build_features`, with `user_features`, and with no features. A plain `cargo build` and `cargo clippy --lib` are clean too — the const is `#[cfg(any(test, feature = "bench-internals"))]`, so it does not sit unused in a normal build.

## Also

The three prose pointers at the emitter now point at the array: `PRODUCER_GAUGES`'s doc in `tests/common/gauges.rs`, and `current_u64`'s marker-names doc in **both** copies of the recorder — `src/test_support/trace_recorder.rs` and its deliberate `tests/common/trace_recorder.rs` mirror, which `docs/testing.md` asks to be kept aligned and which no mechanical check enforces.

All three also state what the array does *not* do: nothing binds their `"seq"`/`"runtime_id"`/gauge-name literals to it. A coordinated rename leaves those literals stale, `current_u64` returns `None`, and the census's strict branch is what refuses it — a live guard, but not a mechanical binding, and the docs now say so rather than implying one.