### PR TITLE
docs: sync the dependency snippets with the released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Tears supports optional features that can be enabled in your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tears = { version = "0.8", features = ["ws", "rustls"] }
+tears = { version = "0.11", features = ["ws", "rustls"] }
 ```
 
 - **`ws`**: Enables WebSocket subscription support
@@ -312,7 +312,7 @@ tears = { version = "0.8", features = ["ws", "rustls"] }
 
 ```toml
 [dependencies]
-tears = { version = "0.8", features = ["http"] }
+tears = { version = "0.11", features = ["http"] }
 ```
 
 - **`http`**: Enables HTTP Query and Mutation support

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tears = { version = "0.9", features = ["ws", "native-tls"] }
+//! tears = { version = "0.11", features = ["ws", "native-tls"] }
 //! ```
 //!
 //! Enables `subscription::websocket::WebSocket`. Requires a TLS feature for `wss://`:
@@ -86,7 +86,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tears = { version = "0.9", features = ["http"] }
+//! tears = { version = "0.11", features = ["http"] }
 //! ```
 //!
 //! Enables `subscription::http` with Query and Mutation support.

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -32,7 +32,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tears = { version = "0.9", features = ["ws"] }
+//! tears = { version = "0.11", features = ["ws"] }
 //! ```
 //!
 //! ## TLS Support
@@ -47,7 +47,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tears = { version = "0.9", features = ["ws", "native-tls"] }
+//! tears = { version = "0.11", features = ["ws", "native-tls"] }
 //! ```
 
 use futures::stream::{BoxStream, SplitSink, SplitStream};


### PR DESCRIPTION
## What

Every `tears = { version = "..." }` snippet a reader can copy now names
`0.11`, matching the install snippet and the crate:

| File | Section | Was |
| --- | --- | --- |
| `README.md` | WebSocket Support | `0.8` |
| `README.md` | HTTP Support | `0.8` |
| `src/lib.rs` | WebSocket Support | `0.9` |
| `src/lib.rs` | HTTP Support | `0.9` |
| `src/subscription/websocket.rs` | Feature Flag | `0.9` |
| `src/subscription/websocket.rs` | TLS Support | `0.9` |

`grep -rn 'tears = ' README.md src/` returns seven lines and they now agree.

## Why

They fell behind one release at a time, not all at once:

| Release | Snippets moved |
| --- | --- |
| `v0.5.0` … `0.8` (each minor) | all of them |
| `0.9.0` (`fc0202c`) | five of seven — the README's two left at `0.8` |
| `0.10.0`, `0.11.0` | the install snippet only — the four in rustdoc left at `0.9` |
| every patch bump | none, correctly: the snippets pin `X.Y` |

Each stale snippet resolves to a crate whose API the surrounding
documentation no longer describes. `0.8` predates `RuntimeConfig` and
`CommandId`. `0.9` predates the reducer-first core and takes a second
`Runtime::new` argument that the surrounding examples do not pass — so the
crate-root page currently tells a reader to depend on a version its own
example does not compile against.

## Scope

Text only: every changed block is ` ```toml `, which rustdoc does not run as
a doctest, and no Rust item is touched. Historical version strings are
deliberately untouched — the changelog, the migration guide and the RFCs
name the release they describe.

Nothing here prevents the drift from recurring. That needs a written release
procedure, of which there is none in the repository today; #350 adds one.

## Verification

- `cargo fmt --all -- --check` clean
- `typos` clean
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` clean over the full
  user-facing feature set (which is what compiles the `websocket` module
  docs at all)
- `just test-doc` green (73 doctests, plus the migration guide's 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)