### PR TITLE
test(observability): read gauge events through one per-event accessor

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -146,13 +146,25 @@ tracing output.
 Read a gauge's *current value* through `current_u64`, never through
 `u64_values(...).last()`: the gauge contract orders events by `seq`, not by
 arrival. The accessor assumes one runtime instance per recorder and
-panics otherwise; a deliberately multi-instance test partitions by
-`runtime_id` itself, the way `src/runtime/load.rs`'s contract rows do.
+panics otherwise; a deliberately multi-instance test reads
+`current_u64_by_runtime`, which applies the same greatest-`seq` rule inside
+each `runtime_id`'s own events and which `current_u64` is the one-instance
+convenience over. A row asserting something else about those events — their
+arrival order, or that `seq` strictly increases inside one partition — reads
+the log itself instead; `src/runtime/load.rs`'s two-instance rows do both.
 The rule covers the gauge snapshot's fields — the ones whose events carry
 a `seq`. Other unsigned-integer fields on the same target (`pulled`,
 `updated`, `shared_pending`, `wait_us`) are per-event readings with no
 current value to take; `current_u64` returns `None` for them, so keep those
 on `u64_values`.
+
+Read several fields of the *same* event through `u64_event_values([...])`
+rather than by zipping as many `u64_values` logs: the per-field logs are
+flattened across events, so zipping them pairs values by position and
+truncates to the shortest input without reporting the mismatch — a field
+that stops riding every event then shifts the tuples or shortens the vector
+instead of failing. `u64_event_values` keeps the per-event grouping and
+refuses an event that records only some of the names.
 
 The INV-LC7 producer-gauge census in `tests/common/gauges.rs` is included
 with the same `#[path]` mechanism as the recorder above; see its module

--- a/src/kernel/producer.rs
+++ b/src/kernel/producer.rs
@@ -343,8 +343,22 @@ mod tests {
         RunKind::Sub(subscription.id().clone())
     }
 
-    /// The four producer gauges as `tears::runtime::load` reports them over
-    /// one run's guard: the values while it is held, then after it drops.
+    /// The three run-scoped producer gauges as `tears::runtime::load` reports
+    /// them over one run's guard: the values while it is held, then after it
+    /// drops. (`blocked`, the fourth field on the same snapshot, belongs to
+    /// the bounded-send layer and no run guard moves it.)
+    ///
+    /// Read per event, not by zipping three flattened per-field logs: `zip`
+    /// pairs by position and truncates to its shortest input without
+    /// reporting the mismatch, so a count that stopped riding every snapshot
+    /// would shift these triples or shorten the vector — and a shortened one
+    /// takes the `is_empty()` rows below with it, passing them on an emission
+    /// gap rather than on the absence they asserted. `u64_event_values`
+    /// refuses a snapshot carrying only some of the three instead.
+    ///
+    /// A snapshot carrying *none* of them is still skipped, so this trace
+    /// still empties out under a total gauge outage — what refuses that is
+    /// the two rows below that expect values, not this shape.
     fn gauge_trace(kind: &RunKind) -> Vec<(u64, u64, u64)> {
         let recorder = TraceRecorder::new().with_target("tears::runtime::load");
         let _guard = recorder.set_default();
@@ -352,15 +366,10 @@ mod tests {
 
         drop(gauge_guard(&observer, kind));
 
-        let subscriptions = recorder.u64_values("subscriptions");
-        let unkeyed = recorder.u64_values("unkeyed_commands");
-        let keyed = recorder.u64_values("keyed_commands");
-
-        subscriptions
+        recorder
+            .u64_event_values(["subscriptions", "unkeyed_commands", "keyed_commands"])
             .into_iter()
-            .zip(unkeyed)
-            .zip(keyed)
-            .map(|((subscriptions, unkeyed), keyed)| (subscriptions, unkeyed, keyed))
+            .map(<(u64, u64, u64)>::from)
             .collect()
     }
 

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -232,7 +232,8 @@ impl Gauges {
 /// followed by RFC 0006 §4.4's four counts.
 ///
 /// The names are the contract, and they are matched *by name* by consumers
-/// that cannot see each other — the test recorders' `current_u64` markers,
+/// that cannot see each other — the test recorders'
+/// `current_u64_by_runtime` markers (which `current_u64` reads through),
 /// the integration census's `PRODUCER_GAUGES`, and the bench subscriber's
 /// `LoadVisitor`. `tracing`'s field names are macro syntax rather than
 /// values, so `GaugeSnapshot::dispatch` cannot be written in terms of this
@@ -586,7 +587,6 @@ impl Drop for DrainGuard<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::panic::{self, AssertUnwindSafe};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -732,29 +732,28 @@ mod tests {
         drop(held);
         drop(also_held);
 
-        // One `runtime_id` and one `seq` per gauge event, each log in arrival
-        // order, so the two line up index by index — the other two event kinds
-        // carry neither field, so nothing else can enter either log.
-        let ids = recorder.u64_values("runtime_id");
-        let seqs = recorder.u64_values("seq");
-        assert_eq!(ids.len(), 6, "six gauge changes fired: {ids:?}");
-        assert_eq!(
-            seqs.len(),
-            ids.len(),
-            "every gauge event carries both fields: {ids:?} / {seqs:?}"
-        );
+        // Every field read off the event that carries it, rather than off as
+        // many flattened per-field logs lined up by index: `u64_event_values`
+        // refuses an event recording only some of the four names, which is
+        // both the pairing the partition below needs and the premise the
+        // recovery half rests on — that every gauge event carries every count.
+        // Positional zips could only assume it, and a length check per field
+        // only narrows the assumption.
+        let events =
+            recorder.u64_event_values(["runtime_id", "seq", "subscriptions", "keyed_commands"]);
+        assert_eq!(events.len(), 6, "six gauge changes fired: {events:?}");
 
         let mut partitions: Vec<(u64, Vec<u64>)> = Vec::new();
-        for (id, seq) in ids.iter().zip(&seqs) {
-            match partitions.iter_mut().find(|(known, _)| known == id) {
-                Some((_, known_seqs)) => known_seqs.push(*seq),
-                None => partitions.push((*id, vec![*seq])),
+        for &[id, seq, _, _] in &events {
+            match partitions.iter_mut().find(|(known, _)| *known == id) {
+                Some((_, known_seqs)) => known_seqs.push(seq),
+                None => partitions.push((id, vec![seq])),
             }
         }
         assert_eq!(
             partitions.len(),
             2,
-            "two runtime instances must yield two partitions: {ids:?}"
+            "two runtime instances must yield two partitions: {events:?}"
         );
         for (id, seqs) in partitions {
             assert!(
@@ -768,41 +767,42 @@ mod tests {
         // `runtime_id` and applying the max-`seq` rule per partition recovers
         // each instance's current values — `first` ended with both
         // subscriptions dropped, `second` with two keyed entries live.
-        let subscriptions = recorder.u64_values("subscriptions");
-        let keyed = recorder.u64_values("keyed_commands");
-        for (name, values) in [
-            ("subscriptions", &subscriptions),
-            ("keyed_commands", &keyed),
-        ] {
-            assert_eq!(
-                values.len(),
-                ids.len(),
-                "every gauge event carries `{name}`: {ids:?} / {values:?}"
-            );
-        }
-        let mut current: BTreeMap<u64, (u64, u64, u64)> = BTreeMap::new();
-        for ((&id, &seq), (&subs, &keyed_now)) in
-            ids.iter().zip(&seqs).zip(subscriptions.iter().zip(&keyed))
-        {
-            let slot = current.entry(id).or_insert((seq, subs, keyed_now));
-            if seq > slot.0 {
-                *slot = (seq, subs, keyed_now);
-            }
-        }
-        let recover = |id: u64| {
-            let &(_, subs, keyed_now) = current.get(&id).expect("both partitions were built above");
-            (subs, keyed_now)
-        };
+        //
+        // Read through `current_u64_by_runtime`, which *is* that rule, rather
+        // than through a partition-then-max hand-rolled here: the rule then
+        // has one implementation, and the row that justifies the reader is the
+        // row that exercises it. What that trades away is recovered on both
+        // sides — the strict-increase half above builds its own partition from
+        // the raw per-event log, so the reader cannot cover for an emitter
+        // that stops ordering; and the reader's own rule is pinned on scripted
+        // events in `src/test_support/trace_recorder.rs`, where no emitter is
+        // involved at all.
+        //
+        // One scan per gauge, because the rule is per gauge: a field's current
+        // value is the value on the greatest-`seq` event carrying *that*
+        // field. Both scans land on one snapshot here, since the read above
+        // refuses an event carrying only some of the four names — but that is
+        // this schema's doing, not something the rule promises, so the
+        // assertions below claim a recovered partition rather than one row.
+        let subscriptions = recorder.current_u64_by_runtime("subscriptions");
+        let keyed = recorder.current_u64_by_runtime("keyed_commands");
+        let recover = |id: u64| (subscriptions.get(&id).copied(), keyed.get(&id).copied());
+        // `runtime_id` is the first name read above, so it is each row's head.
+        let [first_id, ..] = events[0];
         assert_eq!(
-            recover(ids[0]),
-            (0, 0),
-            "first's max-seq event must report its current values"
+            recover(first_id),
+            (Some(0), Some(0)),
+            "first's partition must recover its current values"
         );
-        let second_id = *ids.iter().find(|id| **id != ids[0]).expect("two ids");
+        let second_id = events
+            .iter()
+            .map(|&[id, ..]| id)
+            .find(|id| *id != first_id)
+            .expect("two ids");
         assert_eq!(
             recover(second_id),
-            (0, 2),
-            "second's max-seq event must report its current values"
+            (Some(0), Some(2)),
+            "second's partition must recover its current values"
         );
     }
 

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
@@ -55,9 +55,10 @@ struct TraceRecorderState {
     // the u64 event log below keeps per-event grouping for its own type only.
     field_sets: Mutex<Vec<Vec<String>>>,
     // Each event's unsigned-integer fields kept together, in arrival order —
-    // the single u64 source of truth: `u64_values` flattens it per field, and
-    // `current_u64` pairs a value with the `seq` recorded on its own event,
-    // which a flattened per-field map could not.
+    // the single u64 source of truth: `u64_values` flattens it per field,
+    // `u64_event_values` keeps the grouping, and the current-value reads pair
+    // a value with the `seq` recorded on its own event, which a flattened
+    // per-field map could not.
     u64_events: Mutex<Vec<Vec<(String, u64)>>>,
 }
 
@@ -123,44 +124,116 @@ impl TraceRecorder {
             .collect()
     }
 
-    /// Returns the current value of a gauge field, read the way the gauge
-    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
-    /// the greatest-`seq` event that records `field`. Arrival order is
-    /// never consulted among distinct `seq` values, so the read stays
-    /// correct even if dispatch order diverges from `seq` order; a `seq`
-    /// tie — impossible for a real runtime, whose `seq` strictly increases —
-    /// resolves to the first-arriving match. An event carrying `field`
-    /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
-    /// is ignored; `None` when no event carries all three. The marker
-    /// names must match `GAUGE_EVENT_FIELDS` (`src/runtime/load.rs`), the
-    /// schema's source of truth, which a unit row holds to what
-    /// `GaugeSnapshot::dispatch` actually emits. Nothing binds these two
-    /// literals to that array — a coordinated rename makes this return
-    /// `None`, and the census's strict branch is what refuses it.
+    /// The named unsigned-integer fields of every event that records them,
+    /// grouped per event and ordered as named — the per-event view
+    /// [`Self::u64_values`] flattens away. Each name reads its event's
+    /// *first* occurrence, the way the snapshot fields are read, so a name
+    /// repeated in `fields` simply repeats its column. An event recording
+    /// none of the names is skipped, so the target's other event families
+    /// stay out of the result.
+    ///
+    /// Reading several fields this way rather than zipping as many
+    /// `u64_values` logs is what keeps a caller aligned with the schema:
+    /// `zip` pairs by position, truncates to its shortest input, and reports
+    /// no mismatch, so a field that stops riding every event shifts the
+    /// tuples or shortens the vector silently. Here a partial event fails,
+    /// by name.
+    ///
+    /// That alignment is what two or more names buy. With one name there is
+    /// nothing to align — the read is [`Self::u64_values`] narrowed to each
+    /// event's first occurrence — and with none there would be nothing to
+    /// read at all, which is a compile-time error rather than an empty
+    /// answer (see the const assertion in the body).
     ///
     /// # Panics
     ///
-    /// Panics when the matched events span more than one `runtime_id`,
-    /// since `seq` is comparable only within one runtime instance. An
-    /// event is matched when it carries `seq`, `runtime_id`, and the
-    /// queried field; every snapshot carries every count, so only an
-    /// instance that emits no snapshot at all stays outside the scan. The
-    /// panic message carries the remedies.
+    /// Panics when an event records some of `fields` but not all: such an
+    /// event has no aligned reading, and both ways of inventing one —
+    /// dropping it, or padding the missing name — are the silent
+    /// misalignment this accessor exists to refuse.
     #[must_use]
     #[track_caller]
     #[expect(
         clippy::panic,
-        reason = "a cross-instance read is test misuse, reported with the observed ids"
+        reason = "a partially recorded event is a schema break, reported with the event"
     )]
-    pub fn current_u64(&self, field: &str) -> Option<u64> {
+    pub fn u64_event_values<const N: usize>(&self, fields: [&str; N]) -> Vec<[u64; N]> {
+        // The one shape where "refuses a partial event" would degrade to
+        // silence: with no names every event records none of them, so the
+        // scan below would answer `vec![]` whatever the log holds — an empty
+        // trace that reads like a checked one. No row can pin that, since the
+        // answer is a value rather than a failure, so it is refused where the
+        // caller is written instead.
+        const { assert!(N > 0, "u64_event_values needs at least one field name") };
         let events = self
             .state
             .u64_events
             .lock()
             .expect("trace recorder u64 event log mutex should not be poisoned");
-        let mut runtime_id: Option<u64> = None;
-        let mut clash: Option<(u64, u64)> = None;
-        let mut current: Option<(u64, u64)> = None;
+        let mut rows: Vec<[u64; N]> = Vec::new();
+        let mut partial: Option<Vec<(String, u64)>> = None;
+        for event in events.iter() {
+            let values: Vec<u64> = fields
+                .iter()
+                .filter_map(|name| field_value(event, name))
+                .collect();
+            if values.is_empty() {
+                continue;
+            }
+            // At most one value per name, so a short vector is a name this
+            // event never recorded — never a name recorded twice.
+            let Ok(row) = <[u64; N]>::try_from(values.as_slice()) else {
+                partial = Some(event.clone());
+                break;
+            };
+            rows.push(row);
+        }
+        // Released before the panic below, so a failing guard reports its
+        // own message rather than poisoning the log for every later read.
+        drop(events);
+        if let Some(event) = partial {
+            let missing: Vec<&str> = fields
+                .into_iter()
+                .filter(|name| field_value(&event, name).is_none())
+                .collect();
+            panic!(
+                "u64_event_values({fields:?}) found an event recording only some of the \
+                 names: {missing:?} missing from {event:?}. A partial event has no \
+                 aligned reading — either a name here is not on this event's schema, or \
+                 a field stopped riding every event. The log holds a name only where the \
+                 event recorded it as a non-negative integer"
+            );
+        }
+        rows
+    }
+
+    /// Each observed runtime instance's current value of a gauge field,
+    /// keyed by `runtime_id`: the value on that instance's greatest-`seq`
+    /// event recording `field`. This is the gauge contract's read rule
+    /// (`src/runtime/load.rs`, "Ordering") in full — a subscriber watching
+    /// several runtimes in one process partitions by `runtime_id` first and
+    /// applies the max-`seq` rule inside each partition, since `seq` is
+    /// comparable only within one instance.
+    ///
+    /// Arrival order is never consulted among distinct `seq` values, so the
+    /// read stays correct even if dispatch order diverges from `seq` order;
+    /// a `seq` tie — impossible for a real runtime, whose `seq` strictly
+    /// increases — resolves to the first-arriving match. An event carrying
+    /// `field` without both a `seq` and a `runtime_id` is not a gauge
+    /// snapshot and is ignored; the map is empty when no event carries all
+    /// three. The marker names must match `GAUGE_EVENT_FIELDS`
+    /// (`src/runtime/load.rs`), the schema's source of truth, which a unit
+    /// row holds to what `GaugeSnapshot::dispatch` actually emits. Nothing
+    /// binds these two literals to that array — a coordinated rename empties
+    /// this map, and the census's strict branch is what refuses it.
+    #[must_use]
+    pub fn current_u64_by_runtime(&self, field: &str) -> BTreeMap<u64, u64> {
+        let events = self
+            .state
+            .u64_events
+            .lock()
+            .expect("trace recorder u64 event log mutex should not be poisoned");
+        let mut current: BTreeMap<u64, (u64, u64)> = BTreeMap::new();
         for event in events.iter() {
             // `seq` first: the target's non-snapshot events (the batch and
             // capacity-wait families) fail that lookup, so they skip the
@@ -173,32 +246,49 @@ impl TraceRecorder {
             else {
                 continue;
             };
-            match runtime_id {
-                None => runtime_id = Some(id),
-                Some(seen) if seen != id => {
-                    clash = Some((seen, id));
-                    break;
-                }
-                Some(_) => {}
-            }
-            if current.is_none_or(|(greatest, _)| seq > greatest) {
-                current = Some((seq, value));
+            let slot = current.entry(id).or_insert((seq, value));
+            if seq > slot.0 {
+                *slot = (seq, value);
             }
         }
-        // Released before the panic below, so a failing guard reports its
-        // own message rather than poisoning the log for every later read.
         drop(events);
-        if let Some((first, second)) = clash {
-            panic!(
-                "current_u64({field:?}) matched gauge events from at least two runtime \
-                 instances ({first} and {second}); `seq` is comparable only within one. \
-                 Restructure to observe one runtime per recorder (test-helper observers, \
-                 like `channel`'s throwaway, also count), read `u64_values` and partition \
-                 by `runtime_id` yourself, or — if the script minted no second observer — \
-                 treat it as a one-instance-per-run regression"
-            );
-        }
-        current.map(|(_, value)| value)
+        current
+            .into_iter()
+            .map(|(id, (_, value))| (id, value))
+            .collect()
+    }
+
+    /// Returns the current value of a gauge field, read the way the gauge
+    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
+    /// the greatest-`seq` event that records `field`. This is the
+    /// one-instance convenience over [`Self::current_u64_by_runtime`], and
+    /// inherits every property described there: the `seq` ordering, the tie,
+    /// and what counts as a gauge snapshot at all. `None` when no event
+    /// carries `field` beside both markers.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the matched events span more than one `runtime_id`,
+    /// since `seq` is comparable only within one runtime instance. An
+    /// event is matched when it carries `seq`, `runtime_id`, and the
+    /// queried field; every snapshot carries every count, so only an
+    /// instance that emits no snapshot at all stays outside the scan. The
+    /// panic message carries the remedies.
+    #[must_use]
+    #[track_caller]
+    pub fn current_u64(&self, field: &str) -> Option<u64> {
+        let current = self.current_u64_by_runtime(field);
+        assert!(
+            current.len() <= 1,
+            "current_u64({field:?}) matched gauge events from at least two runtime \
+             instances ({ids:?}); `seq` is comparable only within one. Restructure to \
+             observe one runtime per recorder (test-helper observers, like `channel`'s \
+             throwaway, also count), read `current_u64_by_runtime` and name the \
+             instance you mean, or — if the script minted no second observer — treat \
+             it as a one-instance-per-run regression",
+            ids = current.keys().copied().collect::<Vec<_>>()
+        );
+        current.into_values().next()
     }
 
     /// Returns all string values recorded for the named event field.
@@ -476,6 +566,52 @@ mod tests {
         assert_eq!(recorder.current_u64("absent"), None);
     }
 
+    // The partition half of the same rule: `seq` orders events only inside
+    // one `runtime_id`, so a reader watching several instances keeps one
+    // current value per instance.
+    #[test]
+    fn current_u64_by_runtime_reads_each_instance_by_its_own_seq() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        // Interleaved, with the greater `seq` on the instance whose current
+        // value is not the last to arrive: a read that compared `seq` across
+        // instances, or that took the latest arrival, gets both partitions
+        // wrong.
+        tracing::trace!(target: TARGET, runtime_id = 1u64, seq = 1u64, gauge = 3u64, "first instance");
+        tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 9u64, gauge = 7u64, "second instance, a greater seq");
+        tracing::trace!(target: TARGET, runtime_id = 1u64, seq = 2u64, gauge = 5u64, "first instance's own current value");
+        tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 8u64, gauge = 0u64, "second instance, an earlier seq arriving later");
+        tracing::trace!(target: TARGET, gauge = 4u64, "no markers: not a snapshot");
+        tracing::trace!(target: TARGET, runtime_id = 3u64, seq = 1u64, other = 1u64, "a third instance, recording another field only");
+
+        assert_eq!(
+            recorder.current_u64_by_runtime("gauge"),
+            BTreeMap::from([(1, 5), (2, 7)]),
+            "each instance's greatest-seq reading, whatever arrived last and \
+             whatever `seq` another instance reached — and no key at all for \
+             the instance whose events never carried the field"
+        );
+        assert_eq!(recorder.current_u64_by_runtime("absent"), BTreeMap::new());
+    }
+
+    #[test]
+    fn u64_event_values_groups_fields_per_event() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, left = 1u64, right = 2u64, "both names");
+        tracing::trace!(target: TARGET, elsewhere = 9u64, "neither name: skipped, not padded");
+        tracing::trace!(target: TARGET, right = 4u64, left = 3u64, spare = 9u64, "recorded in the other order, beside a name not asked for");
+
+        assert_eq!(
+            recorder.u64_event_values(["left", "right"]),
+            vec![[1, 2], [3, 4]],
+            "one row per event recording the names, ordered as named rather \
+             than as the event recorded them"
+        );
+    }
+
     // Pinned here and not in the tests/ mirror: one copy suffices for the
     // contract, and mirroring would add a deliberate panic to every
     // including binary for no new coverage of the same source. No
@@ -492,5 +628,18 @@ mod tests {
         tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 9u64, gauge = 0u64, "another");
 
         let _ = recorder.current_u64("gauge");
+    }
+
+    // Pinned in this copy only, for the reason the row above it carries.
+    #[test]
+    #[should_panic(expected = "recording only some of the names")]
+    fn u64_event_values_refuses_a_partial_event() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, left = 1u64, right = 2u64, "a whole event");
+        tracing::trace!(target: TARGET, left = 3u64, "and one that dropped a name");
+
+        let _ = recorder.u64_event_values(["left", "right"]);
     }
 }

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -9,7 +9,7 @@
     reason = "shared cross-target test helper; per-target usage varies (see module docs)"
 )]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
@@ -66,9 +66,10 @@ struct TraceRecorderState {
     // the u64 event log below keeps per-event grouping for its own type only.
     field_sets: Mutex<Vec<Vec<String>>>,
     // Each event's unsigned-integer fields kept together, in arrival order —
-    // the single u64 source of truth: `u64_values` flattens it per field, and
-    // `current_u64` pairs a value with the `seq` recorded on its own event,
-    // which a flattened per-field map could not.
+    // the single u64 source of truth: `u64_values` flattens it per field,
+    // `u64_event_values` keeps the grouping, and the current-value reads pair
+    // a value with the `seq` recorded on its own event, which a flattened
+    // per-field map could not.
     u64_events: Mutex<Vec<Vec<(String, u64)>>>,
 }
 
@@ -153,44 +154,116 @@ impl TraceRecorder {
             .collect()
     }
 
-    /// Returns the current value of a gauge field, read the way the gauge
-    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
-    /// the greatest-`seq` event that records `field`. Arrival order is
-    /// never consulted among distinct `seq` values, so the read stays
-    /// correct even if dispatch order diverges from `seq` order; a `seq`
-    /// tie — impossible for a real runtime, whose `seq` strictly increases —
-    /// resolves to the first-arriving match. An event carrying `field`
-    /// without both a `seq` and a `runtime_id` is not a gauge snapshot and
-    /// is ignored; `None` when no event carries all three. The marker
-    /// names must match `GAUGE_EVENT_FIELDS` (`src/runtime/load.rs`), the
-    /// schema's source of truth, which a unit row holds to what
-    /// `GaugeSnapshot::dispatch` actually emits. Nothing binds these two
-    /// literals to that array — a coordinated rename makes this return
-    /// `None`, and the census's strict branch is what refuses it.
+    /// The named unsigned-integer fields of every event that records them,
+    /// grouped per event and ordered as named — the per-event view
+    /// [`Self::u64_values`] flattens away. Each name reads its event's
+    /// *first* occurrence, the way the snapshot fields are read, so a name
+    /// repeated in `fields` simply repeats its column. An event recording
+    /// none of the names is skipped, so the target's other event families
+    /// stay out of the result.
+    ///
+    /// Reading several fields this way rather than zipping as many
+    /// `u64_values` logs is what keeps a caller aligned with the schema:
+    /// `zip` pairs by position, truncates to its shortest input, and reports
+    /// no mismatch, so a field that stops riding every event shifts the
+    /// tuples or shortens the vector silently. Here a partial event fails,
+    /// by name.
+    ///
+    /// That alignment is what two or more names buy. With one name there is
+    /// nothing to align — the read is [`Self::u64_values`] narrowed to each
+    /// event's first occurrence — and with none there would be nothing to
+    /// read at all, which is a compile-time error rather than an empty
+    /// answer (see the const assertion in the body).
     ///
     /// # Panics
     ///
-    /// Panics when the matched events span more than one `runtime_id`,
-    /// since `seq` is comparable only within one runtime instance. An
-    /// event is matched when it carries `seq`, `runtime_id`, and the
-    /// queried field; every snapshot carries every count, so only an
-    /// instance that emits no snapshot at all stays outside the scan. The
-    /// panic message carries the remedies.
+    /// Panics when an event records some of `fields` but not all: such an
+    /// event has no aligned reading, and both ways of inventing one —
+    /// dropping it, or padding the missing name — are the silent
+    /// misalignment this accessor exists to refuse.
     #[must_use]
     #[track_caller]
     #[expect(
         clippy::panic,
-        reason = "a cross-instance read is test misuse, reported with the observed ids"
+        reason = "a partially recorded event is a schema break, reported with the event"
     )]
-    pub fn current_u64(&self, field: &str) -> Option<u64> {
+    pub fn u64_event_values<const N: usize>(&self, fields: [&str; N]) -> Vec<[u64; N]> {
+        // The one shape where "refuses a partial event" would degrade to
+        // silence: with no names every event records none of them, so the
+        // scan below would answer `vec![]` whatever the log holds — an empty
+        // trace that reads like a checked one. No row can pin that, since the
+        // answer is a value rather than a failure, so it is refused where the
+        // caller is written instead.
+        const { assert!(N > 0, "u64_event_values needs at least one field name") };
         let events = self
             .state
             .u64_events
             .lock()
             .expect("trace recorder u64 event log mutex should not be poisoned");
-        let mut runtime_id: Option<u64> = None;
-        let mut clash: Option<(u64, u64)> = None;
-        let mut current: Option<(u64, u64)> = None;
+        let mut rows: Vec<[u64; N]> = Vec::new();
+        let mut partial: Option<Vec<(String, u64)>> = None;
+        for event in events.iter() {
+            let values: Vec<u64> = fields
+                .iter()
+                .filter_map(|name| field_value(event, name))
+                .collect();
+            if values.is_empty() {
+                continue;
+            }
+            // At most one value per name, so a short vector is a name this
+            // event never recorded — never a name recorded twice.
+            let Ok(row) = <[u64; N]>::try_from(values.as_slice()) else {
+                partial = Some(event.clone());
+                break;
+            };
+            rows.push(row);
+        }
+        // Released before the panic below, so a failing guard reports its
+        // own message rather than poisoning the log for every later read.
+        drop(events);
+        if let Some(event) = partial {
+            let missing: Vec<&str> = fields
+                .into_iter()
+                .filter(|name| field_value(&event, name).is_none())
+                .collect();
+            panic!(
+                "u64_event_values({fields:?}) found an event recording only some of the \
+                 names: {missing:?} missing from {event:?}. A partial event has no \
+                 aligned reading — either a name here is not on this event's schema, or \
+                 a field stopped riding every event. The log holds a name only where the \
+                 event recorded it as a non-negative integer"
+            );
+        }
+        rows
+    }
+
+    /// Each observed runtime instance's current value of a gauge field,
+    /// keyed by `runtime_id`: the value on that instance's greatest-`seq`
+    /// event recording `field`. This is the gauge contract's read rule
+    /// (`src/runtime/load.rs`, "Ordering") in full — a subscriber watching
+    /// several runtimes in one process partitions by `runtime_id` first and
+    /// applies the max-`seq` rule inside each partition, since `seq` is
+    /// comparable only within one instance.
+    ///
+    /// Arrival order is never consulted among distinct `seq` values, so the
+    /// read stays correct even if dispatch order diverges from `seq` order;
+    /// a `seq` tie — impossible for a real runtime, whose `seq` strictly
+    /// increases — resolves to the first-arriving match. An event carrying
+    /// `field` without both a `seq` and a `runtime_id` is not a gauge
+    /// snapshot and is ignored; the map is empty when no event carries all
+    /// three. The marker names must match `GAUGE_EVENT_FIELDS`
+    /// (`src/runtime/load.rs`), the schema's source of truth, which a unit
+    /// row holds to what `GaugeSnapshot::dispatch` actually emits. Nothing
+    /// binds these two literals to that array — a coordinated rename empties
+    /// this map, and the census's strict branch is what refuses it.
+    #[must_use]
+    pub fn current_u64_by_runtime(&self, field: &str) -> BTreeMap<u64, u64> {
+        let events = self
+            .state
+            .u64_events
+            .lock()
+            .expect("trace recorder u64 event log mutex should not be poisoned");
+        let mut current: BTreeMap<u64, (u64, u64)> = BTreeMap::new();
         for event in events.iter() {
             // `seq` first: the target's non-snapshot events (the batch and
             // capacity-wait families) fail that lookup, so they skip the
@@ -203,32 +276,49 @@ impl TraceRecorder {
             else {
                 continue;
             };
-            match runtime_id {
-                None => runtime_id = Some(id),
-                Some(seen) if seen != id => {
-                    clash = Some((seen, id));
-                    break;
-                }
-                Some(_) => {}
-            }
-            if current.is_none_or(|(greatest, _)| seq > greatest) {
-                current = Some((seq, value));
+            let slot = current.entry(id).or_insert((seq, value));
+            if seq > slot.0 {
+                *slot = (seq, value);
             }
         }
-        // Released before the panic below, so a failing guard reports its
-        // own message rather than poisoning the log for every later read.
         drop(events);
-        if let Some((first, second)) = clash {
-            panic!(
-                "current_u64({field:?}) matched gauge events from at least two runtime \
-                 instances ({first} and {second}); `seq` is comparable only within one. \
-                 Restructure to observe one runtime per recorder (test-helper observers, \
-                 like `channel`'s throwaway, also count), read `u64_values` and partition \
-                 by `runtime_id` yourself, or — if the script minted no second observer — \
-                 treat it as a one-instance-per-run regression"
-            );
-        }
-        current.map(|(_, value)| value)
+        current
+            .into_iter()
+            .map(|(id, (_, value))| (id, value))
+            .collect()
+    }
+
+    /// Returns the current value of a gauge field, read the way the gauge
+    /// contract instructs (`src/runtime/load.rs`, "Ordering"): the value on
+    /// the greatest-`seq` event that records `field`. This is the
+    /// one-instance convenience over [`Self::current_u64_by_runtime`], and
+    /// inherits every property described there: the `seq` ordering, the tie,
+    /// and what counts as a gauge snapshot at all. `None` when no event
+    /// carries `field` beside both markers.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the matched events span more than one `runtime_id`,
+    /// since `seq` is comparable only within one runtime instance. An
+    /// event is matched when it carries `seq`, `runtime_id`, and the
+    /// queried field; every snapshot carries every count, so only an
+    /// instance that emits no snapshot at all stays outside the scan. The
+    /// panic message carries the remedies.
+    #[must_use]
+    #[track_caller]
+    pub fn current_u64(&self, field: &str) -> Option<u64> {
+        let current = self.current_u64_by_runtime(field);
+        assert!(
+            current.len() <= 1,
+            "current_u64({field:?}) matched gauge events from at least two runtime \
+             instances ({ids:?}); `seq` is comparable only within one. Restructure to \
+             observe one runtime per recorder (test-helper observers, like `channel`'s \
+             throwaway, also count), read `current_u64_by_runtime` and name the \
+             instance you mean, or — if the script minted no second observer — treat \
+             it as a one-instance-per-run regression",
+            ids = current.keys().copied().collect::<Vec<_>>()
+        );
+        current.into_values().next()
     }
 
     /// Returns all string values recorded for the named event field.
@@ -433,12 +523,12 @@ impl Visit for FieldVisitor {
 }
 
 // Mirrored from the src copy so each integration target that includes this
-// helper also pins its own copy's `current_u64` semantics — the two files
-// are duplicated by policy and drift silently otherwise. The src copy's
-// cross-instance `#[should_panic]` row is *not* mirrored: one copy pins
-// the guard's contract, and running it per target would add a deliberate
-// panic to every including binary for no new coverage of the same
-// source.
+// helper also pins its own copy's current-value and per-event reads — the
+// two files are duplicated by policy and drift silently otherwise. The src
+// copy's two `#[should_panic]` rows (the cross-instance read and the
+// partial event) are *not* mirrored: one copy pins each guard's contract,
+// and running them per target would add deliberate panics to every
+// including binary for no new coverage of the same source.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -470,5 +560,51 @@ mod tests {
              where the arrival-order read differs"
         );
         assert_eq!(recorder.current_u64("absent"), None);
+    }
+
+    // The partition half of the same rule: `seq` orders events only inside
+    // one `runtime_id`, so a reader watching several instances keeps one
+    // current value per instance.
+    #[test]
+    fn current_u64_by_runtime_reads_each_instance_by_its_own_seq() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        // Interleaved, with the greater `seq` on the instance whose current
+        // value is not the last to arrive: a read that compared `seq` across
+        // instances, or that took the latest arrival, gets both partitions
+        // wrong.
+        tracing::trace!(target: TARGET, runtime_id = 1u64, seq = 1u64, gauge = 3u64, "first instance");
+        tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 9u64, gauge = 7u64, "second instance, a greater seq");
+        tracing::trace!(target: TARGET, runtime_id = 1u64, seq = 2u64, gauge = 5u64, "first instance's own current value");
+        tracing::trace!(target: TARGET, runtime_id = 2u64, seq = 8u64, gauge = 0u64, "second instance, an earlier seq arriving later");
+        tracing::trace!(target: TARGET, gauge = 4u64, "no markers: not a snapshot");
+        tracing::trace!(target: TARGET, runtime_id = 3u64, seq = 1u64, other = 1u64, "a third instance, recording another field only");
+
+        assert_eq!(
+            recorder.current_u64_by_runtime("gauge"),
+            BTreeMap::from([(1, 5), (2, 7)]),
+            "each instance's greatest-seq reading, whatever arrived last and \
+             whatever `seq` another instance reached — and no key at all for \
+             the instance whose events never carried the field"
+        );
+        assert_eq!(recorder.current_u64_by_runtime("absent"), BTreeMap::new());
+    }
+
+    #[test]
+    fn u64_event_values_groups_fields_per_event() {
+        let recorder = TraceRecorder::new().with_target(TARGET);
+        let _guard = recorder.set_default();
+
+        tracing::trace!(target: TARGET, left = 1u64, right = 2u64, "both names");
+        tracing::trace!(target: TARGET, elsewhere = 9u64, "neither name: skipped, not padded");
+        tracing::trace!(target: TARGET, right = 4u64, left = 3u64, spare = 9u64, "recorded in the other order, beside a name not asked for");
+
+        assert_eq!(
+            recorder.u64_event_values(["left", "right"]),
+            vec![[1, 2], [3, 4]],
+            "one row per event recording the names, ordered as named rather \
+             than as the event recorded them"
+        );
     }
 }


### PR DESCRIPTION
Closes #332.

`TraceRecorder` has kept each event's unsigned-integer fields grouped since the `current_u64` migration, but nothing exposed that grouping — so the two consumers that need it re-derived it from the flattened per-field views.

## What was wrong

- **`gauge_trace` (`src/kernel/producer.rs`)** rebuilt its per-event `(subscriptions, unkeyed, keyed)` triples by positionally zipping three separately flattened `u64_values` vectors. `zip` pairs by index, truncates to its shortest input and reports no mismatch, so a count that stopped riding every snapshot would shift the triples or shorten the vector — and the two `is_empty()` rows beside it would then pass on an emission outage rather than on the absence they assert.
- **`gauge_seq_strictly_increases_within_each_runtime_id` (`src/runtime/load.rs`)** observes two `LoadObserver`s under one recorder on purpose, so it cannot call `current_u64` (the cross-instance guard panics). It re-implemented the contract's own read rule — partition by `runtime_id`, then take the greatest `seq` — beside the emitter it exists to hold to that rule.

## What this adds

- **`u64_event_values([...]) -> Vec<[u64; N]>`** — the named fields grouped per event, ordered as named. An event recording none of the names is skipped; one recording *some* of them panics, naming the missing field and the whole event. That is the alignment a zip could only assume.
- **`current_u64_by_runtime(field) -> BTreeMap<u64, u64>`** — the contract's read rule itself: one current value per `runtime_id`, each the greatest-`seq` reading among that instance's own events. `current_u64` is now the one-instance convenience over it, and its cross-instance panic names it as the remedy instead of telling the caller to partition by hand.

Both recorder copies get both accessors, per the duplication policy; `docs/testing.md` gains both rules.

## The trade #332 asks to decide

The contract row's recovery half now consumes the reader it justifies. What that gives up is recovered on both sides:

- the strict-increase half above it still builds its own partition from the raw per-event log, so the reader cannot cover for an emitter that stopped ordering; and
- the reader's own rule is pinned on scripted events in the recorder's unit rows, where no emitter is involved at all.

The per-event read there also settles something the old form could only assume: `u64_event_values(["runtime_id", "seq", "subscriptions", "keyed_commands"])` refuses a gauge event carrying only some of the four, which is the premise the recovery half rests on — that every gauge event carries every count. The old form checked it with a length assert per field, which narrows that assumption rather than removing it.

## Dispositions

- `each_observer_gets_its_own_runtime_id`, also named in the issue, is unchanged: it asserts arrival-order attribution over a single field. It hand-rolls nothing the new accessors provide, and a by-runtime map cannot express that claim.
- The issue's alternative shape — a raw `u64_events()` view — is not added. It would hand every caller the field matching back, which is the part being centralised; a caller that needs the whole event still has `field_name_sets`.

## Verification

`just pre-commit` green (fmt, clippy, the full test matrix, the loom mirrors, doctests), plus `RUSTDOCFLAGS=-D warnings cargo doc`.

Two mutations, both run:

1. Making the by-runtime read take the latest arrival instead of the greatest `seq` fails both recorder rows (`current_u64_reads_by_seq_not_by_arrival`, `current_u64_by_runtime_reads_each_instance_by_its_own_seq`). The load contract row keeps passing under it — its scripted emissions happen to arrive in `seq` order per instance — which is exactly why the reader's rule is pinned on its own scripted events and not on that row.
2. Dropping `keyed_commands` from `GaugeSnapshot::dispatch` now fails at the accessor, naming the missing field and the whole event, in the rows that would previously have compared a silently shortened trace.
