### PR TITLE
test(observability): enforce the gauge current-value read in the type

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,20 +143,58 @@ use trace_recorder::TraceRecorder;
 keeps unused tracing code out of integration-test targets that do not assert
 tracing output.
 
-Read a gauge's *current value* through `current_u64`, never through
-`u64_values(...).last()`: the gauge contract orders events by `seq`, not by
-arrival. The accessor assumes one runtime instance per recorder and
-panics otherwise; a deliberately multi-instance test reads
-`current_u64_by_runtime`, which applies the same greatest-`seq` rule inside
-each `runtime_id`'s own events and which `current_u64` is the one-instance
-convenience over. A row asserting something else about those events — their
-arrival order, or that `seq` strictly increases inside one partition — reads
-the log itself instead; `src/runtime/load.rs`'s two-instance rows do both.
-The rule covers the gauge snapshot's fields — the ones whose events carry
-a `seq`. Other unsigned-integer fields on the same target (`pulled`,
-`updated`, `shared_pending`, `wait_us`) are per-event readings with no
-current value to take; `current_u64` returns `None` for them, so keep those
-on `u64_values`.
+Read a gauge's *current value* through `current_u64`: the gauge contract
+orders events by `seq`, not by arrival. The accessor assumes one runtime
+instance per recorder and panics otherwise; a deliberately multi-instance
+test reads `current_u64_by_runtime`, which applies the same greatest-`seq`
+rule inside each `runtime_id`'s own events and which `current_u64` is the
+one-instance convenience over. The rule covers the gauge snapshot's fields —
+the ones whose events carry a `seq`. Other unsigned-integer fields on the
+same target (`pulled`, `updated`, `shared_pending`, `wait_us`) are per-event
+readings with no current value to take; `current_u64` returns `None` for
+them, so keep those on `u64_values`.
+
+`u64_values` returns `Readings`, not a `Vec<u64>`, and that is what keeps the
+arrival-order read out of a current-value assertion: the type publishes no
+positional read — no first, no last, no index, no slice, no iterator — so
+`u64_values(...).last()` does not compile. What stays open are the reads that
+ask what the log contains (`len`, `is_empty`, `contains`, `contains_nonzero`,
+`only`, `all_unique`, `all_equal`), and a row that needs one of those asks for
+it by name rather than reaching into the sequence: `tests/observability.rs`
+takes `all_equal` for one instance's shared `runtime_id` and `all_unique` for
+its distinct `seq` values, and `src/runtime/channel.rs` takes `only` for the
+lone `wait_us` reading it has just established.
+
+A row whose claim really is about arrival order names `arrival_order()` — or
+`into_arrival_order()` where it sorts the readings, indexes them after a move,
+or keeps them past the borrow. Two shapes qualify: an exact emission sequence
+(`src/runtime/load.rs` pinning `[3, 2, 1, 0]` as every value a subscriber saw)
+and a positional read into the log (the same file's `ids[0]` against `ids[2]`,
+or `src/kernel/conformance/quit.rs`'s suffix after a recorded offset).
+
+One grep for `arrival_order` enumerates the rows that take that dependency
+through `Readings`. It is not the whole list, and a divergence between dispatch
+order and `seq` order has to re-examine the rest as well: a row reading the same
+log through `u64_event_values` depends on arrival order while naming nothing.
+`src/runtime/load.rs`'s row that `seq` strictly increases inside one
+`runtime_id` builds its partitions by iterating the rows as they arrived, and
+`src/kernel/producer.rs`'s gauge trace compares exact arrival-order sequences.
+
+Two reads that look positional but are not: "this gauge never fired at all" is
+`is_empty()` on the log — `tests/lifecycle.rs`'s complement census, whose own
+comment says why it reads the log rather than the current value — and "the
+gauge rose while the producers ran" is `contains_nonzero()`, which the INV-LC7
+census takes. Neither needs the opt-out.
+
+The refusal is a rule about the type's surface, enforced by the compiler at
+every call site that goes through `u64_values`. Two paths stay outside it, and
+review is what holds them. An edit that added `last()` to `Readings` would pass
+the whole run. And `u64_event_values` (below) hands back plain `Vec<[u64; N]>`
+rows, where `.last()` still compiles — with a single name that accessor is
+`u64_values` narrowed to each event's first occurrence, so a current-value read
+written that way is the arrival-order read again, on a gauge field. Take the
+current value from `current_u64`, and keep `u64_event_values` for what it is
+for: reading several names off one event together.
 
 Read several fields of the *same* event through `u64_event_values([...])`
 rather than by zipping as many `u64_values` logs: the per-field logs are

--- a/src/kernel/conformance/observability.rs
+++ b/src/kernel/conformance/observability.rs
@@ -65,20 +65,23 @@ fn a_batch_reports_its_dequeues_its_updates_and_the_residue_it_left() {
         vec![1, 2],
         "the cap took two of the three"
     );
+    let pulled = recorder.u64_values("pulled");
     assert_eq!(
-        recorder.u64_values("pulled"),
-        vec![2],
-        "one batch event, for the one batch that pulled anything"
+        pulled.only(),
+        Some(2),
+        "one batch event, for the one batch that pulled anything: {pulled:?}"
     );
+    let updated = recorder.u64_values("updated");
     assert_eq!(
-        recorder.u64_values("updated"),
-        vec![2],
-        "both dequeues reached `update`"
+        updated.only(),
+        Some(2),
+        "both dequeues reached `update`: {updated:?}"
     );
+    let shared_pending = recorder.u64_values("shared_pending");
     assert_eq!(
-        recorder.u64_values("shared_pending"),
-        vec![1],
-        "and the third input is what it left in the data lane"
+        shared_pending.only(),
+        Some(1),
+        "and the third input is what it left in the data lane: {shared_pending:?}"
     );
 }
 
@@ -115,13 +118,20 @@ fn a_revoked_origin_s_envelope_is_pulled_without_being_updated() {
         vec![1],
         "the cancel applied, and the revoked origin's item never reached `update`"
     );
+    let pulled = recorder.u64_values("pulled");
     assert_eq!(
-        recorder.u64_values("pulled"),
-        vec![2],
-        "the discarded envelope is still a dequeue"
+        pulled.only(),
+        Some(2),
+        "the discarded envelope is still a dequeue: {pulled:?}"
     );
-    assert_eq!(recorder.u64_values("updated"), vec![1], "but not an update");
-    assert_eq!(recorder.u64_values("shared_pending"), vec![0]);
+    let updated = recorder.u64_values("updated");
+    assert_eq!(updated.only(), Some(1), "but not an update: {updated:?}");
+    let shared_pending = recorder.u64_values("shared_pending");
+    assert_eq!(
+        shared_pending.only(),
+        Some(0),
+        "and it left nothing in the data lane: {shared_pending:?}"
+    );
 }
 
 // The firing condition, unchanged by row 9 and the one thing the kernel's
@@ -543,7 +553,7 @@ fn blocked_send_channel(
         .step_pass(WakeSource::Data)
         .expect("the filler's send is in the lane");
     assert!(
-        recorder.u64_values("blocked").contains(&1),
+        recorder.u64_values("blocked").contains(1),
         "the released send found the lane full and waited, which is what this row measures"
     );
 

--- a/src/kernel/conformance/quit.rs
+++ b/src/kernel/conformance/quit.rs
@@ -514,7 +514,7 @@ fn a_discarded_quit_s_dequeue_retires_its_origin_with_the_kernel_still_running()
         );
     }
     let readings = recorder.u64_values(KEYED_GAUGE);
-    let recorded_since = &readings[readings_at_retirement..];
+    let recorded_since = &readings.arrival_order()[readings_at_retirement..];
     assert!(
         recorded_since.iter().all(|&count| count == 0),
         "the retirement holds through the drain: no reading recorded after it counts a keyed \

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -340,11 +340,18 @@ mod tests {
             "exactly one capacity-wait event, naming the data lane"
         );
         let waits = recorder.u64_values("wait_us");
-        assert_eq!(waits.len(), 1, "the immediate first send fired no event");
+        assert_eq!(
+            waits.len(),
+            1,
+            "the immediately accepted first send fires no capacity-wait event, so this row \
+             records exactly one wait: {waits:?}"
+        );
+        let wait = waits
+            .only()
+            .expect("the count above admits exactly one reading");
         assert!(
-            waits[0] >= 5_000,
-            "wait_us reflects the ~5ms blocked interval, got {}",
-            waits[0]
+            wait >= 5_000,
+            "wait_us reflects the ~5ms blocked interval, got {wait}"
         );
 
         // The `blocked` gauge rose while the send waited and fell once it was
@@ -352,7 +359,7 @@ mod tests {
         // abort-decrement below.
         let blocked = recorder.u64_values("blocked");
         assert!(
-            blocked.contains(&1),
+            blocked.contains(1),
             "blocked rose while the send waited: {blocked:?}"
         );
         assert_eq!(
@@ -417,7 +424,7 @@ mod tests {
 
         let blocked_values = recorder.u64_values("blocked");
         assert!(
-            blocked_values.contains(&1),
+            blocked_values.contains(1),
             "blocked rose while the send waited: {blocked_values:?}"
         );
         assert_eq!(

--- a/src/runtime/load.rs
+++ b/src/runtime/load.rs
@@ -670,8 +670,8 @@ mod tests {
         drop(first);
 
         assert_eq!(
-            recorder.u64_values("seq"),
-            vec![1, 2, 3, 4],
+            recorder.u64_values("seq").arrival_order(),
+            [1, 2, 3, 4],
             "each of the four gauge changes emits one event with the next `seq`"
         );
     }
@@ -694,7 +694,7 @@ mod tests {
         drop(second.track_subscription());
         drop(first_clone.track_subscription());
 
-        let ids = recorder.u64_values("runtime_id");
+        let ids = recorder.u64_values("runtime_id").into_arrival_order();
         assert_eq!(
             ids.len(),
             6,
@@ -825,7 +825,7 @@ mod tests {
         let second = LoadObserver::default();
         drop(second.track_subscription());
 
-        let ids = recorder.u64_values("runtime_id");
+        let ids = recorder.u64_values("runtime_id").into_arrival_order();
         assert_eq!(ids.len(), 4, "four gauge changes fired: {ids:?}");
         assert_ne!(
             ids[0], ids[2],
@@ -856,12 +856,13 @@ mod tests {
         let _guard = recorder.set_default();
         let fourth = observer.track_subscription();
 
+        let subscriptions = recorder.u64_values("subscriptions");
         assert_eq!(
-            recorder.u64_values("subscriptions"),
-            vec![3],
+            subscriptions.only(),
+            Some(3),
             "the first event after a subscriber attaches must report the true \
              current count (second, third, fourth still held), not a count \
-             that missed the unobserved changes"
+             that missed the unobserved changes: {subscriptions:?}"
         );
 
         drop(second);
@@ -869,8 +870,8 @@ mod tests {
         drop(fourth);
 
         assert_eq!(
-            recorder.u64_values("subscriptions"),
-            vec![3, 2, 1, 0],
+            recorder.u64_values("subscriptions").arrival_order(),
+            [3, 2, 1, 0],
             "every value reached while subscribed is still emitted, and the \
              count never wraps from an unmatched decrement"
         );
@@ -897,8 +898,8 @@ mod tests {
         drop(observer.track_subscription());
 
         assert_eq!(
-            recorder.u64_values("subscriptions"),
-            vec![1, 0],
+            recorder.u64_values("subscriptions").arrival_order(),
+            [1, 0],
             "a subscriber that only answers enabled() for genuine events must \
              still see both gauge changes"
         );
@@ -957,8 +958,8 @@ mod tests {
         drop(first);
 
         assert_eq!(
-            recorder.u64_values("subscriptions"),
-            vec![1, 2, 1, 0],
+            recorder.u64_values("subscriptions").arrival_order(),
+            [1, 2, 1, 0],
             "every reached value, including the peak of 2, is emitted in order"
         );
     }
@@ -977,11 +978,8 @@ mod tests {
             let _guard = at_trace.set_default();
             batch(1, 1, 0);
         }
-        assert_eq!(
-            at_trace.u64_values("pulled"),
-            vec![1],
-            "batch event is TRACE"
-        );
+        let pulled = at_trace.u64_values("pulled");
+        assert_eq!(pulled.only(), Some(1), "batch event is TRACE: {pulled:?}");
 
         let at_debug = TraceRecorder::new()
             .with_target("tears::runtime::load")
@@ -1011,11 +1009,8 @@ mod tests {
             let _guard = at_debug.set_default();
             LoadObserver::default().set_keyed_entries(1);
         }
-        assert_eq!(
-            at_debug.u64_values("keyed_commands"),
-            vec![1],
-            "gauge event is DEBUG"
-        );
+        let keyed = at_debug.u64_values("keyed_commands");
+        assert_eq!(keyed.only(), Some(1), "gauge event is DEBUG: {keyed:?}");
         {
             let _guard = at_trace.set_default();
             LoadObserver::default().set_keyed_entries(1);

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -8,6 +8,14 @@
 pub use async_utils::{assert_pending_until, gate_fetches, wait_until};
 pub use failing_backend::FailingBackend;
 pub use panic_hook::{HookProbe, hook_guard, on_thread, with_silent_panic_hook};
+// `Readings` (the `u64_values` return type) is deliberately not re-exported.
+// No crate-internal caller names it — call sites reach it through
+// `TraceRecorder::u64_values` and read it by method — and an unused
+// re-export fails the `-D warnings` gate on `unused_imports`. The
+// integration mirror needs no export at all: `#[path]` puts its module at
+// that target's crate root, where `tests/common/gauges.rs` names the type in
+// `producer_gauge_report`'s signature. Add the name here the first time a
+// crate-internal helper spells it out.
 pub use trace_recorder::{TraceRecorder, set_default_subscriber};
 
 mod async_utils;

--- a/src/test_support/trace_recorder.rs
+++ b/src/test_support/trace_recorder.rs
@@ -1,5 +1,5 @@
-use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::{self, Debug};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
@@ -108,20 +108,26 @@ impl TraceRecorder {
     }
 
     /// Returns all unsigned-integer values recorded for the named event field
-    /// (covers `u64` and `usize` fields).
+    /// (covers `u64` and `usize` fields), as [`Readings`] — which withholds
+    /// the positional reads a current-value assertion would reach for by
+    /// reflex. See that type for which reads stay open and how to name the
+    /// one that does not.
     #[must_use]
-    pub fn u64_values(&self, field: &str) -> Vec<u64> {
-        self.state
-            .u64_events
-            .lock()
-            .expect("trace recorder u64 event log mutex should not be poisoned")
-            .iter()
-            .flat_map(|event| {
-                // Every occurrence, not `field_value`'s first: the flattened
-                // log must not collapse a field a callsite recorded twice.
-                field_values(event, field)
-            })
-            .collect()
+    pub fn u64_values(&self, field: &str) -> Readings {
+        Readings::new(
+            self.state
+                .u64_events
+                .lock()
+                .expect("trace recorder u64 event log mutex should not be poisoned")
+                .iter()
+                .flat_map(|event| {
+                    // Every occurrence, not `field_value`'s first: the
+                    // flattened log must not collapse a field a callsite
+                    // recorded twice.
+                    field_values(event, field)
+                })
+                .collect(),
+        )
     }
 
     /// The named unsigned-integer fields of every event that records them,
@@ -144,6 +150,12 @@ impl TraceRecorder {
     /// event's first occurrence — and with none there would be nothing to
     /// read at all, which is a compile-time error rather than an empty
     /// answer (see the const assertion in the body).
+    ///
+    /// These rows are a plain `Vec`, so `.last()` compiles here even though
+    /// [`Readings`] refuses it. On a gauge field that read is the
+    /// arrival-order current value the contract forbids: take it from
+    /// [`Self::current_u64`] instead, and keep this accessor for what it is
+    /// for — reading the names on one event together.
     ///
     /// # Panics
     ///
@@ -312,6 +324,145 @@ impl TraceRecorder {
             .lock()
             .expect("trace recorder field-set log mutex should not be poisoned")
             .clone()
+    }
+}
+
+/// The readings one event field took, as the recorder's log holds them —
+/// the gauge counts, whose current value the contract below defines, and
+/// the per-event fields beside them (`pulled`, `wait_us`) that have no
+/// current value to take at all.
+///
+/// The gauge contract (`src/runtime/load.rs`, "Ordering") puts a gauge's
+/// current value on its greatest-`seq` event, and says arrival order
+/// matching `seq` order is an implementation coincidence no consumer may
+/// rely on. A plain `Vec<u64>` hands `.last()` to every caller as the
+/// ergonomic default, which puts the arrival-order read one keystroke from
+/// any current-value assertion — the read #318 removed from six files,
+/// and that nothing but a line of `docs/testing.md` then kept out.
+///
+/// So this type publishes no positional read: no first, no last, no index,
+/// no slice, no iterator. Its methods answer what the log *contains*, and a
+/// caller who means to observe the log *as a sequence* says so by name,
+/// through [`Self::arrival_order`] or [`Self::into_arrival_order`]. Those
+/// two and the `Debug` rendering are order-dependent by construction: they
+/// are the sanctioned way to depend on arrival order rather than exceptions
+/// to a wider claim. No method here takes a closure either, so evaluation
+/// order stays unobservable through a stateful predicate as well.
+///
+/// The current value is not on this type at all. It is
+/// [`TraceRecorder::current_u64`], which reads by `seq`.
+///
+/// The refusal reaches exactly the reads that come through this type, and
+/// the compiler applies it wherever such a call site is written. Two things
+/// stay outside it. A later edit could add `last()` to the impl below —
+/// nothing gates the surface itself. And [`TraceRecorder::u64_event_values`]
+/// reads the same log into plain rows, where `.last()` still compiles: with
+/// one name it is this accessor narrowed to each event's first occurrence,
+/// so a current-value read written that way is the arrival-order read again,
+/// on a gauge field. Both are held by review against this paragraph and
+/// `docs/testing.md`, not by the compiler.
+pub struct Readings(Vec<u64>);
+
+impl Readings {
+    /// Wraps a field's flattened log. Private to this helper, so a test
+    /// takes its readings from the recorder rather than minting them in an
+    /// order the runtime never emitted; the rows below build logs directly
+    /// because a boundary is a shape, not a run.
+    const fn new(values: Vec<u64>) -> Self {
+        Self(values)
+    }
+
+    /// How many readings the field recorded.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the field was never recorded — the "this gauge never fired"
+    /// claim, which is about the log itself and so has no current value to
+    /// read.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Whether some reading was `value`. By value rather than by
+    /// reference: `Readings` is not a slice and should not read like one,
+    /// and a `u64` is `Copy`.
+    #[must_use]
+    pub fn contains(&self, value: u64) -> bool {
+        self.0.contains(&value)
+    }
+
+    /// Whether some reading was above zero — "this gauge rose at some
+    /// point". `false` for an empty log, which is what a gauge that never
+    /// fired never did.
+    #[must_use]
+    pub fn contains_nonzero(&self) -> bool {
+        self.0.iter().any(|&value| value > 0)
+    }
+
+    /// The single reading, when the field recorded exactly one; `None` for
+    /// none, and `None` for several. A caller that has established a lone
+    /// reading takes it here rather than by index, so the "exactly one"
+    /// claim and the value it licenses stay in one place.
+    #[must_use]
+    pub fn only(&self) -> Option<u64> {
+        match *self.0.as_slice() {
+            [value] => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Whether no reading repeats. Vacuously `true` for an empty log and
+    /// for a single reading, which is what the sort-dedup-and-compare-lengths
+    /// idiom this replaces answers there. A row that must also refuse an
+    /// empty log asserts [`Self::is_empty`] beside this one: vacuity is its
+    /// own claim.
+    #[must_use]
+    pub fn all_unique(&self) -> bool {
+        let mut seen = HashSet::with_capacity(self.0.len());
+        self.0.iter().all(|value| seen.insert(*value))
+    }
+
+    /// Whether every reading agrees. Vacuously `true` on the same two
+    /// boundaries as [`Self::all_unique`], and for the same reason: it is
+    /// what the `windows(2)` comparison this replaces answers there.
+    #[must_use]
+    pub fn all_equal(&self) -> bool {
+        self.0.windows(2).all(|pair| pair[0] == pair[1])
+    }
+
+    /// The readings in the order they arrived — the opt-out, for a row
+    /// whose claim really is about arrival order: an exact emission
+    /// sequence, an index into it, a suffix of it.
+    ///
+    /// One grep for this name enumerates the rows that take that dependency
+    /// *through this type*, which is not the whole list. A row reading the
+    /// same log through [`TraceRecorder::u64_event_values`] depends on
+    /// arrival order while naming nothing: `src/runtime/load.rs`'s
+    /// strictly-increasing-`seq` row builds its per-`runtime_id` partitions
+    /// by iterating the rows as they arrived, and `src/kernel/producer.rs`'s
+    /// gauge trace compares exact arrival-order sequences. A divergence
+    /// between dispatch order and `seq` order has to re-examine both sets.
+    #[must_use]
+    pub fn arrival_order(&self) -> &[u64] {
+        &self.0
+    }
+
+    /// [`Self::arrival_order`] by value, for a caller that sorts the
+    /// readings, keeps them past the borrow, or indexes them after a move.
+    #[must_use]
+    pub fn into_arrival_order(self) -> Vec<u64> {
+        self.0
+    }
+}
+
+impl Debug for Readings {
+    /// Renders as the readings alone, so a failure message interpolating a
+    /// `Readings` reads exactly as it did when this was a `Vec<u64>`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
     }
 }
 
@@ -558,8 +709,8 @@ mod tests {
              lacks a runtime_id, and whichever of a seq tie arrived later"
         );
         assert_eq!(
-            recorder.u64_values("gauge"),
-            vec![5, 9, 7, 1, 8],
+            recorder.u64_values("gauge").arrival_order(),
+            [5, 9, 7, 1, 8],
             "while the flattened view keeps every value in arrival order — the last is exactly \
              where the arrival-order read differs"
         );
@@ -593,6 +744,134 @@ mod tests {
              the instance whose events never carried the field"
         );
         assert_eq!(recorder.current_u64_by_runtime("absent"), BTreeMap::new());
+    }
+
+    // The surface `Readings` publishes, boundaries included. Every answer
+    // below is the one the idiom it replaced already gave — `only` for a
+    // length check and an index, `all_unique` for sort-dedup-and-compare,
+    // `all_equal` for `windows(2)`, `contains_nonzero` for `any(> 0)` — so
+    // the migration moved no call site's meaning. Built through the private
+    // constructor: the recorder path is pinned by the row above, and these
+    // shapes (no reading, one, a repeat) are what a log's boundaries are.
+    #[test]
+    fn readings_answer_what_the_log_contains() {
+        let empty = Readings::new(vec![]);
+        let single = Readings::new(vec![7]);
+        let mixed = Readings::new(vec![0, 3, 0]);
+
+        assert_eq!(empty.only(), None, "no reading can be the only one");
+        assert_eq!(single.only(), Some(7), "the lone reading, without an index");
+        assert_eq!(
+            mixed.only(),
+            None,
+            "and three readings have no single one either — the claim `only` \
+             carries is `exactly one`, not `take the first`"
+        );
+
+        assert!(
+            empty.all_unique(),
+            "an empty log has no repeat, which is what sort-dedup-and-compare answered"
+        );
+        assert!(
+            empty.all_equal(),
+            "and no disagreement, which is what `windows(2)` answered"
+        );
+        assert!(single.all_unique(), "one reading cannot repeat");
+        assert!(single.all_equal(), "or disagree with itself");
+        assert!(!mixed.all_unique(), "the zero recurs");
+        assert!(!mixed.all_equal(), "and the three differs from it");
+        assert!(
+            Readings::new(vec![4, 4]).all_equal(),
+            "two agreeing readings agree"
+        );
+        assert!(
+            Readings::new(vec![4, 5]).all_unique(),
+            "and two differing ones are distinct"
+        );
+
+        assert!(
+            !empty.contains_nonzero(),
+            "a gauge that never fired never rose"
+        );
+        assert!(
+            !Readings::new(vec![0, 0]).contains_nonzero(),
+            "nor did one that only ever read zero"
+        );
+        assert!(mixed.contains_nonzero(), "the three is a rise");
+
+        assert!(mixed.contains(3), "a reading the log holds");
+        assert!(!mixed.contains(9), "and one it does not");
+        assert_eq!(mixed.len(), 3, "every occurrence, including the repeat");
+        assert!(empty.is_empty(), "no event carried the field");
+        assert!(!mixed.is_empty(), "while three readings did");
+        assert_eq!(
+            format!("{mixed:?}"),
+            "[0, 3, 0]",
+            "and the readings render as the log alone: a failure message that \
+             interpolates them reads as it did when this was a `Vec<u64>`"
+        );
+    }
+
+    // Order lives behind the opt-out, and nowhere else on the surface.
+    //
+    // Three of the reads can fail here, and the fixtures are picked so that
+    // they can: a pair whose first reading differs separates a
+    // `contains_nonzero` that consulted a position, and a pair that moves a
+    // repeat separates an `all_equal` that compared the ends and an
+    // `all_unique` that compared neighbours.
+    //
+    // The other four cannot be separated by any permutation, since they are
+    // determined by the log's length or by the set of its values, neither of
+    // which a permutation changes. `len` and `contains` ride along here as
+    // the count and membership reads; `only` and `is_empty` are left out
+    // rather than asserted vacuously. The row above pins all four.
+    //
+    // So this row documents intent for the reads it names; it is not a proof
+    // of the type's rule, since a method added later is outside every
+    // assertion here, and review against the type's docs is what covers that.
+    #[test]
+    fn only_the_arrival_order_reads_depend_on_order() {
+        for (forward, backward) in [
+            (Readings::new(vec![0, 3]), Readings::new(vec![3, 0])),
+            (Readings::new(vec![1, 2, 1]), Readings::new(vec![1, 1, 2])),
+        ] {
+            assert_eq!(
+                forward.len(),
+                backward.len(),
+                "a permuted log is as long: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.contains_nonzero(),
+                backward.contains_nonzero(),
+                "and rose in the same readings: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.all_unique(),
+                backward.all_unique(),
+                "with the same repeats: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.all_equal(),
+                backward.all_equal(),
+                "and the same disagreement: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.contains(3),
+                backward.contains(3),
+                "and holds the same readings: {forward:?} against {backward:?}"
+            );
+            assert_ne!(
+                forward.arrival_order(),
+                backward.arrival_order(),
+                "while the opt-out is exactly where the two logs differ"
+            );
+        }
+
+        assert_eq!(
+            Readings::new(vec![1, 2]).into_arrival_order(),
+            vec![1, 2],
+            "which the owned form hands over unchanged"
+        );
     }
 
     #[test]

--- a/tests/common/gauges.rs
+++ b/tests/common/gauges.rs
@@ -12,7 +12,7 @@
 //! item only one target needs (`no_producer_gauge_event_fired` lives in
 //! `lifecycle.rs` for this reason) stays with its caller.
 
-use crate::trace_recorder::TraceRecorder;
+use crate::trace_recorder::{Readings, TraceRecorder};
 
 /// The settling producer gauges RFC 0011 INV-LC7 reads — three of RFC 0006
 /// §4.4's four counts. `blocked`, the fourth, rides the same snapshot but
@@ -107,7 +107,7 @@ pub fn producer_gauges_rose(recorder: &TraceRecorder, expected_active: &[&str]) 
     for field in expected_active {
         let values = recorder.u64_values(field);
         assert!(
-            values.iter().any(|&value| value > 0),
+            values.contains_nonzero(),
             "the {field} gauge must have risen while this row's producers ran, \
              or its fall to zero witnesses nothing: {values:?}"
         );
@@ -173,7 +173,7 @@ pub fn producer_gauges_are_zero(recorder: &TraceRecorder, expected_active: &[&st
 #[must_use]
 pub fn producer_gauge_report(
     recorder: &TraceRecorder,
-) -> [(&'static str, Option<u64>, Vec<u64>); PRODUCER_GAUGES.len()] {
+) -> [(&'static str, Option<u64>, Readings); PRODUCER_GAUGES.len()] {
     PRODUCER_GAUGES.map(|field| {
         (
             field,
@@ -227,11 +227,12 @@ mod tests {
             blocked = 0u64,
             "producer gauges",
         );
+        let seqs = recorder.u64_values("seq");
         assert_eq!(
-            recorder.u64_values("seq"),
-            vec![1],
+            seqs.only(),
+            Some(1),
             "the premise: the marker reads above zero, so an unguarded rise \
-             check on it would pass"
+             check on it would pass: {seqs:?}"
         );
 
         producer_gauges_rose(&recorder, &["seq"]);

--- a/tests/common/trace_recorder.rs
+++ b/tests/common/trace_recorder.rs
@@ -9,8 +9,8 @@
     reason = "shared cross-target test helper; per-target usage varies (see module docs)"
 )]
 
-use std::collections::{BTreeMap, HashMap};
-use std::fmt::Debug;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::{self, Debug};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, OnceLock, PoisonError};
 
@@ -138,20 +138,26 @@ impl TraceRecorder {
     }
 
     /// Returns all unsigned-integer values recorded for the named event field
-    /// (covers `u64` and `usize` fields).
+    /// (covers `u64` and `usize` fields), as [`Readings`] — which withholds
+    /// the positional reads a current-value assertion would reach for by
+    /// reflex. See that type for which reads stay open and how to name the
+    /// one that does not.
     #[must_use]
-    pub fn u64_values(&self, field: &str) -> Vec<u64> {
-        self.state
-            .u64_events
-            .lock()
-            .expect("trace recorder u64 event log mutex should not be poisoned")
-            .iter()
-            .flat_map(|event| {
-                // Every occurrence, not `field_value`'s first: the flattened
-                // log must not collapse a field a callsite recorded twice.
-                field_values(event, field)
-            })
-            .collect()
+    pub fn u64_values(&self, field: &str) -> Readings {
+        Readings::new(
+            self.state
+                .u64_events
+                .lock()
+                .expect("trace recorder u64 event log mutex should not be poisoned")
+                .iter()
+                .flat_map(|event| {
+                    // Every occurrence, not `field_value`'s first: the
+                    // flattened log must not collapse a field a callsite
+                    // recorded twice.
+                    field_values(event, field)
+                })
+                .collect(),
+        )
     }
 
     /// The named unsigned-integer fields of every event that records them,
@@ -174,6 +180,12 @@ impl TraceRecorder {
     /// event's first occurrence — and with none there would be nothing to
     /// read at all, which is a compile-time error rather than an empty
     /// answer (see the const assertion in the body).
+    ///
+    /// These rows are a plain `Vec`, so `.last()` compiles here even though
+    /// [`Readings`] refuses it. On a gauge field that read is the
+    /// arrival-order current value the contract forbids: take it from
+    /// [`Self::current_u64`] instead, and keep this accessor for what it is
+    /// for — reading the names on one event together.
     ///
     /// # Panics
     ///
@@ -342,6 +354,145 @@ impl TraceRecorder {
             .lock()
             .expect("trace recorder field-set log mutex should not be poisoned")
             .clone()
+    }
+}
+
+/// The readings one event field took, as the recorder's log holds them —
+/// the gauge counts, whose current value the contract below defines, and
+/// the per-event fields beside them (`pulled`, `wait_us`) that have no
+/// current value to take at all.
+///
+/// The gauge contract (`src/runtime/load.rs`, "Ordering") puts a gauge's
+/// current value on its greatest-`seq` event, and says arrival order
+/// matching `seq` order is an implementation coincidence no consumer may
+/// rely on. A plain `Vec<u64>` hands `.last()` to every caller as the
+/// ergonomic default, which puts the arrival-order read one keystroke from
+/// any current-value assertion — the read #318 removed from six files,
+/// and that nothing but a line of `docs/testing.md` then kept out.
+///
+/// So this type publishes no positional read: no first, no last, no index,
+/// no slice, no iterator. Its methods answer what the log *contains*, and a
+/// caller who means to observe the log *as a sequence* says so by name,
+/// through [`Self::arrival_order`] or [`Self::into_arrival_order`]. Those
+/// two and the `Debug` rendering are order-dependent by construction: they
+/// are the sanctioned way to depend on arrival order rather than exceptions
+/// to a wider claim. No method here takes a closure either, so evaluation
+/// order stays unobservable through a stateful predicate as well.
+///
+/// The current value is not on this type at all. It is
+/// [`TraceRecorder::current_u64`], which reads by `seq`.
+///
+/// The refusal reaches exactly the reads that come through this type, and
+/// the compiler applies it wherever such a call site is written. Two things
+/// stay outside it. A later edit could add `last()` to the impl below —
+/// nothing gates the surface itself. And [`TraceRecorder::u64_event_values`]
+/// reads the same log into plain rows, where `.last()` still compiles: with
+/// one name it is this accessor narrowed to each event's first occurrence,
+/// so a current-value read written that way is the arrival-order read again,
+/// on a gauge field. Both are held by review against this paragraph and
+/// `docs/testing.md`, not by the compiler.
+pub struct Readings(Vec<u64>);
+
+impl Readings {
+    /// Wraps a field's flattened log. Private to this helper, so a test
+    /// takes its readings from the recorder rather than minting them in an
+    /// order the runtime never emitted; the rows below build logs directly
+    /// because a boundary is a shape, not a run.
+    const fn new(values: Vec<u64>) -> Self {
+        Self(values)
+    }
+
+    /// How many readings the field recorded.
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the field was never recorded — the "this gauge never fired"
+    /// claim, which is about the log itself and so has no current value to
+    /// read.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Whether some reading was `value`. By value rather than by
+    /// reference: `Readings` is not a slice and should not read like one,
+    /// and a `u64` is `Copy`.
+    #[must_use]
+    pub fn contains(&self, value: u64) -> bool {
+        self.0.contains(&value)
+    }
+
+    /// Whether some reading was above zero — "this gauge rose at some
+    /// point". `false` for an empty log, which is what a gauge that never
+    /// fired never did.
+    #[must_use]
+    pub fn contains_nonzero(&self) -> bool {
+        self.0.iter().any(|&value| value > 0)
+    }
+
+    /// The single reading, when the field recorded exactly one; `None` for
+    /// none, and `None` for several. A caller that has established a lone
+    /// reading takes it here rather than by index, so the "exactly one"
+    /// claim and the value it licenses stay in one place.
+    #[must_use]
+    pub fn only(&self) -> Option<u64> {
+        match *self.0.as_slice() {
+            [value] => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Whether no reading repeats. Vacuously `true` for an empty log and
+    /// for a single reading, which is what the sort-dedup-and-compare-lengths
+    /// idiom this replaces answers there. A row that must also refuse an
+    /// empty log asserts [`Self::is_empty`] beside this one: vacuity is its
+    /// own claim.
+    #[must_use]
+    pub fn all_unique(&self) -> bool {
+        let mut seen = HashSet::with_capacity(self.0.len());
+        self.0.iter().all(|value| seen.insert(*value))
+    }
+
+    /// Whether every reading agrees. Vacuously `true` on the same two
+    /// boundaries as [`Self::all_unique`], and for the same reason: it is
+    /// what the `windows(2)` comparison this replaces answers there.
+    #[must_use]
+    pub fn all_equal(&self) -> bool {
+        self.0.windows(2).all(|pair| pair[0] == pair[1])
+    }
+
+    /// The readings in the order they arrived — the opt-out, for a row
+    /// whose claim really is about arrival order: an exact emission
+    /// sequence, an index into it, a suffix of it.
+    ///
+    /// One grep for this name enumerates the rows that take that dependency
+    /// *through this type*, which is not the whole list. A row reading the
+    /// same log through [`TraceRecorder::u64_event_values`] depends on
+    /// arrival order while naming nothing: `src/runtime/load.rs`'s
+    /// strictly-increasing-`seq` row builds its per-`runtime_id` partitions
+    /// by iterating the rows as they arrived, and `src/kernel/producer.rs`'s
+    /// gauge trace compares exact arrival-order sequences. A divergence
+    /// between dispatch order and `seq` order has to re-examine both sets.
+    #[must_use]
+    pub fn arrival_order(&self) -> &[u64] {
+        &self.0
+    }
+
+    /// [`Self::arrival_order`] by value, for a caller that sorts the
+    /// readings, keeps them past the borrow, or indexes them after a move.
+    #[must_use]
+    pub fn into_arrival_order(self) -> Vec<u64> {
+        self.0
+    }
+}
+
+impl Debug for Readings {
+    /// Renders as the readings alone, so a failure message interpolating a
+    /// `Readings` reads exactly as it did when this was a `Vec<u64>`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
     }
 }
 
@@ -554,8 +705,8 @@ mod tests {
              lacks a runtime_id, and whichever of a seq tie arrived later"
         );
         assert_eq!(
-            recorder.u64_values("gauge"),
-            vec![5, 9, 7, 1, 8],
+            recorder.u64_values("gauge").arrival_order(),
+            [5, 9, 7, 1, 8],
             "while the flattened view keeps every value in arrival order — the last is exactly \
              where the arrival-order read differs"
         );
@@ -589,6 +740,134 @@ mod tests {
              the instance whose events never carried the field"
         );
         assert_eq!(recorder.current_u64_by_runtime("absent"), BTreeMap::new());
+    }
+
+    // The surface `Readings` publishes, boundaries included. Every answer
+    // below is the one the idiom it replaced already gave — `only` for a
+    // length check and an index, `all_unique` for sort-dedup-and-compare,
+    // `all_equal` for `windows(2)`, `contains_nonzero` for `any(> 0)` — so
+    // the migration moved no call site's meaning. Built through the private
+    // constructor: the recorder path is pinned by the row above, and these
+    // shapes (no reading, one, a repeat) are what a log's boundaries are.
+    #[test]
+    fn readings_answer_what_the_log_contains() {
+        let empty = Readings::new(vec![]);
+        let single = Readings::new(vec![7]);
+        let mixed = Readings::new(vec![0, 3, 0]);
+
+        assert_eq!(empty.only(), None, "no reading can be the only one");
+        assert_eq!(single.only(), Some(7), "the lone reading, without an index");
+        assert_eq!(
+            mixed.only(),
+            None,
+            "and three readings have no single one either — the claim `only` \
+             carries is `exactly one`, not `take the first`"
+        );
+
+        assert!(
+            empty.all_unique(),
+            "an empty log has no repeat, which is what sort-dedup-and-compare answered"
+        );
+        assert!(
+            empty.all_equal(),
+            "and no disagreement, which is what `windows(2)` answered"
+        );
+        assert!(single.all_unique(), "one reading cannot repeat");
+        assert!(single.all_equal(), "or disagree with itself");
+        assert!(!mixed.all_unique(), "the zero recurs");
+        assert!(!mixed.all_equal(), "and the three differs from it");
+        assert!(
+            Readings::new(vec![4, 4]).all_equal(),
+            "two agreeing readings agree"
+        );
+        assert!(
+            Readings::new(vec![4, 5]).all_unique(),
+            "and two differing ones are distinct"
+        );
+
+        assert!(
+            !empty.contains_nonzero(),
+            "a gauge that never fired never rose"
+        );
+        assert!(
+            !Readings::new(vec![0, 0]).contains_nonzero(),
+            "nor did one that only ever read zero"
+        );
+        assert!(mixed.contains_nonzero(), "the three is a rise");
+
+        assert!(mixed.contains(3), "a reading the log holds");
+        assert!(!mixed.contains(9), "and one it does not");
+        assert_eq!(mixed.len(), 3, "every occurrence, including the repeat");
+        assert!(empty.is_empty(), "no event carried the field");
+        assert!(!mixed.is_empty(), "while three readings did");
+        assert_eq!(
+            format!("{mixed:?}"),
+            "[0, 3, 0]",
+            "and the readings render as the log alone: a failure message that \
+             interpolates them reads as it did when this was a `Vec<u64>`"
+        );
+    }
+
+    // Order lives behind the opt-out, and nowhere else on the surface.
+    //
+    // Three of the reads can fail here, and the fixtures are picked so that
+    // they can: a pair whose first reading differs separates a
+    // `contains_nonzero` that consulted a position, and a pair that moves a
+    // repeat separates an `all_equal` that compared the ends and an
+    // `all_unique` that compared neighbours.
+    //
+    // The other four cannot be separated by any permutation, since they are
+    // determined by the log's length or by the set of its values, neither of
+    // which a permutation changes. `len` and `contains` ride along here as
+    // the count and membership reads; `only` and `is_empty` are left out
+    // rather than asserted vacuously. The row above pins all four.
+    //
+    // So this row documents intent for the reads it names; it is not a proof
+    // of the type's rule, since a method added later is outside every
+    // assertion here, and review against the type's docs is what covers that.
+    #[test]
+    fn only_the_arrival_order_reads_depend_on_order() {
+        for (forward, backward) in [
+            (Readings::new(vec![0, 3]), Readings::new(vec![3, 0])),
+            (Readings::new(vec![1, 2, 1]), Readings::new(vec![1, 1, 2])),
+        ] {
+            assert_eq!(
+                forward.len(),
+                backward.len(),
+                "a permuted log is as long: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.contains_nonzero(),
+                backward.contains_nonzero(),
+                "and rose in the same readings: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.all_unique(),
+                backward.all_unique(),
+                "with the same repeats: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.all_equal(),
+                backward.all_equal(),
+                "and the same disagreement: {forward:?} against {backward:?}"
+            );
+            assert_eq!(
+                forward.contains(3),
+                backward.contains(3),
+                "and holds the same readings: {forward:?} against {backward:?}"
+            );
+            assert_ne!(
+                forward.arrival_order(),
+                backward.arrival_order(),
+                "while the opt-out is exactly where the two logs differ"
+            );
+        }
+
+        assert_eq!(
+            Readings::new(vec![1, 2]).into_arrival_order(),
+            vec![1, 2],
+            "which the owned form hands over unchanged"
+        );
     }
 
     #[test]

--- a/tests/observability.rs
+++ b/tests/observability.rs
@@ -132,20 +132,30 @@ async fn producer_gauges_rise_and_fall_over_a_run() -> Result<()> {
         }
     }
 
+    // Both reads below are vacuously true on an empty log, and the census
+    // above does not rule one out: it reads the field-name sets, which record
+    // a name whatever type carried it, while these read the unsigned-integer
+    // log. A marker re-emitted as a string — or as a negative integer — would
+    // satisfy every assertion above and empty both reads, so each states its
+    // own non-emptiness first.
     let ids = recorder.u64_values("runtime_id");
     assert!(
-        ids.windows(2).all(|pair| pair[0] == pair[1]),
+        !ids.is_empty(),
+        "the gauge events above carry a runtime_id the unsigned-integer log can read"
+    );
+    assert!(
+        ids.all_equal(),
         "one run is one runtime instance, so its gauge events share one \
          runtime_id: {ids:?}"
     );
 
-    let mut seqs = recorder.u64_values("seq");
-    let emitted = seqs.len();
-    seqs.sort_unstable();
-    seqs.dedup();
-    assert_eq!(
-        seqs.len(),
-        emitted,
+    let seqs = recorder.u64_values("seq");
+    assert!(
+        !seqs.is_empty(),
+        "and a seq the unsigned-integer log can read"
+    );
+    assert!(
+        seqs.all_unique(),
         "no two gauge events of one runtime may share a seq: {seqs:?}"
     );
 


### PR DESCRIPTION
Closes #334.

## What

`TraceRecorder::u64_values` returned a `Vec<u64>`, so `.last()` was the ergonomic
default at every call site and the arrival-order read sat one keystroke from any
current-value assertion. The gauge contract (`src/runtime/load.rs`, "Ordering")
puts the current value on the greatest-`seq` event and says arrival order matching
`seq` order is a coincidence no consumer may rely on, so that read is a contract
violation that compiles and passes today. #318 removed it from six files; what kept
it out since was a line of `docs/testing.md` and nothing else.

The accessor now returns `Readings`, which publishes no positional read — no first,
no last, no index, no slice, no iterator — so the reflex path does not compile. The
reads that ask what the log *contains* stay open (`len`, `is_empty`, `contains`,
`contains_nonzero`, `only`, `all_unique`, `all_equal`), and no method takes a
closure, so evaluation order is not observable through a stateful predicate either.
A row whose claim really is about arrival order names `arrival_order()` or
`into_arrival_order()`.

## Migration

Fourteen call sites that looked positional but were not take a named content read:
ten assertions on a one-reading log become `only`, and a lone reading behind a
length check, a rise check, a shared `runtime_id` and distinct `seq` values take
`only`, `contains_nonzero`, `all_equal` and `all_unique`. What stays on the opt-out
is what means it — four exact emission sequences, two index reads, one suffix — so
a grep for `arrival_order` lists those rather than a majority of false positives.
Each converted site keeps its diagnostic: every `only()` interpolates the readings,
which the exact-vector compare used to print.

`tests/observability.rs` also gains the non-emptiness guards its two reads need:
both are vacuously true on an empty log, and the field-name census above cannot
rule that out, since it records a name whatever type carried it while these read
the unsigned-integer log.

## What is enforced, and what is not

The compiler covers call sites that go through `u64_values`, in every target. Three
paths stay on review and are named where they live:

- an edit could add `last()` to `Readings` itself;
- `u64_event_values` returns plain rows where `.last()` compiles — with one name it
  is `u64_values` narrowed, so its own documentation now says a current value is not
  read that way;
- rows that iterate those rows depend on arrival order without naming it, which is
  why `arrival_order`'s documentation points at the two that do (`src/runtime/load.rs`'s
  strictly-increasing-`seq` row, `src/kernel/producer.rs`'s gauge trace).

`test_support` is `#[cfg(test)]`, so there is no public-API or SemVer impact, and
no RFC changes: the gauge ordering contract is untouched — only how a test reaches
a value it already defines.

## Verification

- `just pre-commit` green (`fmt-check`, `clippy -D warnings`, `test --all-targets`,
  `clippy-loom`, `test-mirrors`, `test-doc`).
- Negative check, by temporary probe: `u64_values(f).last()` → E0599 "`Readings` is
  not an iterator", `.iter()` → E0599, `[0]` → E0608. The probe was reverted and is
  not part of the diff; the refusal itself is not under test (`trybuild` was
  considered and declined — snapshot diagnostics drift on the `beta` leg of the
  matrix, for a `cfg(test)`-only internal type).
- Mutation check on the permutation row's fixtures: `contains_nonzero` rewritten to
  read the first reading, `all_equal` to compare the ends, and `all_unique` to
  compare neighbours each fail the row.
- Both mirrors received a byte-identical `Readings` block and rows; their
  pre-existing intentional differences are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)