### PR TITLE
docs(migrations): say where the include entry actually fails

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ include = [
     "benches/**/*",
     # `src/lib.rs` pulls this guide in with `include_str!` under
     # `cfg(doctest)`. `cargo publish` verifies with `cargo build`, which drops
-    # the item before the macro runs, so leaving it out breaks
-    # `cargo test --doc` in the published crate and nowhere earlier; the
-    # `doctest` job packages and extracts the crate to catch that.
+    # the item before the macro runs, so publishing itself never notices this
+    # entry missing; what does is `just test-doc-packaged`, which packages and
+    # extracts the crate and runs the doctests inside it — runnable here
+    # before committing, and run by CI's `doctest` job either way.
     # Named file by file rather than `docs/migrations/**/*`, which would also
     # ship `docs/migrations/README.md` — a maintainer policy index, not crate
     # content.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -32,12 +32,14 @@ which of these changes reaches me, and how do I tell?
 
   - `include_str!` in `src/lib.rs`, under `cfg(doctest)`.
   - The file in `include` in `Cargo.toml`, named individually so the
-    maintainer-facing files here (this README) stay out of the package.
-    **This is the loud one**, and only just: nothing fails until someone
-    runs `cargo test --doc` against the *published* crate, because `cargo
-    publish` verifies with `cargo build`, which drops the `cfg(doctest)`
-    item before the macro runs. `just test-doc-packaged` reproduces the
-    published tree and is what the CI `doctest` job runs.
+    maintainer-facing files here (this README) stay out of the package. **This
+    is the loud one**, and only because a recipe exists to make it so.
+    Publishing does not notice: `cargo publish` verifies with `cargo build`,
+    which drops the `cfg(doctest)` item before the macro expands, so the
+    verification build never looks for the file at all. What does catch it is
+    `just test-doc-packaged`, which reproduces the packaged tree and runs the
+    doctests inside it, and which the CI `doctest` job runs — so a missing
+    entry fails in CI rather than at publication.
   - A row in the index below. Miss it and nothing fails at all — the guide
     is merely unfindable from here.
   - A pointer from the release's own `CHANGELOG.md` section, which is where


### PR DESCRIPTION
## What

One bullet in `docs/migrations/README.md` placed a failure somewhere it does
not happen, and contradicted its own next sentence doing it.

Before:

> **This is the loud one**, and only just: nothing fails until someone runs
> `cargo test --doc` against the *published* crate, because `cargo publish`
> verifies with `cargo build`, which drops the `cfg(doctest)` item before the
> macro runs. `just test-doc-packaged` reproduces the published tree and is
> what the CI `doctest` job runs.

Both halves cannot hold. `just test-doc-packaged` packages the crate,
extracts it, and runs the doctests inside the result, and `ci.yml`'s
`doctest` job runs that recipe — on `pull_request` as well as `push`
(`ci.yml:4-7`, `ci.yml:351`). So a missing `include` entry fails on the PR
that drops it, not after publication.

`Cargo.toml`'s `include` comment carried the identical claim ("and nowhere
earlier", immediately followed by the job that catches it earlier), and is
the copy a maintainer editing that list actually has open. It is corrected
here too — fixing one of two copies would have left the wrong one at the
point of use.

Neither copy names CI's triggers. An earlier revision of this PR restated
them in both files, which review caught as the same two-copies drift the
bullet exists to repair — `ci.yml` is the only source of truth, nothing
checks a prose copy of it, and the restatement was already wrong (`push`
filters the pushed ref, not a base). What a reader of the `include` list
needs is that CI's `doctest` job catches this; the trigger matrix adds a
drift surface and nothing actionable. `justfile:190-193` deliberately names
no trigger either.

## Why the sentence existed

The distinction it was reaching for is real, and is kept: no ordinary build
notices. `cargo publish` verifies with `cargo build`, which drops the
`cfg(doctest)` item before the macro runs, so the entry is missed right
through to the published crate. What catches it is that one recipe. The
bullet now says that, instead of relocating the failure to publish time.

## Why it matters here

The list this bullet sits in exists to sort the four edits by what reports
them missing — the other three are reported by nothing. A reader who takes
this one as post-publish has no reason to treat the packaged-doctest job as
load-bearing, which inverts the point the list is making.

## Provenance

I introduced this phrasing in #352 by carrying it forward from the text that
bullet replaced, without re-checking it — the same failure mode #350
documents, on the very PR correcting that bullet. It surfaced in review of
#350, which cites this file.

## Verification

`ci.yml:4-7` triggers on `pull_request`; `ci.yml:351` runs
`just test-doc-packaged`; the recipe runs `cargo package --no-verify
--allow-dirty`, extracts the `.crate`, and runs `cargo test --doc` inside
it. `typos` clean. This file is not packaged, so nothing here reaches the
crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

