### PR TITLE
docs(migrations): count the edits a guide takes, and say which are silent

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -26,14 +26,28 @@ which of these changes reaches me, and how do I tell?
   snippets are compiled by `cargo test --doc` and cannot drift from the API.
   It adds no public module, so it can be deleted once the release it covers is
   far enough back.
-- **Adding a guide takes two edits, not one.** Besides the `include_str!` in
-  `src/lib.rs`, add the file to `include` in `Cargo.toml` — named
-  individually, so the maintainer-facing files here (this README) stay out of
-  the package. Miss it and nothing fails until someone runs `cargo test --doc`
-  against the *published* crate: `cargo publish` verifies with `cargo build`,
-  which drops the `cfg(doctest)` item before the macro runs. `just
-  test-doc-packaged` reproduces the published tree and is what the CI
-  `doctest` job runs; removing a guide means removing both edits.
+- **Adding a guide is four edits besides the file itself, and only one of
+  them fails loudly.** Removing a guide undoes the first three; the fourth
+  is repointed rather than removed.
+
+  - `include_str!` in `src/lib.rs`, under `cfg(doctest)`.
+  - The file in `include` in `Cargo.toml`, named individually so the
+    maintainer-facing files here (this README) stay out of the package.
+    **This is the loud one**, and only just: nothing fails until someone
+    runs `cargo test --doc` against the *published* crate, because `cargo
+    publish` verifies with `cargo build`, which drops the `cfg(doctest)`
+    item before the macro runs. `just test-doc-packaged` reproduces the
+    published tree and is what the CI `doctest` job runs.
+  - A row in the index below. Miss it and nothing fails at all — the guide
+    is merely unfindable from here.
+  - A pointer from the release's own `CHANGELOG.md` section, which is where
+    an upgrading reader starts and the only one of these paths they are
+    likely to be on. 0.11.0's is the blockquote above its `Added` list, and
+    it is repo-relative. Nothing reports this one either. When the guide is
+    eventually deleted, repoint this link at the release's tag rather than
+    dropping it: the entry describes a past release and stays as it was
+    written, and that release's published notes already link the guide
+    there.
 - "Before" snippets are marked `ignore`; they describe an API that is gone.
   Where "this no longer builds" is the point being taught, use `compile_fail`
   against the current API instead.


### PR DESCRIPTION
## What

`docs/migrations/README.md` claimed that adding a migration guide "takes two
edits, not one". It takes four besides the guide file, and the two the count
missed are the two that nothing reports.

| Edit | What catches it missing |
| --- | --- |
| `include_str!` in `src/lib.rs`, under `cfg(doctest)` | the guide simply is not in rustdoc |
| the file in `include` in `Cargo.toml` | `just test-doc-packaged`, and only against the published crate |
| a row in this file's index table | nothing |
| a pointer from the release's `CHANGELOG.md` section | nothing |

They are enumerated rather than counted now. A count is what went stale
here, so replacing it with a larger count would repeat the mistake.

## Evidence

`7156ba6` — the only guide this repository has ever added — touched the
guide, `src/lib.rs`, this file's index table and `CHANGELOG.md`. The
`Cargo.toml` `include` entry followed separately in `d9180bc`, which is
itself the shape of the problem: the edit the old text called out as the
missable one was in fact missed, and the doctest job is what found it.

The changelog pointer matters most and is guarded least. 0.11.0's is the
blockquote above its `Added` list, and it is the only one of these paths an
upgrading reader is actually on.

## Removal is not the symmetric operation

The old text ended "removing a guide means removing both edits". Extending
that to four would collide with the rule that changelog entries describe a
past release and stay as they were written — and with the published release
notes, which already link the guide at its tag, a URL that survives the file
being deleted from `main`. So removal undoes three and repoints the fourth.

## Why this is its own PR

It was part of #350 (the release procedure), which cites this file rather
than restating it. That PR is being rewritten from scratch; this correction
has been stable across four review rounds and does not depend on it.

## Verification

All four edits confirmed present in the tree: `src/lib.rs:172-173`, the
individually-named `/docs/migrations/0.10-to-0.11.md` in `Cargo.toml`'s
`include`, the index row, and `CHANGELOG.md:12-16`. `gh release view
v0.11.0` confirms the published notes carry the tag-pinned absolute URL the
"repoint rather than drop" advice relies on. `typos` clean; this file is not
packaged, so nothing here reaches the crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)