### PR TITLE
fix(testing): read the last turn in the kernel settle wait

### DIFF
--- a/src/testing/driver.rs
+++ b/src/testing/driver.rs
@@ -1118,9 +1118,24 @@ impl<P: Program, B: Backend> TestDriver<P, B> {
         let settled = executor.block_on(async {
             let settle = kernel.settle();
             tokio::pin!(settle);
-            for _ in 0..TURN_BUDGET {
+            // One read more than turns. `0..TURN_BUDGET` read before each
+            // turn but never after the last, so a join set that drained *on*
+            // turn `TURN_BUDGET` was reported as one that never drained. The
+            // bound sits between the read and the turn, counting up like
+            // `settle` and `confirm` above; the turns still number exactly
+            // `TURN_BUDGET`, which is what the assertion prints.
+            //
+            // Those two end on the assertion itself, where this breaks and
+            // asserts outside the executor. Not because it must — a panic
+            // inside `block_on` propagates fine — but so the message is
+            // raised on the caller's frame rather than from inside a
+            // future being driven.
+            for turns in 0..=TURN_BUDGET {
                 if let Poll::Ready(report) = futures::poll!(settle.as_mut()) {
                     return Some(report);
+                }
+                if turns == TURN_BUDGET {
+                    break;
                 }
                 executor_turn().await;
             }


### PR DESCRIPTION
Closes #343.

## The defect

`TestDriver::settle_kernel` (`src/testing/driver.rs`) polled the settle future *before* each turn and never after the last one:

```rust
for _ in 0..TURN_BUDGET {
    if let Poll::Ready(report) = futures::poll!(settle.as_mut()) {
        return Some(report);
    }
    executor_turn().await;
}
None
```

`TURN_BUDGET` turns were spent and `TURN_BUDGET` polls made, so the final `executor_turn()` opened a window nothing read. A terminated kernel whose join set drained *on* that turn returned `None`, and the driver asserted:

```
bounded settle exhausted after 1024 executor turns: the terminated kernel's join set did not drain
```

— a correct drain reported as a hang, with a message stating a cause that had not happened.

## The fix

The bound moves before the turn, which is the shape `confirm` (`:812`) and `settle` (`:922`) in this same file already use. `TURN_BUDGET` turns across `TURN_BUDGET + 1` polls, so the count the assertion prints stays true.

## Verification

Forcing the bound and counting what the loop actually spends:

```
PROBE polls=1025 turns=1024 budget=1024
```

Exactly `TURN_BUDGET` turns, one more poll than that. Before the change the same probe reports `polls=1024`, which is the missing read.

Also: `cargo test --lib` 589 passed, `just clippy` (`--all-targets`, `build_features`) and `just fmt-check` clean.

## The rest of `src/testing/`

The issue asked for a sweep. There is one other bounded loop in the module (`:1766` after this change), and it is **not** affected — it re-reads `wake_source_ready` in the assertion after the loop, so its last turn is observed. `settle` and `confirm` were already assert-before-turn. So this was the only instance.

## Why it was not in #341

That PR swept this defect class out of `kernel::conformance`'s fixtures, where it appeared six times, and is scoped to `#[cfg(test)]` code. `testing` is `pub mod` — shipped test-support that dependants use — so this belongs in a change that can be reviewed as a public-surface edit rather than riding along on a fixture sweep.

