### PR TITLE
test(panic): let the hook-order test count only its own panic

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -211,11 +211,15 @@ is the recording test's own obligation.** The guard serializes hook swaps, not
 the rest of the binary: any test in the process may panic while a recording hook
 is installed, and there is no way to enumerate — let alone guard — every test
 that panics on purpose, since `#[should_panic]` tests panic by construction. So
-a test that counts hook activity counts only panics raised on its own threads,
-the way `HookProbe` does, and the hook-restoration test in
-`src/test_support/panic_hook.rs` applies the same filter for the same reason.
-A recording hook without that filter is the defect: it asserts a count over the
-whole process while claiming to measure one test.
+a test that records hook activity records only panics raised on its own threads,
+through `crate::test_support::on_thread(prefix)` — the check `HookProbe` applies
+to its counts, and the one the hand-rolled recording hooks in `src/panic.rs` and
+`src/test_support/panic_hook.rs` apply for the same reason. A test whose panic
+is raised inline passes its own full path, since libtest names the thread after
+it — or, where that does not fit on a line, a leading part of the path that no
+other test's name shares; a test that drives its own runtime passes the prefix
+it stamped on the workers. A recording hook without that filter is the defect:
+it asserts over the whole process while claiming to measure one test.
 
 **A loom model takes the guard because it is a hook swapper**, which is the
 first rule of this section rather than a category of its own. Loom drives each

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -131,12 +131,14 @@ pub fn compose_hook(restore: impl Fn() + Sync + Send + 'static, next: PanicHook)
 
 #[cfg(test)]
 mod tests {
-    use crate::test_support::{HookProbe, hook_guard};
+    use crate::test_support::{HookProbe, hook_guard, on_thread};
 
     use super::*;
 
     use std::future::pending;
+    use std::panic::AssertUnwindSafe;
     use std::sync::{Arc, Mutex};
+    use std::thread;
 
     use futures::future::join_all;
     use tokio::runtime::Builder;
@@ -151,51 +153,167 @@ mod tests {
         }
     }
 
-    #[test]
-    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
-    fn test_compose_hook_restores_then_delegates_once() {
-        // Serialize against other tests that touch the global panic hook or
-        // panic, so a concurrent panic cannot invoke our recording hook.
-        let _hook_guard = hook_guard();
-
-        // Records the order (and therefore the count) of the two stages.
-        // `restore` must run first so the terminal is usable before the
-        // delegated reporter prints.
+    /// Runs `trigger` with a composed hook installed that records the order of
+    /// its two stages, counting only panics raised on threads named with
+    /// `prefix`, and returns what it recorded.
+    ///
+    /// The filter is the recording test's own obligation: the caller's
+    /// [`hook_guard`] serializes hook swaps, not the rest of the binary, so any
+    /// `#[should_panic]` row passing on another thread would otherwise append a
+    /// stage pair of its own (docs/testing.md "Process-Global Panic Hook
+    /// Tests"). Callers hold the guard across the whole call.
+    ///
+    /// An unexpected panic out of `trigger` — a failed thread spawn, say — is
+    /// caught long enough to reinstall the previous hook and then resumed, the
+    /// same shape `with_silent_panic_hook` uses. A drop guard could not do it:
+    /// `set_hook` panics when called from a panicking thread, so restoring
+    /// mid-unwind is not available, and leaving the recording hook installed
+    /// would strip every later panic in the binary of its reported location.
+    fn record_hook_stages(prefix: &'static str, trigger: impl FnOnce()) -> Vec<&'static str> {
         let order = Arc::new(Mutex::new(Vec::<&'static str>::new()));
-
         let restore_order = order.clone();
         let next_order = order.clone();
+
         let next: PanicHook = Box::new(move |_info| {
-            next_order
-                .lock()
-                .expect("order mutex should not be poisoned")
-                .push("next");
+            if on_thread(prefix) {
+                next_order
+                    .lock()
+                    .expect("order mutex should not be poisoned")
+                    .push("next");
+            }
         });
         let hook = compose_hook(
             move || {
-                restore_order
-                    .lock()
-                    .expect("order mutex should not be poisoned")
-                    .push("restore");
+                if on_thread(prefix) {
+                    restore_order
+                        .lock()
+                        .expect("order mutex should not be poisoned")
+                        .push("restore");
+                }
             },
             next,
         );
 
-        // `PanicHookInfo` cannot be constructed directly, so drive the composed
-        // hook through the real panic runtime and catch the unwind.
         let previous = panic::take_hook();
         panic::set_hook(hook);
-        let _ = panic::catch_unwind(|| panic!("trigger"));
+        let triggered = panic::catch_unwind(AssertUnwindSafe(trigger));
         panic::set_hook(previous);
+        if let Err(payload) = triggered {
+            panic::resume_unwind(payload);
+        }
 
-        let recorded = order
+        order
             .lock()
             .expect("order mutex should not be poisoned")
-            .clone();
+            .clone()
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_compose_hook_restores_then_delegates_once() {
+        // libtest names each test's thread after the test's full path, and the
+        // panic below is raised inline, so this is the thread the hook records
+        // from.
+        const PROBE: &str = "panic::tests::test_compose_hook_restores_then_delegates_once";
+
+        // Serialize against other tests that swap the global panic hook, so
+        // one of them cannot install over the recording hook.
+        let _hook_guard = hook_guard();
+
+        // `restore` must run first so the terminal is usable before the
+        // delegated reporter prints. `PanicHookInfo` cannot be constructed
+        // directly, so drive the composed hook through the real panic runtime
+        // and catch the unwind.
+        let recorded = record_hook_stages(PROBE, || {
+            let _ = panic::catch_unwind(|| panic!("trigger"));
+        });
+
         assert_eq!(
             recorded,
             vec!["restore", "next"],
             "restore must run exactly once, before the delegated hook"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_recording_hook_ignores_a_panic_from_another_thread() {
+        const PROBE: &str = "panic::tests::test_recording_hook_ignores_a_panic_from_another_thread";
+        const FOREIGN: &str = "tears-panic-foreign";
+
+        // A panic on a differently named thread, standing in for the
+        // `#[should_panic]` rows: they panic on their own libtest threads and
+        // take no guard, so their panics reach whichever hook is installed.
+        fn panic_elsewhere() {
+            thread::Builder::new()
+                .name(FOREIGN.to_owned())
+                .spawn(|| {
+                    let _ = panic::catch_unwind(|| panic!("foreign panic"));
+                })
+                .expect("the foreign thread should spawn")
+                .join()
+                .expect("the foreign thread should not unwind");
+        }
+
+        let _hook_guard = hook_guard();
+
+        // A foreign panic on either side of this test's own, the interleaving
+        // that appended a second and a third stage pair before the filter. The
+        // inline panic is also the positive control: without it the assertion
+        // below would pass on an empty record, and so would survive a `PROBE`
+        // that had stopped matching the thread libtest names after this test.
+        let recorded = record_hook_stages(PROBE, || {
+            panic_elsewhere();
+            let _ = panic::catch_unwind(|| panic!("trigger"));
+            panic_elsewhere();
+        });
+
+        assert_eq!(
+            recorded,
+            vec!["restore", "next"],
+            "only this test's own panic may be recorded"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic, reason = "driving the panic hook requires a real panic")]
+    fn test_an_unwinding_trigger_restores_the_previous_hook() {
+        const PROBE: &str = "panic::tests::test_an_unwinding_trigger_restores_the_previous_hook";
+
+        let _hook_guard = hook_guard();
+
+        // Stands in for the previous hook — the real one reports a panic's
+        // location. A recording hook left installed over it would strip that
+        // from every later panic in the binary, so the helper has to reinstall
+        // it even when the trigger unwinds, as a failed thread spawn would.
+        let reports = Arc::new(Mutex::new(0_usize));
+        let counted = reports.clone();
+        let original = panic::take_hook();
+        panic::set_hook(Box::new(move |_info| {
+            if on_thread(PROBE) {
+                *counted
+                    .lock()
+                    .expect("report counter should not be poisoned") += 1;
+            }
+        }));
+
+        let outcome = panic::catch_unwind(AssertUnwindSafe(|| {
+            record_hook_stages(PROBE, || panic!("the trigger unwinds"))
+        }));
+        // Reaches the hook that is installed now, whichever one that is.
+        let _ = panic::catch_unwind(|| panic!("after the window"));
+
+        let installed = panic::take_hook();
+        panic::set_hook(original);
+        drop(installed);
+
+        assert!(outcome.is_err(), "the trigger's panic must be resumed");
+        assert_eq!(
+            *reports
+                .lock()
+                .expect("report counter should not be poisoned"),
+            1,
+            "the previous hook must be back once the window closes"
         );
     }
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -7,7 +7,7 @@
 
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
 pub use failing_backend::FailingBackend;
-pub use panic_hook::{HookProbe, hook_guard, with_silent_panic_hook};
+pub use panic_hook::{HookProbe, hook_guard, on_thread, with_silent_panic_hook};
 pub use trace_recorder::{TraceRecorder, set_default_subscriber};
 
 mod async_utils;

--- a/src/test_support/panic_hook.rs
+++ b/src/test_support/panic_hook.rs
@@ -149,7 +149,14 @@ impl Drop for HookProbe {
     }
 }
 
-fn on_thread(prefix: &str) -> bool {
+/// Reports whether the calling thread's name starts with `prefix`.
+///
+/// The filter a recording panic hook applies to keep panics raised by other
+/// tests out of its records (docs/testing.md "Process-Global Panic Hook
+/// Tests"): libtest names each test's thread after the test's full path, and
+/// a test that drives a multi-thread runtime stamps its workers with a prefix
+/// of its own.
+pub fn on_thread(prefix: &str) -> bool {
     thread::current()
         .name()
         .is_some_and(|name| name.starts_with(prefix))


### PR DESCRIPTION
## Summary

`panic::tests::test_compose_hook_restores_then_delegates_once` installed a recording panic hook process-wide and asserted the recorded stages were exactly `["restore", "next"]`. It took `hook_guard()`, but the guard serializes hook *swaps*, not the rest of the binary: the 31 `#[should_panic]` rows in `src/testing/driver.rs`, `src/testing.rs`, `src/kernel/accounting.rs` and `src/kernel/conformance/bounded.rs` panic on their own libtest threads and take nothing. Any of them landing inside the window appended another `restore`/`next` pair and failed the assertion — reachable at a raised `--test-threads`, not at CI's default (#306).

The fix is the rule `docs/testing.md` "Process-Global Panic Hook Tests" already states and `HookProbe` already follows: **a recording hook filters by thread name.** It needs no cooperation from the 31 rows and no new obligation on the next panicking test.

## Changes

- `src/panic.rs`: the hook assembly moves into a `record_hook_stages(prefix, trigger)` helper that records a stage only when the panic was raised on a thread named with `prefix`. Each inline-panic row passes its own full path, which is what libtest names its thread.
- `src/panic.rs`: `test_recording_hook_ignores_a_panic_from_another_thread` drives a foreign-thread panic on either side of its own inline panic — the interleaving that appended the second and third stage pairs — and asserts exactly one pair is recorded. The inline panic is the positive control, so the row cannot pass on an empty record if its prefix ever stops matching.
- `src/panic.rs`: `record_hook_stages` now catches an unexpected unwind out of `trigger`, reinstalls the previous hook, and resumes — the shape `with_silent_panic_hook` uses. A drop guard cannot serve here: `set_hook` panics when called from a panicking thread. `test_an_unwinding_trigger_restores_the_previous_hook` pins it; without the catch, a failed thread spawn inside the window would leave the recording hook installed and strip every later panic in the binary of its reported location.
- `src/test_support/panic_hook.rs`: `on_thread` is exported (through the `#[cfg(test)]` `test_support` module, so the public API surface is unchanged) so both recording hooks apply one check rather than two copies.
- `docs/testing.md`: the filter paragraph now names the shared `on_thread` helper and says how to choose the prefix — a test's own full path for an inline panic, or, where that does not fit on a line (as in `src/test_support/panic_hook.rs`), a leading part of it no other test's name shares; the stamped worker prefix for a test that drives its own runtime.

## Verification

- `cargo test` (all targets): every target passes; `cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` are clean. CI was green on both earlier revisions of this branch.
- **Mutation checks**, each reverted afterwards:
  - `on_thread(prefix)` → `true`: the foreign-panic row fails with three stage pairs, the payload shape #306 reported.
  - `PROBE` renamed so it no longer matches: the same row fails on an empty record, so it cannot rot into a vacuous pass.
  - `catch_unwind(...)` → a bare `trigger()`: the unwind row fails with `left: 0, right: 1`, i.e. the previous hook was not reinstalled.
- Every inline-panic row's `PROBE` was checked mechanically against its own test path; the four `tears-panic-probe-*` constants are runtime worker prefixes by design.
- `panic::tests` also pass at `--test-threads=1`, where libtest still names the thread after the test.
- 10 sequential runs of the lib suite at `--test-threads=32`: 0 failures.

Closes #306