### PR TITLE
test(observability): make the census's rise guards defend themselves

### DIFF
--- a/tests/common/gauges.rs
+++ b/tests/common/gauges.rs
@@ -74,15 +74,29 @@ pub const SETTLE_STEPS: usize = 1_000;
 /// those and *pass*, asserting that the ordering counter rose. The guard is
 /// what keeps this half unable to satisfy itself on a non-gauge.
 ///
+/// An empty `expected_active` is refused, which is the opposite of what
+/// [`producer_gauges_are_zero`] does with one — read the two together, since
+/// a caller usually hands the same slice to both. Empty is a meaningful
+/// reading there (no producers to settle) and no reading at all here, and
+/// letting it through would take both halves of the census vacuous at once:
+/// a rise check that asserts nothing beside a settle loop that returns on
+/// its first iteration.
+///
 /// Written as a plain loop rather than an iterator chain for the same
 /// `#[track_caller]` reason as [`producer_gauges_are_zero`].
 ///
 /// # Panics
 ///
-/// If any name is outside [`PRODUCER_GAUGES`], or any named gauge has no
-/// reading above zero.
+/// If `expected_active` is empty, if any name in it is outside
+/// [`PRODUCER_GAUGES`], or if any named gauge has no reading above zero.
 #[track_caller]
 pub fn producer_gauges_rose(recorder: &TraceRecorder, expected_active: &[&str]) {
+    assert!(
+        !expected_active.is_empty(),
+        "an empty rise check asserts nothing, and its caller hands the same slice to \
+         `producer_gauges_are_zero`, where empty is the tolerant reading — so both halves \
+         of the census would go vacuous at once"
+    );
     assert!(
         expected_active
             .iter()
@@ -169,15 +183,69 @@ pub fn producer_gauge_report(
     })
 }
 
-// Compiled per including target, so this row runs once per binary — the
+// Compiled per including target, so these rows run once per binary — the
 // deliberate cost of each target pinning the census it links against.
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // The strict/tolerant split is the census's whole contract: an active
-    // gauge with no events is a silenced instrument, not a settled one,
-    // while a gauge the row never raises may legitimately have none.
+    /// The target `GaugeSnapshot::dispatch` emits on, so a row here can
+    /// stand up an event of the shape the census reads.
+    const LOAD_TARGET: &str = "tears::runtime::load";
+
+    // The two guards on the rise half. Its sibling's strict/tolerant split
+    // has `an_active_gauge_with_no_events_is_not_settled` below; these two
+    // had nothing, and a rise check that quietly asserts nothing leaves no
+    // trace to notice. Both are `#[should_panic]` rather than checks on an
+    // extracted predicate, because the guards *are* asserts — a predicate
+    // tested beside them would be pinned without its use.
+    //
+    // Safe to panic here, unlike the `#[should_panic]` rows #306 is about:
+    // those share the lib binary with `panic`'s recording-hook row, which
+    // counts hook invocations. The integration targets this module compiles
+    // into have no hook-counting row — `common/panic_hook.rs` silences
+    // reporting and asserts nothing about it.
+    #[test]
+    #[should_panic(expected = "outside the census")]
+    fn a_non_census_name_cannot_satisfy_the_rise_half() {
+        // The recorder is installed and a real gauge-shaped event emitted,
+        // so `seq` genuinely reads above zero. That is what makes this row
+        // witness the hazard rather than the guard's message: without the
+        // guard the rise assert *passes* here, on the ordering counter
+        // having risen. `u64_values` matches a bare field name across the
+        // whole target, so nothing but the guard separates a census gauge
+        // from the two markers every event carries.
+        let recorder = TraceRecorder::new().with_target(LOAD_TARGET);
+        let _guard = recorder.set_default();
+        tracing::debug!(
+            target: LOAD_TARGET,
+            runtime_id = 1u64,
+            seq = 1u64,
+            subscriptions = 0u64,
+            unkeyed_commands = 0u64,
+            keyed_commands = 0u64,
+            blocked = 0u64,
+            "producer gauges",
+        );
+        assert_eq!(
+            recorder.u64_values("seq"),
+            vec![1],
+            "the premise: the marker reads above zero, so an unguarded rise \
+             check on it would pass"
+        );
+
+        producer_gauges_rose(&recorder, &["seq"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "asserts nothing")]
+    fn an_empty_rise_check_is_refused() {
+        producer_gauges_rose(&TraceRecorder::new(), &[]);
+    }
+
+    // The strict/tolerant split is the settle half's whole contract: an
+    // active gauge with no events is a silenced instrument, not a settled
+    // one, while a gauge the row never raises may legitimately have none.
     #[test]
     fn an_active_gauge_with_no_events_is_not_settled() {
         let recorder = TraceRecorder::new();


### PR DESCRIPTION
Closes #339.

## Two vacuity paths and one undefended guard

**An empty `expected_active` asserted nothing.** That is not the trade its sibling makes: `producer_gauges_are_zero` documents empty as a tolerant no-producers reading and has a row that passes `&[]` on purpose. This half has no such meaning and no such caller.

The hazard is that both halves go vacuous together. `assert_two_stage_postconditions` hands the *same* slice to each, so an empty one gives a rise check that asserts nothing **and** a settle loop that returns on iteration zero — the silenced-instrument vacuity the census exists to prevent, reached through the helper written to prevent it. It cannot be empty today (its `expected_active` is seeded with `"keyed_commands"`), which is why #339 filed it rather than #338 fixing it.

**The membership guard had no row.** It is the only thing between this helper and a false pass on a non-census name: `u64_values` reads a name off the whole `tears::runtime::load` target, and every gauge event carries `seq` and `runtime_id`, both above zero by construction — so `producer_gauges_rose(&recorder, &["seq"])` would pass by asserting that the ordering counter rose. That was verified by a throwaway probe during #338's review, which left nothing in the tree to fail if the guard were later removed.

## Verification

Both rows fail when their guard is disabled:

```
test gauges::tests::an_empty_rise_check_is_refused - should panic ... FAILED
test gauges::tests::a_non_census_name_cannot_satisfy_the_rise_half - should panic ... FAILED
```

Unmutated: `cargo test --test lifecycle --test observability` — 17 + 5 passed. `just clippy` (`--all-targets`, `build_features`) and `just fmt-check` clean.

## On `#[should_panic]`, which #339 flagged as the cost to weigh

The guards *are* asserts, so pinning them means catching their panic; a check on an extracted predicate would pin the predicate and not its use.

#339 raised #306's hazard against this. It does not transfer, and I checked rather than assumed: #306's 31 rows share the **lib** binary with `panic`'s recording-hook row, which installs a counting hook and asserts it ran exactly once, so a foreign panic inside that window corrupts the count. This module compiles into `tests/lifecycle.rs` and `tests/observability.rs` — separate binaries — and neither has a hook-counting row. `tests/lifecycle.rs` does include `common/panic_hook.rs`, but that helper only silences reporting and asserts nothing about invocations (`grep` over `tests/` finds no hook-count assertion at all).

The per-binary duplication is the module's stated policy rather than an exception to it: its doc already says each row is "compiled per including target, so this row runs once per binary — the deliberate cost of each target pinning the census it links against."