### PR TITLE
docs: write dashboard.rs a second time, with composed reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,27 @@ Create custom subscriptions by implementing the `SubscriptionSource` trait.
 
 ## Examples
 
-Check out the [`examples/`](examples/) directory for more examples:
+Check out the [`examples/`](examples/) directory. They fall into two groups,
+and each group is named after what a reader arrives knowing.
+
+### Application structure
+
+Named after the application, because someone choosing a structure knows the
+shape of their problem and not yet the name of the API. Read them in order:
+each one is the previous one at the next scale.
 
 - [`counter.rs`](examples/counter.rs) - A simple counter with timer and keyboard input
-- [`panic_hook.rs`](examples/panic_hook.rs) - Restoring the terminal on panic with `install_panic_hook`
 - [`views.rs`](examples/views.rs) - Multiple view states with navigation and conditional subscriptions
-- [`dashboard.rs`](examples/dashboard.rs) - Structured state management with nested state and child messages
+- [`dashboard.rs`](examples/dashboard.rs) - Structured state management, with the root owning the wiring
+- [`dashboard_composed.rs`](examples/dashboard_composed.rs) - The same application with composed reducers: a keyed collection of child reducers, an optionally-present child, automatic scope application and teardown of removed children
+
+### Framework features
+
+Named after the API item they demonstrate, because that is what a reader
+arrives looking for. `http_todo.rs` carries both, as a feature that needs a
+real application to be worth showing.
+
+- [`panic_hook.rs`](examples/panic_hook.rs) - Restoring the terminal on panic with `install_panic_hook`
 - [`signals.rs`](examples/signals.rs) - OS signal handling with graceful shutdown (SIGINT, SIGTERM, etc.)
 - [`command_timeout_retry.rs`](examples/command_timeout_retry.rs) - Enforcing a `Command` deadline with `timeout` and recovering from failures with `retry`
 - [`command_cancellation.rs`](examples/command_cancellation.rs) - Cancelling superseded in-flight commands with `cancellable`/`cancellable_with` and `CancelPolicy`
@@ -246,9 +261,10 @@ Run an example:
 
 ```bash
 cargo run --example counter
-cargo run --example panic_hook
 cargo run --example views
 cargo run --example dashboard
+cargo run --example dashboard_composed
+cargo run --example panic_hook
 cargo run --example signals
 cargo run --example command_timeout_retry
 cargo run --example command_cancellation
@@ -287,6 +303,14 @@ runnable tests ship with these examples:
 cargo test --example command_timeout_retry
 cargo test --example command_cancellation
 cargo test --example dashboard
+```
+
+A composed `Program` is driven with `tears::testing::TestDriver` rather than
+`TestStore`, which takes an `Application`; `examples/dashboard_composed.rs`
+carries two worked `TestDriver` tests:
+
+```bash
+cargo test --example dashboard_composed
 ```
 
 Repository-wide test conventions live in [docs/testing.md](docs/testing.md).

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ cargo test --example dashboard
 
 A composed `Program` is driven with `tears::testing::TestDriver` rather than
 `TestStore`, which takes an `Application`; `examples/dashboard_composed.rs`
-carries two worked `TestDriver` tests:
+carries worked `TestDriver` tests:
 
 ```bash
 cargo test --example dashboard_composed

--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ feature, one child per row of a `Keyed` collection, or an optionally-present
 child in a `Slot` — and `into_program` closes the stack into a runnable
 `Program` for `ProgramRuntime`. Every boundary qualifies the identities its
 child produces with its own segment, so rows declaring the same subscription or
-keying the same command do not collide. The two that hold a collection —
-`for_each` and `presented` — additionally tear a removed child's runs down, so
-no removal leaks a run; `scope` composes one child in place, where there is no
-collection for an instance to leave.
+keying the same command do not collide. The two whose child can leave —
+`for_each` over a `Keyed` collection and `presented` over a `Slot` —
+additionally tear a departed child's runs down, so no removal leaks a run;
+`scope` composes one child in place, and that child is always there.
 
 An `Application` is run through an adapter over the same kernel, so this is a
 way to write a program rather than a second runtime. See

--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ cargo test --example command_cancellation
 cargo test --example dashboard
 ```
 
-A composed `Program` is driven with `tears::testing::TestDriver` rather than
-`TestStore`, which takes an `Application`; `examples/dashboard_composed.rs`
-carries worked `TestDriver` tests:
+`TestStore` takes an `Application`, so a composed `Program` is driven with
+`tears::testing::TestDriver` instead; `examples/dashboard_composed.rs` carries
+worked `TestDriver` tests:
 
 ```bash
 cargo test --example dashboard_composed

--- a/README.md
+++ b/README.md
@@ -231,10 +231,12 @@ A `Reducer` owns one state transition and the subscriptions that state declares.
 `scope`, `for_each` and `presented` compose one under a parent — a sibling
 feature, one child per row of a `Keyed` collection, or an optionally-present
 child in a `Slot` — and `into_program` closes the stack into a runnable
-`Program` for `ProgramRuntime`. Each boundary qualifies the identities its child
-produces with its own segment and tears a removed child's runs down, so rows
-declaring the same subscription or keying the same command do not collide and no
-removal leaks a run.
+`Program` for `ProgramRuntime`. Every boundary qualifies the identities its
+child produces with its own segment, so rows declaring the same subscription or
+keying the same command do not collide. The two that hold a collection —
+`for_each` and `presented` — additionally tear a removed child's runs down, so
+no removal leaks a run; `scope` composes one child in place, where there is no
+collection for an instance to leave.
 
 An `Application` is run through an adapter over the same kernel, so this is a
 way to write a program rather than a second runtime. See
@@ -250,8 +252,9 @@ and each group is named after what a reader arrives knowing.
 ### Application structure
 
 Named after the application, because someone choosing a structure knows the
-shape of their problem and not yet the name of the API. Read them in order:
-each one is the previous one at the next scale.
+shape of their problem and not yet the name of the API. The first three are a
+scale, each one the previous grown; the fourth is the third one rewritten, so
+read it beside `dashboard.rs` rather than after it.
 
 - [`counter.rs`](examples/counter.rs) - A simple counter with timer and keyboard input
 - [`views.rs`](examples/views.rs) - Multiple view states with navigation and conditional subscriptions

--- a/README.md
+++ b/README.md
@@ -225,6 +225,23 @@ Tears follows **The Elm Architecture (TEA)** pattern:
 
 Create custom subscriptions by implementing the `SubscriptionSource` trait.
 
+### Composing Reducers
+
+A `Reducer` owns one state transition and the subscriptions that state declares.
+`scope`, `for_each` and `presented` compose one under a parent — a sibling
+feature, one child per row of a `Keyed` collection, or an optionally-present
+child in a `Slot` — and `into_program` closes the stack into a runnable
+`Program` for `ProgramRuntime`. Each boundary qualifies the identities its child
+produces with its own segment and tears a removed child's runs down, so rows
+declaring the same subscription or keying the same command do not collide and no
+removal leaks a run.
+
+An `Application` is run through an adapter over the same kernel, so this is a
+way to write a program rather than a second runtime. See
+[docs/composition.md](docs/composition.md) for when the rewrite is worth it, and
+[`examples/dashboard_composed.rs`](examples/dashboard_composed.rs) for
+`dashboard.rs` written the other way.
+
 ## Examples
 
 Check out the [`examples/`](examples/) directory. They fall into two groups,

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -86,6 +86,15 @@ the root reducer, so the root keeps exactly the messages that are its own.
   instance's scope. The removed instance's subscriptions stop, its in-flight
   commands are cancelled, and the cleanup hooks it registered run.
 
+- **It discards what it cannot route.** A message addressed to a key the
+  collection no longer holds, or to a slot with no occupant, reaches no reducer
+  and is dropped — with no diagnostic, and with no way for the sender to learn
+  it went nowhere. That is reachable from ordinary code: a root that returns
+  `Command::message` for a row, and an update that removes the row before the
+  message is delivered, leaves the row's work simply not done. Where that
+  matters, keep the decision and the work in one reduce rather than splitting
+  them across a message.
+
 Building initial state records nothing: `Keyed::from_iter` and an insert into an
 absent key remove no instance, so growing a collection during `init` is fine.
 The four shapes that *do* record belong inside a `reduce`, where the boundary

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -138,15 +138,14 @@ itself.
 `TestStore` takes an `Application`, so a composed program is driven with
 `tears::testing::TestDriver` instead: it constructs from the same inputs the
 production entry point takes, boots the program, and steps whole passes, with
-the sends a producer makes released one grant at a time. Four tests in
-`dashboard_composed.rs` drive that example's own stack that way — the same
-`Reducer` value `main` runs, closed with the same `init` and `view`, and started
-from a `Setup` carrying a scripted input instead of the binary's seed. They are
-the ones whose names begin `identical_child_identities`, `every_removal`,
-`a_repeated_setup_message` and `replacing_a_row`, and they are the shape to
-copy. The rest of that file's rows call the root reducer and the key decoder
-directly, which is a cheaper loop and a different claim: it never crosses a
-boundary, so it would pass with the composition taken out.
+the sends a producer makes released one grant at a time. The rows in
+`dashboard_composed.rs` that build a `TestDriver` drive that example's own stack
+that way — the same `Reducer` value `main` runs, closed with the same `init` and
+`view`, and started from a `Setup` carrying a scripted input instead of the
+binary's seed. They are the shape to copy. The rest of that file's rows call the
+root reducer and the key decoder directly, which is a cheaper loop and a
+different claim: it never crosses a boundary, so it would pass with the
+composition taken out.
 
 Two observations are worth designing tests around, because they are what
 composition changes:

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -1,0 +1,139 @@
+# Composing Reducers
+
+`Application` and the composition API describe the same program. An
+`Application` is run through an adapter that makes the application value the
+state and `update` the `reduce`, on the same kernel a composed program runs on,
+so moving between them changes how a program is *written* and not how it is
+executed.
+
+This guide is about when that rewrite pays for itself. The worked example is
+one application written both ways: [`examples/dashboard.rs`](../examples/dashboard.rs)
+with the root owning the wiring, and
+[`examples/dashboard_composed.rs`](../examples/dashboard_composed.rs) with
+boundaries owning it. The reference for each item is the
+[`tears::reducer`](https://docs.rs/tears/latest/tears/reducer/) module.
+
+## Keep the `Application`
+
+A single `Application` is the right shape while the root can still answer
+every question about the whole program:
+
+- One state struct, or a root struct whose child structs are plain data the
+  root updates directly.
+- A `Message` enum the root matches exhaustively, forwarding child variants by
+  hand where it helps (`dashboard.rs` is this, at the size where it still reads
+  well).
+- Commands and subscriptions whose identities the root can keep distinct by
+  choosing distinct values — one timer per interval, one command id per
+  concern.
+
+Nothing here is improved by adding boundaries. `TestStore` drives an
+`Application` directly, which is the shortest test loop the crate offers.
+
+## Move to composed reducers
+
+The signal is not size, it is **repeated identities**. Compose when a child
+feature exists in more than one instance at a time, or comes and goes:
+
+- **A collection of children.** Every row wants the same subscription and the
+  same command id, and only the row it belongs to tells two of them apart.
+- **An optionally-present child.** A modal, a detail pane, an editor: its
+  subscriptions must start when it appears and stop when it is dismissed or
+  replaced, and the replacement's runs must not inherit the old occupant's.
+- **A child you want to write once and place twice.** A reducer over its own
+  state and message type is complete on its own; the boundary supplies the
+  projection and the message mapping at each placement.
+
+Hand-written, the first two are where the bugs are. Removing a row means
+remembering every command id and subscription that row had; replacing a modal
+means tearing down the old occupant *before* the new one starts. Both are
+correct-by-omission problems: the code that forgets them still compiles, still
+passes single-instance tests, and leaks a run per removal.
+
+## The three boundaries
+
+Each combinator wraps a parent reducer and one child, and the result is still a
+reducer over the root's state and message — which is why they chain.
+
+| Combinator | Child state lives in | Segment |
+| --- | --- | --- |
+| `scope` | a field of the parent's state | a fixed value you choose |
+| `for_each` | a `Keyed<K, ChildState>` | the row's key |
+| `presented` | a `Slot<ChildState>` | a fixed value you choose |
+
+`into_program` closes the stack with the two root-level functions composition
+has no place for: `init` and `view`.
+
+A child with no commands and no subscriptions of its own has no identities to
+qualify, so `scope` buys it code organisation rather than separation — which is
+a fine reason to reach for it, and a reason not to expect anything more.
+
+The outermost boundary sees a message first. What no boundary claims reaches
+the root reducer, so the root keeps exactly the messages that are its own.
+
+## What a boundary does, so you do not
+
+- **It qualifies identities.** Everything identity-bearing in the command a
+  child returned — spawn keys, explicit cancels, cleanup registrations — and
+  every subscription the child declares is qualified with that boundary's
+  segment. Two rows declaring the same timer are two subscriptions; two rows
+  keyed on the same command id occupy two slots. Application code writes no
+  `.scoped(...)`, and cannot omit or double-apply one.
+- **It tears removed instances down.** `Keyed` and `Slot` record a removal when
+  one happens — `Keyed::remove`, `Slot::dismiss`, and the two replacing shapes,
+  `Keyed::insert` over an occupied key and `Slot::present` over an occupied slot
+  — and the boundary turns each recorded removal into one teardown of that
+  instance's scope. The removed instance's subscriptions stop, its in-flight
+  commands are cancelled, and the cleanup hooks it registered run.
+
+Building initial state records nothing: `Keyed::from_iter` and an insert into an
+absent key remove no instance, so growing a collection during `init` is fine.
+The four shapes that *do* record belong inside a `reduce`, where the boundary
+drains them in the same update.
+
+## Three things stay at the root
+
+**`view` does.** `Reducer` has no `view` and only `Program` does: pane layout,
+draw order and area allocation are decisions about the whole frame, so
+composing child views is ordinary function calls over the root state.
+
+**`init`'s command does.** It is the root's command and crosses no boundary, so
+nothing it starts is scoped to a child. Work that belongs to a child — the
+first fetch, a cleanup hook that must anchor at the child's scope — starts as a
+message routed *through* the boundary. In the worked example that is
+`TaskMessage::Watch`: the root inserts the row and returns
+`Command::message(Message::Task(id, TaskMessage::Watch))`, and the row's own
+reduce registers its hook.
+
+The same rule explains `Command::on_teardown`'s placement. A registration
+anchors at the scope of the boundary it is built at, and one built at the root
+anchors where no teardown reaches it.
+
+**Work that spans two children does.** A child is handed its own projected
+state and nothing else, so it can reach neither the collection it sits beside
+nor the slot it sits in. Anything that touches two of them is a root message.
+In the worked example that is `Message::SaveNotes`: the details pane's edited
+notes are written onto the task the pane was opened for by the root, which then
+asks the row to sync through the boundary rather than starting that command
+itself.
+
+## Testing a composition
+
+`TestStore` takes an `Application`, so a composed program is driven with
+`tears::testing::TestDriver` instead: it constructs from the same inputs the
+production entry point takes, boots the program, and steps whole passes, with
+the sends a producer makes released one grant at a time. The two tests in
+`dashboard_composed.rs` drive that example's own stack — the same `Reducer`
+value `main` runs, closed with the same `init` and `view`, and started from a
+`Setup` carrying a scripted input instead of the binary's seed — and are the
+shape to copy.
+
+Two observations are worth designing tests around, because they are what
+composition changes:
+
+- The run identities a step started, which is where "these two rows did not
+  collide" is visible.
+- A cleanup hook's own side effect. `Command::on_teardown` takes a future whose
+  `Output` is `()`, so a finalizer sends no message; give it a sink the test can
+  read, and let the view render the same sink if the application wants to show
+  it.

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -138,11 +138,15 @@ itself.
 `TestStore` takes an `Application`, so a composed program is driven with
 `tears::testing::TestDriver` instead: it constructs from the same inputs the
 production entry point takes, boots the program, and steps whole passes, with
-the sends a producer makes released one grant at a time. The tests in
-`dashboard_composed.rs` drive that example's own stack — the same `Reducer`
-value `main` runs, closed with the same `init` and `view`, and started from a
-`Setup` carrying a scripted input instead of the binary's seed — and are the
-shape to copy.
+the sends a producer makes released one grant at a time. Four tests in
+`dashboard_composed.rs` drive that example's own stack that way — the same
+`Reducer` value `main` runs, closed with the same `init` and `view`, and started
+from a `Setup` carrying a scripted input instead of the binary's seed. They are
+the ones whose names begin `identical_child_identities`, `every_removal`,
+`a_repeated_setup_message` and `replacing_a_row`, and they are the shape to
+copy. The rest of that file's rows call the root reducer and the key decoder
+directly, which is a cheaper loop and a different claim: it never crosses a
+boundary, so it would pass with the composition taken out.
 
 Two observations are worth designing tests around, because they are what
 composition changes:

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -91,7 +91,7 @@ absent key remove no instance, so growing a collection during `init` is fine.
 The four shapes that *do* record belong inside a `reduce`, where the boundary
 drains them in the same update.
 
-## Three things stay at the root
+## What stays at the root
 
 **`view` does.** `Reducer` has no `view` and only `Program` does: pane layout,
 draw order and area allocation are decisions about the whole frame, so
@@ -105,12 +105,13 @@ message routed *through* the boundary. In the worked example that is
 `Command::message(Message::Task(id, TaskMessage::Watch))`, and the row's own
 reduce registers its hook.
 
-**Handle such a setup message idempotently.** Nothing guarantees it arrives
-once — a second key press decided against a state the first message has not
-been applied to yet produces a second — and a teardown fires *every*
-registration its scope holds, so a child that arms on each one reports two
-teardowns for one removal. A flag on the child's state is enough; the successor
-instance a replacement creates gets a fresh one.
+Such a setup message has to be handled *idempotently* by the child, which is
+the child's side of the same rule. Nothing guarantees it arrives once — a
+second key press decided against a state the first message has not been applied
+to yet produces a second — and a teardown fires *every* registration its scope
+holds, so a child that arms on each one reports two teardowns for one removal.
+A flag on the child's state is enough; the successor instance a replacement
+creates gets a fresh one.
 
 The same rule explains `Command::on_teardown`'s placement. A registration
 anchors at the scope of the boundary it is built at, and one built at the root
@@ -129,7 +130,7 @@ itself.
 `TestStore` takes an `Application`, so a composed program is driven with
 `tears::testing::TestDriver` instead: it constructs from the same inputs the
 production entry point takes, boots the program, and steps whole passes, with
-the sends a producer makes released one grant at a time. The two tests in
+the sends a producer makes released one grant at a time. The tests in
 `dashboard_composed.rs` drive that example's own stack — the same `Reducer`
 value `main` runs, closed with the same `init` and `view`, and started from a
 `Setup` carrying a scripted input instead of the binary's seed — and are the

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -85,7 +85,6 @@ the root reducer, so the root keeps exactly the messages that are its own.
   — and the boundary turns each recorded removal into one teardown of that
   instance's scope. The removed instance's subscriptions stop, its in-flight
   commands are cancelled, and the cleanup hooks it registered run.
-
 - **It discards what it cannot route.** A message addressed to a key the
   collection no longer holds, or to a slot with no occupant, reaches no reducer
   and is dropped — with no diagnostic, and with no way for the sender to learn

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -105,6 +105,13 @@ message routed *through* the boundary. In the worked example that is
 `Command::message(Message::Task(id, TaskMessage::Watch))`, and the row's own
 reduce registers its hook.
 
+**Handle such a setup message idempotently.** Nothing guarantees it arrives
+once — a second key press decided against a state the first message has not
+been applied to yet produces a second — and a teardown fires *every*
+registration its scope holds, so a child that arms on each one reports two
+teardowns for one removal. A flag on the child's state is enough; the successor
+instance a replacement creates gets a fresh one.
+
 The same rule explains `Command::on_teardown`'s placement. A registration
 anchors at the scope of the boundary it is built at, and one built at the root
 anchors where no teardown reaches it.

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -665,6 +665,16 @@ mod tests {
         Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
     }
 
+    /// The same for the release a terminal that reports both would send after
+    /// it.
+    fn key_release(code: KeyCode) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new_with_kind(
+            code,
+            KeyModifiers::empty(),
+            KeyEventKind::Release,
+        )))
+    }
+
     /// Sending the child message directly walks focus through the panels.
     #[test]
     fn focus_next_cycles_through_panels() {
@@ -734,6 +744,40 @@ mod tests {
         store.send(key(KeyCode::Char('q')));
         store.receive_matching(|msg| matches!(msg, Message::Quit));
         store.receive_quit();
+        store.finish();
+    }
+
+    /// The details panel is a text field, so 'q' is a character there rather
+    /// than a request to quit. Tab is how you leave that focus.
+    #[test]
+    fn quit_key_is_text_while_the_details_panel_has_focus() {
+        let mut store = TestStore::<App>::new(());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+        let notes = store.state().details.notes.clone();
+
+        store.send(key(KeyCode::Char('q')));
+        store.receive_matching(|msg| matches!(msg, Message::Details(DetailMessage::Input('q'))));
+
+        assert_eq!(store.state().details.notes, format!("{notes}q"));
+        store.finish();
+    }
+
+    /// A terminal that reports releases as well as presses sends two events
+    /// per keystroke. Only the press is an instruction.
+    #[test]
+    fn a_key_release_asks_for_nothing() {
+        let mut store = TestStore::<App>::new(());
+        assert_eq!(store.state().focus, Focus::Navigation);
+
+        store.send(key_release(KeyCode::Tab));
+
+        assert_eq!(
+            store.state().focus,
+            Focus::Navigation,
+            "the release is not a second Tab"
+        );
         store.finish();
     }
 }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -168,10 +168,9 @@ impl Application for App {
             // Not releases. A terminal that reports them — Windows, or a
             // session with the kitty keyboard protocol on — sends two events
             // for one press, and the second would be acted on. A *repeat* is
-            // kept, and is the other thing entirely: a held key is repetition
-            // the reader is asking for. Testing for `Press` would drop those
-            // with the releases, and a held Down would move the selection
-            // once.
+            // kept: a held key is repetition the reader is asking for, and
+            // testing for `Press` would drop those with the releases, leaving
+            // a held Down to move the selection once.
             Message::Terminal(Event::Key(key)) if key.kind != KeyEventKind::Release => {
                 return handle_key_event(self.focus, key);
             }
@@ -654,8 +653,9 @@ impl StatusState {
     }
 }
 
-/// Every binding here is for an unmodified key. Raw mode delivers no SIGINT, so
-/// a reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
+/// Every binding here is for an unmodified key, apart from a shifted character,
+/// which is how an uppercase letter arrives. Raw mode delivers no SIGINT, so a
+/// reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
 /// bound to — clearing the activity log — and Ctrl+D would have deleted a task.
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     // The way out of raw mode, from any focus: the details editor holds `q`
@@ -663,14 +663,18 @@ fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
         return Command::message(Message::Quit).into();
     }
-    // Every binding below is for an unmodified key, so a chord this
-    // application does not bind is answered here rather than falling through
-    // to the bare key's. Above the match and not on the character arms,
-    // because `Enter`, `Up`/`Down`, `Tab` and `Esc` arrive with modifiers too.
-    if key
-        .modifiers
-        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-    {
+    // Every binding below is for an unmodified key, with one exception: a
+    // shifted character on its way into the details editor, which is how an
+    // uppercase letter arrives. Anything else carrying a modifier is a chord
+    // this application does not bind and must not fall through to the bare
+    // key's. Testing for `CONTROL` and `ALT` alone leaves four of the six
+    // through — Shift+Down would move the task selection. Letting `SHIFT`
+    // through generally is no better: it would reach the task bindings, where
+    // `d` deletes.
+    let shifted_text = focus == Focus::Details
+        && matches!(key.code, KeyCode::Char(_))
+        && key.modifiers == KeyModifiers::SHIFT;
+    if !key.modifiers.is_empty() && !shifted_text {
         return Command::none();
     }
     match key.code {
@@ -897,13 +901,14 @@ mod tests {
         store.finish();
     }
 
-    /// A `CONTROL` chord runs no bare-key binding, and Ctrl+C leaves.
+    /// A modified key runs no bare-key binding, and Ctrl+C leaves.
     ///
     /// Raw mode delivers no SIGINT, so Ctrl+C arrives as an ordinary key
     /// event; without the guard it would have cleared the activity log, and
-    /// Ctrl+D would have deleted the selected task.
+    /// Ctrl+D would have deleted the selected task. Shift+Down would have moved
+    /// the selection.
     #[test]
-    fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
+    fn a_modified_key_runs_no_bare_binding_and_ctrl_c_leaves() {
         let mut store = TestStore::<App>::new(ExitReason::default());
         store.send(Message::FocusNext);
         assert_eq!(store.state().focus, Focus::Tasks);
@@ -919,7 +924,13 @@ mod tests {
             KeyCode::Tab,
             KeyCode::Down,
         ] {
-            for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+            for modifiers in [
+                KeyModifiers::CONTROL,
+                KeyModifiers::ALT,
+                KeyModifiers::SHIFT,
+                KeyModifiers::SUPER,
+                KeyModifiers::META,
+            ] {
                 store.send(chord_with(code, modifiers));
             }
         }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -254,7 +254,7 @@ impl App {
                     task.notes.clone_from(&self.details.notes);
                     self.activity
                         .push(format!("updated notes for {}", task.title));
-                    self.status.set_info("Saved task notes");
+                    self.status.set_info(outcome.status);
                 } else {
                     // Silence here would leave the footer reporting the edit
                     // that was not saved.
@@ -976,6 +976,30 @@ mod tests {
             store.state().status.message,
             "No task selected",
             "the save wrote nothing and says so"
+        );
+        store.finish();
+    }
+
+    /// Saving reports through the outcome the panel returned rather than a
+    /// copy of it, so the two cannot drift.
+    #[test]
+    fn saving_reports_the_panel_s_own_status() {
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+
+        store.send(Message::Details(DetailMessage::Input('x')));
+        store.send(Message::Details(DetailMessage::Save));
+
+        assert!(
+            store.state().tasks.tasks[0].notes.ends_with('x'),
+            "the edit reached the task"
+        );
+        assert_eq!(
+            store.state().status.message,
+            "Saved task notes",
+            "and the footer says what the panel asked it to"
         );
         store.finish();
     }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -686,7 +686,7 @@ impl StatusState {
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     // The way out of raw mode, from any focus: the details editor holds `q`
     // but nothing holds this.
-    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+    if key.code == KeyCode::Char('c') && key.modifiers == KeyModifiers::CONTROL {
         return Command::message(Message::Quit).into();
     }
     // Every binding below is for an unmodified key, with one exception: a
@@ -994,20 +994,15 @@ mod tests {
         );
 
         // A delete that deleted nothing is the same case as a move that moved
-        // nothing, and the message kind cannot tell them apart.
-        store.send(Message::FocusNext);
-        store.send(Message::FocusNext);
-        store.send(Message::FocusNext);
+        // nothing, and the message kind cannot tell them apart. The messages
+        // below are sent directly, so no focus is walked: only
+        // `handle_key_event` reads it.
         for _ in 0..3 {
             store.send(Message::Tasks(TaskMessage::Delete));
         }
         assert!(store.state().tasks.tasks.is_empty());
-        store.send(Message::FocusNext);
-        store.send(Message::FocusNext);
         store.send(Message::Details(DetailMessage::Input('y')));
         let typed = store.state().details.notes.clone();
-        store.send(Message::FocusNext);
-        store.send(Message::FocusNext);
 
         store.send(Message::Tasks(TaskMessage::Delete));
 
@@ -1021,6 +1016,26 @@ mod tests {
             typed,
             "so the edit is still there"
         );
+        store.finish();
+    }
+
+    /// Ctrl+C leaves, and only Ctrl+C.
+    ///
+    /// A chord that merely *contains* `CONTROL` is one this application does
+    /// not bind, so it asks for nothing — `finish` is the assertion, since it
+    /// fails on output left unaccounted for and a quit request is output.
+    #[test]
+    fn a_chord_that_merely_contains_control_is_not_the_quit() {
+        let mut store = TestStore::<App>::new(ExitReason::default());
+
+        for modifiers in [
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            KeyModifiers::CONTROL | KeyModifiers::SUPER,
+        ] {
+            store.send(chord_with(KeyCode::Char('c'), modifiers));
+        }
+
         store.finish();
     }
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -296,13 +296,7 @@ impl App {
     }
 
     fn render_header(frame: &mut Frame, area: Rect, focus: Focus) {
-        // `q` is text while the details editor has it, so the hint follows the
-        // guard in `handle_key_event` rather than contradicting it.
-        let text = if focus == Focus::Details {
-            "Dashboard state example | Tab: leave the editor"
-        } else {
-            "Dashboard state example | Tab: focus | q: quit"
-        };
+        let text = header_text(focus);
         let block = Block::default()
             .borders(Borders::ALL)
             .title("Structured State");
@@ -558,6 +552,21 @@ impl DetailOutcome {
             status: status.into(),
             action: DetailAction::Reset,
         }
+    }
+}
+
+/// The header, which names a quit that works at the focus it is read from.
+///
+/// `q` is text while the details editor has it, so the hint follows the guard
+/// in `handle_key_event` rather than contradicting it. Dropping `q` there left
+/// no quit named at all: `Tab` and then `q` still works, but `Ctrl+C` is the
+/// one that does not ask the reader to leave first, and raw mode means the
+/// application is the only thing that can answer it.
+const fn header_text(focus: Focus) -> &'static str {
+    if matches!(focus, Focus::Details) {
+        "Dashboard state example | Tab: leave the editor | Ctrl+C: quit"
+    } else {
+        "Dashboard state example | Tab: focus | q: quit"
     }
 }
 
@@ -830,6 +839,38 @@ mod tests {
             KeyModifiers::empty(),
             kind,
         )))
+    }
+
+    /// The header names a quit that answers where it is read.
+    ///
+    /// `q` is text once the editor has the focus, so the header stops naming it
+    /// there — and naming only `Tab` left that focus with no quit named at all.
+    /// This reads the key each branch offers rather than trusting the two to
+    /// stay in step with the guard in `handle_key_event`.
+    #[test]
+    fn the_header_names_a_quit_that_answers_where_it_is_read() {
+        assert!(
+            header_text(Focus::Tasks).contains("q: quit"),
+            "away from the editor the header offers `q`"
+        );
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(key(KeyCode::Char('q')));
+        store.receive_matching(|msg| matches!(msg, Message::Quit));
+        store.receive_quit();
+        store.finish();
+
+        assert!(
+            header_text(Focus::Details).contains("Ctrl+C: quit"),
+            "in the editor it offers the chord instead, because `q` is text"
+        );
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+        store.send(chord(KeyCode::Char('c')));
+        store.receive_matching(|msg| matches!(msg, Message::Quit));
+        store.receive_quit();
+        store.finish();
     }
 
     /// The panel's hint names only keys that work where it is read.

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -901,6 +901,28 @@ mod tests {
         store.finish();
     }
 
+    /// A terminal error leaves a reason behind, because the quit that follows
+    /// it leaves nowhere to draw the report.
+    ///
+    /// `main` prints the recorded line after restoring the terminal. What this
+    /// row holds is the half the application owns: that the reason is written
+    /// down at all, rather than lost with the screen.
+    #[test]
+    fn a_terminal_error_leaves_a_reason_behind() {
+        let reason = ExitReason::default();
+        let mut store = TestStore::<App>::new(reason.clone());
+
+        store.send(Message::TerminalError("broken pipe".to_owned()));
+        store.receive_quit();
+
+        assert_eq!(
+            reason.take().as_deref(),
+            Some("broken pipe"),
+            "the reason is left where `main` can still read it"
+        );
+        store.finish();
+    }
+
     /// A modified key runs no bare-key binding, and Ctrl+C leaves.
     ///
     /// Raw mode delivers no SIGINT, so Ctrl+C arrives as an ordinary key

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -171,7 +171,7 @@ impl Application for App {
         ])
         .areas(body);
 
-        Self::render_header(frame, header);
+        Self::render_header(frame, header, self.focus);
         self.navigation
             .render(frame, nav_area, self.focus == Focus::Navigation);
         self.tasks
@@ -232,8 +232,14 @@ impl App {
         self.status.set_info("Cleared activity log");
     }
 
-    fn render_header(frame: &mut Frame, area: Rect) {
-        let text = "Dashboard state example | Tab: focus | q: quit";
+    fn render_header(frame: &mut Frame, area: Rect, focus: Focus) {
+        // `q` is text while the details editor has it, so the hint follows the
+        // guard in `handle_key_event` rather than contradicting it.
+        let text = if focus == Focus::Details {
+            "Dashboard state example | Tab: leave the editor"
+        } else {
+            "Dashboard state example | Tab: focus | q: quit"
+        };
         let block = Block::default()
             .borders(Borders::ALL)
             .title("Structured State");

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -20,7 +20,7 @@
 //! Run with: cargo run --example dashboard
 
 use color_eyre::eyre::Result;
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
 use tears::prelude::*;
@@ -226,6 +226,10 @@ impl App {
                     self.activity
                         .push(format!("updated notes for {}", task.title));
                     self.status.set_info("Saved task notes");
+                } else {
+                    // Silence here would leave the footer reporting the edit
+                    // that was not saved.
+                    self.status.set_info("No task selected");
                 }
             }
             // Esc throws the edits away and reads the selected task again,
@@ -612,8 +616,19 @@ impl StatusState {
     }
 }
 
+/// Every bare-character binding here excludes `CONTROL`. Raw mode delivers no
+/// SIGINT, so a reader pressing Ctrl+C to leave would otherwise have run
+/// whatever `c` is bound to — clearing the activity log — and Ctrl+D would have
+/// deleted a task.
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
+    let control = key.modifiers.contains(KeyModifiers::CONTROL);
     match key.code {
+        // The way out of raw mode, from any focus: the details editor holds
+        // `q` but nothing holds this.
+        KeyCode::Char('c') if control => Command::message(Message::Quit).into(),
+        // Anything else with `CONTROL` on is a chord this application has no
+        // binding for, and it must not fall through to the bare key's.
+        KeyCode::Char(_) if control => Command::none(),
         // Guarded like the other printable keys below, so `q` stays typable in
         // the details editor. This panel is always present, and Esc rereads the
         // selected task's notes rather than leaving, so Tab is how you get out
@@ -689,13 +704,17 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crossterm::event::KeyModifiers;
     use tears::testing::TestStore;
 
     /// Builds the `Terminal` message a keystroke would produce, so a test can
     /// exercise the same `handle_key_event` path the subscription feeds.
     fn key(code: KeyCode) -> Message {
         Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
+    }
+
+    /// The same held with `CONTROL`.
+    fn chord(code: KeyCode) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::CONTROL)))
     }
 
     /// The same for the other two kinds a terminal can report.
@@ -817,6 +836,55 @@ mod tests {
             store.state().details.notes,
             original,
             "the edit is gone and the task's own notes are back"
+        );
+        store.finish();
+    }
+
+    /// A `CONTROL` chord runs no bare-key binding, and Ctrl+C leaves.
+    ///
+    /// Raw mode delivers no SIGINT, so Ctrl+C arrives as an ordinary key
+    /// event; without the guard it would have cleared the activity log, and
+    /// Ctrl+D would have deleted the selected task.
+    #[test]
+    fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
+        let mut store = TestStore::<App>::new(());
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Tasks);
+        let before = store.state().tasks.tasks.len();
+
+        store.send(chord(KeyCode::Char('d')));
+        assert_eq!(
+            store.state().tasks.tasks.len(),
+            before,
+            "Ctrl+D is a chord this application does not bind"
+        );
+
+        store.send(chord(KeyCode::Char('c')));
+        store.receive_matching(|msg| matches!(msg, Message::Quit));
+        store.receive_quit();
+        store.finish();
+    }
+
+    /// Saving with no task selected says so rather than leaving the footer
+    /// reporting the edit it did not write.
+    #[test]
+    fn saving_without_a_task_reports_rather_than_going_silent() {
+        let mut store = TestStore::<App>::new(());
+        store.send(Message::FocusNext);
+        for _ in 0..3 {
+            store.send(Message::Tasks(TaskMessage::Delete));
+        }
+        assert!(store.state().tasks.tasks.is_empty());
+
+        store.send(Message::Details(DetailMessage::Input('a')));
+        assert_eq!(store.state().status.message, "Editing notes");
+
+        store.send(Message::Details(DetailMessage::Save));
+
+        assert_eq!(
+            store.state().status.message,
+            "No task selected",
+            "the save wrote nothing and says so"
         );
         store.finish();
     }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -275,13 +275,15 @@ impl App {
             DetailAction::Reset => {
                 let reloaded = self.tasks.selected_task().is_some();
                 self.details.sync_from_task(self.tasks.selected_task());
-                // With no task there is nothing to reread, and the panel says
-                // so; the footer must not claim otherwise, for the reason the
-                // `Save` arm above has an `else`.
+                // With no task there is nothing to reread, but the panel is
+                // emptied all the same — so this arm is not the `Save` arm's
+                // no-op, and the footer says what became of what was typed
+                // rather than only why.
                 if reloaded {
                     self.status.set_info(outcome.status);
                 } else {
-                    self.status.set_info("No task selected");
+                    self.status
+                        .set_info("Discarded the notes; no task selected");
                 }
             }
             DetailAction::Keep => self.status.set_info(outcome.status),
@@ -1178,12 +1180,19 @@ mod tests {
         }
         assert!(store.state().tasks.tasks.is_empty());
 
+        store.send(Message::Details(DetailMessage::Input('a')));
+        assert!(store.state().details.notes.ends_with('a'));
+
         store.send(Message::Details(DetailMessage::Reset));
 
+        assert!(
+            store.state().details.notes.is_empty(),
+            "the panel is emptied, so this is not a no-op"
+        );
         assert_eq!(
             store.state().status.message,
-            "No task selected",
-            "there was nothing to reread"
+            "Discarded the notes; no task selected",
+            "and the footer says what became of what was typed"
         );
         store.finish();
     }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -138,10 +138,13 @@ impl Application for App {
             Message::Tasks(msg) => self.update_tasks(msg),
             Message::Details(msg) => self.update_details(msg),
             Message::Activity(msg) => self.update_activity(msg),
-            // Presses only. A terminal that reports releases too — Windows, or
-            // a session with the kitty keyboard protocol on — would otherwise
-            // turn one keystroke into two messages.
-            Message::Terminal(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+            // Not releases. A terminal that reports them — Windows, or a
+            // session with the kitty keyboard protocol on — would otherwise
+            // turn one keystroke into two messages. A *repeat* is an
+            // instruction and is kept: the same protocol that delivers
+            // releases is the one that reports a held key, and dropping those
+            // would make a held Down move the selection once.
+            Message::Terminal(Event::Key(key)) if key.kind != KeyEventKind::Release => {
                 return handle_key_event(self.focus, key);
             }
             Message::Terminal(_) => {}
@@ -409,7 +412,7 @@ impl TaskListState {
 
     fn delete_selected(&mut self) -> TaskOutcome {
         if self.tasks.is_empty() {
-            return TaskOutcome::status("No task to delete");
+            return TaskOutcome::status("No task selected");
         }
 
         let removed = self.tasks.remove(self.selected);
@@ -694,13 +697,12 @@ mod tests {
         Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
     }
 
-    /// The same for the release a terminal that reports both would send after
-    /// it.
-    fn key_release(code: KeyCode) -> Message {
+    /// The same for the other two kinds a terminal can report.
+    fn key_of(code: KeyCode, kind: KeyEventKind) -> Message {
         Message::Terminal(Event::Key(KeyEvent::new_with_kind(
             code,
             KeyModifiers::empty(),
-            KeyEventKind::Release,
+            kind,
         )))
     }
 
@@ -819,18 +821,27 @@ mod tests {
     }
 
     /// A terminal that reports releases as well as presses sends two events
-    /// per keystroke. Only the press is an instruction.
+    /// per keystroke. The release is not an instruction; a repeat is.
     #[test]
-    fn a_key_release_asks_for_nothing() {
+    fn a_key_release_asks_for_nothing_and_a_repeat_asks() {
         let mut store = TestStore::<App>::new(());
         assert_eq!(store.state().focus, Focus::Navigation);
 
-        store.send(key_release(KeyCode::Tab));
-
+        store.send(key_of(KeyCode::Tab, KeyEventKind::Release));
         assert_eq!(
             store.state().focus,
             Focus::Navigation,
             "the release is not a second Tab"
+        );
+
+        // The protocol that reports releases is the one that reports a held
+        // key, so a filter written as `== Press` would drop these too.
+        store.send(key_of(KeyCode::Tab, KeyEventKind::Repeat));
+        store.receive_matching(|msg| matches!(msg, Message::FocusNext));
+        assert_eq!(
+            store.state().focus,
+            Focus::Tasks,
+            "a held Tab keeps cycling"
         );
         store.finish();
     }

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -679,10 +679,9 @@ impl StatusState {
     }
 }
 
-/// Every binding here is for an unmodified key, apart from a shifted character,
-/// which is how an uppercase letter arrives. Raw mode delivers no SIGINT, so a
-/// reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
-/// bound to — clearing the activity log — and Ctrl+D would have deleted a task.
+/// Raw mode delivers no SIGINT, so Ctrl+C arrives here as an ordinary key
+/// event; what the guards below make of it and of every other modified key is
+/// written where they are.
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     // The way out of raw mode, from any focus: the details editor holds `q`
     // but nothing holds this.

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -405,13 +405,26 @@ impl TaskListState {
 
     fn update(&mut self, msg: TaskMessage) -> TaskOutcome {
         match msg {
+            // Clamping at an end leaves the selection where it was, and
+            // saying it moved would be the footer reporting an operation that
+            // did not happen.
             TaskMessage::Up => {
+                let before = self.selected;
                 self.selected = self.selected.saturating_sub(1);
-                TaskOutcome::status("Selected previous task")
+                if self.selected == before {
+                    TaskOutcome::status("Nothing further that way")
+                } else {
+                    TaskOutcome::status("Selected previous task")
+                }
             }
             TaskMessage::Down => {
+                let before = self.selected;
                 self.selected = (self.selected + 1).min(self.tasks.len().saturating_sub(1));
-                TaskOutcome::status("Selected next task")
+                if self.selected == before {
+                    TaskOutcome::status("Nothing further that way")
+                } else {
+                    TaskOutcome::status("Selected next task")
+                }
             }
             TaskMessage::Toggle => self.toggle_selected(),
             TaskMessage::Add => self.add_task(),
@@ -898,6 +911,26 @@ mod tests {
             original,
             "the edit is gone and the task's own notes are back"
         );
+        store.finish();
+    }
+
+    /// Moving the selection past an end says nothing moved.
+    ///
+    /// The list clamps, so the selection stays where it was, and reporting a
+    /// move would be the footer describing an operation that did not happen.
+    #[test]
+    fn a_selection_move_past_an_end_says_nothing_moved() {
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().tasks.selected, 0);
+
+        store.send(Message::Tasks(TaskMessage::Up));
+        assert_eq!(store.state().tasks.selected, 0, "already at the top");
+        assert_eq!(store.state().status.message, "Nothing further that way");
+
+        store.send(Message::Tasks(TaskMessage::Down));
+        assert_eq!(store.state().tasks.selected, 1);
+        assert_eq!(store.state().status.message, "Selected next task");
         store.finish();
     }
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -219,7 +219,7 @@ impl App {
             if let Some(task) = self.tasks.selected_task_mut() {
                 task.notes.clone_from(&self.details.notes);
                 self.activity
-                    .push(format!("Updated notes for '{}'", task.title));
+                    .push(format!("updated notes for {}", task.title));
                 self.status.set_info("Saved task notes");
             }
         } else {

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -215,15 +215,22 @@ impl App {
     fn update_details(&mut self, msg: DetailMessage) {
         let outcome = self.details.update(msg);
 
-        if outcome.save_requested {
-            if let Some(task) = self.tasks.selected_task_mut() {
-                task.notes.clone_from(&self.details.notes);
-                self.activity
-                    .push(format!("updated notes for {}", task.title));
-                self.status.set_info("Saved task notes");
+        match outcome.action {
+            DetailAction::Save => {
+                if let Some(task) = self.tasks.selected_task_mut() {
+                    task.notes.clone_from(&self.details.notes);
+                    self.activity
+                        .push(format!("updated notes for {}", task.title));
+                    self.status.set_info("Saved task notes");
+                }
             }
-        } else {
-            self.status.set_info(outcome.status);
+            // Esc throws the edits away and reads the selected task again,
+            // which is what the panel's hint offers and what `Reset` names.
+            DetailAction::Reset => {
+                self.details.sync_from_task(self.tasks.selected_task());
+                self.status.set_info(outcome.status);
+            }
+            DetailAction::Keep => self.status.set_info(outcome.status),
         }
     }
 
@@ -438,24 +445,45 @@ struct DetailState {
     notes: String,
 }
 
+/// What the details panel wants the root to do with its buffer.
+///
+/// The panel holds a copy of the selected task's notes and cannot reach the
+/// task itself, so both of the interesting outcomes are requests to the root.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DetailAction {
+    /// Leave the buffer and the task as they are.
+    Keep,
+    /// Write the buffer onto the selected task.
+    Save,
+    /// Throw the buffer away and read the selected task again.
+    Reset,
+}
+
 #[derive(Debug, Clone)]
 struct DetailOutcome {
     status: String,
-    save_requested: bool,
+    action: DetailAction,
 }
 
 impl DetailOutcome {
     fn status(status: impl Into<String>) -> Self {
         Self {
             status: status.into(),
-            save_requested: false,
+            action: DetailAction::Keep,
         }
     }
 
     fn save(status: impl Into<String>) -> Self {
         Self {
             status: status.into(),
-            save_requested: true,
+            action: DetailAction::Save,
+        }
+    }
+
+    fn reset(status: impl Into<String>) -> Self {
+        Self {
+            status: status.into(),
+            action: DetailAction::Reset,
         }
     }
 }
@@ -490,7 +518,7 @@ impl DetailState {
                 DetailOutcome::status("Editing notes")
             }
             DetailMessage::Save => DetailOutcome::save("Saved task notes"),
-            DetailMessage::Reset => DetailOutcome::status("No changes saved"),
+            DetailMessage::Reset => DetailOutcome::reset("Reloaded the selected task"),
         }
     }
 
@@ -583,8 +611,9 @@ impl StatusState {
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     match key.code {
         // Guarded like the other printable keys below, so `q` stays typable in
-        // the details editor. This panel is always present — Esc reloads the
-        // notes rather than leaving — so Tab is how you get out of it.
+        // the details editor. This panel is always present, and Esc rereads the
+        // selected task's notes rather than leaving, so Tab is how you get out
+        // of this focus.
         KeyCode::Char('q') if focus != Focus::Details => Command::message(Message::Quit).into(),
         KeyCode::Tab => Command::message(Message::FocusNext).into(),
         KeyCode::Up => match focus {
@@ -761,6 +790,31 @@ mod tests {
         store.receive_matching(|msg| matches!(msg, Message::Details(DetailMessage::Input('q'))));
 
         assert_eq!(store.state().details.notes, format!("{notes}q"));
+        store.finish();
+    }
+
+    /// Esc throws the buffer away and reads the selected task again, which is
+    /// what the panel's hint offers and what `Reset` names.
+    #[test]
+    fn escape_rereads_the_selected_task_s_notes() {
+        let mut store = TestStore::<App>::new(());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+        let original = store.state().details.notes.clone();
+
+        store.send(key(KeyCode::Char('x')));
+        store.receive_matching(|msg| matches!(msg, Message::Details(DetailMessage::Input('x'))));
+        assert_eq!(store.state().details.notes, format!("{original}x"));
+
+        store.send(key(KeyCode::Esc));
+        store.receive_matching(|msg| matches!(msg, Message::Details(DetailMessage::Reset)));
+
+        assert_eq!(
+            store.state().details.notes,
+            original,
+            "the edit is gone and the task's own notes are back"
+        );
         store.finish();
     }
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -405,9 +405,13 @@ impl TaskListState {
 
     fn update(&mut self, msg: TaskMessage) -> TaskOutcome {
         match msg {
-            // Clamping at an end leaves the selection where it was, and
-            // saying it moved would be the footer reporting an operation that
-            // did not happen.
+            TaskMessage::Up | TaskMessage::Down if self.tasks.is_empty() => {
+                TaskOutcome::status("No task selected")
+            }
+            // An empty list is not an end, and `Toggle` and `Delete` below
+            // already answer it. Clamping at a real end leaves the selection
+            // where it was, and saying it moved would be the footer reporting
+            // an operation that did not happen.
             TaskMessage::Up => {
                 let before = self.selected;
                 self.selected = self.selected.saturating_sub(1);
@@ -931,6 +935,17 @@ mod tests {
         store.send(Message::Tasks(TaskMessage::Down));
         assert_eq!(store.state().tasks.selected, 1);
         assert_eq!(store.state().status.message, "Selected next task");
+
+        // An empty list is not an end: `Toggle` and `Delete` answer it with
+        // "No task selected", and a move has to agree with them.
+        for _ in 0..3 {
+            store.send(Message::Tasks(TaskMessage::Delete));
+        }
+        assert!(store.state().tasks.tasks.is_empty());
+        for msg in [TaskMessage::Up, TaskMessage::Down] {
+            store.send(Message::Tasks(msg));
+            assert_eq!(store.state().status.message, "No task selected");
+        }
         store.finish();
     }
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -1,4 +1,4 @@
-//! Structured state management example.
+//! Structured state management, with the root owning the wiring.
 //!
 //! This example shows how to organize a larger application without putting all
 //! state and update logic in one place:
@@ -6,6 +6,16 @@
 //! - Root `Message` wraps child messages such as `TaskMessage`.
 //! - Each child state updates only its own local data.
 //! - The root coordinates cross-component effects such as activity logging.
+//!
+//! That is the right shape while every child is a single instance whose
+//! command ids and subscriptions the root can keep distinct by choosing
+//! distinct values. [`dashboard_composed.rs`](dashboard_composed.rs) is this
+//! same application written with composed reducers, for when a child exists in
+//! more than one instance at a time or comes and goes: there the task list is a
+//! keyed collection with one child reducer per row and the details pane is an
+//! optionally-present child, and each boundary qualifies its child's identities
+//! and tears a removed child's runs down. `docs/composition.md` is the guide to
+//! choosing between the two.
 //!
 //! Run with: cargo run --example dashboard
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -32,12 +32,12 @@ const ACTIVITY_LIMIT: usize = 8;
 
 /// Where the run leaves a reason `main` can print once the terminal is back.
 ///
-/// A handle rather than a field of the state, and for the reason
-/// `dashboard_composed.rs` has one: a terminal error quits, `main` restores the
+/// A handle rather than a field of the state, and the same one
+/// `dashboard_composed.rs` has: a terminal error quits, `main` restores the
 /// terminal immediately after, and anything written to the screen — or to
 /// stderr while the alternate screen is up — goes with it. The report has to
 /// outlive the run to be a report at all.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 struct ExitReason(Arc<Mutex<Option<String>>>);
 
 impl ExitReason {
@@ -122,7 +122,7 @@ enum ActivityMessage {
     Clear,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct App {
     reason: ExitReason,
     focus: Focus,

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -20,7 +20,7 @@
 //! Run with: cargo run --example dashboard
 
 use color_eyre::eyre::Result;
-use crossterm::event::{Event, KeyCode, KeyEvent};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
 use tears::prelude::*;
@@ -138,7 +138,12 @@ impl Application for App {
             Message::Tasks(msg) => self.update_tasks(msg),
             Message::Details(msg) => self.update_details(msg),
             Message::Activity(msg) => self.update_activity(msg),
-            Message::Terminal(Event::Key(key)) => return handle_key_event(self.focus, key),
+            // Presses only. A terminal that reports releases too — Windows, or
+            // a session with the kitty keyboard protocol on — would otherwise
+            // turn one keystroke into two messages.
+            Message::Terminal(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                return handle_key_event(self.focus, key);
+            }
             Message::Terminal(_) => {}
             Message::TerminalError(e) => {
                 eprintln!("Terminal error: {e}");
@@ -572,7 +577,8 @@ impl StatusState {
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     match key.code {
         // Guarded like the other printable keys below, so `q` stays typable in
-        // the details editor. Esc leaves that panel first.
+        // the details editor. This panel is always present — Esc reloads the
+        // notes rather than leaving — so Tab is how you get out of it.
         KeyCode::Char('q') if focus != Focus::Details => Command::message(Message::Quit).into(),
         KeyCode::Tab => Command::message(Message::FocusNext).into(),
         KeyCode::Up => match focus {

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -19,6 +19,8 @@
 //!
 //! Run with: cargo run --example dashboard
 
+use std::sync::{Arc, Mutex};
+
 use color_eyre::eyre::Result;
 use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::prelude::*;
@@ -27,6 +29,29 @@ use tears::prelude::*;
 use tears::subscription::terminal::TerminalEvents;
 
 const ACTIVITY_LIMIT: usize = 8;
+
+/// Where the run leaves a reason `main` can print once the terminal is back.
+///
+/// A handle rather than a field of the state, and for the reason
+/// `dashboard_composed.rs` has one: a terminal error quits, `main` restores the
+/// terminal immediately after, and anything written to the screen — or to
+/// stderr while the alternate screen is up — goes with it. The report has to
+/// outlive the run to be a report at all.
+#[derive(Clone, Default)]
+struct ExitReason(Arc<Mutex<Option<String>>>);
+
+impl ExitReason {
+    fn set(&self, reason: String) {
+        *self.0.lock().expect("the exit reason lock is not poisoned") = Some(reason);
+    }
+
+    fn take(&self) -> Option<String> {
+        self.0
+            .lock()
+            .expect("the exit reason lock is not poisoned")
+            .take()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Focus {
@@ -97,8 +122,9 @@ enum ActivityMessage {
     Clear,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 struct App {
+    reason: ExitReason,
     focus: Focus,
     navigation: NavigationState,
     tasks: TaskListState,
@@ -109,14 +135,15 @@ struct App {
 
 impl Application for App {
     type Message = Message;
-    type Flags = ();
+    type Flags = ExitReason;
 
-    fn new(_flags: ()) -> (Self, Command<Message>) {
+    fn new(reason: ExitReason) -> (Self, Command<Message>) {
         let tasks = TaskListState::new();
         let details = DetailState::from_task(tasks.selected_task());
 
         (
             Self {
+                reason,
                 focus: Focus::Navigation,
                 navigation: NavigationState::new(),
                 tasks,
@@ -150,7 +177,10 @@ impl Application for App {
             }
             Message::Terminal(_) => {}
             Message::TerminalError(e) => {
-                eprintln!("Terminal error: {e}");
+                // Recorded rather than printed: the quit below ends the run and
+                // `main` restores the terminal immediately after, so this is
+                // reported once there is a screen left to report it on.
+                self.reason.set(e);
                 return Command::quit();
             }
             Message::Quit => return Command::quit(),
@@ -235,8 +265,16 @@ impl App {
             // Esc throws the edits away and reads the selected task again,
             // which is what the panel's hint offers and what `Reset` names.
             DetailAction::Reset => {
+                let reloaded = self.tasks.selected_task().is_some();
                 self.details.sync_from_task(self.tasks.selected_task());
-                self.status.set_info(outcome.status);
+                // With no task there is nothing to reread, and the panel says
+                // so; the footer must not claim otherwise, for the reason the
+                // `Save` arm above has an `else`.
+                if reloaded {
+                    self.status.set_info(outcome.status);
+                } else {
+                    self.status.set_info("No task selected");
+                }
             }
             DetailAction::Keep => self.status.set_info(outcome.status),
         }
@@ -616,19 +654,26 @@ impl StatusState {
     }
 }
 
-/// Every bare-character binding here excludes `CONTROL`. Raw mode delivers no
-/// SIGINT, so a reader pressing Ctrl+C to leave would otherwise have run
-/// whatever `c` is bound to — clearing the activity log — and Ctrl+D would have
-/// deleted a task.
+/// Every binding here is for an unmodified key. Raw mode delivers no SIGINT, so
+/// a reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
+/// bound to — clearing the activity log — and Ctrl+D would have deleted a task.
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
-    let control = key.modifiers.contains(KeyModifiers::CONTROL);
+    // The way out of raw mode, from any focus: the details editor holds `q`
+    // but nothing holds this.
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        return Command::message(Message::Quit).into();
+    }
+    // Every binding below is for an unmodified key, so a chord this
+    // application does not bind is answered here rather than falling through
+    // to the bare key's. Above the match and not on the character arms,
+    // because `Enter`, `Up`/`Down`, `Tab` and `Esc` arrive with modifiers too.
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    {
+        return Command::none();
+    }
     match key.code {
-        // The way out of raw mode, from any focus: the details editor holds
-        // `q` but nothing holds this.
-        KeyCode::Char('c') if control => Command::message(Message::Quit).into(),
-        // Anything else with `CONTROL` on is a chord this application has no
-        // binding for, and it must not fall through to the bare key's.
-        KeyCode::Char(_) if control => Command::none(),
         // Guarded like the other printable keys below, so `q` stays typable in
         // the details editor. This panel is always present, and Esc rereads the
         // selected task's notes rather than leaving, so Tab is how you get out
@@ -685,11 +730,18 @@ async fn main() -> Result<()> {
     let mut terminal = ratatui::init();
 
     // Run application at 60 FPS
-    let runtime = Runtime::<App>::new(());
+    let reason = ExitReason::default();
+    let runtime = Runtime::<App>::new(reason.clone());
     let result = runtime.run(&mut terminal).await;
 
     // Restore terminal
     ratatui::restore();
+
+    // What the run had to say and could not show, now that there is a screen
+    // to say it on.
+    if let Some(reason) = reason.take() {
+        eprintln!("Terminal error: {reason}");
+    }
 
     result?;
 
@@ -714,7 +766,12 @@ mod tests {
 
     /// The same held with `CONTROL`.
     fn chord(code: KeyCode) -> Message {
-        Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::CONTROL)))
+        chord_with(code, KeyModifiers::CONTROL)
+    }
+
+    /// The same under any modifiers.
+    fn chord_with(code: KeyCode, modifiers: KeyModifiers) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new(code, modifiers)))
     }
 
     /// The same for the other two kinds a terminal can report.
@@ -729,7 +786,7 @@ mod tests {
     /// Sending the child message directly walks focus through the panels.
     #[test]
     fn focus_next_cycles_through_panels() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         assert_eq!(store.state().focus, Focus::Navigation);
 
         store.send(Message::FocusNext);
@@ -744,7 +801,7 @@ mod tests {
     /// `Command::message(FocusNext)` the store delivers as the next message.
     #[test]
     fn tab_key_emits_focus_next() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
 
         store.send(key(KeyCode::Tab));
         store.receive_matching(|msg| matches!(msg, Message::FocusNext));
@@ -757,7 +814,7 @@ mod tests {
     /// entry.
     #[test]
     fn toggle_marks_selected_task_done() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         assert!(!store.state().tasks.tasks[0].done);
         let activity_before = store.state().activity.entries.len();
 
@@ -772,7 +829,7 @@ mod tests {
     /// id counter keeps advancing.
     #[test]
     fn add_then_delete_returns_to_original_count() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         assert_eq!(store.state().tasks.tasks.len(), 3);
         assert_eq!(store.state().tasks.next_id, 4);
 
@@ -790,7 +847,7 @@ mod tests {
     /// quit request.
     #[test]
     fn quit_key_requests_shutdown() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
 
         store.send(key(KeyCode::Char('q')));
         store.receive_matching(|msg| matches!(msg, Message::Quit));
@@ -802,7 +859,7 @@ mod tests {
     /// than a request to quit. Tab is how you leave that focus.
     #[test]
     fn quit_key_is_text_while_the_details_panel_has_focus() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         store.send(Message::FocusNext);
         store.send(Message::FocusNext);
         assert_eq!(store.state().focus, Focus::Details);
@@ -819,7 +876,7 @@ mod tests {
     /// what the panel's hint offers and what `Reset` names.
     #[test]
     fn escape_rereads_the_selected_task_s_notes() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         store.send(Message::FocusNext);
         store.send(Message::FocusNext);
         assert_eq!(store.state().focus, Focus::Details);
@@ -847,16 +904,39 @@ mod tests {
     /// Ctrl+D would have deleted the selected task.
     #[test]
     fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         store.send(Message::FocusNext);
         assert_eq!(store.state().focus, Focus::Tasks);
         let before = store.state().tasks.tasks.len();
 
-        store.send(chord(KeyCode::Char('d')));
+        // Not only the characters: `Enter`, the arrows, `Tab` and `Esc` arrive
+        // with modifiers too.
+        let selected = store.state().tasks.selected;
+        for code in [
+            KeyCode::Char('d'),
+            KeyCode::Char('n'),
+            KeyCode::Char(' '),
+            KeyCode::Tab,
+            KeyCode::Down,
+        ] {
+            for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+                store.send(chord_with(code, modifiers));
+            }
+        }
         assert_eq!(
             store.state().tasks.tasks.len(),
             before,
-            "Ctrl+D is a chord this application does not bind"
+            "no chord added or deleted a task"
+        );
+        assert_eq!(
+            store.state().tasks.selected,
+            selected,
+            "and none moved the selection"
+        );
+        assert_eq!(
+            store.state().focus,
+            Focus::Tasks,
+            "and none cycled the focus"
         );
 
         store.send(chord(KeyCode::Char('c')));
@@ -869,7 +949,7 @@ mod tests {
     /// reporting the edit it did not write.
     #[test]
     fn saving_without_a_task_reports_rather_than_going_silent() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         store.send(Message::FocusNext);
         for _ in 0..3 {
             store.send(Message::Tasks(TaskMessage::Delete));
@@ -889,11 +969,32 @@ mod tests {
         store.finish();
     }
 
+    /// Escaping with no task selected says so rather than reporting a reload
+    /// that had nothing to read.
+    #[test]
+    fn escaping_without_a_task_reports_rather_than_claiming_a_reload() {
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        for _ in 0..3 {
+            store.send(Message::Tasks(TaskMessage::Delete));
+        }
+        assert!(store.state().tasks.tasks.is_empty());
+
+        store.send(Message::Details(DetailMessage::Reset));
+
+        assert_eq!(
+            store.state().status.message,
+            "No task selected",
+            "there was nothing to reread"
+        );
+        store.finish();
+    }
+
     /// A terminal that reports releases as well as presses sends two events
     /// per keystroke. The release is not an instruction; a repeat is.
     #[test]
     fn a_key_release_asks_for_nothing_and_a_repeat_asks() {
-        let mut store = TestStore::<App>::new(());
+        let mut store = TestStore::<App>::new(ExitReason::default());
         assert_eq!(store.state().focus, Focus::Navigation);
 
         store.send(key_of(KeyCode::Tab, KeyEventKind::Release));

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -571,7 +571,9 @@ impl StatusState {
 
 fn handle_key_event(focus: Focus, key: KeyEvent) -> Command<Message> {
     match key.code {
-        KeyCode::Char('q') => Command::message(Message::Quit).into(),
+        // Guarded like the other printable keys below, so `q` stays typable in
+        // the details editor. Esc leaves that panel first.
+        KeyCode::Char('q') if focus != Focus::Details => Command::message(Message::Quit).into(),
         KeyCode::Tab => Command::message(Message::FocusNext).into(),
         KeyCode::Up => match focus {
             Focus::Navigation => {

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -236,8 +236,17 @@ impl App {
     }
 
     fn update_tasks(&mut self, msg: TaskMessage) {
+        let selected_before = self.tasks.selected;
         let outcome = self.tasks.update(msg);
-        self.details.sync_from_task(self.tasks.selected_task());
+        // Rereading the panel throws away whatever was typed into it, so it
+        // runs only where the selected task can have changed: the index moved,
+        // or a row was added or removed under it. A move that clamped at an end
+        // changed nothing, and the footer says so.
+        if self.tasks.selected != selected_before
+            || matches!(msg, TaskMessage::Add | TaskMessage::Delete)
+        {
+            self.details.sync_from_task(self.tasks.selected_task());
+        }
 
         if let Some(entry) = outcome.activity {
             self.activity.push(entry);
@@ -946,6 +955,43 @@ mod tests {
             store.send(Message::Tasks(msg));
             assert_eq!(store.state().status.message, "No task selected");
         }
+        store.finish();
+    }
+
+    /// A selection move that changed nothing leaves the notes alone.
+    ///
+    /// Rereading the panel throws away what was typed into it, and a move that
+    /// clamped at an end changed which task is selected not at all — so doing
+    /// it there would discard an edit while the footer said nothing happened.
+    #[test]
+    fn a_move_that_changed_nothing_keeps_the_edit() {
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Details);
+        let notes = store.state().details.notes.clone();
+        store.send(Message::Details(DetailMessage::Input('x')));
+
+        store.send(Message::Tasks(TaskMessage::Up));
+
+        assert_eq!(
+            store.state().status.message,
+            "Nothing further that way",
+            "the selection was already at the top"
+        );
+        assert_eq!(
+            store.state().details.notes,
+            format!("{notes}x"),
+            "so the edit is still there"
+        );
+
+        // A move that does change the selection rereads, which is what the
+        // reread is for.
+        store.send(Message::Tasks(TaskMessage::Down));
+        assert_eq!(
+            store.state().details.notes,
+            store.state().tasks.tasks[1].notes
+        );
         store.finish();
     }
 

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -561,6 +561,22 @@ impl DetailOutcome {
     }
 }
 
+/// The details panel's hint, which is guarded because every key in it is.
+///
+/// `Enter` and `Esc` both require a `Details` focus, and at `Focus::Tasks` the
+/// letters belong to the list — `d` deletes the selected row and `r` reloads
+/// it. This is the milder half of the pair: here `Enter` elsewhere is inert
+/// rather than destructive, where `dashboard_composed.rs` turns it into a
+/// replacement that discards the buffer. The line is wrong the same way in
+/// both.
+const fn details_hint(focused: bool) -> &'static str {
+    if focused {
+        "Type to edit, Enter to save, Esc to reload selected task."
+    } else {
+        "Tab to this pane to edit, save or reload its notes."
+    }
+}
+
 impl DetailState {
     fn from_task(task: Option<&Task>) -> Self {
         let Some(task) = task else {
@@ -602,8 +618,10 @@ impl DetailState {
             "Details"
         };
         let text = format!(
-            "{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to reload selected task.",
-            self.title, self.notes
+            "{}\n\nNotes:\n{}_\n\n{}",
+            self.title,
+            self.notes,
+            details_hint(focused)
         );
         let paragraph = Paragraph::new(text)
             .wrap(Wrap { trim: false })
@@ -812,6 +830,38 @@ mod tests {
             KeyModifiers::empty(),
             kind,
         )))
+    }
+
+    /// The panel's hint names only keys that work where it is read.
+    ///
+    /// The panel is drawn at every focus, and the keys it names are not: `Enter`
+    /// and `Esc` need a `Details` focus, and at `Focus::Tasks` the letters are
+    /// the list's — `d` deletes the selected row. `dashboard_composed.rs` has
+    /// the sharper version of the same line, where the promised save is a
+    /// replacement that discards the buffer.
+    #[test]
+    fn the_panel_hint_names_keys_that_work_where_it_is_read() {
+        assert_eq!(
+            details_hint(true),
+            "Type to edit, Enter to save, Esc to reload selected task.",
+            "with the focus, the line names the keys it has"
+        );
+        assert_eq!(
+            details_hint(false),
+            "Tab to this pane to edit, save or reload its notes.",
+            "without it, the line names where those keys have to land instead"
+        );
+
+        // The decode the guard exists for, read rather than argued.
+        let mut store = TestStore::<App>::new(ExitReason::default());
+        store.send(Message::FocusNext);
+        assert_eq!(store.state().focus, Focus::Tasks);
+
+        // No `receive_matching` follows, and `finish` is what makes that an
+        // assertion: away from the panel the key decodes to `Command::none()`,
+        // so the store has nothing to deliver. A save would be a message here.
+        store.send(key(KeyCode::Enter));
+        store.finish();
     }
 
     /// Sending the child message directly walks focus through the panels.

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -237,14 +237,14 @@ impl App {
 
     fn update_tasks(&mut self, msg: TaskMessage) {
         let selected_before = self.tasks.selected;
+        let count_before = self.tasks.tasks.len();
         let outcome = self.tasks.update(msg);
         // Rereading the panel throws away whatever was typed into it, so it
-        // runs only where the selected task can have changed: the index moved,
-        // or a row was added or removed under it. A move that clamped at an end
-        // changed nothing, and the footer says so.
-        if self.tasks.selected != selected_before
-            || matches!(msg, TaskMessage::Add | TaskMessage::Delete)
-        {
+        // runs only where the selected task can have changed: the selection
+        // moved, or the list grew or shrank under it. Asking what kind of
+        // message this was instead would reread on a delete that deleted
+        // nothing, and on nothing else it would get right.
+        if self.tasks.selected != selected_before || self.tasks.tasks.len() != count_before {
             self.details.sync_from_task(self.tasks.selected_task());
         }
 
@@ -992,6 +992,35 @@ mod tests {
             store.state().details.notes,
             store.state().tasks.tasks[1].notes
         );
+
+        // A delete that deleted nothing is the same case as a move that moved
+        // nothing, and the message kind cannot tell them apart.
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        for _ in 0..3 {
+            store.send(Message::Tasks(TaskMessage::Delete));
+        }
+        assert!(store.state().tasks.tasks.is_empty());
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+        store.send(Message::Details(DetailMessage::Input('y')));
+        let typed = store.state().details.notes.clone();
+        store.send(Message::FocusNext);
+        store.send(Message::FocusNext);
+
+        store.send(Message::Tasks(TaskMessage::Delete));
+
+        assert_eq!(
+            store.state().status.message,
+            "No task selected",
+            "there was nothing to delete"
+        );
+        assert_eq!(
+            store.state().details.notes,
+            typed,
+            "so the edit is still there"
+        );
         store.finish();
     }
 
@@ -1045,6 +1074,7 @@ mod tests {
                 KeyModifiers::ALT,
                 KeyModifiers::SHIFT,
                 KeyModifiers::SUPER,
+                KeyModifiers::HYPER,
                 KeyModifiers::META,
             ] {
                 store.send(chord_with(code, modifiers));

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -1023,7 +1023,10 @@ mod tests {
     ///
     /// A chord that merely *contains* `CONTROL` is one this application does
     /// not bind, so it asks for nothing — `finish` is the assertion, since it
-    /// fails on output left unaccounted for and a quit request is output.
+    /// fails on output left unaccounted for and a `Message::Quit` this row
+    /// never receives is output. The quit itself is never applied: it would
+    /// take that message being received and `update` returning
+    /// `Command::quit()`.
     #[test]
     fn a_chord_that_merely_contains_control_is_not_the_quit() {
         let mut store = TestStore::<App>::new(ExitReason::default());

--- a/examples/dashboard.rs
+++ b/examples/dashboard.rs
@@ -139,11 +139,12 @@ impl Application for App {
             Message::Details(msg) => self.update_details(msg),
             Message::Activity(msg) => self.update_activity(msg),
             // Not releases. A terminal that reports them — Windows, or a
-            // session with the kitty keyboard protocol on — would otherwise
-            // turn one keystroke into two messages. A *repeat* is an
-            // instruction and is kept: the same protocol that delivers
-            // releases is the one that reports a held key, and dropping those
-            // would make a held Down move the selection once.
+            // session with the kitty keyboard protocol on — sends two events
+            // for one press, and the second would be acted on. A *repeat* is
+            // kept, and is the other thing entirely: a held key is repetition
+            // the reader is asking for. Testing for `Press` would drop those
+            // with the releases, and a held Down would move the selection
+            // once.
             Message::Terminal(Event::Key(key)) if key.kind != KeyEventKind::Release => {
                 return handle_key_event(self.focus, key);
             }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -174,7 +174,15 @@ enum Message {
     FocusNext,
     SelectPrev,
     SelectNext,
-    AddTask(TaskId, String),
+    /// Adds a task under a **freshly allocated** key.
+    ///
+    /// The key is chosen by the reduce and not by the caller on purpose. A
+    /// caller reading `next_id` off the state reads a value the `AddTask`
+    /// messages already in flight have not been applied to yet, so two of them
+    /// would name the same key — and inserting over an occupied key is a
+    /// replacement, which would tear the first row down instead of adding a
+    /// second.
+    AddTask(String),
     DeleteTask(TaskId),
     /// Discards a row's instance and starts a fresh one under the same key.
     ReloadTask(TaskId),
@@ -202,6 +210,12 @@ enum NavigationMessage {
 enum TaskMessage {
     /// The row's one-time setup, routed through the row boundary so the hook it
     /// registers anchors at the row's scope.
+    ///
+    /// **Handled idempotently**, because nothing guarantees it arrives once: a
+    /// key press asks for it through `Command::message`, so two presses decided
+    /// against the same state produce two of these, and every registration a
+    /// scope holds is fired by the teardown that selects it. A second
+    /// registration would put two lines in the activity log for one removal.
     Watch,
     Toggle,
     Sync,
@@ -211,7 +225,8 @@ enum TaskMessage {
 
 #[derive(Debug)]
 enum DetailsMessage {
-    /// The occupant's one-time setup, for the reason [`TaskMessage::Watch`] is.
+    /// The occupant's one-time setup, for the reason [`TaskMessage::Watch`] is,
+    /// and handled idempotently for the same reason.
     Open,
     Loaded(String),
     Input(char),
@@ -259,6 +274,8 @@ struct TaskState {
     title: String,
     done: bool,
     notes: String,
+    /// Whether this instance's setup has already run; see [`TaskMessage::Watch`].
+    watched: bool,
     syncing: bool,
     ticks: u32,
 }
@@ -269,6 +286,7 @@ impl TaskState {
             title,
             done: false,
             notes,
+            watched: false,
             syncing: false,
             ticks: 0,
         }
@@ -279,6 +297,8 @@ struct DetailsState {
     task: TaskId,
     title: String,
     notes: String,
+    /// Whether this instance's setup has already run; see [`DetailsMessage::Open`].
+    opened: bool,
     loading: bool,
     ticks: u32,
 }
@@ -289,6 +309,7 @@ impl DetailsState {
             task,
             title,
             notes,
+            opened: false,
             loading: true,
             ticks: 0,
         }
@@ -339,14 +360,19 @@ impl Reducer for Root {
                 select(state, forward);
                 Command::none()
             }
-            Message::AddTask(id, title) => {
+            Message::AddTask(label) => {
+                let id = TaskId(state.next_id);
+                state.next_id += 1;
                 // Insertion into an absent key records no removal: nothing was
-                // running under it to tear down.
+                // running under it to tear down. The key is fresh, so this is
+                // that case and never the replacing one.
                 state.tasks.insert(
                     id,
-                    TaskState::new(title, "Add notes in the details pane.".to_owned()),
+                    TaskState::new(
+                        format!("{label} #{}", id.0),
+                        "Add notes in the details pane.".to_owned(),
+                    ),
                 );
-                state.next_id = state.next_id.max(id.0 + 1);
                 state.selected = Some(id);
                 state.status = "Added a task";
                 Command::message(Message::Task(id, TaskMessage::Watch)).into()
@@ -364,6 +390,10 @@ impl Reducer for Root {
                     id,
                     TaskState::new(title, "Reloaded from the server.".to_owned()),
                 );
+                // The pane was opened for the instance that just left, and it
+                // holds that instance's title and notes; leaving it open would
+                // let a later `SaveNotes` write them back over the reload.
+                close_details_opened_on(state, id);
                 state.status = "Reloaded the task";
                 Command::message(Message::Task(id, TaskMessage::Watch)).into()
             }
@@ -377,9 +407,7 @@ impl Reducer for Root {
                 state.activity.push(format!("deleted: {}", task.title));
                 // A details pane open on the row that just left goes with it,
                 // and the slot's own boundary originates that teardown.
-                if state.details.get().is_some_and(|open| open.task == id) {
-                    state.details.dismiss();
-                }
+                close_details_opened_on(state, id);
                 if state.selected == Some(id) {
                     state.selected = state.tasks.keys().next().copied();
                 }
@@ -402,7 +430,7 @@ impl Reducer for Root {
                 Command::message(Message::Details(DetailsMessage::Open)).into()
             }
             Message::CloseDetails => {
-                state.details.dismiss();
+                close_details(state);
                 state.status = "Closed the details pane";
                 Command::none()
             }
@@ -498,6 +526,10 @@ impl Reducer for Task {
     fn reduce(&self, state: &mut TaskState, message: TaskMessage) -> Command<TaskMessage> {
         match message {
             TaskMessage::Watch => {
+                if state.watched {
+                    return Command::message(TaskMessage::Sync).into();
+                }
+                state.watched = true;
                 let activity = self.activity.clone();
                 let title = state.title.clone();
                 Command::batch([
@@ -551,6 +583,10 @@ impl Reducer for Details {
     fn reduce(&self, state: &mut DetailsState, message: DetailsMessage) -> Command<DetailsMessage> {
         match message {
             DetailsMessage::Open => {
+                if state.opened {
+                    return Command::none();
+                }
+                state.opened = true;
                 let activity = self.activity.clone();
                 let title = state.title.clone();
                 Command::batch([
@@ -672,11 +708,7 @@ fn seed() -> Vec<Message> {
         "Plan next subscription API",
     ]
     .into_iter()
-    .enumerate()
-    .map(|(index, title)| {
-        let id = u32::try_from(index).expect("three seeds fit") + 1;
-        Message::AddTask(TaskId(id), title.to_owned())
-    })
+    .map(|label| Message::AddTask(label.to_owned()))
     .collect()
 }
 
@@ -816,6 +848,25 @@ fn render_activity(state: &App, frame: &mut Frame<'_>, area: Rect) {
     );
 }
 
+/// Dismisses the details pane and returns the focus it took.
+///
+/// Dismissal is a removal, so the slot's boundary tears the occupant's runs
+/// down; restoring the focus is this function's own half, and without it every
+/// printable key would keep routing to a slot that has no occupant to claim it.
+fn close_details(state: &mut App) {
+    state.details.dismiss();
+    if state.focus == Focus::Details {
+        state.focus = Focus::Tasks;
+    }
+}
+
+/// The same, but only when the pane is open on `task`.
+fn close_details_opened_on(state: &mut App, task: TaskId) {
+    if state.details.get().is_some_and(|open| open.task == task) {
+        close_details(state);
+    }
+}
+
 /// Moves the task selection, wrapping.
 fn select(state: &mut App, forward: bool) {
     let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
@@ -852,10 +903,9 @@ fn key_message(state: &App, code: KeyCode) -> Option<Message> {
         KeyCode::Char(' ') if state.focus == Focus::Tasks => state
             .selected
             .map(|id| Message::Task(id, TaskMessage::Toggle)),
-        KeyCode::Char('n') if state.focus == Focus::Tasks => Some(Message::AddTask(
-            TaskId(state.next_id),
-            format!("New task {}", state.next_id),
-        )),
+        KeyCode::Char('n') if state.focus == Focus::Tasks => {
+            Some(Message::AddTask("New task".to_owned()))
+        }
         KeyCode::Char('d') if state.focus == Focus::Tasks => {
             state.selected.map(Message::DeleteTask)
         }
@@ -1029,11 +1079,13 @@ mod tests {
     #[test]
     fn identical_child_identities_stay_apart_under_their_boundaries() {
         let activity = ActivityLog::default();
+        // `AddTask` allocates the key, so the two rows below are `TaskId(1)`
+        // and `TaskId(2)` in script order and the later messages can name them.
         let mut driver = scripted(
             &activity,
             vec![
-                Message::AddTask(TaskId(1), "alpha".to_owned()),
-                Message::AddTask(TaskId(2), "beta".to_owned()),
+                Message::AddTask("alpha".to_owned()),
+                Message::AddTask("beta".to_owned()),
                 Message::OpenDetails(TaskId(1)),
             ],
         );
@@ -1095,19 +1147,21 @@ mod tests {
         let mut driver = scripted(
             &activity,
             vec![
-                Message::AddTask(TaskId(1), "alpha".to_owned()),
-                Message::AddTask(TaskId(2), "beta".to_owned()),
+                Message::AddTask("alpha".to_owned()),
+                Message::AddTask("beta".to_owned()),
                 Message::OpenDetails(TaskId(1)),
                 // Presenting over an occupied slot: a replacement, which is a
                 // removal of the occupant.
                 Message::OpenDetails(TaskId(2)),
-                // Inserting over an occupied key: the same, one collection
-                // over.
+                // An occupied slot dismissed.
+                Message::CloseDetails,
+                // Inserting over an occupied key: a replacement, one collection
+                // over. The slot is empty by now, so this pass tears exactly
+                // one instance down and the order below stays the removal
+                // order rather than a race between two finalizers.
                 Message::ReloadTask(TaskId(2)),
                 // A row leaving the keyed collection.
                 Message::DeleteTask(TaskId(1)),
-                // An occupied slot dismissed.
-                Message::CloseDetails,
             ],
         );
 
@@ -1131,38 +1185,130 @@ mod tests {
 
         // Replacing the occupant removes it.
         let report = deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "closed details: alpha"));
+        driver.settle(TURNS, || recorded(&activity, "closed details: alpha #1"));
         let open = anonymous(&report, "occupant setup message");
         deliver(&mut driver, &open);
+
+        // Dismissing the slot removes its occupant.
+        deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "closed details: beta #2"));
 
         // Replacing a row removes it, and the successor starts fresh under the
         // same key.
         let report = deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "stopped watching: beta"));
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: beta #2"));
         let watch = anonymous(&report, "row setup message");
         deliver(&mut driver, &watch);
 
-        // Removing a row removes it, and leaves the other row alone.
+        // Removing a row removes it, and leaves the successor row alone.
         deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "stopped watching: alpha"));
-
-        // Dismissing the slot removes its occupant.
-        deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "closed details: beta"));
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: alpha #1"));
 
         assert_eq!(
             activity.entries(),
             vec![
-                "closed details: alpha".to_owned(),
-                "stopped watching: beta".to_owned(),
+                "closed details: alpha #1".to_owned(),
+                "closed details: beta #2".to_owned(),
+                "stopped watching: beta #2".to_owned(),
                 // The root's own line, written by the reduce that removed the
                 // row, before the teardown it originated ran.
-                "deleted: alpha".to_owned(),
-                "stopped watching: alpha".to_owned(),
-                "closed details: beta".to_owned(),
+                "deleted: alpha #1".to_owned(),
+                "stopped watching: alpha #1".to_owned(),
             ],
             "one teardown per removal, in removal order, and none for the successor row that is \
              still present"
+        );
+    }
+
+    /// A child's setup message is not guaranteed to arrive once, and a second
+    /// one must not arm a second hook.
+    ///
+    /// Two `Enter` presses decided against the same state both ask to open the
+    /// pane. The first occupant is replaced before it ever handles its `Open`,
+    /// so it registered nothing and its removal reports nothing; both `Open`
+    /// messages then reach the survivor. Every registration a scope holds is
+    /// fired by the teardown that selects it, so a child that armed on each
+    /// would put two lines in the log for one removal.
+    #[test]
+    fn a_repeated_setup_message_arms_one_hook() {
+        let activity = ActivityLog::default();
+        let mut driver = scripted(
+            &activity,
+            vec![
+                Message::AddTask("alpha".to_owned()),
+                Message::OpenDetails(TaskId(1)),
+                Message::OpenDetails(TaskId(1)),
+                Message::CloseDetails,
+            ],
+        );
+
+        let boot = driver.boot();
+        assert!(boot.terminated.is_none(), "bootstrap did not terminate");
+        let script = anonymous(&boot, "scripted input run");
+        add_task(&mut driver, &script);
+
+        // Both opens land before either `Open` is delivered, which is what a
+        // second key press ahead of the first message looks like.
+        let first = deliver(&mut driver, &script);
+        let second = deliver(&mut driver, &script);
+        assert!(
+            activity.entries().is_empty(),
+            "the replaced occupant never handled its `Open`, so it had registered nothing"
+        );
+
+        let first = anonymous(&first, "occupant setup message");
+        let second = anonymous(&second, "occupant setup message");
+        deliver(&mut driver, &first);
+        deliver(&mut driver, &second);
+
+        deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "closed details: alpha #1"));
+
+        assert_eq!(
+            activity.entries(),
+            vec!["closed details: alpha #1".to_owned()],
+            "one removal, one line: the second `Open` armed nothing"
+        );
+    }
+
+    /// Replacing a row closes a pane opened on the instance that left.
+    ///
+    /// The pane holds the replaced instance's title and notes, so leaving it
+    /// open would let a later `SaveNotes` write them back over the reload.
+    ///
+    /// Both teardowns are originated by the same reduce, so this asserts which
+    /// hooks fired and not the order they finished in.
+    #[test]
+    fn replacing_a_row_closes_a_pane_opened_on_it() {
+        let activity = ActivityLog::default();
+        let mut driver = scripted(
+            &activity,
+            vec![
+                Message::AddTask("alpha".to_owned()),
+                Message::OpenDetails(TaskId(1)),
+                Message::ReloadTask(TaskId(1)),
+            ],
+        );
+
+        let boot = driver.boot();
+        assert!(boot.terminated.is_none(), "bootstrap did not terminate");
+        let script = anonymous(&boot, "scripted input run");
+        add_task(&mut driver, &script);
+
+        let report = deliver(&mut driver, &script);
+        let open = anonymous(&report, "occupant setup message");
+        deliver(&mut driver, &open);
+
+        deliver(&mut driver, &script);
+        driver.settle(TURNS, || {
+            recorded(&activity, "stopped watching: alpha #1")
+                && recorded(&activity, "closed details: alpha #1")
+        });
+
+        assert_eq!(
+            activity.entries().len(),
+            2,
+            "the row and the pane opened on it, and nothing else"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -4,6 +4,14 @@
 //! the selected task, an activity log and a status line, cycled through with
 //! Tab. What differs is who owns the wiring.
 //!
+//! Two things differ besides, and a diff of the two files will show them.
+//! Every child here has **runs of its own** — a timer and a keyed request —
+//! where `dashboard.rs` has neither: qualification and teardown are about runs,
+//! so a child with none gives a boundary nothing to do. And three keys are not
+//! the same: `r` reloads a row, Enter opens the pane from the task list, and
+//! Esc closes the pane, where `dashboard.rs` reloads the notes into a panel
+//! that is always there.
+//!
 //! In `dashboard.rs` the root owns it. `App::update` matches every child
 //! variant and forwards it, `App::subscriptions` is the root's alone, and any
 //! work a task started would be the root's to stop when that task is deleted.
@@ -441,8 +449,16 @@ impl Reducer for Root {
                 Command::message(Message::Details(DetailsMessage::Open)).into()
             }
             Message::CloseDetails => {
-                close_details(state);
-                state.status = "Closed the details pane";
+                // Esc is guarded on the focus rather than on `editing_notes`,
+                // so it is the way out of a `Details` focus with nothing behind
+                // it — which is also why the status has to say which of the two
+                // happened. Dismissing an empty slot removes no instance and
+                // records nothing.
+                state.status = if close_details(state) {
+                    "Closed the details pane"
+                } else {
+                    "Left the details pane"
+                };
                 Command::none()
             }
             Message::SaveNotes => {
@@ -865,11 +881,12 @@ fn render_activity(state: &App, frame: &mut Frame<'_>, area: Rect) {
 /// Dismissal is a removal, so the slot's boundary tears the occupant's runs
 /// down; restoring the focus is this function's own half, and without it every
 /// printable key would keep routing to a slot that has no occupant to claim it.
-fn close_details(state: &mut App) {
-    state.details.dismiss();
+fn close_details(state: &mut App) -> bool {
+    let dismissed = state.details.dismiss().is_some();
     if state.focus == Focus::Details {
         state.focus = Focus::Tasks;
     }
+    dismissed
 }
 
 /// The same, but only when the pane is open on `task`.
@@ -1374,6 +1391,51 @@ mod tests {
         assert!(
             matches!(key_message(&state, KeyCode::Char('q')), Some(Message::Quit)),
             "and an open pane the focus is not on does not hold the key"
+        );
+    }
+
+    /// Esc leaves a `Details` focus whether or not a pane is behind it, and
+    /// says which of the two it did.
+    ///
+    /// It is guarded on the focus and not on `editing_notes`, because a focus
+    /// with an empty slot behind it still needs a way out. Dismissing an empty
+    /// slot removes no instance, so reporting a close there would describe a
+    /// teardown that never happened, in the file whose subject is which
+    /// removals produce which teardowns.
+    #[test]
+    fn escaping_an_empty_pane_leaves_it_without_claiming_a_close() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+
+        state.focus = Focus::Details;
+        let _nothing_to_close = Root.reduce(&mut state, Message::CloseDetails);
+        assert_eq!(
+            state.focus,
+            Focus::Tasks,
+            "the focus is restored either way, which is what makes Esc the way out"
+        );
+        assert_eq!(
+            state.status, "Left the details pane",
+            "there was no occupant, so nothing was closed"
+        );
+
+        state.details.present(DetailsState::new(
+            TaskId(1),
+            "alpha".to_owned(),
+            String::new(),
+        ));
+        state.focus = Focus::Details;
+        let _closed = Root.reduce(&mut state, Message::CloseDetails);
+        assert!(
+            !state.details.is_present(),
+            "an occupant is dismissed, which is the removal the boundary tears down"
+        );
+        assert_eq!(
+            state.status, "Closed the details pane",
+            "and only then does the status say so"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1004,6 +1004,10 @@ fn save_notes(state: &mut App) -> Command<Message> {
 /// to differ in structure, and a selection that wrapped here would read as
 /// something composition did.
 fn select(state: &mut App, forward: bool) {
+    // Before the guard below, so an empty list still moves the line: every
+    // other operation reports, and `dashboard.rs` reports here too, so going
+    // silent would leave the footer describing whatever came before it.
+    state.status = "Selected another task";
     let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
     if keys.is_empty() {
         return;
@@ -1018,7 +1022,6 @@ fn select(state: &mut App, forward: bool) {
         None => 0,
     };
     state.selected = keys.get(next).copied();
-    state.status = "Selected another task";
 }
 
 /// Whether a key press is going into the notes editor.
@@ -1643,6 +1646,14 @@ mod tests {
             state.selected,
             Some(TaskId(1)),
             "and the new last row when the deleted one was last"
+        );
+
+        let _emptied = Root.reduce(&mut state, Message::DeleteTask(TaskId(1)));
+        let _nowhere_to_go = Root.reduce(&mut state, Message::SelectNext);
+        assert_eq!(
+            state.status, "Selected another task",
+            "an empty list has nowhere to move to, and still reports rather \
+             than leaving the last operation's line standing"
         );
     }
 

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -428,19 +428,13 @@ impl Reducer for Root {
                 // Not releases. A terminal that reports them — Windows, or a
                 // session with the kitty keyboard protocol on — sends two
                 // events for one press, and the second would be acted on: `n`
-                // would add two rows where one was asked for, and Enter would
-                // open the pane and then replace it with a second pane on the
-                // same row — a removal nobody asked for, in a file about which
-                // removals happen.
+                // would add two rows where one was asked for, and `d` would
+                // delete twice.
                 //
-                // A *repeat* is kept, and is the other thing entirely: a held
-                // key is repetition the reader is asking for. It is not the
-                // same as the duplicate above, though — `open_details` moves
-                // the focus, so a held Enter opens the pane once and then
-                // saves into it, while the press and its release are both
-                // decoded before either lands and so both see the focus that
-                // opens. Testing for `Press` would drop the repeats with the
-                // releases, and a held Down would move the selection once.
+                // A *repeat* is kept: a held key is repetition the reader is
+                // asking for, and testing for `Press` would drop those with
+                // the releases, leaving a held Down to move the selection
+                // once.
                 Event::Key(key) if key.kind != KeyEventKind::Release => {
                     key_message(state, key).map_or_else(Command::none, |message| {
                         // A boundary claims a child-addressed message, so the
@@ -1125,10 +1119,11 @@ const fn child_status(message: &Message) -> Option<&'static str> {
 
 /// The message a key press asks for, if any.
 ///
-/// Every binding here is for an unmodified key. Raw mode delivers no SIGINT, so
-/// a reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
+/// Every binding here is for an unmodified key, apart from a shifted character,
+/// which is how an uppercase letter arrives. Raw mode delivers no SIGINT, so a
+/// reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
 /// bound to — clearing the activity log — while Ctrl+D and Ctrl+R would have
-/// deleted and reloaded a row, and Ctrl+Enter would have replaced the pane's
+/// deleted and reloaded a row, and Shift+Enter would have replaced the pane's
 /// occupant, which is a removal.
 fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
     // The way out of raw mode, from any focus: the notes editor holds `q` but
@@ -1136,16 +1131,19 @@ fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
     if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
         return Some(Message::Quit);
     }
-    // Every binding below is for an unmodified key, so a chord this
-    // application does not bind is answered here rather than falling through
-    // to the bare key's. Above the match and not on the character arms,
-    // because `Enter`, `Up`/`Down`, `Tab`, `Esc` and `Backspace` arrive with
-    // modifiers too: Ctrl+Enter would open the pane — replacing an occupant,
-    // which is a removal — and Alt+q would quit.
-    if key
-        .modifiers
-        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
-    {
+    // Every binding below is for an unmodified key, with one exception: a
+    // shifted character on its way into the notes editor, which is how an
+    // uppercase letter arrives. Anything else carrying a modifier is a chord
+    // this application does not bind and must not fall through to the bare
+    // key's. Testing for `CONTROL` and `ALT` alone leaves four of the six
+    // through — Shift+Enter would open the pane, replacing an occupant, which
+    // is a removal, and Shift+Down would move the selection. Letting `SHIFT`
+    // through generally is no better: it would reach the row bindings, where
+    // `d` deletes.
+    let shifted_text = editing_notes(state)
+        && matches!(key.code, KeyCode::Char(_))
+        && key.modifiers == KeyModifiers::SHIFT;
+    if !key.modifiers.is_empty() && !shifted_text {
         return None;
     }
     match key.code {
@@ -1926,13 +1924,15 @@ mod tests {
         );
     }
 
-    /// A `CONTROL` chord runs no bare-key binding, and Ctrl+C leaves.
+    /// A modified key runs no bare-key binding, and Ctrl+C leaves.
     ///
     /// Raw mode delivers no SIGINT, so Ctrl+C arrives as an ordinary key
     /// event. Without the guard it would have found whatever `c` is bound to —
-    /// and Ctrl+D and Ctrl+R would have found the destructive two.
+    /// and Ctrl+D and Ctrl+R would have found the destructive two. `SHIFT` is
+    /// the exception, and only on a character: that is how an uppercase letter
+    /// arrives.
     #[test]
-    fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
+    fn a_modified_key_runs_no_bare_binding_and_ctrl_c_leaves() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
             reason: ExitReason::default(),
@@ -1958,7 +1958,13 @@ mod tests {
             KeyCode::Up,
             KeyCode::Down,
         ] {
-            for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+            for modifiers in [
+                KeyModifiers::CONTROL,
+                KeyModifiers::ALT,
+                KeyModifiers::SHIFT,
+                KeyModifiers::SUPER,
+                KeyModifiers::META,
+            ] {
                 assert!(
                     chord(&state, code, modifiers).is_none(),
                     "{code:?} with {modifiers:?} is a chord this application does not bind"
@@ -1995,14 +2001,24 @@ mod tests {
         for (code, modifiers) in [
             (KeyCode::Char('x'), KeyModifiers::CONTROL),
             (KeyCode::Char('q'), KeyModifiers::ALT),
+            (KeyCode::Char('d'), KeyModifiers::SUPER),
             (KeyCode::Backspace, KeyModifiers::CONTROL),
+            (KeyCode::Backspace, KeyModifiers::SHIFT),
             (KeyCode::Esc, KeyModifiers::ALT),
+            (KeyCode::Enter, KeyModifiers::SHIFT),
         ] {
             assert!(
                 chord(&state, code, modifiers).is_none(),
                 "{code:?} with {modifiers:?} neither edits nor leaves"
             );
         }
+        assert!(
+            matches!(
+                chord(&state, KeyCode::Char('X'), KeyModifiers::SHIFT),
+                Some(Message::Details(DetailsMessage::Input('X')))
+            ),
+            "while a shifted character is how an uppercase letter arrives"
+        );
     }
 
     /// A terminal error is recorded, because the quit that follows it leaves

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -58,9 +58,7 @@
 //!   write (`synced:`, `loaded details:`), which `dashboard.rs` has no
 //!   counterpart for because nothing there completes with a value later — its
 //!   commands hand a message straight back; `reloaded:`, for a key it
-//!   does not have; and the terminal-error line, which this file records and
-//!   `main` prints after restoring the terminal, where `dashboard.rs` prints it
-//!   from inside the run. Every row-scoped line names the row's key, because
+//!   does not have. Every row-scoped line names the row's key, because
 //!   here there is one and two rows added with `n` share a title.
 //! - **The status line is fixed before the child runs**, for every operation
 //!   a boundary claims. `dashboard.rs`'s root runs those updates itself and
@@ -117,14 +115,6 @@ const SYNC: &str = "sync";
 /// How long the stand-in requests take.
 const REQUEST_MS: u64 = 900;
 
-/// What a terminal-error line is written under.
-///
-/// Named once because two places have to agree on it: the reduce that records
-/// the reason, and the `main` that reads it back after restoring the terminal.
-/// A literal at each end would let one change silently and leave the other
-/// matching nothing.
-const TERMINAL_ERROR: &str = "terminal error: ";
-
 /// How many activity lines the pane keeps.
 const ACTIVITY_LIMIT: usize = 8;
 
@@ -160,6 +150,30 @@ impl ActivityLog {
         self.0
             .lock()
             .expect("the activity log lock is not poisoned")
+    }
+}
+
+/// Where the run leaves a reason `main` can print once the terminal is back.
+///
+/// A handle of its own rather than a line in the activity log, and the same one
+/// `dashboard.rs` has: a terminal error quits, `main` restores the terminal
+/// immediately after, and anything written to the screen — or to stderr while
+/// the alternate screen is up — goes with it. The report has to outlive the run
+/// to be a report at all, and a log the pane never draws again is not where it
+/// can do that.
+#[derive(Clone, Debug, Default)]
+struct ExitReason(Arc<Mutex<Option<String>>>);
+
+impl ExitReason {
+    fn set(&self, reason: String) {
+        *self.0.lock().expect("the exit reason lock is not poisoned") = Some(reason);
+    }
+
+    fn take(&self) -> Option<String> {
+        self.0
+            .lock()
+            .expect("the exit reason lock is not poisoned")
+            .take()
     }
 }
 
@@ -201,6 +215,8 @@ impl Focus {
 struct Setup {
     /// The activity log the reducers, the finalizers and the view share.
     activity: ActivityLog,
+    /// Where a terminal error is left for `main`.
+    reason: ExitReason,
     /// Messages dispatched at startup.
     ///
     /// `init`'s command is the *root's* command: it crosses no boundary, so
@@ -301,6 +317,7 @@ enum ActivityMessage {
 
 /// The root state. Each child's state is a field of it.
 struct App {
+    reason: ExitReason,
     focus: Focus,
     navigation: NavigationState,
     tasks: Keyed<TaskId, TaskState>,
@@ -441,11 +458,11 @@ impl Reducer for Root {
                 _ => Command::none(),
             },
             Message::TerminalError(error) => {
-                // Recorded rather than printed. The quit below ends the run
-                // and `main` restores the terminal immediately after, so this
-                // is the only report there is — and `main` prints it once the
-                // screen it would have been drawn on is gone.
-                state.activity.push(format!("{TERMINAL_ERROR}{error}"));
+                // Recorded rather than printed, and not into the activity log:
+                // the quit below ends the run and `main` restores the terminal
+                // immediately after, so the pane that would have shown it is
+                // never drawn again.
+                state.reason.set(error);
                 Command::quit()
             }
             Message::Quit => Command::quit(),
@@ -727,10 +744,12 @@ fn dashboard(activity: ActivityLog) -> impl Reducer<State = App, Message = Messa
 fn init(setup: Setup) -> (App, Command<Message>) {
     let Setup {
         activity,
+        reason,
         input,
         keyboard,
     } = setup;
     let state = App {
+        reason,
         focus: Focus::Navigation,
         navigation: NavigationState::new(),
         tasks: Keyed::new(),
@@ -1179,24 +1198,23 @@ async fn main() -> Result<()> {
 
     let activity = ActivityLog::default();
     activity.push("Application started".to_owned());
+    let reason = ExitReason::default();
     let setup = Setup {
         activity: activity.clone(),
+        reason: reason.clone(),
         input: seed(),
         keyboard: true,
     };
-    let program = dashboard(activity.clone()).into_program(init, view);
+    let program = dashboard(activity).into_program(init, view);
 
     let mut terminal = ratatui::init();
     let result = ProgramRuntime::new(program, setup).run(&mut terminal).await;
     ratatui::restore();
 
-    // What the run had to say and could not show. A terminal error quits, so
-    // the pane holding this line is never drawn again; printing it here is
-    // after the restore rather than into a screen that is about to go.
-    for line in activity.entries() {
-        if let Some(reason) = line.strip_prefix(TERMINAL_ERROR) {
-            eprintln!("Terminal error: {reason}");
-        }
+    // What the run had to say and could not show, now that there is a screen
+    // to say it on.
+    if let Some(reason) = reason.take() {
+        eprintln!("Terminal error: {reason}");
     }
 
     let _exit = result?;
@@ -1233,6 +1251,7 @@ mod tests {
     ) -> TestDriver<impl Program<Flags = Setup>, TestBackend> {
         let setup = Setup {
             activity: activity.clone(),
+            reason: ExitReason::default(),
             input,
             keyboard: false,
         };
@@ -1619,6 +1638,7 @@ mod tests {
     fn q_is_typed_into_the_notes_editor_only_while_one_is_open() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1661,6 +1681,7 @@ mod tests {
     fn escaping_an_empty_pane_leaves_it_without_claiming_a_close() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1704,6 +1725,7 @@ mod tests {
     fn the_selection_clamps_and_survives_a_delete_in_place() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1766,6 +1788,7 @@ mod tests {
     fn a_child_addressed_key_still_moves_the_status_line() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1802,6 +1825,7 @@ mod tests {
     fn a_repeat_is_an_instruction_and_a_release_is_not() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1833,6 +1857,7 @@ mod tests {
     fn a_key_needing_a_selection_reports_when_there_is_none() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1864,6 +1889,7 @@ mod tests {
     fn reloading_a_row_discards_what_was_local_to_it() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1898,6 +1924,7 @@ mod tests {
     fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
         let (mut state, _bootstrap) = init(Setup {
             activity: ActivityLog::default(),
+            reason: ExitReason::default(),
             input: Vec::new(),
             keyboard: false,
         });
@@ -1975,18 +2002,20 @@ mod tests {
     /// at all, rather than lost with the screen.
     #[test]
     fn a_terminal_error_leaves_a_reason_behind() {
-        let activity = ActivityLog::default();
+        let reason = ExitReason::default();
         let (mut state, _bootstrap) = init(Setup {
-            activity: activity.clone(),
+            activity: ActivityLog::default(),
+            reason: reason.clone(),
             input: Vec::new(),
             keyboard: false,
         });
 
         let quit = Root.reduce(&mut state, Message::TerminalError("broken pipe".to_owned()));
 
-        assert!(
-            recorded(&activity, "terminal error: broken pipe"),
-            "the reason is written down where `main` can still read it"
+        assert_eq!(
+            reason.take().as_deref(),
+            Some("broken pipe"),
+            "the reason is left where `main` can still read it"
         );
         assert!(!quit.is_none(), "and the run ends");
     }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1047,7 +1047,6 @@ fn delete_task(state: &mut App, id: TaskId) -> Command<Message> {
     Command::none()
 }
 
-/// Presents the details pane for a row.
 /// Whether the open pane holds notes the task does not.
 ///
 /// [`save_notes`] is the only thing that copies the buffer onto the task, so
@@ -1073,6 +1072,7 @@ fn unsaved_notes(state: &App) -> bool {
     })
 }
 
+/// Presents the details pane for a row.
 fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
     let Some(task) = state.tasks.get(&id) else {
         state.status = "That task is gone";

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1,0 +1,1168 @@
+//! [`dashboard.rs`](dashboard.rs) written with composed reducers.
+//!
+//! The same application: a navigation list, a task list, a details pane for
+//! the selected task, an activity log and a status line, cycled through with
+//! Tab. What differs is who owns the wiring.
+//!
+//! In `dashboard.rs` the root owns it. `App::update` matches every child
+//! variant and forwards it, `App::subscriptions` is the root's alone, and any
+//! work a task started would be the root's to stop when that task is deleted.
+//! That is the right shape while every child is a single instance whose
+//! identities the root can keep distinct by hand.
+//!
+//! Here the task list is a [`Keyed`] collection with one child reducer per
+//! row, and the details pane is a [`Slot`] whose occupant comes and goes. Both
+//! break that assumption: every row wants the same timer and the same command
+//! id, and only the row it belongs to tells two of them apart. So:
+//!
+//! - [`ReducerExt::scope`] composes the two fixed siblings (`Navigation` and
+//!   `Activity`) under segments of their own.
+//! - [`ReducerExt::for_each`] composes one `Task` per row, each under its key.
+//! - [`ReducerExt::presented`] composes the `Details` occupant.
+//! - [`ReducerExt::into_program`] closes the stack with the two root-level
+//!   functions composition has no place for: `init` and `view`.
+//!
+//! Every timer below is declared on the **same interval** and every command
+//! keyed with the **same** `CommandId::new(SYNC)`. Written by hand those are
+//! collisions: one timer shared by every row, one sync slot for the whole
+//! application. Composed they are not, and no `.scoped(...)` call appears
+//! anywhere in this file.
+//!
+//! Removal is the other half. A row leaves through [`Keyed::remove`] or is
+//! replaced by [`Keyed::insert`]; the occupant leaves through [`Slot::dismiss`]
+//! or a replacing [`Slot::present`]. The boundary turns each of those into a
+//! teardown of that instance's scope, so its timer stops and its in-flight sync
+//! is cancelled without this file asking for either. The `on_teardown` hooks
+//! each child registers write the line you see in the activity pane when it
+//! happens — a finalizer produces no message by design, so the log it writes to
+//! is a handle rather than a message.
+//!
+//! Cross-child work stays the root's. Saving the details pane's notes back
+//! onto the task it was opened for touches two children, so it is a root
+//! message; see `Message::SaveNotes`.
+//!
+//! Run with: `cargo run --example dashboard_composed`
+//! Test with: `cargo test --example dashboard_composed`
+
+use std::num::NonZeroU64;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+use color_eyre::eyre::Result;
+use crossterm::event::{Event, KeyCode};
+use futures::stream;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use tears::ProgramRuntime;
+use tears::command::CommandId;
+use tears::prelude::*;
+use tears::reducer::{Keyed, Reducer, ReducerExt, Slot};
+use tears::subscription::terminal::TerminalEvents;
+use tears::subscription::time::{Timer, TimerEvent};
+use tokio::time::sleep;
+
+/// The interval every timer in this example is declared on.
+///
+/// Deliberately one constant: `Timer`'s subscription key *is* its interval, so
+/// every declaration below carries the same raw identity. What keeps them from
+/// collapsing into one subscription is the segment each boundary applies.
+const TICK_MS: u64 = 1_000;
+
+/// The command id every stand-in request in this example runs under.
+///
+/// Deliberately one constant too. Keyed on it without a boundary, two rows'
+/// syncs would cancel each other; under `for_each` they are two slots.
+const SYNC: &str = "sync";
+
+/// How long the stand-in requests take.
+const REQUEST_MS: u64 = 900;
+
+/// How many activity lines the pane keeps.
+const ACTIVITY_LIMIT: usize = 8;
+
+/// The activity log, shared by the reducers that write to it and the teardown
+/// finalizers that report through it.
+///
+/// It is a handle rather than a plain `Vec` for one reason:
+/// [`Command::on_teardown`] takes a future with `Output = ()`, so a finalizer
+/// cannot send a message and needs somewhere to write that outlives the reduce
+/// that registered it. Everything else about it is ordinary state — it is the
+/// `Activity` child's whole state, and the root view renders it.
+#[derive(Clone, Default)]
+struct ActivityLog(Arc<Mutex<Vec<String>>>);
+
+impl ActivityLog {
+    fn push(&self, entry: String) {
+        let mut entries = self.entries_mut();
+        entries.push(entry);
+        if entries.len() > ACTIVITY_LIMIT {
+            entries.remove(0);
+        }
+    }
+
+    fn clear(&self) {
+        self.entries_mut().clear();
+    }
+
+    fn entries(&self) -> Vec<String> {
+        self.entries_mut().clone()
+    }
+
+    fn entries_mut(&self) -> MutexGuard<'_, Vec<String>> {
+        self.0
+            .lock()
+            .expect("the activity log lock is not poisoned")
+    }
+}
+
+/// The fixed segments this composition uses.
+///
+/// A `for_each` boundary segments by the row's own key, so only the three
+/// fixed-segment boundaries need a value here.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Segment {
+    Navigation,
+    Activity,
+    Details,
+}
+
+/// A task's key, and therefore its segment at the row boundary.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct TaskId(u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Focus {
+    Navigation,
+    Tasks,
+    Details,
+    Activity,
+}
+
+impl Focus {
+    const fn next(self) -> Self {
+        match self {
+            Self::Navigation => Self::Tasks,
+            Self::Tasks => Self::Details,
+            Self::Details => Self::Activity,
+            Self::Activity => Self::Navigation,
+        }
+    }
+}
+
+/// What the program is started with.
+struct Setup {
+    /// The activity log the reducers, the finalizers and the view share.
+    activity: ActivityLog,
+    /// Messages dispatched at startup.
+    ///
+    /// `init`'s command is the *root's* command: it crosses no boundary, so
+    /// nothing it starts is scoped to a child. Work that belongs to a child
+    /// therefore starts as a message routed through the boundary — which is
+    /// what these are — rather than as a command returned from here.
+    input: Vec<Message>,
+    /// Whether the root reads the terminal. The runnable binary does; a test
+    /// driving this program scripts `input` instead and leaves the terminal
+    /// alone.
+    keyboard: bool,
+}
+
+#[derive(Debug)]
+enum Message {
+    Terminal(Event),
+    TerminalError(String),
+    Quit,
+    FocusNext,
+    SelectPrev,
+    SelectNext,
+    AddTask(TaskId, String),
+    DeleteTask(TaskId),
+    /// Discards a row's instance and starts a fresh one under the same key.
+    ReloadTask(TaskId),
+    OpenDetails(TaskId),
+    CloseDetails,
+    /// Writes the occupant's edited notes onto the task it was opened for.
+    ///
+    /// Two children, so the root does it: a child is handed its own projected
+    /// state and can reach neither the collection it sits beside nor the slot
+    /// it sits in.
+    SaveNotes,
+    Navigation(NavigationMessage),
+    Task(TaskId, TaskMessage),
+    Details(DetailsMessage),
+    Activity(ActivityMessage),
+}
+
+#[derive(Debug)]
+enum NavigationMessage {
+    Up,
+    Down,
+}
+
+#[derive(Debug)]
+enum TaskMessage {
+    /// The row's one-time setup, routed through the row boundary so the hook it
+    /// registers anchors at the row's scope.
+    Watch,
+    Toggle,
+    Sync,
+    Synced(String),
+    Tick,
+}
+
+#[derive(Debug)]
+enum DetailsMessage {
+    /// The occupant's one-time setup, for the reason [`TaskMessage::Watch`] is.
+    Open,
+    Loaded(String),
+    Input(char),
+    Backspace,
+    Tick,
+}
+
+#[derive(Debug)]
+enum ActivityMessage {
+    Clear,
+}
+
+/// The root state. Each child's state is a field of it.
+struct App {
+    focus: Focus,
+    navigation: NavigationState,
+    tasks: Keyed<TaskId, TaskState>,
+    details: Slot<DetailsState>,
+    activity: ActivityLog,
+    status: &'static str,
+    selected: Option<TaskId>,
+    next_id: u32,
+    keyboard: bool,
+}
+
+struct NavigationState {
+    items: Vec<&'static str>,
+    selected: usize,
+}
+
+impl NavigationState {
+    fn new() -> Self {
+        Self {
+            items: vec!["Inbox", "Today", "Upcoming", "Archive"],
+            selected: 0,
+        }
+    }
+
+    fn selected_label(&self) -> &'static str {
+        self.items[self.selected]
+    }
+}
+
+struct TaskState {
+    title: String,
+    done: bool,
+    notes: String,
+    syncing: bool,
+    ticks: u32,
+}
+
+impl TaskState {
+    const fn new(title: String, notes: String) -> Self {
+        Self {
+            title,
+            done: false,
+            notes,
+            syncing: false,
+            ticks: 0,
+        }
+    }
+}
+
+struct DetailsState {
+    task: TaskId,
+    title: String,
+    notes: String,
+    loading: bool,
+    ticks: u32,
+}
+
+impl DetailsState {
+    const fn new(task: TaskId, title: String, notes: String) -> Self {
+        Self {
+            task,
+            title,
+            notes,
+            loading: true,
+            ticks: 0,
+        }
+    }
+}
+
+/// A stand-in for a request to a server.
+async fn request(what: String) -> String {
+    sleep(Duration::from_millis(REQUEST_MS)).await;
+    what
+}
+
+/// The heartbeat every child with runs of its own declares, on the one shared
+/// interval.
+fn tick<Msg: Send + 'static>(to_message: fn(TimerEvent) -> Msg) -> Subscription<Msg> {
+    Subscription::new(Timer::new(
+        NonZeroU64::new(TICK_MS).expect("the tick interval is non-zero"),
+    ))
+    .map(to_message)
+}
+
+/// The root reducer: what none of the boundaries claimed lands here.
+struct Root;
+
+impl Reducer for Root {
+    type State = App;
+    type Message = Message;
+
+    fn reduce(&self, state: &mut App, message: Message) -> Command<Message> {
+        match message {
+            Message::Terminal(event) => match event {
+                Event::Key(key) => key_message(state, key.code)
+                    .map_or_else(Command::none, |message| Command::message(message).into()),
+                _ => Command::none(),
+            },
+            Message::TerminalError(error) => {
+                state.activity.push(format!("terminal error: {error}"));
+                Command::quit()
+            }
+            Message::Quit => Command::quit(),
+            Message::FocusNext => {
+                state.focus = state.focus.next();
+                state.status = "Changed focus";
+                Command::none()
+            }
+            Message::SelectPrev | Message::SelectNext => {
+                let forward = matches!(message, Message::SelectNext);
+                select(state, forward);
+                Command::none()
+            }
+            Message::AddTask(id, title) => {
+                // Insertion into an absent key records no removal: nothing was
+                // running under it to tear down.
+                state.tasks.insert(
+                    id,
+                    TaskState::new(title, "Add notes in the details pane.".to_owned()),
+                );
+                state.next_id = state.next_id.max(id.0 + 1);
+                state.selected = Some(id);
+                state.status = "Added a task";
+                Command::message(Message::Task(id, TaskMessage::Watch)).into()
+            }
+            Message::ReloadTask(id) => {
+                let Some(task) = state.tasks.get(&id) else {
+                    return Command::none();
+                };
+                // Inserting over an occupied key is a replacement, and a
+                // replacement is a removal: the boundary tears the old
+                // instance's runs down before this command's spawns start the
+                // successor's.
+                let title = task.title.clone();
+                state.tasks.insert(
+                    id,
+                    TaskState::new(title, "Reloaded from the server.".to_owned()),
+                );
+                state.status = "Reloaded the task";
+                Command::message(Message::Task(id, TaskMessage::Watch)).into()
+            }
+            Message::DeleteTask(id) => {
+                // `remove` records the removal; the row boundary drains it in
+                // this same reduce and merges the row's teardown into the
+                // command returned here. Nothing below asks for that.
+                let Some(task) = state.tasks.remove(&id) else {
+                    return Command::none();
+                };
+                state.activity.push(format!("deleted: {}", task.title));
+                // A details pane open on the row that just left goes with it,
+                // and the slot's own boundary originates that teardown.
+                if state.details.get().is_some_and(|open| open.task == id) {
+                    state.details.dismiss();
+                }
+                if state.selected == Some(id) {
+                    state.selected = state.tasks.keys().next().copied();
+                }
+                state.status = "Deleted the task";
+                Command::none()
+            }
+            Message::OpenDetails(id) => {
+                let Some(task) = state.tasks.get(&id) else {
+                    return Command::none();
+                };
+                // Presenting over an occupied slot is a replacement too, for
+                // the same reason `ReloadTask` is.
+                state.details.present(DetailsState::new(
+                    id,
+                    task.title.clone(),
+                    task.notes.clone(),
+                ));
+                state.focus = Focus::Details;
+                state.status = "Opened the details pane";
+                Command::message(Message::Details(DetailsMessage::Open)).into()
+            }
+            Message::CloseDetails => {
+                state.details.dismiss();
+                state.status = "Closed the details pane";
+                Command::none()
+            }
+            Message::SaveNotes => {
+                let Some(open) = state.details.get() else {
+                    return Command::none();
+                };
+                let (task_id, notes) = (open.task, open.notes.clone());
+                let Some(task) = state.tasks.get_mut(&task_id) else {
+                    return Command::none();
+                };
+                task.notes = notes;
+                state
+                    .activity
+                    .push(format!("updated notes for '{}'", task.title));
+                state.status = "Saved the notes";
+                // The row's own sync is the row's to run, so it is asked for
+                // through the boundary rather than started here.
+                Command::message(Message::Task(task_id, TaskMessage::Sync)).into()
+            }
+            // Claimed by a boundary above this reducer and never routed here.
+            Message::Navigation(_)
+            | Message::Task(..)
+            | Message::Details(_)
+            | Message::Activity(_) => Command::none(),
+        }
+    }
+
+    fn subscriptions(&self, state: &App) -> Vec<Subscription<Message>> {
+        if !state.keyboard {
+            return Vec::new();
+        }
+        vec![
+            Subscription::new(TerminalEvents::new()).map(|result| match result {
+                Ok(event) => Message::Terminal(event),
+                Err(error) => Message::TerminalError(error.to_string()),
+            }),
+        ]
+    }
+}
+
+/// A fixed sibling with no runs of its own: `scope` buys code organisation
+/// here, not identity separation.
+struct Navigation;
+
+impl Reducer for Navigation {
+    type State = NavigationState;
+    type Message = NavigationMessage;
+
+    fn reduce(
+        &self,
+        state: &mut NavigationState,
+        message: NavigationMessage,
+    ) -> Command<NavigationMessage> {
+        match message {
+            NavigationMessage::Up => state.selected = state.selected.saturating_sub(1),
+            NavigationMessage::Down => {
+                state.selected = (state.selected + 1).min(state.items.len().saturating_sub(1));
+            }
+        }
+        Command::none()
+    }
+}
+
+/// The other fixed sibling.
+struct Activity;
+
+impl Reducer for Activity {
+    type State = ActivityLog;
+    type Message = ActivityMessage;
+
+    fn reduce(
+        &self,
+        state: &mut ActivityLog,
+        message: ActivityMessage,
+    ) -> Command<ActivityMessage> {
+        match message {
+            ActivityMessage::Clear => state.clear(),
+        }
+        Command::none()
+    }
+}
+
+/// One row of the keyed collection.
+struct Task {
+    activity: ActivityLog,
+}
+
+impl Reducer for Task {
+    type State = TaskState;
+    type Message = TaskMessage;
+
+    fn reduce(&self, state: &mut TaskState, message: TaskMessage) -> Command<TaskMessage> {
+        match message {
+            TaskMessage::Watch => {
+                let activity = self.activity.clone();
+                let title = state.title.clone();
+                Command::batch([
+                    // Registered here rather than at the root, so it anchors at
+                    // this row's scope and the row's own teardown selects it. A
+                    // registration made outside a boundary anchors at the root,
+                    // which no teardown reaches.
+                    Command::on_teardown(async move {
+                        activity.push(format!("stopped watching: {title}"));
+                    }),
+                    Command::message(TaskMessage::Sync).into(),
+                ])
+            }
+            TaskMessage::Toggle => {
+                state.done = !state.done;
+                Command::message(TaskMessage::Sync).into()
+            }
+            TaskMessage::Sync => {
+                state.syncing = true;
+                let title = state.title.clone();
+                Command::perform(request(title), TaskMessage::Synced)
+                    .cancellable(CommandId::new(SYNC))
+                    .into()
+            }
+            TaskMessage::Synced(title) => {
+                state.syncing = false;
+                self.activity.push(format!("synced: {title}"));
+                Command::none()
+            }
+            TaskMessage::Tick => {
+                state.ticks += 1;
+                Command::none()
+            }
+        }
+    }
+
+    fn subscriptions(&self, _state: &TaskState) -> Vec<Subscription<TaskMessage>> {
+        vec![tick(|TimerEvent::Tick| TaskMessage::Tick)]
+    }
+}
+
+/// The optionally-present child.
+struct Details {
+    activity: ActivityLog,
+}
+
+impl Reducer for Details {
+    type State = DetailsState;
+    type Message = DetailsMessage;
+
+    fn reduce(&self, state: &mut DetailsState, message: DetailsMessage) -> Command<DetailsMessage> {
+        match message {
+            DetailsMessage::Open => {
+                let activity = self.activity.clone();
+                let title = state.title.clone();
+                Command::batch([
+                    Command::on_teardown(async move {
+                        activity.push(format!("closed details: {title}"));
+                    }),
+                    Command::perform(request(state.title.clone()), DetailsMessage::Loaded)
+                        // The same id every row's sync uses. Two boundaries,
+                        // two slots.
+                        .cancellable(CommandId::new(SYNC))
+                        .into(),
+                ])
+            }
+            DetailsMessage::Loaded(title) => {
+                state.loading = false;
+                self.activity.push(format!("loaded details: {title}"));
+                Command::none()
+            }
+            DetailsMessage::Input(character) => {
+                state.notes.push(character);
+                Command::none()
+            }
+            DetailsMessage::Backspace => {
+                state.notes.pop();
+                Command::none()
+            }
+            DetailsMessage::Tick => {
+                state.ticks += 1;
+                Command::none()
+            }
+        }
+    }
+
+    fn subscriptions(&self, _state: &DetailsState) -> Vec<Subscription<DetailsMessage>> {
+        vec![tick(|TimerEvent::Tick| DetailsMessage::Tick)]
+    }
+}
+
+/// The composition: one root and four boundaries over it.
+///
+/// Each call adds one boundary and the result is still a reducer over the
+/// root's state and message, which is why they chain. The outermost boundary
+/// gets first refusal on a message; what no boundary claims reaches [`Root`].
+fn dashboard(activity: ActivityLog) -> impl Reducer<State = App, Message = Message> {
+    Root.scope(
+        Navigation,
+        Segment::Navigation,
+        |state| &state.navigation,
+        |state| &mut state.navigation,
+        |message| match message {
+            Message::Navigation(inner) => Ok(inner),
+            other => Err(other),
+        },
+        Message::Navigation,
+    )
+    .scope(
+        Activity,
+        Segment::Activity,
+        |state| &state.activity,
+        |state| &mut state.activity,
+        |message| match message {
+            Message::Activity(inner) => Ok(inner),
+            other => Err(other),
+        },
+        Message::Activity,
+    )
+    .for_each(
+        Task {
+            activity: activity.clone(),
+        },
+        |state| &state.tasks,
+        |state| &mut state.tasks,
+        |message| match message {
+            Message::Task(id, inner) => Ok((id, inner)),
+            other => Err(other),
+        },
+        Message::Task,
+    )
+    .presented(
+        Details { activity },
+        Segment::Details,
+        |state| &state.details,
+        |state| &mut state.details,
+        |message| match message {
+            Message::Details(inner) => Ok(inner),
+            other => Err(other),
+        },
+        Message::Details,
+    )
+}
+
+/// The root's initial state and the command dispatched at bootstrap.
+fn init(setup: Setup) -> (App, Command<Message>) {
+    let Setup {
+        activity,
+        input,
+        keyboard,
+    } = setup;
+    let state = App {
+        focus: Focus::Navigation,
+        navigation: NavigationState::new(),
+        tasks: Keyed::new(),
+        details: Slot::empty(),
+        activity,
+        status: "Ready",
+        selected: None,
+        next_id: 1,
+        keyboard,
+    };
+    (state, Command::stream(stream::iter(input)).into())
+}
+
+/// The tasks the runnable binary starts with, as the startup messages that
+/// route each one through the row boundary.
+fn seed() -> Vec<Message> {
+    [
+        "Review release checklist",
+        "Update onboarding guide",
+        "Plan next subscription API",
+    ]
+    .into_iter()
+    .enumerate()
+    .map(|(index, title)| {
+        let id = u32::try_from(index).expect("three seeds fit") + 1;
+        Message::AddTask(TaskId(id), title.to_owned())
+    })
+    .collect()
+}
+
+/// The root view. `Reducer` has no `view` and only `Program` does, so
+/// composing child panes is ordinary function calls over the root state.
+fn view(state: &App, frame: &mut Frame<'_>) {
+    let [header, body, activity, footer] = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(8),
+        Constraint::Length(7),
+        Constraint::Length(3),
+    ])
+    .areas(frame.area());
+
+    let [nav_area, tasks_area, details_area] = Layout::horizontal([
+        Constraint::Length(24),
+        Constraint::Percentage(40),
+        Constraint::Percentage(60),
+    ])
+    .areas(body);
+
+    frame.render_widget(
+        Paragraph::new(format!(
+            "Composed dashboard · {} | Tab: focus | q: quit",
+            state.navigation.selected_label()
+        ))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Reducer Composition"),
+        ),
+        header,
+    );
+    render_navigation(state, frame, nav_area);
+    render_tasks(state, frame, tasks_area);
+    render_details(state, frame, details_area);
+    render_activity(state, frame, activity);
+    frame.render_widget(
+        Paragraph::new(format!("Status: {}", state.status))
+            .block(Block::default().borders(Borders::ALL).title("Status")),
+        footer,
+    );
+}
+
+fn pane_title(label: &str, focused: bool) -> String {
+    if focused {
+        format!("{label} [focused]")
+    } else {
+        label.to_owned()
+    }
+}
+
+fn render_navigation(state: &App, frame: &mut Frame<'_>, area: Rect) {
+    let items = state
+        .navigation
+        .items
+        .iter()
+        .enumerate()
+        .map(|(index, label)| {
+            let marker = if index == state.navigation.selected {
+                ">"
+            } else {
+                " "
+            };
+            ListItem::new(format!("{marker} {label}"))
+        });
+    frame.render_widget(
+        List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(pane_title("Navigation", state.focus == Focus::Navigation)),
+        ),
+        area,
+    );
+}
+
+fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
+    let items = state.tasks.iter().map(|(id, task)| {
+        let marker = if state.selected == Some(*id) {
+            ">"
+        } else {
+            " "
+        };
+        let checkbox = if task.done { "[x]" } else { "[ ]" };
+        let sync = if task.syncing { " (syncing)" } else { "" };
+        ListItem::new(format!(
+            "{marker} {checkbox} {} · {}s{sync}",
+            task.title, task.ticks
+        ))
+    });
+    frame.render_widget(
+        List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
+            "{} (up/down, space, n, d, r, enter)",
+            pane_title("Tasks", state.focus == Focus::Tasks)
+        ))),
+        area,
+    );
+}
+
+fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
+    let text = state.details.get().map_or_else(
+        || "No details open. Select a task and press Enter.".to_owned(),
+        |open| {
+            format!(
+                "{} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",
+                open.title,
+                open.ticks,
+                if open.loading { " (loading)" } else { "" },
+                open.notes
+            )
+        },
+    );
+    frame.render_widget(
+        Paragraph::new(text).wrap(Wrap { trim: false }).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(pane_title("Details", state.focus == Focus::Details)),
+        ),
+        area,
+    );
+}
+
+fn render_activity(state: &App, frame: &mut Frame<'_>, area: Rect) {
+    let items: Vec<ListItem<'_>> = state
+        .activity
+        .entries()
+        .iter()
+        .rev()
+        .map(|entry| ListItem::new(format!("- {entry}")))
+        .collect();
+    frame.render_widget(
+        List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
+            "{} (c: clear)",
+            pane_title("Activity", state.focus == Focus::Activity)
+        ))),
+        area,
+    );
+}
+
+/// Moves the task selection, wrapping.
+fn select(state: &mut App, forward: bool) {
+    let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
+    if keys.is_empty() {
+        return;
+    }
+    let position = state
+        .selected
+        .and_then(|selected| keys.iter().position(|key| *key == selected));
+    let next = match position {
+        Some(index) if forward => (index + 1) % keys.len(),
+        Some(index) => (index + keys.len() - 1) % keys.len(),
+        None => 0,
+    };
+    state.selected = keys.get(next).copied();
+    state.status = "Selected another task";
+}
+
+/// The message a key press asks for, if any.
+fn key_message(state: &App, code: KeyCode) -> Option<Message> {
+    match code {
+        KeyCode::Char('q') => Some(Message::Quit),
+        KeyCode::Tab => Some(Message::FocusNext),
+        KeyCode::Up => match state.focus {
+            Focus::Navigation => Some(Message::Navigation(NavigationMessage::Up)),
+            Focus::Tasks => Some(Message::SelectPrev),
+            _ => None,
+        },
+        KeyCode::Down => match state.focus {
+            Focus::Navigation => Some(Message::Navigation(NavigationMessage::Down)),
+            Focus::Tasks => Some(Message::SelectNext),
+            _ => None,
+        },
+        KeyCode::Char(' ') if state.focus == Focus::Tasks => state
+            .selected
+            .map(|id| Message::Task(id, TaskMessage::Toggle)),
+        KeyCode::Char('n') if state.focus == Focus::Tasks => Some(Message::AddTask(
+            TaskId(state.next_id),
+            format!("New task {}", state.next_id),
+        )),
+        KeyCode::Char('d') if state.focus == Focus::Tasks => {
+            state.selected.map(Message::DeleteTask)
+        }
+        KeyCode::Char('r') if state.focus == Focus::Tasks => {
+            state.selected.map(Message::ReloadTask)
+        }
+        KeyCode::Enter if state.focus == Focus::Tasks => state.selected.map(Message::OpenDetails),
+        KeyCode::Char('c') if state.focus == Focus::Activity => {
+            Some(Message::Activity(ActivityMessage::Clear))
+        }
+        KeyCode::Enter if state.focus == Focus::Details => Some(Message::SaveNotes),
+        KeyCode::Esc if state.focus == Focus::Details => Some(Message::CloseDetails),
+        KeyCode::Backspace if state.focus == Focus::Details => {
+            Some(Message::Details(DetailsMessage::Backspace))
+        }
+        KeyCode::Char(character) if state.focus == Focus::Details => {
+            Some(Message::Details(DetailsMessage::Input(character)))
+        }
+        _ => None,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
+    let activity = ActivityLog::default();
+    activity.push("Application started".to_owned());
+    let setup = Setup {
+        activity: activity.clone(),
+        input: seed(),
+        keyboard: true,
+    };
+    let program = dashboard(activity).into_program(init, view);
+
+    let mut terminal = ratatui::init();
+    let result = ProgramRuntime::new(program, setup).run(&mut terminal).await;
+    ratatui::restore();
+
+    let _exit = result?;
+    Ok(())
+}
+
+/// Deterministic tests for this example's composition, driven by
+/// `tears::testing::TestDriver` (RFC 0008 §9). `TestStore` takes an
+/// `Application`, which is what `dashboard.rs`'s tests use; a composed
+/// `Program` is driven here instead. Run them with
+/// `cargo test --example dashboard_composed`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ratatui::Terminal;
+    use ratatui::backend::{Backend, TestBackend};
+    use tears::reducer::Program;
+    use tears::testing::{Confirmed, RunKind, RunName, StepReport, TestDriver, WakeSource};
+    use tears::{RuntimeConfig, SubscriptionId};
+
+    /// The turn budget every driving call below states.
+    const TURNS: usize = 64;
+
+    /// The program `main` runs, driven message by message.
+    ///
+    /// The same `dashboard` stack, closed with the same `init` and the same
+    /// `view`. Only the `Setup` differs: a scripted `input` instead of the
+    /// binary's seed, and `keyboard` off so the run reads no terminal.
+    fn scripted(
+        activity: &ActivityLog,
+        input: Vec<Message>,
+    ) -> TestDriver<impl Program<Flags = Setup>, TestBackend> {
+        let setup = Setup {
+            activity: activity.clone(),
+            input,
+            keyboard: false,
+        };
+        let terminal = Terminal::new(TestBackend::new(80, 24)).expect("the test backend is built");
+        TestDriver::new(
+            dashboard(activity.clone()).into_program(init, view),
+            setup,
+            RuntimeConfig::new(),
+            terminal,
+        )
+    }
+
+    /// Releases one of `run`'s sends and runs the pass that delivers it.
+    fn deliver<P: Program, B: Backend>(
+        driver: &mut TestDriver<P, B>,
+        run: &RunName,
+    ) -> StepReport<B::Error> {
+        let token = driver.grant(run.clone()).expect("no grant is outstanding");
+        assert_eq!(
+            driver.confirm(TURNS, token),
+            Confirmed::Accepted,
+            "the released send reached the data lane"
+        );
+        let report = driver
+            .step_pass(WakeSource::Data)
+            .expect("the data lane is ready");
+        assert!(
+            report.terminated.is_none(),
+            "the pass did not terminate the program"
+        );
+        report
+    }
+
+    /// The one anonymous run a step started — the message a reduce asked for.
+    fn anonymous<E>(report: &StepReport<E>, what: &str) -> RunName {
+        one(
+            report
+                .started
+                .iter()
+                .filter(|run| run.kind() == RunKind::Anonymous)
+                .cloned()
+                .collect(),
+            what,
+        )
+    }
+
+    /// The subscription identities a step started.
+    fn subscriptions<E>(report: &StepReport<E>) -> Vec<SubscriptionId> {
+        report
+            .started
+            .iter()
+            .filter_map(|run| match run.kind() {
+                RunKind::Subscription(id) => Some(id),
+                RunKind::Keyed(_) | RunKind::Anonymous => None,
+            })
+            .collect()
+    }
+
+    /// The command identities the keyed runs a step started carry.
+    fn keys<E>(report: &StepReport<E>) -> Vec<CommandId> {
+        report
+            .started
+            .iter()
+            .filter_map(|run| match run.kind() {
+                RunKind::Keyed(id) => Some(id),
+                RunKind::Subscription(_) | RunKind::Anonymous => None,
+            })
+            .collect()
+    }
+
+    fn one<T>(mut values: Vec<T>, what: &str) -> T {
+        assert_eq!(values.len(), 1, "expected exactly one {what}");
+        values.pop().expect("the length was just asserted")
+    }
+
+    fn recorded(activity: &ActivityLog, line: &str) -> bool {
+        activity.entries().iter().any(|entry| entry == line)
+    }
+
+    /// Adds one task and drives it to the keyed sync its row runs, returning
+    /// the identities that row's boundary produced.
+    fn add_task<P: Program, B: Backend>(
+        driver: &mut TestDriver<P, B>,
+        script: &RunName,
+    ) -> (SubscriptionId, CommandId) {
+        let report = deliver(driver, script);
+        let timer = one(subscriptions(&report), "row timer");
+        let watch = anonymous(&report, "row setup message");
+        let report = deliver(driver, &watch);
+        let sync = anonymous(&report, "row sync message");
+        (timer, one(keys(&deliver(driver, &sync)), "row sync"))
+    }
+
+    /// Every timer in this composition is declared on one interval and every
+    /// request keyed under one command id, and no two of them collide.
+    ///
+    /// That is the boundary's doing and nothing else's: `dashboard` writes no
+    /// `.scoped(...)`, and neither does any reducer in this file.
+    #[test]
+    fn identical_child_identities_stay_apart_under_their_boundaries() {
+        let activity = ActivityLog::default();
+        let mut driver = scripted(
+            &activity,
+            vec![
+                Message::AddTask(TaskId(1), "alpha".to_owned()),
+                Message::AddTask(TaskId(2), "beta".to_owned()),
+                Message::OpenDetails(TaskId(1)),
+            ],
+        );
+
+        // Nothing declares a subscription over state that is not there yet, so
+        // bootstrap starts the scripted input and nothing else.
+        let boot = driver.boot();
+        assert!(boot.terminated.is_none(), "bootstrap did not terminate");
+        assert!(
+            subscriptions(&boot).is_empty(),
+            "no row and no occupant, so no timer"
+        );
+        let script = anonymous(&boot, "scripted input run");
+
+        let (alpha_timer, alpha_sync) = add_task(&mut driver, &script);
+        let (beta_timer, beta_sync) = add_task(&mut driver, &script);
+
+        // The occupant declares the same timer again and keys its load with
+        // the same id, one boundary over.
+        let report = deliver(&mut driver, &script);
+        let details_timer = one(subscriptions(&report), "occupant timer");
+        let open = anonymous(&report, "occupant setup message");
+        let details_load = one(keys(&deliver(&mut driver, &open)), "occupant load");
+
+        assert_ne!(
+            alpha_timer, beta_timer,
+            "each row's timer is qualified by that row's key, so the two rows declaring the same \
+             interval are two subscriptions"
+        );
+        assert_ne!(
+            alpha_timer, details_timer,
+            "and the slot's segment separates the occupant's timer from a row's"
+        );
+        assert_ne!(
+            alpha_sync, beta_sync,
+            "each row's sync is keyed under that row's segment, so one row's sync cannot cancel \
+             another's"
+        );
+        assert_ne!(
+            alpha_sync, details_load,
+            "nor can the occupant's load, one boundary over"
+        );
+        assert_ne!(
+            alpha_sync,
+            CommandId::new(SYNC),
+            "and no run occupies the unqualified id the reducers wrote"
+        );
+    }
+
+    /// The four removal shapes a boundary tears down, and the one thing that is
+    /// not a removal.
+    ///
+    /// Nothing in this file calls `Command::teardown`: each `stopped watching`
+    /// and `closed details` line below is a hook a child registered, fired by
+    /// the teardown its boundary originated when the instance left.
+    #[test]
+    fn every_removal_tears_its_instance_down() {
+        let activity = ActivityLog::default();
+        let mut driver = scripted(
+            &activity,
+            vec![
+                Message::AddTask(TaskId(1), "alpha".to_owned()),
+                Message::AddTask(TaskId(2), "beta".to_owned()),
+                Message::OpenDetails(TaskId(1)),
+                // Presenting over an occupied slot: a replacement, which is a
+                // removal of the occupant.
+                Message::OpenDetails(TaskId(2)),
+                // Inserting over an occupied key: the same, one collection
+                // over.
+                Message::ReloadTask(TaskId(2)),
+                // A row leaving the keyed collection.
+                Message::DeleteTask(TaskId(1)),
+                // An occupied slot dismissed.
+                Message::CloseDetails,
+            ],
+        );
+
+        let boot = driver.boot();
+        assert!(boot.terminated.is_none(), "bootstrap did not terminate");
+        let script = anonymous(&boot, "scripted input run");
+
+        // Both rows added and set up, so both have a hook registered under
+        // their own key.
+        add_task(&mut driver, &script);
+        add_task(&mut driver, &script);
+        assert!(
+            activity.entries().is_empty(),
+            "an insert into an absent key removes no instance, so nothing is torn down"
+        );
+
+        // The slot's first occupant, set up the same way.
+        let report = deliver(&mut driver, &script);
+        let open = anonymous(&report, "occupant setup message");
+        deliver(&mut driver, &open);
+
+        // Replacing the occupant removes it.
+        let report = deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "closed details: alpha"));
+        let open = anonymous(&report, "occupant setup message");
+        deliver(&mut driver, &open);
+
+        // Replacing a row removes it, and the successor starts fresh under the
+        // same key.
+        let report = deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: beta"));
+        let watch = anonymous(&report, "row setup message");
+        deliver(&mut driver, &watch);
+
+        // Removing a row removes it, and leaves the other row alone.
+        deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: alpha"));
+
+        // Dismissing the slot removes its occupant.
+        deliver(&mut driver, &script);
+        driver.settle(TURNS, || recorded(&activity, "closed details: beta"));
+
+        assert_eq!(
+            activity.entries(),
+            vec![
+                "closed details: alpha".to_owned(),
+                "stopped watching: beta".to_owned(),
+                // The root's own line, written by the reduce that removed the
+                // row, before the teardown it originated ran.
+                "deleted: alpha".to_owned(),
+                "stopped watching: alpha".to_owned(),
+                "closed details: beta".to_owned(),
+            ],
+            "one teardown per removal, in removal order, and none for the successor row that is \
+             still present"
+        );
+    }
+}

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -71,11 +71,14 @@
 //!   the selection throws an unsaved edit away; here the occupant is fixed to
 //!   the task it was opened for, because a `Slot` holds an instance rather than
 //!   a view of whatever is selected.
-//! - **The tasks arrive as messages** rather than as initial state, because
-//!   `init`'s command crosses no boundary and a row's setup has to. That they
-//!   start with the same notes and none marked done is not composition's doing
-//!   but `AddTask`'s: it carries a title and nothing else, and a setup message
-//!   carrying more would cross the same boundary just as well.
+//! - **The tasks arrive as messages** rather than being built into the initial
+//!   state. `init` could build them — `Keyed::from_iter` records no removal, so
+//!   growing a collection there is fine — and this file routes them through
+//!   `AddTask` so the seed and the `n` key take one path. What `init`'s command
+//!   cannot do is start work *under a child's scope*, so the row's own setup is
+//!   a message either way. That the rows start with the same notes and none
+//!   marked done is `AddTask`'s doing rather than composition's: it carries a
+//!   title and nothing else.
 //!
 //! Run with: `cargo run --example dashboard_composed`
 //! Test with: `cargo test --example dashboard_composed`
@@ -227,6 +230,12 @@ enum Message {
     AddTask(String),
     DeleteTask(TaskId),
     /// Discards a row's instance and starts a fresh one under the same key.
+    ///
+    /// The successor is the server's version of the task, so everything local
+    /// to the instance that left is gone with it: the `done` flag, and any
+    /// notes `SaveNotes` had written into it. That is what a replacement is
+    /// here — the old instance is torn down and the new one starts fresh — and
+    /// carrying state across would make it something else.
     ReloadTask(TaskId),
     OpenDetails(TaskId),
     CloseDetails,
@@ -391,18 +400,18 @@ impl Reducer for Root {
         match message {
             Message::Terminal(event) => match event {
                 // Not releases. A terminal that reports them — Windows, or a
-                // session with the kitty keyboard protocol on — would
-                // otherwise turn one keystroke into two messages, and every
-                // operation here is one a reader means to perform once: `n`
-                // would add two rows rather than the one asked for, and Enter
-                // would open the pane and then replace it with a second pane on
-                // the same row — a removal the reader never asked for, in a
-                // file about which removals happen.
+                // session with the kitty keyboard protocol on — sends two
+                // events for one press, and the second would be acted on: `n`
+                // would add two rows where one was asked for, and Enter would
+                // open the pane and then replace it with a second pane on the
+                // same row — a removal nobody asked for, in a file about which
+                // removals happen.
                 //
-                // A *repeat* is an instruction and is kept. The same protocol
-                // that delivers releases is the one that reports a held key,
-                // so testing for `Press` would drop those too and a held Down
-                // would move the selection once.
+                // A *repeat* is kept, and is the other thing entirely: a held
+                // key is repetition the reader is asking for, so holding Enter
+                // does replace the pane, over and over, exactly as pressing it
+                // twice would. Testing for `Press` would drop those with the
+                // releases, and a held Down would move the selection once.
                 Event::Key(key) if key.kind != KeyEventKind::Release => {
                     key_message(state, key.code).map_or_else(Command::none, |message| {
                         // A boundary claims a child-addressed message, so the
@@ -944,7 +953,9 @@ fn reload_task(state: &mut App, id: TaskId) -> Command<Message> {
     state
         .activity
         .push(format!("reloaded: #{} {}", id.0, task_title));
-    state.status = "Reloaded the task";
+    // Says what the successor threw away, because a cleared checkbox is
+    // otherwise the only sign that it did.
+    state.status = "Reloaded the task, discarding its local state";
     Command::message(Message::Task(id, TaskMessage::Watch)).into()
 }
 
@@ -1790,5 +1801,38 @@ mod tests {
 
         let _reported = Root.reduce(&mut state, Message::NoTaskSelected);
         assert_eq!(state.status, "No task selected");
+    }
+
+    /// Reloading a row is a replacement, so the successor starts fresh and
+    /// everything local to the instance that left goes with it.
+    ///
+    /// A cleared checkbox is otherwise the only sign, so the status says it.
+    #[test]
+    fn reloading_a_row_discards_what_was_local_to_it() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+        let row = state
+            .tasks
+            .get_mut(&TaskId(1))
+            .expect("the row that was just added");
+        row.done = true;
+        row.notes = "edited and saved".to_owned();
+
+        let _reloaded = Root.reduce(&mut state, Message::ReloadTask(TaskId(1)));
+
+        let row = state.tasks.get(&TaskId(1)).expect("the successor");
+        assert!(!row.done, "the done flag was the old instance's");
+        assert_ne!(
+            row.notes, "edited and saved",
+            "and so were the notes saved into it"
+        );
+        assert_eq!(
+            state.status, "Reloaded the task, discarding its local state",
+            "which the reader is told, since the cleared checkbox is the only other sign"
+        );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -88,7 +88,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use crossterm::event::{Event, KeyCode, KeyEventKind};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use futures::stream;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
@@ -413,7 +413,7 @@ impl Reducer for Root {
                 // twice would. Testing for `Press` would drop those with the
                 // releases, and a held Down would move the selection once.
                 Event::Key(key) if key.kind != KeyEventKind::Release => {
-                    key_message(state, key.code).map_or_else(Command::none, |message| {
+                    key_message(state, key).map_or_else(Command::none, |message| {
                         // A boundary claims a child-addressed message, so the
                         // root never sees it land and the arms for those below
                         // are unreachable. Its status is set here, at the
@@ -1080,8 +1080,20 @@ const fn child_status(message: &Message) -> Option<&'static str> {
 }
 
 /// The message a key press asks for, if any.
-fn key_message(state: &App, code: KeyCode) -> Option<Message> {
-    match code {
+///
+/// Every bare-character binding here excludes `CONTROL`. Raw mode delivers no
+/// SIGINT, so a reader pressing Ctrl+C to leave would otherwise have run
+/// whatever `c` is bound to — clearing the activity log — and Ctrl+D and Ctrl+R
+/// would have deleted and reloaded a row.
+fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
+    let control = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        // The way out of raw mode, from any focus: the notes editor holds `q`
+        // but nothing holds this.
+        KeyCode::Char('c') if control => Some(Message::Quit),
+        // Anything else with `CONTROL` on is a chord this application has no
+        // binding for, and it must not fall through to the bare key's.
+        KeyCode::Char(_) if control => None,
         // Guarded like every other printable key below, so `q` stays typable
         // in the notes editor. Esc closes the pane, which is how you leave it.
         KeyCode::Char('q') if !editing_notes(state) => Some(Message::Quit),
@@ -1271,6 +1283,11 @@ mod tests {
                 line.starts_with("stopped watching: ") || line.starts_with("closed details: ")
             })
             .collect()
+    }
+
+    /// What an unmodified key press decodes to.
+    fn bare(state: &App, code: KeyCode) -> Option<Message> {
+        key_message(state, KeyEvent::new(code, KeyModifiers::empty()))
     }
 
     /// The message the terminal subscription produces for a key press.
@@ -1572,7 +1589,7 @@ mod tests {
 
         state.focus = Focus::Details;
         assert!(
-            matches!(key_message(&state, KeyCode::Char('q')), Some(Message::Quit)),
+            matches!(bare(&state, KeyCode::Char('q')), Some(Message::Quit)),
             "the focus is on an empty pane, so there is no editor to type into"
         );
 
@@ -1583,7 +1600,7 @@ mod tests {
         ));
         assert!(
             matches!(
-                key_message(&state, KeyCode::Char('q')),
+                bare(&state, KeyCode::Char('q')),
                 Some(Message::Details(DetailsMessage::Input('q')))
             ),
             "with an occupant the key is text"
@@ -1591,7 +1608,7 @@ mod tests {
 
         state.focus = Focus::Tasks;
         assert!(
-            matches!(key_message(&state, KeyCode::Char('q')), Some(Message::Quit)),
+            matches!(bare(&state, KeyCode::Char('q')), Some(Message::Quit)),
             "and an open pane the focus is not on does not hold the key"
         );
     }
@@ -1793,7 +1810,7 @@ mod tests {
             KeyCode::Enter,
         ] {
             assert!(
-                matches!(key_message(&state, code), Some(Message::NoTaskSelected)),
+                matches!(bare(&state, code), Some(Message::NoTaskSelected)),
                 "{code:?} needs a row and there is none, so it reports rather than \
                  leaving the last operation's line standing"
             );
@@ -1833,6 +1850,53 @@ mod tests {
         assert_eq!(
             state.status, "Reloaded the task, discarding its local state",
             "which the reader is told, since the cleared checkbox is the only other sign"
+        );
+    }
+
+    /// A `CONTROL` chord runs no bare-key binding, and Ctrl+C leaves.
+    ///
+    /// Raw mode delivers no SIGINT, so Ctrl+C arrives as an ordinary key
+    /// event. Without the guard it would have found whatever `c` is bound to —
+    /// and Ctrl+D and Ctrl+R would have found the destructive two.
+    #[test]
+    fn a_control_chord_runs_no_bare_binding_and_ctrl_c_leaves() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+
+        let chord =
+            |state: &App, code| key_message(state, KeyEvent::new(code, KeyModifiers::CONTROL));
+
+        state.focus = Focus::Tasks;
+        for code in [KeyCode::Char('d'), KeyCode::Char('r'), KeyCode::Char(' ')] {
+            assert!(
+                chord(&state, code).is_none(),
+                "{code:?} with CONTROL is a chord this application does not bind"
+            );
+        }
+
+        state.focus = Focus::Activity;
+        assert!(
+            matches!(chord(&state, KeyCode::Char('c')), Some(Message::Quit)),
+            "Ctrl+C leaves rather than clearing the log the bare key clears"
+        );
+
+        state.details.present(DetailsState::new(
+            TaskId(1),
+            "alpha".to_owned(),
+            String::new(),
+        ));
+        state.focus = Focus::Details;
+        assert!(
+            matches!(chord(&state, KeyCode::Char('c')), Some(Message::Quit)),
+            "and from the notes editor too, which holds the bare `q` but not this"
+        );
+        assert!(
+            chord(&state, KeyCode::Char('x')).is_none(),
+            "while another chord inserts no character"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -67,10 +67,10 @@
 //!   sets the line where it dispatches the message, so nothing the child
 //!   computes can appear in it.
 //! - **The details buffer does not follow the selection.** `dashboard.rs`
-//!   rereads the panel from the selected task on every task message, so moving
-//!   the selection throws an unsaved edit away; here the occupant is fixed to
-//!   the task it was opened for, because a `Slot` holds an instance rather than
-//!   a view of whatever is selected.
+//!   rereads the panel whenever the selected task can have changed — a move, an
+//!   add, a delete — so any of those throws an unsaved edit away; here the
+//!   occupant is fixed to the task it was opened for, because a `Slot` holds an
+//!   instance rather than a view of whatever is selected.
 //! - **The tasks arrive as messages** rather than being built into the initial
 //!   state. `init` could build them — `Keyed::from_iter` records no removal, so
 //!   growing a collection there is fine — and this file routes them through
@@ -78,7 +78,9 @@
 //!   cannot do is start work *under a child's scope*, so the row's own setup is
 //!   a message either way. That the rows start with the same notes and none
 //!   marked done is `AddTask`'s doing rather than composition's: it carries a
-//!   title and nothing else.
+//!   title and nothing else. So is the row selected at startup — adding a task
+//!   selects it, so this binary opens on the last of the three where
+//!   `dashboard.rs` opens on the first.
 //!
 //! Run with: `cargo run --example dashboard_composed`
 //! Test with: `cargo test --example dashboard_composed`

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -888,7 +888,9 @@ fn select(state: &mut App, forward: bool) {
 /// The message a key press asks for, if any.
 fn key_message(state: &App, code: KeyCode) -> Option<Message> {
     match code {
-        KeyCode::Char('q') => Some(Message::Quit),
+        // Guarded like every other printable key below, so `q` stays typable
+        // in the notes editor. Esc leaves that pane first.
+        KeyCode::Char('q') if state.focus != Focus::Details => Some(Message::Quit),
         KeyCode::Tab => Some(Message::FocusNext),
         KeyCode::Up => match state.focus {
             Focus::Navigation => Some(Message::Navigation(NavigationMessage::Up)),

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1110,7 +1110,8 @@ fn select(state: &mut App, forward: bool) {
     let next = match position {
         Some(index) if forward => (index + 1).min(last),
         Some(index) => index.saturating_sub(1),
-        None => 0,
+        None if forward => 0,
+        None => last,
     };
     let moved = keys.get(next).copied();
     // Clamping at an end leaves the selection where it was, and saying it moved
@@ -1161,12 +1162,9 @@ const fn child_status(message: &Message) -> Option<&'static str> {
 
 /// The message a key press asks for, if any.
 ///
-/// Every binding here is for an unmodified key, apart from a shifted character,
-/// which is how an uppercase letter arrives. Raw mode delivers no SIGINT, so a
-/// reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
-/// bound to — clearing the activity log — while Ctrl+D and Ctrl+R would have
-/// deleted and reloaded a row, and Shift+Enter would have replaced the pane's
-/// occupant, which is a removal.
+/// Raw mode delivers no SIGINT, so Ctrl+C arrives here as an ordinary key
+/// event; what the guards below make of it and of every other modified key is
+/// written where they are.
 fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
     // The way out of raw mode, from any focus: the notes editor holds `q` but
     // nothing holds this.
@@ -1518,6 +1516,12 @@ mod tests {
 
     /// The four removal shapes a boundary tears down, and the one thing that is
     /// not a removal.
+    ///
+    /// The comparison below is exact, and holds however long the run takes:
+    /// the rows' keyed requests sleep in real time, but `deliver` grants a
+    /// named run and `settle` grants nothing, so a request that finishes waits
+    /// at the gate and its `synced:` or `loaded details:` line is never
+    /// written.
     ///
     /// Nothing in this file calls `Command::teardown`: each `stopped watching`
     /// and `closed details` line below is a hook a child registered, fired by
@@ -2157,6 +2161,41 @@ mod tests {
         assert_eq!(
             state.status, "Opened the details pane, replacing the one that was open",
             "the slot was occupied, so the occupant went"
+        );
+    }
+
+    /// With nothing selected, a move goes to the end it started from.
+    ///
+    /// The application cannot reach that state: `selected` is `None` only when
+    /// the collection is empty, and the root answers an empty collection before
+    /// `select` is called. This pins what the arm does rather than covering a
+    /// path, so the direction cannot be dropped without something failing.
+    #[test]
+    fn a_move_with_nothing_selected_goes_to_the_end_it_started_from() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        for _ in 0..3 {
+            let _added = Root.reduce(&mut state, Message::AddTask("task".to_owned()));
+        }
+
+        state.selected = None;
+        select(&mut state, true);
+        assert_eq!(
+            state.selected,
+            Some(TaskId(1)),
+            "forward from nowhere is the first row"
+        );
+
+        state.selected = None;
+        select(&mut state, false);
+        assert_eq!(
+            state.selected,
+            Some(TaskId(3)),
+            "and backward is the last, not the first again"
         );
     }
 

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1031,13 +1031,22 @@ fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
     };
     // Presenting over an occupied slot is a replacement too, for the same
     // reason `ReloadTask` is.
-    state.details.present(DetailsState::new(
-        id,
-        task.title.clone(),
-        task.notes.clone(),
-    ));
+    let replaced = state
+        .details
+        .present(DetailsState::new(
+            id,
+            task.title.clone(),
+            task.notes.clone(),
+        ))
+        .is_some();
     state.focus = Focus::Details;
-    state.status = "Opened the details pane";
+    // A replacement is a removal, and the occupant it removes may hold edits
+    // nobody saved. Said for the reason `reload_task` says what it discarded.
+    state.status = if replaced {
+        "Opened the details pane, replacing the one that was open"
+    } else {
+        "Opened the details pane"
+    };
     Command::message(Message::Details(DetailsMessage::Open)).into()
 }
 
@@ -1221,11 +1230,13 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-/// Deterministic tests for this example's composition, driven by
-/// `tears::testing::TestDriver` (RFC 0008 §9). `TestStore` takes an
-/// `Application`, which is what `dashboard.rs`'s tests use; a composed
-/// `Program` is driven here instead. Run them with
-/// `cargo test --example dashboard_composed`.
+/// Deterministic tests for this example's composition.
+///
+/// The rows that build a `TestDriver` (RFC 0008 §9) drive the composed
+/// `Program` itself — `TestStore` takes an `Application`, so it cannot. The
+/// rest call the root reducer and the key decoder directly, which is a cheaper
+/// loop that crosses no boundary and would pass with the composition taken
+/// out. Run them with `cargo test --example dashboard_composed`.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2018,5 +2029,35 @@ mod tests {
             "the reason is left where `main` can still read it"
         );
         assert!(!quit.is_none(), "and the run ends");
+    }
+
+    /// Opening a pane over an open one replaces its occupant, and says so.
+    ///
+    /// A replacement is a removal, and the occupant it removes can hold edits
+    /// nobody saved. `reload_task` reports what it discarded for the same
+    /// reason; nothing but the status distinguishes the two cases here.
+    #[test]
+    fn opening_a_pane_over_an_open_one_says_it_replaced_it() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        for _ in 0..2 {
+            let _added = Root.reduce(&mut state, Message::AddTask("task".to_owned()));
+        }
+
+        let _first = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+        assert_eq!(
+            state.status, "Opened the details pane",
+            "the slot was empty, so nothing was removed"
+        );
+
+        let _second = Root.reduce(&mut state, Message::OpenDetails(TaskId(2)));
+        assert_eq!(
+            state.status, "Opened the details pane, replacing the one that was open",
+            "the slot was occupied, so the occupant went"
+        );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -484,15 +484,28 @@ impl Reducer for Root {
             Message::DeleteTask(id) => delete_task(state, id),
             Message::OpenDetails(id) => open_details(state, id),
             Message::CloseDetails => {
+                // The pane is the only place edited notes live until
+                // `SaveNotes` writes them onto the task, so closing one whose
+                // buffer has moved away from the task throws those edits away.
+                // Named for the reason `open_details` and `reload_task` name
+                // what they discard — and only when the two actually differ,
+                // so an Esc straight after a save does not report the loss of
+                // notes that already reached the task.
+                let unsaved = state.details.get().is_some_and(|open| {
+                    state
+                        .tasks
+                        .get(&open.task)
+                        .is_some_and(|task| task.notes != open.notes)
+                });
                 // Esc is guarded on the focus rather than on `editing_notes`,
                 // so it is the way out of a `Details` focus with nothing behind
                 // it — which is also why the status has to say which of the two
                 // happened. Dismissing an empty slot removes no instance and
                 // records nothing.
-                state.status = if close_details(state) {
-                    "Closed the details pane"
-                } else {
-                    "Left the details pane"
+                state.status = match (close_details(state), unsaved) {
+                    (true, true) => "Closed the details pane, discarding notes nobody saved",
+                    (true, false) => "Closed the details pane",
+                    (false, _) => "Left the details pane",
                 };
                 Command::none()
             }
@@ -880,11 +893,14 @@ fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
 
 fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
     let text = state.details.get().map_or_else(
-        // Names something reachable from where it is printed. Enter does
-        // nothing at this focus — the slot is empty, so neither the task
-        // list's arm nor the editor's claims it — and a hint pointing at an
-        // inert key is the footer's silence one pane over.
-        || "No details open. Tab to the task list and press Enter on a task.".to_owned(),
+        // Names something reachable from where it is printed, without
+        // naming a focus or a number of keys to get out of one: this pane is
+        // drawn whenever the slot is empty, at every focus, so an instruction
+        // to Tab to the task list was wrong for a reader already in it. Enter
+        // is inert at a `Details` focus — the slot is empty, so neither the
+        // task list's arm nor the editor's claims it — which is why the hint
+        // says where the key has to land and not only which key it is.
+        || "No details open. Press Enter on a task in the task list.".to_owned(),
         |open| {
             format!(
                 "#{} {} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",
@@ -1038,6 +1054,17 @@ fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
         state.status = "That task is gone";
         return Command::none();
     };
+    // A replacement is a removal, and the occupant it removes may hold edits
+    // nobody saved — the same loss `CloseDetails` reports, read the same way
+    // and before the `present` that causes it. What replaces the pane is a
+    // different pane, so the old buffer leaves the screen along with any sign
+    // of what was in it.
+    let unsaved = state.details.get().is_some_and(|open| {
+        state
+            .tasks
+            .get(&open.task)
+            .is_some_and(|task| task.notes != open.notes)
+    });
     // Presenting over an occupied slot is a replacement too, for the same
     // reason `ReloadTask` is.
     let replaced = state
@@ -1049,12 +1076,10 @@ fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
         ))
         .is_some();
     state.focus = Focus::Details;
-    // A replacement is a removal, and the occupant it removes may hold edits
-    // nobody saved. Said for the reason `reload_task` says what it discarded.
-    state.status = if replaced {
-        "Opened the details pane, replacing the one that was open"
-    } else {
-        "Opened the details pane"
+    state.status = match (replaced, unsaved) {
+        (true, true) => "Replaced the open details pane, discarding notes nobody saved",
+        (true, false) => "Opened the details pane, replacing the one that was open",
+        (false, _) => "Opened the details pane",
     };
     Command::message(Message::Details(DetailsMessage::Open)).into()
 }
@@ -1796,6 +1821,70 @@ mod tests {
         );
     }
 
+    /// Closing an occupied pane is the one removal that can lose work, so the
+    /// status says when it does — and only then. The buffer is the sole home
+    /// of an edit until [`save_notes`] copies it onto the task, which makes
+    /// "the two differ" exactly "there is something to lose". A pane closed
+    /// straight after a save has nothing outstanding, and a footer that
+    /// mourned notes there would read as if the save had not landed.
+    #[test]
+    fn closing_a_pane_says_when_it_throws_an_edit_away() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+        let id = *state.tasks.keys().next().expect("the row was inserted");
+        let stored = state
+            .tasks
+            .get(&id)
+            .expect("the row was inserted")
+            .notes
+            .clone();
+        let _opened = Root.reduce(&mut state, Message::OpenDetails(id));
+        // What a `DetailsMessage::Input` leaves behind. The claim under test
+        // is the root's reading of the buffer, and the boundary that carries
+        // the key press is what the `TestDriver` rows exercise.
+        state
+            .details
+            .get_mut()
+            .expect("the pane is open")
+            .notes
+            .push('!');
+
+        let _closed = Root.reduce(&mut state, Message::CloseDetails);
+        assert_eq!(
+            state.status, "Closed the details pane, discarding notes nobody saved",
+            "the buffer had moved away from the task, and closing it is where that went"
+        );
+        assert_eq!(
+            state
+                .tasks
+                .get(&id)
+                .expect("the row outlives the pane")
+                .notes,
+            stored,
+            "and the task still holds what it held, which is what makes it a loss"
+        );
+
+        let _reopened = Root.reduce(&mut state, Message::OpenDetails(id));
+        state
+            .details
+            .get_mut()
+            .expect("the pane is open again")
+            .notes
+            .push('!');
+        let _saved = Root.reduce(&mut state, Message::SaveNotes);
+        let _closed_again = Root.reduce(&mut state, Message::CloseDetails);
+        assert_eq!(
+            state.status, "Closed the details pane",
+            "the edit reached the task, so this close threw nothing away"
+        );
+    }
+
     /// The selection behaves as `dashboard.rs`'s does: it stops at the ends,
     /// and a delete leaves it on the row that moved up into the position.
     ///
@@ -2138,7 +2227,11 @@ mod tests {
     ///
     /// A replacement is a removal, and the occupant it removes can hold edits
     /// nobody saved. `reload_task` reports what it discarded for the same
-    /// reason; nothing but the status distinguishes the two cases here.
+    /// reason; nothing but the status distinguishes the three cases here.
+    /// The discard is reported on the same terms `CloseDetails` reports it
+    /// on — only when the buffer had moved away from the task — so a
+    /// replacement of an untouched pane does not mourn notes that were never
+    /// typed.
     #[test]
     fn opening_a_pane_over_an_open_one_says_it_replaced_it() {
         let (mut state, _bootstrap) = init(Setup {
@@ -2160,7 +2253,19 @@ mod tests {
         let _second = Root.reduce(&mut state, Message::OpenDetails(TaskId(2)));
         assert_eq!(
             state.status, "Opened the details pane, replacing the one that was open",
-            "the slot was occupied, so the occupant went"
+            "the slot was occupied, but its buffer still matched the task"
+        );
+
+        state
+            .details
+            .get_mut()
+            .expect("the pane is open")
+            .notes
+            .push('!');
+        let _third = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+        assert_eq!(
+            state.status, "Replaced the open details pane, discarding notes nobody saved",
+            "this occupant held an edit, and the replacement is where it went"
         );
     }
 

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -5,12 +5,15 @@
 //! Tab. What differs is who owns the wiring.
 //!
 //! Two things differ besides, and a diff of the two files will show them.
-//! Every child here has **runs of its own** — a timer and a keyed request —
-//! where `dashboard.rs` has neither: qualification and teardown are about runs,
-//! so a child with none gives a boundary nothing to do. And three keys are not
-//! the same: `r` reloads a row, Enter opens the pane from the task list, and
-//! Esc closes the pane, where `dashboard.rs` reloads the notes into a panel
-//! that is always there.
+//! The **row children and the pane's occupant** have runs of their own — a
+//! timer and a keyed request each — where `dashboard.rs` has neither, its one
+//! subscription being the root's terminal source. That is not incidental:
+//! qualification and teardown are about runs, so a child with none gives a
+//! boundary nothing to do. `Navigation` and `Activity` are exactly that case
+//! and are composed anyway, for the organisation rather than the separation.
+//! And three keys are not the same: `r` reloads a row, Enter opens the pane
+//! from the task list, and Esc closes the pane, where `dashboard.rs` reloads
+//! the notes into a panel that is always there.
 //!
 //! In `dashboard.rs` the root owns it. `App::update` matches every child
 //! variant and forwards it, `App::subscriptions` is the root's alone, and any
@@ -380,74 +383,10 @@ impl Reducer for Root {
                 select(state, forward);
                 Command::none()
             }
-            Message::AddTask(title) => {
-                let id = TaskId(state.next_id);
-                state.next_id += 1;
-                // Insertion into an absent key records no removal: nothing was
-                // running under it to tear down. The key is fresh, so this is
-                // that case and never the replacing one.
-                state.tasks.insert(
-                    id,
-                    TaskState::new(id, title, "Add notes in the details pane.".to_owned()),
-                );
-                state.selected = Some(id);
-                state.status = "Added a task";
-                Command::message(Message::Task(id, TaskMessage::Watch)).into()
-            }
-            Message::ReloadTask(id) => {
-                let Some(task) = state.tasks.get(&id) else {
-                    return Command::none();
-                };
-                // Inserting over an occupied key is a replacement, and a
-                // replacement is a removal: the boundary tears the old
-                // instance's runs down before this command's spawns start the
-                // successor's.
-                let title = task.title.clone();
-                state.tasks.insert(
-                    id,
-                    TaskState::new(id, title, "Reloaded from the server.".to_owned()),
-                );
-                // The pane was opened for the instance that just left, and it
-                // holds that instance's title and notes; leaving it open would
-                // let a later `SaveNotes` write them back over the reload.
-                close_details_opened_on(state, id);
-                state.status = "Reloaded the task";
-                Command::message(Message::Task(id, TaskMessage::Watch)).into()
-            }
-            Message::DeleteTask(id) => {
-                // `remove` records the removal; the row boundary drains it in
-                // this same reduce and merges the row's teardown into the
-                // command returned here. Nothing below asks for that.
-                let Some(task) = state.tasks.remove(&id) else {
-                    return Command::none();
-                };
-                state
-                    .activity
-                    .push(format!("deleted: #{} {}", id.0, task.title));
-                // A details pane open on the row that just left goes with it,
-                // and the slot's own boundary originates that teardown.
-                close_details_opened_on(state, id);
-                if state.selected == Some(id) {
-                    state.selected = state.tasks.keys().next().copied();
-                }
-                state.status = "Deleted the task";
-                Command::none()
-            }
-            Message::OpenDetails(id) => {
-                let Some(task) = state.tasks.get(&id) else {
-                    return Command::none();
-                };
-                // Presenting over an occupied slot is a replacement too, for
-                // the same reason `ReloadTask` is.
-                state.details.present(DetailsState::new(
-                    id,
-                    task.title.clone(),
-                    task.notes.clone(),
-                ));
-                state.focus = Focus::Details;
-                state.status = "Opened the details pane";
-                Command::message(Message::Details(DetailsMessage::Open)).into()
-            }
+            Message::AddTask(title) => add_task(state, title),
+            Message::ReloadTask(id) => reload_task(state, id),
+            Message::DeleteTask(id) => delete_task(state, id),
+            Message::OpenDetails(id) => open_details(state, id),
             Message::CloseDetails => {
                 // Esc is guarded on the focus rather than on `editing_notes`,
                 // so it is the way out of a `Details` focus with nothing behind
@@ -461,23 +400,7 @@ impl Reducer for Root {
                 };
                 Command::none()
             }
-            Message::SaveNotes => {
-                let Some(open) = state.details.get() else {
-                    return Command::none();
-                };
-                let (task_id, notes) = (open.task, open.notes.clone());
-                let Some(task) = state.tasks.get_mut(&task_id) else {
-                    return Command::none();
-                };
-                task.notes = notes;
-                state
-                    .activity
-                    .push(format!("updated notes for '{}'", task.title));
-                state.status = "Saved the notes";
-                // The row's own sync is the row's to run, so it is asked for
-                // through the boundary rather than started here.
-                Command::message(Message::Task(task_id, TaskMessage::Sync)).into()
-            }
+            Message::SaveNotes => save_notes(state),
             // Claimed by a boundary above this reducer and never routed here.
             Message::Navigation(_)
             | Message::Task(..)
@@ -554,7 +477,12 @@ impl Reducer for Task {
         match message {
             TaskMessage::Watch => {
                 if state.watched {
-                    return Command::message(TaskMessage::Sync).into();
+                    // Inert, like the occupant's re-entry path: the first
+                    // `Watch` this instance saw already asked for the sync, and
+                    // a second request here would cancel that one in flight
+                    // under the shared id. Idempotent in its effect and not
+                    // only in its registration.
+                    return Command::none();
                 }
                 state.watched = true;
                 let activity = self.activity.clone();
@@ -576,7 +504,10 @@ impl Reducer for Task {
             }
             TaskMessage::Sync => {
                 state.syncing = true;
-                let title = state.title.clone();
+                // Named the way the teardown line is: two rows added with `n`
+                // share a title, and an activity log that cannot tell them
+                // apart is the one thing this example must not have.
+                let title = format!("#{} {}", state.id.0, state.title);
                 Command::perform(request(title), TaskMessage::Synced)
                     .cancellable(CommandId::new(SYNC))
                     .into()
@@ -876,11 +807,18 @@ fn render_activity(state: &App, frame: &mut Frame<'_>, area: Rect) {
     );
 }
 
-/// Dismisses the details pane and returns the focus it took.
+/// Dismisses the details pane, reporting whether there was an occupant to
+/// dismiss.
 ///
 /// Dismissal is a removal, so the slot's boundary tears the occupant's runs
-/// down; restoring the focus is this function's own half, and without it every
-/// printable key would keep routing to a slot that has no occupant to claim it.
+/// down — but only when there was one, which is why the caller is told: an
+/// empty slot records nothing, and the status must not claim a close that did
+/// not happen.
+///
+/// Restoring the focus is this function's other half, and it guards nothing:
+/// [`editing_notes`] already asks the slot, so a `Details` focus over an empty
+/// slot swallows no key. What it buys is that the focus does not sit on a pane
+/// the user cannot see.
 fn close_details(state: &mut App) -> bool {
     let dismissed = state.details.dismiss().is_some();
     if state.focus == Focus::Details {
@@ -896,7 +834,114 @@ fn close_details_opened_on(state: &mut App, task: TaskId) {
     }
 }
 
-/// Moves the task selection, wrapping.
+/// Adds a task under a freshly allocated key.
+fn add_task(state: &mut App, title: String) -> Command<Message> {
+    let id = TaskId(state.next_id);
+    state.next_id += 1;
+    // Insertion into an absent key records no removal: nothing was running
+    // under it to tear down. The key is fresh, so this is that case and never
+    // the replacing one.
+    state.tasks.insert(
+        id,
+        TaskState::new(id, title, "Add notes in the details pane.".to_owned()),
+    );
+    state.selected = Some(id);
+    state.status = "Added a task";
+    Command::message(Message::Task(id, TaskMessage::Watch)).into()
+}
+
+/// Replaces a row's instance with a fresh one under the same key.
+fn reload_task(state: &mut App, id: TaskId) -> Command<Message> {
+    let Some(task) = state.tasks.get(&id) else {
+        return Command::none();
+    };
+    // Inserting over an occupied key is a replacement, and a replacement is a
+    // removal: the boundary tears the old instance's runs down before this
+    // command's spawns start the successor's.
+    let title = task.title.clone();
+    state.tasks.insert(
+        id,
+        TaskState::new(id, title, "Reloaded from the server.".to_owned()),
+    );
+    // The pane was opened for the instance that just left, and it holds that
+    // instance's title and notes; leaving it open would let a later
+    // `SaveNotes` write them back over the reload.
+    close_details_opened_on(state, id);
+    state.status = "Reloaded the task";
+    Command::message(Message::Task(id, TaskMessage::Watch)).into()
+}
+
+/// Removes a row.
+fn delete_task(state: &mut App, id: TaskId) -> Command<Message> {
+    // Read before the removal, because it is a position in the collection and
+    // the removal is what changes it.
+    let position = state.tasks.keys().position(|key| *key == id);
+    // `remove` records the removal; the row boundary drains it in this same
+    // reduce and merges the row's teardown into the command returned here.
+    // Nothing below asks for that.
+    let Some(task) = state.tasks.remove(&id) else {
+        return Command::none();
+    };
+    state
+        .activity
+        .push(format!("deleted: #{} {}", id.0, task.title));
+    // A details pane open on the row that just left goes with it, and the
+    // slot's own boundary originates that teardown.
+    close_details_opened_on(state, id);
+    if state.selected == Some(id) {
+        // The row that moved up into the position, or the new last row when
+        // the deleted one was last — `dashboard.rs`'s behaviour, expressed
+        // over keys instead of indices.
+        let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
+        state.selected = position
+            .map(|index| index.min(keys.len().saturating_sub(1)))
+            .and_then(|index| keys.get(index).copied());
+    }
+    state.status = "Deleted the task";
+    Command::none()
+}
+
+/// Presents the details pane for a row.
+fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
+    let Some(task) = state.tasks.get(&id) else {
+        return Command::none();
+    };
+    // Presenting over an occupied slot is a replacement too, for the same
+    // reason `ReloadTask` is.
+    state.details.present(DetailsState::new(
+        id,
+        task.title.clone(),
+        task.notes.clone(),
+    ));
+    state.focus = Focus::Details;
+    state.status = "Opened the details pane";
+    Command::message(Message::Details(DetailsMessage::Open)).into()
+}
+
+/// Writes the pane's edited notes onto the task it was opened for.
+fn save_notes(state: &mut App) -> Command<Message> {
+    let Some(open) = state.details.get() else {
+        return Command::none();
+    };
+    let (task_id, notes) = (open.task, open.notes.clone());
+    let Some(task) = state.tasks.get_mut(&task_id) else {
+        return Command::none();
+    };
+    task.notes = notes;
+    state
+        .activity
+        .push(format!("updated notes for '{}'", task.title));
+    state.status = "Saved the notes";
+    // The row's own sync is the row's to run, so it is asked for through the
+    // boundary rather than started here.
+    Command::message(Message::Task(task_id, TaskMessage::Sync)).into()
+}
+
+/// Moves the task selection, stopping at the ends.
+///
+/// Clamped and not wrapped, because `dashboard.rs` clamps: the pair is meant
+/// to differ in structure, and a selection that wrapped here would read as
+/// something composition did.
 fn select(state: &mut App, forward: bool) {
     let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
     if keys.is_empty() {
@@ -905,9 +950,10 @@ fn select(state: &mut App, forward: bool) {
     let position = state
         .selected
         .and_then(|selected| keys.iter().position(|key| *key == selected));
+    let last = keys.len() - 1;
     let next = match position {
-        Some(index) if forward => (index + 1) % keys.len(),
-        Some(index) => (index + keys.len() - 1) % keys.len(),
+        Some(index) if forward => (index + 1).min(last),
+        Some(index) => index.saturating_sub(1),
         None => 0,
     };
     state.selected = keys.get(next).copied();
@@ -1101,7 +1147,7 @@ mod tests {
 
     /// Adds one task and drives it to the keyed sync its row runs, returning
     /// the identities that row's boundary produced.
-    fn add_task<P: Program, B: Backend>(
+    fn add_task_and_sync<P: Program, B: Backend>(
         driver: &mut TestDriver<P, B>,
         script: &RunName,
     ) -> (SubscriptionId, CommandId) {
@@ -1142,8 +1188,8 @@ mod tests {
         );
         let script = anonymous(&boot, "scripted input run");
 
-        let (alpha_timer, alpha_sync) = add_task(&mut driver, &script);
-        let (beta_timer, beta_sync) = add_task(&mut driver, &script);
+        let (alpha_timer, alpha_sync) = add_task_and_sync(&mut driver, &script);
+        let (beta_timer, beta_sync) = add_task_and_sync(&mut driver, &script);
 
         // The occupant declares the same timer again and keys its load with
         // the same id, one boundary over.
@@ -1213,8 +1259,8 @@ mod tests {
 
         // Both rows added and set up, so both have a hook registered under
         // their own key.
-        add_task(&mut driver, &script);
-        add_task(&mut driver, &script);
+        add_task_and_sync(&mut driver, &script);
+        add_task_and_sync(&mut driver, &script);
         assert!(
             activity.entries().is_empty(),
             "an insert into an absent key removes no instance, so nothing is torn down"
@@ -1287,7 +1333,7 @@ mod tests {
         let boot = driver.boot();
         assert!(boot.terminated.is_none(), "bootstrap did not terminate");
         let script = anonymous(&boot, "scripted input run");
-        add_task(&mut driver, &script);
+        add_task_and_sync(&mut driver, &script);
 
         // Both opens land before either `Open` is delivered, which is what a
         // second key press ahead of the first message looks like.
@@ -1335,7 +1381,7 @@ mod tests {
         let boot = driver.boot();
         assert!(boot.terminated.is_none(), "bootstrap did not terminate");
         let script = anonymous(&boot, "scripted input run");
-        add_task(&mut driver, &script);
+        add_task_and_sync(&mut driver, &script);
 
         let report = deliver(&mut driver, &script);
         let open = anonymous(&report, "occupant setup message");
@@ -1436,6 +1482,60 @@ mod tests {
         assert_eq!(
             state.status, "Closed the details pane",
             "and only then does the status say so"
+        );
+    }
+
+    /// The selection behaves as `dashboard.rs`'s does: it stops at the ends,
+    /// and a delete leaves it on the row that moved up into the position.
+    ///
+    /// Neither is composition's doing, which is the point — the pair is meant
+    /// to differ in structure, so a selection that wrapped or jumped to the
+    /// first row would read as something a boundary did.
+    #[test]
+    fn the_selection_clamps_and_survives_a_delete_in_place() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        for _ in 0..3 {
+            let _watch = Root.reduce(&mut state, Message::AddTask("task".to_owned()));
+        }
+        assert_eq!(
+            state.selected,
+            Some(TaskId(3)),
+            "adding selects the row it added"
+        );
+
+        let _at_the_end = Root.reduce(&mut state, Message::SelectNext);
+        assert_eq!(
+            state.selected,
+            Some(TaskId(3)),
+            "the last row is an end, not a wrap"
+        );
+        for _ in 0..3 {
+            let _upwards = Root.reduce(&mut state, Message::SelectPrev);
+        }
+        assert_eq!(
+            state.selected,
+            Some(TaskId(1)),
+            "and so is the first, after one step past it"
+        );
+
+        state.selected = Some(TaskId(2));
+        let _middle = Root.reduce(&mut state, Message::DeleteTask(TaskId(2)));
+        assert_eq!(
+            state.selected,
+            Some(TaskId(3)),
+            "the row that moved up into the deleted one's position"
+        );
+
+        state.selected = Some(TaskId(3));
+        let _last = Root.reduce(&mut state, Message::DeleteTask(TaskId(3)));
+        assert_eq!(
+            state.selected,
+            Some(TaskId(1)),
+            "and the new last row when the deleted one was last"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -2016,6 +2016,7 @@ mod tests {
                 KeyModifiers::ALT,
                 KeyModifiers::SHIFT,
                 KeyModifiers::SUPER,
+                KeyModifiers::HYPER,
                 KeyModifiers::META,
             ] {
                 assert!(

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -880,7 +880,11 @@ fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
 
 fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
     let text = state.details.get().map_or_else(
-        || "No details open. Select a task and press Enter.".to_owned(),
+        // Names something reachable from where it is printed. Enter does
+        // nothing at this focus — the slot is empty, so neither the task
+        // list's arm nor the editor's claims it — and a hint pointing at an
+        // inert key is the footer's silence one pane over.
+        || "No details open. Tab to the task list and press Enter on a task.".to_owned(),
         |open| {
             format!(
                 "#{} {} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -51,19 +51,25 @@
 //!   boundary nothing to do. `Navigation` and `Activity` are exactly that case
 //!   and are composed anyway, for the organisation rather than the separation.
 //! - **Three keys are not the same.** `r` reloads a row, Enter opens the pane
-//!   from the task list, and Esc closes the pane, where `dashboard.rs` reloads
-//!   the notes into a panel that is always there.
-//! - **The activity log carries the same entries, plus two kinds this file
-//!   has and that one cannot.** The teardown lines a removal fires, and the
-//!   completion lines the children's runs write — `synced:`, `loaded details:`
-//!   — which `dashboard.rs` has no counterpart for because it runs no commands.
-//!   Every row-scoped line names the row's key, because here there is one and
-//!   two rows added with `n` share a title.
+//!   from the task list, and Esc closes the pane, where `dashboard.rs` rereads
+//!   the selected task's notes into a panel that is always there.
+//! - **The activity log carries the same entries and more of its own.** The
+//!   teardown lines a removal fires; the completion lines the children's runs
+//!   write (`synced:`, `loaded details:`), which `dashboard.rs` has no
+//!   counterpart for because it runs no commands; `reloaded:`, for a key it
+//!   does not have; and the terminal-error line, which it prints to stderr on
+//!   its way out instead. Every row-scoped line names the row's key, because
+//!   here there is one and two rows added with `n` share a title.
 //! - **The status line is fixed before the child runs**, for every operation
 //!   a boundary claims. `dashboard.rs`'s root runs those updates itself and
 //!   can report what they produced — "Selected section: Today"; here the root
 //!   sets the line where it dispatches the message, so nothing the child
 //!   computes can appear in it.
+//! - **The details buffer does not follow the selection.** `dashboard.rs`
+//!   rereads the panel from the selected task on every task message, so moving
+//!   the selection throws an unsaved edit away; here the occupant is fixed to
+//!   the task it was opened for, because a `Slot` holds an instance rather than
+//!   a view of whatever is selected.
 //! - **The tasks arrive as messages** rather than as initial state, because
 //!   `init`'s command crosses no boundary and a row's setup has to. That they
 //!   start with the same notes and none marked done is not composition's doing
@@ -1383,12 +1389,18 @@ mod tests {
         deliver(&mut driver, &script);
         driver.settle(TURNS, || recorded(&activity, "stopped watching: #1 alpha"));
 
+        // Without the script's own `added:` lines, which are setup rather than
+        // subject and which put the comparison exactly on `ACTIVITY_LIMIT`: one
+        // more entry from anywhere would evict the *first* of them and report a
+        // missing head, sending a maintainer to the wrong end of the list.
+        let written: Vec<String> = activity
+            .entries()
+            .into_iter()
+            .filter(|line| !line.starts_with("added: "))
+            .collect();
         assert_eq!(
-            activity.entries(),
+            written,
             vec![
-                // What a reduce wrote, which `dashboard.rs` writes too.
-                "added: #1 alpha".to_owned(),
-                "added: #2 beta".to_owned(),
                 "closed details: #1 alpha".to_owned(),
                 "closed details: #2 beta".to_owned(),
                 "reloaded: #2 beta".to_owned(),

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -33,9 +33,10 @@
 //! or a replacing [`Slot::present`]. The boundary turns each of those into a
 //! teardown of that instance's scope, so its timer stops and its in-flight sync
 //! is cancelled without this file asking for either. The `on_teardown` hooks
-//! each child registers write the line you see in the activity pane when it
-//! happens — a finalizer produces no message by design, so the log it writes to
-//! is a handle rather than a message.
+//! each child registers write the line the activity pane carries. A finalizer
+//! produces no message by design — which is why the log is a handle rather than
+//! a message, and why the pane shows that line the next time something draws
+//! rather than at the moment the hook runs.
 //!
 //! Cross-child work stays the root's. Saving the details pane's notes back
 //! onto the task it was opened for touches two children, so it is a root
@@ -1133,16 +1134,20 @@ fn editing_notes(state: &App) -> bool {
 /// these and the root's `reduce` never sees them. That fixes what the line can
 /// say before the child has run: nothing the child computes can appear in it,
 /// so where `dashboard.rs` reports "Selected section: Today" — its root having
-/// run the child update itself — these name the operation and stop there.
+/// run the child update itself — these name what was asked for and stop there.
+/// Naming an outcome would be claiming one: the navigation list clamps at its
+/// ends, clearing an empty log clears nothing, and a backspace on an empty
+/// buffer removes nothing, and this line is written before any of that is
+/// known.
 ///
 /// A line set here cannot be left standing as a lie. A root message that
 /// removes what the child was addressed to writes its own status when it
 /// lands, and a landing is always after the dispatch that queued it.
 const fn child_status(message: &Message) -> Option<&'static str> {
     match message {
-        Message::Navigation(_) => Some("Selected another section"),
-        Message::Task(_, TaskMessage::Toggle) => Some("Toggled the task"),
-        Message::Activity(_) => Some("Cleared the activity log"),
+        Message::Navigation(_) => Some("Moving through the sections"),
+        Message::Task(_, TaskMessage::Toggle) => Some("Toggling the task"),
+        Message::Activity(_) => Some("Clearing the activity log"),
         Message::Details(_) => Some("Editing the notes"),
         _ => None,
     }
@@ -1852,21 +1857,21 @@ mod tests {
         state.focus = Focus::Navigation;
         let _navigating = Root.reduce(&mut state, key_press(KeyCode::Down));
         assert_eq!(
-            state.status, "Selected another section",
+            state.status, "Moving through the sections",
             "the navigation child claims the message, so the root says so here"
         );
 
         state.focus = Focus::Activity;
         let _clearing = Root.reduce(&mut state, key_press(KeyCode::Char('c')));
         assert_eq!(
-            state.status, "Cleared the activity log",
+            state.status, "Clearing the activity log",
             "and the same for the log child"
         );
 
         state.focus = Focus::Tasks;
         let _toggling = Root.reduce(&mut state, key_press(KeyCode::Char(' ')));
         assert_eq!(
-            state.status, "Toggled the task",
+            state.status, "Toggling the task",
             "and for a row, which is claimed by key"
         );
     }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -241,8 +241,8 @@ enum Message {
     /// A key that needs a selected row arrived with none.
     ///
     /// A message rather than nothing, so the footer stops describing whatever
-    /// came before it — the reason `select` sets its status before the guard
-    /// that returns early on an empty collection.
+    /// came before it. An empty collection gets this answer too, so one
+    /// condition has one line however it was asked for.
     NoTaskSelected,
     /// Adds a task under a **freshly allocated** key.
     ///
@@ -1092,21 +1092,28 @@ const fn no_task_selected(state: &mut App) -> Command<Message> {
 /// to differ in structure, and a selection that wrapped here would read as
 /// something composition did.
 fn select(state: &mut App, forward: bool) {
+    // An empty collection does not arrive here: the root answers that with
+    // `no_task_selected`, so both ways of asking for a row that is not there
+    // give one answer.
     let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
-    if keys.is_empty() {
-        return;
-    }
-    state.status = "Selected another task";
     let position = state
         .selected
         .and_then(|selected| keys.iter().position(|key| *key == selected));
-    let last = keys.len() - 1;
+    let last = keys.len().saturating_sub(1);
     let next = match position {
         Some(index) if forward => (index + 1).min(last),
         Some(index) => index.saturating_sub(1),
         None => 0,
     };
-    state.selected = keys.get(next).copied();
+    let moved = keys.get(next).copied();
+    // Clamping at an end leaves the selection where it was, and saying it moved
+    // would be the footer reporting an operation that did not happen.
+    state.status = if moved == state.selected {
+        "Nothing further that way"
+    } else {
+        "Selected another task"
+    };
+    state.selected = moved;
 }
 
 /// Whether a key press is going into the notes editor.
@@ -1127,6 +1134,10 @@ fn editing_notes(state: &App) -> bool {
 /// say before the child has run: nothing the child computes can appear in it,
 /// so where `dashboard.rs` reports "Selected section: Today" — its root having
 /// run the child update itself — these name the operation and stop there.
+///
+/// A line set here cannot be left standing as a lie. A root message that
+/// removes what the child was addressed to writes its own status when it
+/// lands, and a landing is always after the dispatch that queued it.
 const fn child_status(message: &Message) -> Option<&'static str> {
     match message {
         Message::Navigation(_) => Some("Selected another section"),
@@ -1784,6 +1795,10 @@ mod tests {
             Some(TaskId(3)),
             "the last row is an end, not a wrap"
         );
+        assert_eq!(
+            state.status, "Nothing further that way",
+            "and the footer does not report a move that did not happen"
+        );
         for _ in 0..3 {
             let _upwards = Root.reduce(&mut state, Message::SelectPrev);
         }
@@ -1890,9 +1905,9 @@ mod tests {
 
     /// A key that needs a selected row says so when there is none.
     ///
-    /// Silence would leave the footer describing the operation before it — the
-    /// reason `select` sets its status ahead of its own empty-collection
-    /// guard.
+    /// Silence would leave the footer describing the operation before it. A
+    /// selection move over an empty collection gets the same line, so the
+    /// condition has one answer.
     #[test]
     fn a_key_needing_a_selection_reports_when_there_is_none() {
         let (mut state, _bootstrap) = init(Setup {

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -117,6 +117,14 @@ const SYNC: &str = "sync";
 /// How long the stand-in requests take.
 const REQUEST_MS: u64 = 900;
 
+/// What a terminal-error line is written under.
+///
+/// Named once because two places have to agree on it: the reduce that records
+/// the reason, and the `main` that reads it back after restoring the terminal.
+/// A literal at each end would let one change silently and leave the other
+/// matching nothing.
+const TERMINAL_ERROR: &str = "terminal error: ";
+
 /// How many activity lines the pane keeps.
 const ACTIVITY_LIMIT: usize = 8;
 
@@ -437,7 +445,7 @@ impl Reducer for Root {
                 // and `main` restores the terminal immediately after, so this
                 // is the only report there is — and `main` prints it once the
                 // screen it would have been drawn on is gone.
-                state.activity.push(format!("terminal error: {error}"));
+                state.activity.push(format!("{TERMINAL_ERROR}{error}"));
                 Command::quit()
             }
             Message::Quit => Command::quit(),
@@ -1089,19 +1097,30 @@ const fn child_status(message: &Message) -> Option<&'static str> {
 
 /// The message a key press asks for, if any.
 ///
-/// Every bare-character binding here excludes `CONTROL`. Raw mode delivers no
-/// SIGINT, so a reader pressing Ctrl+C to leave would otherwise have run
-/// whatever `c` is bound to — clearing the activity log — and Ctrl+D and Ctrl+R
-/// would have deleted and reloaded a row.
+/// Every binding here is for an unmodified key. Raw mode delivers no SIGINT, so
+/// a reader pressing Ctrl+C to leave would otherwise have run whatever `c` is
+/// bound to — clearing the activity log — while Ctrl+D and Ctrl+R would have
+/// deleted and reloaded a row, and Ctrl+Enter would have replaced the pane's
+/// occupant, which is a removal.
 fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
-    let control = key.modifiers.contains(KeyModifiers::CONTROL);
+    // The way out of raw mode, from any focus: the notes editor holds `q` but
+    // nothing holds this.
+    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        return Some(Message::Quit);
+    }
+    // Every binding below is for an unmodified key, so a chord this
+    // application does not bind is answered here rather than falling through
+    // to the bare key's. Above the match and not on the character arms,
+    // because `Enter`, `Up`/`Down`, `Tab`, `Esc` and `Backspace` arrive with
+    // modifiers too: Ctrl+Enter would open the pane — replacing an occupant,
+    // which is a removal — and Alt+q would quit.
+    if key
+        .modifiers
+        .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    {
+        return None;
+    }
     match key.code {
-        // The way out of raw mode, from any focus: the notes editor holds `q`
-        // but nothing holds this.
-        KeyCode::Char('c') if control => Some(Message::Quit),
-        // Anything else with `CONTROL` on is a chord this application has no
-        // binding for, and it must not fall through to the bare key's.
-        KeyCode::Char(_) if control => None,
         // Guarded like every other printable key below, so `q` stays typable
         // in the notes editor. Esc closes the pane, which is how you leave it.
         KeyCode::Char('q') if !editing_notes(state) => Some(Message::Quit),
@@ -1175,7 +1194,7 @@ async fn main() -> Result<()> {
     // the pane holding this line is never drawn again; printing it here is
     // after the restore rather than into a screen that is about to go.
     for line in activity.entries() {
-        if let Some(reason) = line.strip_prefix("terminal error: ") {
+        if let Some(reason) = line.strip_prefix(TERMINAL_ERROR) {
             eprintln!("Terminal error: {reason}");
         }
     }
@@ -1473,9 +1492,9 @@ mod tests {
         driver.settle(TURNS, || recorded(&activity, "stopped watching: #1 alpha"));
 
         // Without the script's own `added:` lines, which are setup rather than
-        // subject and which put the comparison exactly on `ACTIVITY_LIMIT`: one
-        // more entry from anywhere would evict the *first* of them and report a
-        // missing head, sending a maintainer to the wrong end of the list.
+        // subject. They are also the two the log would shed first — it sits
+        // exactly on `ACTIVITY_LIMIT` — so dropping them here keeps this
+        // comparison about the teardowns rather than about the buffer's size.
         let written: Vec<String> = activity
             .entries()
             .into_iter()
@@ -1885,20 +1904,41 @@ mod tests {
         let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
 
         let chord =
-            |state: &App, code| key_message(state, KeyEvent::new(code, KeyModifiers::CONTROL));
+            |state: &App, code, modifiers| key_message(state, KeyEvent::new(code, modifiers));
 
+        // Not only the characters: `Enter`, the arrows, `Tab`, `Esc` and
+        // `Backspace` arrive with modifiers too, and Ctrl+Enter would open the
+        // pane — replacing an occupant, which is a removal.
         state.focus = Focus::Tasks;
-        for code in [KeyCode::Char('d'), KeyCode::Char('r'), KeyCode::Char(' ')] {
-            assert!(
-                chord(&state, code).is_none(),
-                "{code:?} with CONTROL is a chord this application does not bind"
-            );
+        for code in [
+            KeyCode::Char('d'),
+            KeyCode::Char('r'),
+            KeyCode::Char(' '),
+            KeyCode::Char('n'),
+            KeyCode::Enter,
+            KeyCode::Tab,
+            KeyCode::Up,
+            KeyCode::Down,
+        ] {
+            for modifiers in [KeyModifiers::CONTROL, KeyModifiers::ALT] {
+                assert!(
+                    chord(&state, code, modifiers).is_none(),
+                    "{code:?} with {modifiers:?} is a chord this application does not bind"
+                );
+            }
         }
 
         state.focus = Focus::Activity;
         assert!(
-            matches!(chord(&state, KeyCode::Char('c')), Some(Message::Quit)),
+            matches!(
+                chord(&state, KeyCode::Char('c'), KeyModifiers::CONTROL),
+                Some(Message::Quit)
+            ),
             "Ctrl+C leaves rather than clearing the log the bare key clears"
+        );
+        assert!(
+            chord(&state, KeyCode::Char('c'), KeyModifiers::ALT).is_none(),
+            "while Alt+c is bound to nothing and clears nothing"
         );
 
         state.details.present(DetailsState::new(
@@ -1908,13 +1948,23 @@ mod tests {
         ));
         state.focus = Focus::Details;
         assert!(
-            matches!(chord(&state, KeyCode::Char('c')), Some(Message::Quit)),
+            matches!(
+                chord(&state, KeyCode::Char('c'), KeyModifiers::CONTROL),
+                Some(Message::Quit)
+            ),
             "and from the notes editor too, which holds the bare `q` but not this"
         );
-        assert!(
-            chord(&state, KeyCode::Char('x')).is_none(),
-            "while another chord inserts no character"
-        );
+        for (code, modifiers) in [
+            (KeyCode::Char('x'), KeyModifiers::CONTROL),
+            (KeyCode::Char('q'), KeyModifiers::ALT),
+            (KeyCode::Backspace, KeyModifiers::CONTROL),
+            (KeyCode::Esc, KeyModifiers::ALT),
+        ] {
+            assert!(
+                chord(&state, code, modifiers).is_none(),
+                "{code:?} with {modifiers:?} neither edits nor leaves"
+            );
+        }
     }
 
     /// A terminal error is recorded, because the quit that follows it leaves

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -4,17 +4,6 @@
 //! the selected task, an activity log and a status line, cycled through with
 //! Tab. What differs is who owns the wiring.
 //!
-//! Two things differ besides, and a diff of the two files will show them.
-//! The **row children and the pane's occupant** have runs of their own — a
-//! timer and a keyed request each — where `dashboard.rs` has neither, its one
-//! subscription being the root's terminal source. That is not incidental:
-//! qualification and teardown are about runs, so a child with none gives a
-//! boundary nothing to do. `Navigation` and `Activity` are exactly that case
-//! and are composed anyway, for the organisation rather than the separation.
-//! And three keys are not the same: `r` reloads a row, Enter opens the pane
-//! from the task list, and Esc closes the pane, where `dashboard.rs` reloads
-//! the notes into a panel that is always there.
-//!
 //! In `dashboard.rs` the root owns it. `App::update` matches every child
 //! variant and forwards it, `App::subscriptions` is the root's alone, and any
 //! work a task started would be the root's to stop when that task is deleted.
@@ -51,6 +40,26 @@
 //! Cross-child work stays the root's. Saving the details pane's notes back
 //! onto the task it was opened for touches two children, so it is a root
 //! message; see `Message::SaveNotes`.
+//!
+//! A diff of the two files shows more than the wiring. What is worth knowing
+//! before reading one:
+//!
+//! - The **row children and the pane's occupant** have runs of their own — a
+//!   timer and a keyed request each — where `dashboard.rs` has neither, its one
+//!   subscription being the root's terminal source. That is not incidental:
+//!   qualification and teardown are about runs, so a child with none gives a
+//!   boundary nothing to do. `Navigation` and `Activity` are exactly that case
+//!   and are composed anyway, for the organisation rather than the separation.
+//! - **Three keys are not the same.** `r` reloads a row, Enter opens the pane
+//!   from the task list, and Esc closes the pane, where `dashboard.rs` reloads
+//!   the notes into a panel that is always there.
+//! - **The activity log carries the same entries, plus the teardown lines** a
+//!   removal fires here and nothing fires there. Every row-scoped line names
+//!   the row's key, because here there is one and two rows added with `n` share
+//!   a title.
+//! - **The tasks arrive as messages** rather than as initial state, because
+//!   `init`'s command crosses no boundary and a row's setup has to. They start
+//!   with the same notes and none marked done as a result.
 //!
 //! Run with: `cargo run --example dashboard_composed`
 //! Test with: `cargo test --example dashboard_composed`
@@ -500,6 +509,9 @@ impl Reducer for Task {
             }
             TaskMessage::Toggle => {
                 state.done = !state.done;
+                let verb = if state.done { "completed" } else { "reopened" };
+                self.activity
+                    .push(format!("{verb}: #{} {}", state.id.0, state.title));
                 Command::message(TaskMessage::Sync).into()
             }
             TaskMessage::Sync => {
@@ -546,12 +558,15 @@ impl Reducer for Details {
                 }
                 state.opened = true;
                 let activity = self.activity.clone();
-                let title = format!("#{} {}", state.task.0, state.title);
+                // Named the way every other row-scoped line is; see
+                // `TaskMessage::Sync`.
+                let name = format!("#{} {}", state.task.0, state.title);
+                let title = name.clone();
                 Command::batch([
                     Command::on_teardown(async move {
                         activity.push(format!("closed details: {title}"));
                     }),
-                    Command::perform(request(state.title.clone()), DetailsMessage::Loaded)
+                    Command::perform(request(name), DetailsMessage::Loaded)
                         // The same id every row's sync uses. Two boundaries,
                         // two slots.
                         .cancellable(CommandId::new(SYNC))
@@ -675,7 +690,7 @@ fn seed() -> Vec<Message> {
 fn view(state: &App, frame: &mut Frame<'_>) {
     let [header, body, activity, footer] = Layout::vertical([
         Constraint::Length(3),
-        Constraint::Min(8),
+        Constraint::Min(10),
         Constraint::Length(7),
         Constraint::Length(3),
     ])
@@ -683,8 +698,8 @@ fn view(state: &App, frame: &mut Frame<'_>) {
 
     let [nav_area, tasks_area, details_area] = Layout::horizontal([
         Constraint::Length(24),
-        Constraint::Percentage(40),
-        Constraint::Percentage(60),
+        Constraint::Percentage(36),
+        Constraint::Percentage(64),
     ])
     .areas(body);
 
@@ -848,6 +863,7 @@ fn add_task(state: &mut App, title: String) -> Command<Message> {
     // Insertion into an absent key records no removal: nothing was running
     // under it to tear down. The key is fresh, so this is that case and never
     // the replacing one.
+    state.activity.push(format!("added: #{} {}", id.0, title));
     state.tasks.insert(
         id,
         TaskState::new(id, title, "Add notes in the details pane.".to_owned()),
@@ -937,7 +953,7 @@ fn save_notes(state: &mut App) -> Command<Message> {
     task.notes = notes;
     state
         .activity
-        .push(format!("updated notes for '{}'", task.title));
+        .push(format!("updated notes for #{} {}", task_id.0, task.title));
     state.status = "Saved the notes";
     // The row's own sync is the row's to run, so it is asked for through the
     // boundary rather than started here.
@@ -1148,6 +1164,19 @@ mod tests {
         values.pop().expect("the length was just asserted")
     }
 
+    /// The lines a teardown hook wrote, which is what most of these rows are
+    /// about. The log also carries the entries a reduce writes — `added:`,
+    /// `deleted:` — which `dashboard.rs` writes too.
+    fn teardowns(activity: &ActivityLog) -> Vec<String> {
+        activity
+            .entries()
+            .into_iter()
+            .filter(|line| {
+                line.starts_with("stopped watching: ") || line.starts_with("closed details: ")
+            })
+            .collect()
+    }
+
     fn recorded(activity: &ActivityLog, line: &str) -> bool {
         activity.entries().iter().any(|entry| entry == line)
     }
@@ -1269,7 +1298,7 @@ mod tests {
         add_task_and_sync(&mut driver, &script);
         add_task_and_sync(&mut driver, &script);
         assert!(
-            activity.entries().is_empty(),
+            teardowns(&activity).is_empty(),
             "an insert into an absent key removes no instance, so nothing is torn down"
         );
 
@@ -1302,6 +1331,9 @@ mod tests {
         assert_eq!(
             activity.entries(),
             vec![
+                // What a reduce wrote, which `dashboard.rs` writes too.
+                "added: #1 alpha".to_owned(),
+                "added: #2 beta".to_owned(),
                 "closed details: #1 alpha".to_owned(),
                 "closed details: #2 beta".to_owned(),
                 "stopped watching: #2 beta".to_owned(),
@@ -1347,7 +1379,7 @@ mod tests {
         let first = deliver(&mut driver, &script);
         let second = deliver(&mut driver, &script);
         assert!(
-            activity.entries().is_empty(),
+            teardowns(&activity).is_empty(),
             "the replaced occupant never handled its `Open`, so it had registered nothing"
         );
 
@@ -1360,7 +1392,7 @@ mod tests {
         driver.settle(TURNS, || recorded(&activity, "closed details: #1 alpha"));
 
         assert_eq!(
-            activity.entries(),
+            teardowns(&activity),
             vec!["closed details: #1 alpha".to_owned()],
             "one removal, one line: the second `Open` armed nothing"
         );
@@ -1401,7 +1433,7 @@ mod tests {
         });
 
         assert_eq!(
-            activity.entries().len(),
+            teardowns(&activity).len(),
             2,
             "the row and the pane opened on it, and nothing else"
         );

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -961,6 +961,10 @@ fn add_task(state: &mut App, title: String) -> Command<Message> {
 /// Replaces a row's instance with a fresh one under the same key.
 fn reload_task(state: &mut App, id: TaskId) -> Command<Message> {
     let Some(task) = state.tasks.get(&id) else {
+        // The key was read off a state this message had not been applied to
+        // yet, and the row has gone since — the hazard `Message::AddTask`
+        // describes, arriving at a reader instead of at a collection.
+        state.status = "That task is gone";
         return Command::none();
     };
     // Inserting over an occupied key is a replacement, and a replacement is a
@@ -1021,6 +1025,7 @@ fn delete_task(state: &mut App, id: TaskId) -> Command<Message> {
 /// Presents the details pane for a row.
 fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
     let Some(task) = state.tasks.get(&id) else {
+        state.status = "That task is gone";
         return Command::none();
     };
     // Presenting over an occupied slot is a replacement too, for the same
@@ -1047,10 +1052,12 @@ fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
 /// Writes the pane's edited notes onto the task it was opened for.
 fn save_notes(state: &mut App) -> Command<Message> {
     let Some(open) = state.details.get() else {
+        state.status = "No details pane is open";
         return Command::none();
     };
     let (task_id, notes) = (open.task, open.notes.clone());
     let Some(task) = state.tasks.get_mut(&task_id) else {
+        state.status = "That task is gone";
         return Command::none();
     };
     task.notes = notes;
@@ -1447,6 +1454,17 @@ mod tests {
             alpha_sync,
             CommandId::new(SYNC),
             "and no run occupies the unqualified id the reducers wrote"
+        );
+        // `Segment::Details` is the third variant and `beta` is `TaskId(2)`, so
+        // this is the pair whose segments differ in nothing but the type the
+        // structural key carries with them.
+        assert_ne!(
+            beta_timer, details_timer,
+            "a key and a fixed segment that erase to the same value are still two"
+        );
+        assert_ne!(
+            beta_sync, details_load,
+            "and so are the runs keyed under them"
         );
     }
 
@@ -2074,6 +2092,46 @@ mod tests {
         assert_eq!(
             state.status, "Opened the details pane, replacing the one that was open",
             "the slot was occupied, so the occupant went"
+        );
+    }
+
+    /// A key read against a row that has gone since says so.
+    ///
+    /// `Message::AddTask` describes the hazard: a key handler reads the
+    /// selection off a state the messages already in flight have not been
+    /// applied to, so `d` and then `r` in quick succession both name the row
+    /// `d` is about to remove. The second arrives at a collection that no
+    /// longer holds it, and going quiet there would leave the footer reporting
+    /// the delete as though the reload had worked.
+    #[test]
+    fn an_operation_on_a_row_that_has_gone_says_so() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+        let _deleted = Root.reduce(&mut state, Message::DeleteTask(TaskId(1)));
+        assert_eq!(state.status, "Deleted the task");
+
+        for message in [
+            Message::ReloadTask(TaskId(1)),
+            Message::OpenDetails(TaskId(1)),
+        ] {
+            state.status = "Untouched";
+            let _late = Root.reduce(&mut state, message);
+            assert_eq!(
+                state.status, "That task is gone",
+                "the row was read before the delete landed"
+            );
+        }
+
+        state.status = "Untouched";
+        let _nothing_open = Root.reduce(&mut state, Message::SaveNotes);
+        assert_eq!(
+            state.status, "No details pane is open",
+            "and a save with no pane says that instead"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -690,8 +690,15 @@ fn view(state: &App, frame: &mut Frame<'_>) {
 
     frame.render_widget(
         Paragraph::new(format!(
-            "Composed dashboard · {} | Tab: focus | q: quit",
-            state.navigation.selected_label()
+            "Composed dashboard · {} | Tab: focus | {}",
+            state.navigation.selected_label(),
+            // `q` is text while the notes editor has it, so the hint follows
+            // the guard rather than contradicting it.
+            if editing_notes(state) {
+                "esc: close pane"
+            } else {
+                "q: quit"
+            }
         ))
         .block(
             Block::default()

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -53,13 +53,21 @@
 //! - **Three keys are not the same.** `r` reloads a row, Enter opens the pane
 //!   from the task list, and Esc closes the pane, where `dashboard.rs` reloads
 //!   the notes into a panel that is always there.
-//! - **The activity log carries the same entries, plus the teardown lines** a
-//!   removal fires here and nothing fires there. Every row-scoped line names
-//!   the row's key, because here there is one and two rows added with `n` share
-//!   a title.
+//! - **The activity log carries the same entries, plus two kinds this file
+//!   has and that one cannot.** The teardown lines a removal fires, and the
+//!   completion lines the children's runs write — `synced:`, `loaded details:`
+//!   — which `dashboard.rs` has no counterpart for because it runs no commands.
+//!   Every row-scoped line names the row's key, because here there is one and
+//!   two rows added with `n` share a title.
+//! - **The status line names the request, not the outcome**, for the three
+//!   operations a boundary claims. `dashboard.rs`'s root runs those updates
+//!   itself and reports what they did; here the root sets the line where it
+//!   dispatches the message, before the child has run.
 //! - **The tasks arrive as messages** rather than as initial state, because
-//!   `init`'s command crosses no boundary and a row's setup has to. They start
-//!   with the same notes and none marked done as a result.
+//!   `init`'s command crosses no boundary and a row's setup has to. That they
+//!   start with the same notes and none marked done is not composition's doing
+//!   but `AddTask`'s: it carries a title and nothing else, and a setup message
+//!   carrying more would cross the same boundary just as well.
 //!
 //! Run with: `cargo run --example dashboard_composed`
 //! Test with: `cargo test --example dashboard_composed`
@@ -373,8 +381,20 @@ impl Reducer for Root {
                 // otherwise turn one keystroke into two messages, and in this
                 // file two `AddTask`s or two `OpenDetails` are two removals
                 // and two teardown lines.
-                Event::Key(key) if key.kind == KeyEventKind::Press => key_message(state, key.code)
-                    .map_or_else(Command::none, |message| Command::message(message).into()),
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    key_message(state, key.code).map_or_else(Command::none, |message| {
+                        // A boundary claims a child-addressed message, so the
+                        // root never sees it land and the arms for those below
+                        // are unreachable. Its status is set here, at the
+                        // dispatch, which is why the line says what was asked
+                        // for rather than what happened: what happened is the
+                        // child's, and a child reports to its own state.
+                        if let Some(status) = child_status(&message) {
+                            state.status = status;
+                        }
+                        Command::message(message).into()
+                    })
+                }
                 _ => Command::none(),
             },
             Message::TerminalError(error) => {
@@ -410,7 +430,8 @@ impl Reducer for Root {
                 Command::none()
             }
             Message::SaveNotes => save_notes(state),
-            // Claimed by a boundary above this reducer and never routed here.
+            // Claimed by a boundary above this reducer and never routed here;
+            // `child_status` is where these get their status line.
             Message::Navigation(_)
             | Message::Task(..)
             | Message::Details(_)
@@ -994,6 +1015,22 @@ fn editing_notes(state: &App) -> bool {
     state.focus == Focus::Details && state.details.is_present()
 }
 
+/// The status line a child-addressed message deserves.
+///
+/// Read at the dispatch rather than at the landing, because a boundary claims
+/// these and the root's `reduce` never sees them. That fixes what the line can
+/// say: `dashboard.rs`'s root runs the child update itself and can report the
+/// outcome — "Selected section: Today" — while this one is naming the request.
+const fn child_status(message: &Message) -> Option<&'static str> {
+    match message {
+        Message::Navigation(_) => Some("Selected another section"),
+        Message::Task(_, TaskMessage::Toggle) => Some("Toggled the task"),
+        Message::Activity(_) => Some("Cleared the activity log"),
+        Message::Details(_) => Some("Editing the notes"),
+        _ => None,
+    }
+}
+
 /// The message a key press asks for, if any.
 fn key_message(state: &App, code: KeyCode) -> Option<Message> {
     match code {
@@ -1069,6 +1106,7 @@ async fn main() -> Result<()> {
 mod tests {
     use super::*;
 
+    use crossterm::event::{KeyEvent, KeyModifiers};
     use ratatui::Terminal;
     use ratatui::backend::{Backend, TestBackend};
     use tears::reducer::Program;
@@ -1175,6 +1213,11 @@ mod tests {
                 line.starts_with("stopped watching: ") || line.starts_with("closed details: ")
             })
             .collect()
+    }
+
+    /// The message the terminal subscription produces for a key press.
+    fn key_press(code: KeyCode) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
     }
 
     fn recorded(activity: &ActivityLog, line: &str) -> bool {
@@ -1575,6 +1618,43 @@ mod tests {
             state.selected,
             Some(TaskId(1)),
             "and the new last row when the deleted one was last"
+        );
+    }
+
+    /// A key press that a boundary will claim still moves the status line.
+    ///
+    /// The root's arms for those messages are unreachable — a boundary takes
+    /// them first — so a status set when they land would never be set at all.
+    /// It is set at the dispatch instead, which is also why it names the
+    /// request: the outcome belongs to a child the root has not run yet.
+    #[test]
+    fn a_child_addressed_key_still_moves_the_status_line() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+
+        state.focus = Focus::Navigation;
+        let _navigating = Root.reduce(&mut state, key_press(KeyCode::Down));
+        assert_eq!(
+            state.status, "Selected another section",
+            "the navigation child claims the message, so the root says so here"
+        );
+
+        state.focus = Focus::Activity;
+        let _clearing = Root.reduce(&mut state, key_press(KeyCode::Char('c')));
+        assert_eq!(
+            state.status, "Cleared the activity log",
+            "and the same for the log child"
+        );
+
+        state.focus = Focus::Tasks;
+        let _toggling = Root.reduce(&mut state, key_press(KeyCode::Char(' ')));
+        assert_eq!(
+            state.status, "Toggled the task",
+            "and for a row, which is claimed by key"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -804,13 +804,7 @@ fn view(state: &App, frame: &mut Frame<'_>) {
         Paragraph::new(format!(
             "Composed dashboard · {} | Tab: focus | {}",
             state.navigation.selected_label(),
-            // `q` is text while the notes editor has it, so the hint follows
-            // the guard rather than contradicting it.
-            if editing_notes(state) {
-                "esc: close pane"
-            } else {
-                "q: quit"
-            }
+            header_keys(editing_notes(state))
         ))
         .block(
             Block::default()
@@ -883,6 +877,21 @@ fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
         ))),
         area,
     );
+}
+
+/// The header's second half, which names a quit that works where it is read.
+///
+/// `q` is text while the notes editor has it, so the hint follows the guard
+/// rather than contradicting it. Naming only `esc: close pane` there left no
+/// quit named at all: closing the pane and then pressing `q` still works, but
+/// `Ctrl+C` is the one that does not ask the reader to leave first, and raw
+/// mode means the application is the only thing that can answer it.
+const fn header_keys(editing: bool) -> &'static str {
+    if editing {
+        "esc: close pane | Ctrl+C: quit"
+    } else {
+        "q: quit"
+    }
 }
 
 /// The open pane's hint, which is guarded because every key in it is.
@@ -2313,6 +2322,59 @@ mod tests {
                 "and the status is about the row, not about the buffer"
             );
         }
+    }
+
+    /// The header names a quit that answers where it is read.
+    ///
+    /// `q` is text once the notes editor has the pane, so the header stops
+    /// naming it there — and naming only the pane's own key left that focus
+    /// with no quit named at all. This reads the key each branch offers rather
+    /// than trusting the two to stay in step with the guard.
+    #[test]
+    fn the_header_names_a_quit_that_answers_where_it_is_read() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        assert!(!editing_notes(&state), "nothing is open yet");
+        assert!(
+            header_keys(false).contains("q: quit"),
+            "outside the editor the header offers `q`"
+        );
+        assert!(
+            matches!(bare(&state, KeyCode::Char('q')), Some(Message::Quit)),
+            "and `q` is answered there"
+        );
+
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+        let _opened = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+        assert!(
+            editing_notes(&state),
+            "the pane has the focus and an occupant"
+        );
+        assert!(
+            header_keys(true).contains("Ctrl+C: quit"),
+            "in the editor it offers the chord instead"
+        );
+        assert!(
+            matches!(
+                key_message(
+                    &state,
+                    KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)
+                ),
+                Some(Message::Quit)
+            ),
+            "and the chord is answered there"
+        );
+        assert!(
+            matches!(
+                bare(&state, KeyCode::Char('q')),
+                Some(Message::Details(DetailsMessage::Input('q')))
+            ),
+            "which is why the header stops naming `q` here"
+        );
     }
 
     /// The open pane's hint names only keys that work where it is read.

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -460,18 +460,20 @@ impl Reducer for Root {
                 Command::quit()
             }
             Message::Quit => Command::quit(),
-            Message::NoTaskSelected => {
-                state.status = "No task selected";
-                Command::none()
-            }
+            Message::NoTaskSelected => no_task_selected(state),
             Message::FocusNext => {
                 state.focus = state.focus.next();
                 state.status = "Changed focus";
                 Command::none()
             }
             Message::SelectPrev | Message::SelectNext => {
-                let forward = matches!(message, Message::SelectNext);
-                select(state, forward);
+                if state.tasks.is_empty() {
+                    // The same answer the four keys that need a row give, for
+                    // the same condition. Reporting a move instead would be
+                    // this example teaching two things about one state.
+                    return no_task_selected(state);
+                }
+                select(state, matches!(message, Message::SelectNext));
                 Command::none()
             }
             Message::AddTask(title) => add_task(state, title),
@@ -1074,20 +1076,27 @@ fn save_notes(state: &mut App) -> Command<Message> {
     Command::message(Message::Task(task_id, TaskMessage::Sync)).into()
 }
 
+/// What a key that needs a selected row reports when there is none.
+///
+/// One place holds the line, because two of them mean it: the message a key
+/// decodes to when nothing is selected, and a selection move over an empty
+/// collection.
+const fn no_task_selected(state: &mut App) -> Command<Message> {
+    state.status = "No task selected";
+    Command::none()
+}
+
 /// Moves the task selection, stopping at the ends.
 ///
 /// Clamped and not wrapped, because `dashboard.rs` clamps: the pair is meant
 /// to differ in structure, and a selection that wrapped here would read as
 /// something composition did.
 fn select(state: &mut App, forward: bool) {
-    // Before the guard below, so an empty list still moves the line: every
-    // other operation reports, and `dashboard.rs` reports here too, so going
-    // silent would leave the footer describing whatever came before it.
-    state.status = "Selected another task";
     let keys: Vec<TaskId> = state.tasks.keys().copied().collect();
     if keys.is_empty() {
         return;
     }
+    state.status = "Selected another task";
     let position = state
         .selected
         .and_then(|selected| keys.iter().position(|key| *key == selected));
@@ -1803,9 +1812,9 @@ mod tests {
         let _emptied = Root.reduce(&mut state, Message::DeleteTask(TaskId(1)));
         let _nowhere_to_go = Root.reduce(&mut state, Message::SelectNext);
         assert_eq!(
-            state.status, "Selected another task",
-            "an empty list has nowhere to move to, and still reports rather \
-             than leaving the last operation's line standing"
+            state.status, "No task selected",
+            "an empty list gets the answer the other four keys give, not a \
+             move it did not make"
         );
     }
 

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -885,6 +885,23 @@ fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
     );
 }
 
+/// The open pane's hint, which is guarded because every key in it is.
+///
+/// `Type to edit` and `Enter to save` need [`editing_notes`] and `Esc to close`
+/// needs a `Details` focus, which with the slot occupied is the same condition.
+/// Printed at every focus, the line named keys that do something else where it
+/// was read: at `Focus::Tasks` the `Enter` arm above the editor's reopens the
+/// pane over this occupant, and a replacement discards the buffer the line was
+/// offering to save. The empty branch above is worded the way it is for the
+/// weaker version of this — a key that is merely inert.
+const fn details_hint(focus: Focus) -> &'static str {
+    if matches!(focus, Focus::Details) {
+        "Type to edit, Enter to save, Esc to close."
+    } else {
+        "Tab to this pane to edit, save or close it."
+    }
+}
+
 fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
     let text = state.details.get().map_or_else(
         // Names something reachable from where it is printed, without
@@ -897,12 +914,13 @@ fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
         || "No details open. Press Enter on a task in the task list.".to_owned(),
         |open| {
             format!(
-                "#{} {} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",
+                "#{} {} · {}s{}\n\nNotes:\n{}_\n\n{}",
                 open.task.0,
                 open.title,
                 open.ticks,
                 if open.loading { " (loading)" } else { "" },
-                open.notes
+                open.notes,
+                details_hint(state.focus)
             )
         },
     );
@@ -2295,6 +2313,58 @@ mod tests {
                 "and the status is about the row, not about the buffer"
             );
         }
+    }
+
+    /// The open pane's hint names only keys that work where it is read.
+    ///
+    /// Not merely a nicety: the pane is drawn at every focus, and at
+    /// `Focus::Tasks` the `Enter` arm above the editor's reopens the pane over
+    /// this occupant. A replacement is a removal, so the key the line offered
+    /// as a save is the one that throws the buffer away.
+    #[test]
+    fn the_open_panes_hint_names_keys_that_work_where_it_is_read() {
+        assert_eq!(
+            details_hint(Focus::Details),
+            "Type to edit, Enter to save, Esc to close.",
+            "at the focus that has all three, the line names all three"
+        );
+        for focus in [Focus::Tasks, Focus::Activity, Focus::Navigation] {
+            assert_eq!(
+                details_hint(focus),
+                "Tab to this pane to edit, save or close it.",
+                "and anywhere else it names where the keys have to land instead"
+            );
+        }
+
+        // The decode the guard exists for, read rather than argued.
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            reason: ExitReason::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+        let _opened = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+        state
+            .details
+            .get_mut()
+            .expect("the pane is open")
+            .notes
+            .push('!');
+        state.focus = Focus::Tasks;
+        assert!(
+            matches!(
+                bare(&state, KeyCode::Enter),
+                Some(Message::OpenDetails(TaskId(1)))
+            ),
+            "with the pane open behind another focus, Enter reopens rather than saves"
+        );
+
+        let _reopened = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+        assert_eq!(
+            state.status, "Replaced the open details pane, discarding notes nobody saved",
+            "and that is the removal, so a hint promising a save there promises the opposite"
+        );
     }
 
     /// Opening a pane over an open one replaces its occupant, and says so.

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -487,16 +487,10 @@ impl Reducer for Root {
                 // The pane is the only place edited notes live until
                 // `SaveNotes` writes them onto the task, so closing one whose
                 // buffer has moved away from the task throws those edits away.
-                // Named for the reason `open_details` and `reload_task` name
-                // what they discard — and only when the two actually differ,
-                // so an Esc straight after a save does not report the loss of
-                // notes that already reached the task.
-                let unsaved = state.details.get().is_some_and(|open| {
-                    state
-                        .tasks
-                        .get(&open.task)
-                        .is_some_and(|task| task.notes != open.notes)
-                });
+                // Read before the close that causes it; [`unsaved_notes`]
+                // carries why this removal reports the buffer and two others
+                // do not.
+                let unsaved = unsaved_notes(state);
                 // Esc is guarded on the focus rather than on `editing_notes`,
                 // so it is the way out of a `Details` focus with nothing behind
                 // it — which is also why the status has to say which of the two
@@ -1012,7 +1006,9 @@ fn reload_task(state: &mut App, id: TaskId) -> Command<Message> {
         .activity
         .push(format!("reloaded: #{} {}", id.0, task_title));
     // Says what the successor threw away, because a cleared checkbox is
-    // otherwise the only sign that it did.
+    // otherwise the only sign that it did. The pane's buffer goes with it and
+    // is not named apart from it: the reload overwrites the row's notes either
+    // way, so a save would have bought nothing. See [`unsaved_notes`].
     state.status = "Reloaded the task, discarding its local state";
     Command::message(Message::Task(id, TaskMessage::Watch)).into()
 }
@@ -1044,27 +1040,48 @@ fn delete_task(state: &mut App, id: TaskId) -> Command<Message> {
             .map(|index| index.min(keys.len().saturating_sub(1)))
             .and_then(|index| keys.get(index).copied());
     }
+    // The row is what left, and a pane open on it went too. That buffer is not
+    // reported as a loss of its own for the reason [`unsaved_notes`] gives:
+    // there is no surviving row a save could have put the notes on.
     state.status = "Deleted the task";
     Command::none()
 }
 
 /// Presents the details pane for a row.
+/// Whether the open pane holds notes the task does not.
+///
+/// [`save_notes`] is the only thing that copies the buffer onto the task, so
+/// this is exactly "pressing Enter first would have kept it" — which is what
+/// decides which removals report the buffer separately.
+///
+/// `Message::CloseDetails` and [`open_details`] over an occupant ask, because
+/// the task the pane was opened for keeps its notes: the edit is the only thing
+/// that goes, and a save would have preserved it.
+///
+/// [`reload_task`] and [`delete_task`] do not ask, and not because their loss is
+/// smaller. Reload overwrites the row's notes with the server's copy and delete
+/// takes the row away, so under both, a reader who had pressed Enter first would
+/// have lost the notes just the same. Naming the buffer there would offer a
+/// remedy that does not exist. What those two discard is the row, and that is
+/// what their own status says.
+fn unsaved_notes(state: &App) -> bool {
+    state.details.get().is_some_and(|open| {
+        state
+            .tasks
+            .get(&open.task)
+            .is_some_and(|task| task.notes != open.notes)
+    })
+}
+
 fn open_details(state: &mut App, id: TaskId) -> Command<Message> {
     let Some(task) = state.tasks.get(&id) else {
         state.status = "That task is gone";
         return Command::none();
     };
     // A replacement is a removal, and the occupant it removes may hold edits
-    // nobody saved — the same loss `CloseDetails` reports, read the same way
-    // and before the `present` that causes it. What replaces the pane is a
-    // different pane, so the old buffer leaves the screen along with any sign
-    // of what was in it.
-    let unsaved = state.details.get().is_some_and(|open| {
-        state
-            .tasks
-            .get(&open.task)
-            .is_some_and(|task| task.notes != open.notes)
-    });
+    // nobody saved — the same loss `CloseDetails` reports, read before the
+    // `present` that causes it.
+    let unsaved = unsaved_notes(state);
     // Presenting over an occupied slot is a replacement too, for the same
     // reason `ReloadTask` is.
     let replaced = state
@@ -1619,6 +1636,15 @@ mod tests {
         // subject. They are also the two the log would shed first — it sits
         // exactly on `ACTIVITY_LIMIT` — so dropping them here keeps this
         // comparison about the teardowns rather than about the buffer's size.
+        // Reading the eviction question off the log instead of off arithmetic
+        // done in a review: a line added above would push this one out first,
+        // and this fails naming that rather than leaving the comparison below
+        // to fail about its own contents.
+        assert_eq!(
+            activity.entries().first().map(String::as_str),
+            Some("added: #1 alpha"),
+            "the log still holds its oldest line, so nothing below is missing for want of room"
+        );
         let written: Vec<String> = activity
             .entries()
             .into_iter()
@@ -2221,6 +2247,54 @@ mod tests {
             "the reason is left where `main` can still read it"
         );
         assert!(!quit.is_none(), "and the run ends");
+    }
+
+    /// The two removals that take the row do not report the buffer separately,
+    /// and this pins that rather than leaving it to the prose.
+    ///
+    /// Both close a pane open on the row, so both lose whatever was typed into
+    /// it. Neither names it, because neither offers the remedy naming it would
+    /// imply: the reload overwrites the row's notes and the delete takes the row,
+    /// so a reader who had pressed Enter first would have lost the notes anyway.
+    /// A drift toward `CloseDetails`'s wording here would be that offer.
+    #[test]
+    fn a_removal_that_takes_the_row_does_not_report_the_buffer_apart_from_it() {
+        for (message, expected) in [
+            (
+                Message::ReloadTask(TaskId(1)),
+                "Reloaded the task, discarding its local state",
+            ),
+            (Message::DeleteTask(TaskId(1)), "Deleted the task"),
+        ] {
+            let (mut state, _bootstrap) = init(Setup {
+                activity: ActivityLog::default(),
+                reason: ExitReason::default(),
+                input: Vec::new(),
+                keyboard: false,
+            });
+            let _added = Root.reduce(&mut state, Message::AddTask("alpha".to_owned()));
+            let _opened = Root.reduce(&mut state, Message::OpenDetails(TaskId(1)));
+            state
+                .details
+                .get_mut()
+                .expect("the pane is open")
+                .notes
+                .push('!');
+            assert!(
+                unsaved_notes(&state),
+                "the buffer has moved away from the task, which is the loss under test"
+            );
+
+            let _removed = Root.reduce(&mut state, message);
+            assert!(
+                !state.details.is_present(),
+                "the pane open on the row went with it, so the edit is gone"
+            );
+            assert_eq!(
+                state.status, expected,
+                "and the status is about the row, not about the buffer"
+            );
+        }
     }
 
     /// Opening a pane over an open one replaces its occupant, and says so.

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1001,6 +1001,7 @@ fn delete_task(state: &mut App, id: TaskId) -> Command<Message> {
     // reduce and merges the row's teardown into the command returned here.
     // Nothing below asks for that.
     let Some(task) = state.tasks.remove(&id) else {
+        state.status = "That task is gone";
         return Command::none();
     };
     state
@@ -1057,7 +1058,10 @@ fn save_notes(state: &mut App) -> Command<Message> {
     };
     let (task_id, notes) = (open.task, open.notes.clone());
     let Some(task) = state.tasks.get_mut(&task_id) else {
-        state.status = "That task is gone";
+        // Defensive, and unreachable through the keys: both paths that remove
+        // a row — `delete_task` and `reload_task` — close a pane opened on it
+        // first, and the reload puts a row back under the same key. No status
+        // here, because a line nobody can reach is a line nobody can check.
         return Command::none();
     };
     task.notes = notes;
@@ -2118,6 +2122,7 @@ mod tests {
         for message in [
             Message::ReloadTask(TaskId(1)),
             Message::OpenDetails(TaskId(1)),
+            Message::DeleteTask(TaskId(1)),
         ] {
             state.status = "Untouched";
             let _late = Root.reduce(&mut state, message);

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -49,7 +49,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use crossterm::event::{Event, KeyCode};
+use crossterm::event::{Event, KeyCode, KeyEventKind};
 use futures::stream;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
@@ -271,6 +271,12 @@ impl NavigationState {
 }
 
 struct TaskState {
+    /// The row's own key.
+    ///
+    /// Redundant with the key the collection holds it under, and kept anyway:
+    /// a child is handed its own state and nothing else, so this is how a hook
+    /// it registers can name which row it was.
+    id: TaskId,
     title: String,
     done: bool,
     notes: String,
@@ -281,8 +287,9 @@ struct TaskState {
 }
 
 impl TaskState {
-    const fn new(title: String, notes: String) -> Self {
+    const fn new(id: TaskId, title: String, notes: String) -> Self {
         Self {
+            id,
             title,
             done: false,
             notes,
@@ -341,7 +348,12 @@ impl Reducer for Root {
     fn reduce(&self, state: &mut App, message: Message) -> Command<Message> {
         match message {
             Message::Terminal(event) => match event {
-                Event::Key(key) => key_message(state, key.code)
+                // Presses only. A terminal that reports releases too — Windows,
+                // or a session with the kitty keyboard protocol on — would
+                // otherwise turn one keystroke into two messages, and in this
+                // file two `AddTask`s or two `OpenDetails` are two removals
+                // and two teardown lines.
+                Event::Key(key) if key.kind == KeyEventKind::Press => key_message(state, key.code)
                     .map_or_else(Command::none, |message| Command::message(message).into()),
                 _ => Command::none(),
             },
@@ -360,7 +372,7 @@ impl Reducer for Root {
                 select(state, forward);
                 Command::none()
             }
-            Message::AddTask(label) => {
+            Message::AddTask(title) => {
                 let id = TaskId(state.next_id);
                 state.next_id += 1;
                 // Insertion into an absent key records no removal: nothing was
@@ -368,10 +380,7 @@ impl Reducer for Root {
                 // that case and never the replacing one.
                 state.tasks.insert(
                     id,
-                    TaskState::new(
-                        format!("{label} #{}", id.0),
-                        "Add notes in the details pane.".to_owned(),
-                    ),
+                    TaskState::new(id, title, "Add notes in the details pane.".to_owned()),
                 );
                 state.selected = Some(id);
                 state.status = "Added a task";
@@ -388,7 +397,7 @@ impl Reducer for Root {
                 let title = task.title.clone();
                 state.tasks.insert(
                     id,
-                    TaskState::new(title, "Reloaded from the server.".to_owned()),
+                    TaskState::new(id, title, "Reloaded from the server.".to_owned()),
                 );
                 // The pane was opened for the instance that just left, and it
                 // holds that instance's title and notes; leaving it open would
@@ -404,7 +413,9 @@ impl Reducer for Root {
                 let Some(task) = state.tasks.remove(&id) else {
                     return Command::none();
                 };
-                state.activity.push(format!("deleted: {}", task.title));
+                state
+                    .activity
+                    .push(format!("deleted: #{} {}", id.0, task.title));
                 // A details pane open on the row that just left goes with it,
                 // and the slot's own boundary originates that teardown.
                 close_details_opened_on(state, id);
@@ -531,7 +542,7 @@ impl Reducer for Task {
                 }
                 state.watched = true;
                 let activity = self.activity.clone();
-                let title = state.title.clone();
+                let title = format!("#{} {}", state.id.0, state.title);
                 Command::batch([
                     // Registered here rather than at the root, so it anchors at
                     // this row's scope and the row's own teardown selects it. A
@@ -588,7 +599,7 @@ impl Reducer for Details {
                 }
                 state.opened = true;
                 let activity = self.activity.clone();
-                let title = state.title.clone();
+                let title = format!("#{} {}", state.task.0, state.title);
                 Command::batch([
                     Command::on_teardown(async move {
                         activity.push(format!("closed details: {title}"));
@@ -795,8 +806,8 @@ fn render_tasks(state: &App, frame: &mut Frame<'_>, area: Rect) {
         let checkbox = if task.done { "[x]" } else { "[ ]" };
         let sync = if task.syncing { " (syncing)" } else { "" };
         ListItem::new(format!(
-            "{marker} {checkbox} {} · {}s{sync}",
-            task.title, task.ticks
+            "{marker} {checkbox} #{} {} · {}s{sync}",
+            id.0, task.title, task.ticks
         ))
     });
     frame.render_widget(
@@ -813,7 +824,8 @@ fn render_details(state: &App, frame: &mut Frame<'_>, area: Rect) {
         || "No details open. Select a task and press Enter.".to_owned(),
         |open| {
             format!(
-                "{} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",
+                "#{} {} · {}s{}\n\nNotes:\n{}_\n\nType to edit, Enter to save, Esc to close.",
+                open.task.0,
                 open.title,
                 open.ticks,
                 if open.loading { " (loading)" } else { "" },
@@ -885,12 +897,23 @@ fn select(state: &mut App, forward: bool) {
     state.status = "Selected another task";
 }
 
+/// Whether a key press is going into the notes editor.
+///
+/// Focus alone does not answer that. The pane lives in a `Slot`, and
+/// [`Focus::next`] walks through `Details` whether or not the slot is occupied,
+/// so most of the time that focus has no editor behind it. A guard written
+/// against the focus would swallow keys — `q` included — into a boundary with
+/// no occupant to claim them.
+fn editing_notes(state: &App) -> bool {
+    state.focus == Focus::Details && state.details.is_present()
+}
+
 /// The message a key press asks for, if any.
 fn key_message(state: &App, code: KeyCode) -> Option<Message> {
     match code {
         // Guarded like every other printable key below, so `q` stays typable
-        // in the notes editor. Esc leaves that pane first.
-        KeyCode::Char('q') if state.focus != Focus::Details => Some(Message::Quit),
+        // in the notes editor. Esc closes the pane, which is how you leave it.
+        KeyCode::Char('q') if !editing_notes(state) => Some(Message::Quit),
         KeyCode::Tab => Some(Message::FocusNext),
         KeyCode::Up => match state.focus {
             Focus::Navigation => Some(Message::Navigation(NavigationMessage::Up)),
@@ -918,12 +941,12 @@ fn key_message(state: &App, code: KeyCode) -> Option<Message> {
         KeyCode::Char('c') if state.focus == Focus::Activity => {
             Some(Message::Activity(ActivityMessage::Clear))
         }
-        KeyCode::Enter if state.focus == Focus::Details => Some(Message::SaveNotes),
+        KeyCode::Enter if editing_notes(state) => Some(Message::SaveNotes),
         KeyCode::Esc if state.focus == Focus::Details => Some(Message::CloseDetails),
-        KeyCode::Backspace if state.focus == Focus::Details => {
+        KeyCode::Backspace if editing_notes(state) => {
             Some(Message::Details(DetailsMessage::Backspace))
         }
-        KeyCode::Char(character) if state.focus == Focus::Details => {
+        KeyCode::Char(character) if editing_notes(state) => {
             Some(Message::Details(DetailsMessage::Input(character)))
         }
         _ => None,
@@ -1187,35 +1210,35 @@ mod tests {
 
         // Replacing the occupant removes it.
         let report = deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "closed details: alpha #1"));
+        driver.settle(TURNS, || recorded(&activity, "closed details: #1 alpha"));
         let open = anonymous(&report, "occupant setup message");
         deliver(&mut driver, &open);
 
         // Dismissing the slot removes its occupant.
         deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "closed details: beta #2"));
+        driver.settle(TURNS, || recorded(&activity, "closed details: #2 beta"));
 
         // Replacing a row removes it, and the successor starts fresh under the
         // same key.
         let report = deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "stopped watching: beta #2"));
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: #2 beta"));
         let watch = anonymous(&report, "row setup message");
         deliver(&mut driver, &watch);
 
         // Removing a row removes it, and leaves the successor row alone.
         deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "stopped watching: alpha #1"));
+        driver.settle(TURNS, || recorded(&activity, "stopped watching: #1 alpha"));
 
         assert_eq!(
             activity.entries(),
             vec![
-                "closed details: alpha #1".to_owned(),
-                "closed details: beta #2".to_owned(),
-                "stopped watching: beta #2".to_owned(),
+                "closed details: #1 alpha".to_owned(),
+                "closed details: #2 beta".to_owned(),
+                "stopped watching: #2 beta".to_owned(),
                 // The root's own line, written by the reduce that removed the
                 // row, before the teardown it originated ran.
-                "deleted: alpha #1".to_owned(),
-                "stopped watching: alpha #1".to_owned(),
+                "deleted: #1 alpha".to_owned(),
+                "stopped watching: #1 alpha".to_owned(),
             ],
             "one teardown per removal, in removal order, and none for the successor row that is \
              still present"
@@ -1264,11 +1287,11 @@ mod tests {
         deliver(&mut driver, &second);
 
         deliver(&mut driver, &script);
-        driver.settle(TURNS, || recorded(&activity, "closed details: alpha #1"));
+        driver.settle(TURNS, || recorded(&activity, "closed details: #1 alpha"));
 
         assert_eq!(
             activity.entries(),
-            vec!["closed details: alpha #1".to_owned()],
+            vec!["closed details: #1 alpha".to_owned()],
             "one removal, one line: the second `Open` armed nothing"
         );
     }
@@ -1303,14 +1326,54 @@ mod tests {
 
         deliver(&mut driver, &script);
         driver.settle(TURNS, || {
-            recorded(&activity, "stopped watching: alpha #1")
-                && recorded(&activity, "closed details: alpha #1")
+            recorded(&activity, "stopped watching: #1 alpha")
+                && recorded(&activity, "closed details: #1 alpha")
         });
 
         assert_eq!(
             activity.entries().len(),
             2,
             "the row and the pane opened on it, and nothing else"
+        );
+    }
+
+    /// `q` quits unless the notes editor is actually there to receive it.
+    ///
+    /// The pane is a `Slot` and the focus cycle passes through `Details`
+    /// either way, so a guard written against the focus alone would swallow
+    /// `q` into a boundary with no occupant — leaving a focus the header still
+    /// advertises `q: quit` from, where it does nothing.
+    #[test]
+    fn q_is_typed_into_the_notes_editor_only_while_one_is_open() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+
+        state.focus = Focus::Details;
+        assert!(
+            matches!(key_message(&state, KeyCode::Char('q')), Some(Message::Quit)),
+            "the focus is on an empty pane, so there is no editor to type into"
+        );
+
+        state.details.present(DetailsState::new(
+            TaskId(1),
+            "alpha".to_owned(),
+            String::new(),
+        ));
+        assert!(
+            matches!(
+                key_message(&state, KeyCode::Char('q')),
+                Some(Message::Details(DetailsMessage::Input('q')))
+            ),
+            "with an occupant the key is text"
+        );
+
+        state.focus = Focus::Tasks;
+        assert!(
+            matches!(key_message(&state, KeyCode::Char('q')), Some(Message::Quit)),
+            "and an open pane the focus is not on does not hold the key"
         );
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -1166,7 +1166,7 @@ const fn child_status(message: &Message) -> Option<&'static str> {
 fn key_message(state: &App, key: KeyEvent) -> Option<Message> {
     // The way out of raw mode, from any focus: the notes editor holds `q` but
     // nothing holds this.
-    if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+    if key.code == KeyCode::Char('c') && key.modifiers == KeyModifiers::CONTROL {
         return Some(Message::Quit);
     }
     // Every binding below is for an unmodified key, with one exception: a
@@ -1406,6 +1406,19 @@ mod tests {
         )))
     }
 
+    /// Hands the driver turns and waits for nothing.
+    ///
+    /// A claim that a hook did *not* fire has to be made after whatever would
+    /// have fired has had its chance: a finalizer is a spawned run, so it does
+    /// not write its line in the pass that tore its scope down.
+    fn spend_turns<P: Program, B: Backend>(driver: &mut TestDriver<P, B>, turns: usize) {
+        let mut spent = 0_usize;
+        driver.settle(turns + 1, || {
+            spent += 1;
+            spent > turns
+        });
+    }
+
     fn recorded(activity: &ActivityLog, line: &str) -> bool {
         activity.entries().iter().any(|entry| entry == line)
     }
@@ -1537,6 +1550,7 @@ mod tests {
         // their own key.
         add_task_and_sync(&mut driver, &script);
         add_task_and_sync(&mut driver, &script);
+        spend_turns(&mut driver, TURNS);
         assert!(
             teardowns(&activity).is_empty(),
             "an insert into an absent key removes no instance, so nothing is torn down"
@@ -1623,12 +1637,13 @@ mod tests {
 
         // Both opens land before either `Open` is delivered, which is what a
         // second key press ahead of the first message looks like.
+        // The replaced occupant had registered nothing: a hook is armed by the
+        // child's own `Open`, which has not been delivered, and one armed at
+        // the root would anchor where the slot's teardown cannot reach it. So
+        // the removal here fires nothing, and the line below is the whole of
+        // what this row claims.
         let first = deliver(&mut driver, &script);
         let second = deliver(&mut driver, &script);
-        assert!(
-            teardowns(&activity).is_empty(),
-            "the replaced occupant never handled its `Open`, so it had registered nothing"
-        );
 
         let first = anonymous(&first, "occupant setup message");
         let second = anonymous(&second, "occupant setup message");
@@ -2053,6 +2068,16 @@ mod tests {
             "and from the notes editor too, which holds the bare `q` but not this"
         );
         for (code, modifiers) in [
+            // Ctrl+C leaves, and only Ctrl+C: a chord that merely contains
+            // `CONTROL` is one this application does not bind.
+            (
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            ),
+            (
+                KeyCode::Char('c'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
             (KeyCode::Char('x'), KeyModifiers::CONTROL),
             (KeyCode::Char('q'), KeyModifiers::ALT),
             (KeyCode::Char('d'), KeyModifiers::SUPER),

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -58,8 +58,9 @@
 //!   write (`synced:`, `loaded details:`), which `dashboard.rs` has no
 //!   counterpart for because nothing there completes with a value later — its
 //!   commands hand a message straight back; `reloaded:`, for a key it
-//!   does not have; and the terminal-error line, which it prints to stderr on
-//!   its way out instead. Every row-scoped line names the row's key, because
+//!   does not have; and the terminal-error line, which this file records and
+//!   `main` prints after restoring the terminal, where `dashboard.rs` prints it
+//!   from inside the run. Every row-scoped line names the row's key, because
 //!   here there is one and two rows added with `n` share a title.
 //! - **The status line is fixed before the child runs**, for every operation
 //!   a boundary claims. `dashboard.rs`'s root runs those updates itself and
@@ -408,9 +409,12 @@ impl Reducer for Root {
                 // removals happen.
                 //
                 // A *repeat* is kept, and is the other thing entirely: a held
-                // key is repetition the reader is asking for, so holding Enter
-                // does replace the pane, over and over, exactly as pressing it
-                // twice would. Testing for `Press` would drop those with the
+                // key is repetition the reader is asking for. It is not the
+                // same as the duplicate above, though — `open_details` moves
+                // the focus, so a held Enter opens the pane once and then
+                // saves into it, while the press and its release are both
+                // decoded before either lands and so both see the focus that
+                // opens. Testing for `Press` would drop the repeats with the
                 // releases, and a held Down would move the selection once.
                 Event::Key(key) if key.kind != KeyEventKind::Release => {
                     key_message(state, key).map_or_else(Command::none, |message| {
@@ -429,6 +433,10 @@ impl Reducer for Root {
                 _ => Command::none(),
             },
             Message::TerminalError(error) => {
+                // Recorded rather than printed. The quit below ends the run
+                // and `main` restores the terminal immediately after, so this
+                // is the only report there is — and `main` prints it once the
+                // screen it would have been drawn on is gone.
                 state.activity.push(format!("terminal error: {error}"));
                 Command::quit()
             }
@@ -1157,11 +1165,20 @@ async fn main() -> Result<()> {
         input: seed(),
         keyboard: true,
     };
-    let program = dashboard(activity).into_program(init, view);
+    let program = dashboard(activity.clone()).into_program(init, view);
 
     let mut terminal = ratatui::init();
     let result = ProgramRuntime::new(program, setup).run(&mut terminal).await;
     ratatui::restore();
+
+    // What the run had to say and could not show. A terminal error quits, so
+    // the pane holding this line is never drawn again; printing it here is
+    // after the restore rather than into a screen that is about to go.
+    for line in activity.entries() {
+        if let Some(reason) = line.strip_prefix("terminal error: ") {
+            eprintln!("Terminal error: {reason}");
+        }
+    }
 
     let _exit = result?;
     Ok(())
@@ -1898,5 +1915,29 @@ mod tests {
             chord(&state, KeyCode::Char('x')).is_none(),
             "while another chord inserts no character"
         );
+    }
+
+    /// A terminal error is recorded, because the quit that follows it leaves
+    /// nowhere to draw the report.
+    ///
+    /// `main` prints the recorded line after restoring the terminal. What this
+    /// row holds is the half the program owns: that the reason is written down
+    /// at all, rather than lost with the screen.
+    #[test]
+    fn a_terminal_error_leaves_a_reason_behind() {
+        let activity = ActivityLog::default();
+        let (mut state, _bootstrap) = init(Setup {
+            activity: activity.clone(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+
+        let quit = Root.reduce(&mut state, Message::TerminalError("broken pipe".to_owned()));
+
+        assert!(
+            recorded(&activity, "terminal error: broken pipe"),
+            "the reason is written down where `main` can still read it"
+        );
+        assert!(!quit.is_none(), "and the run ends");
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -56,7 +56,8 @@
 //! - **The activity log carries the same entries and more of its own.** The
 //!   teardown lines a removal fires; the completion lines the children's runs
 //!   write (`synced:`, `loaded details:`), which `dashboard.rs` has no
-//!   counterpart for because it runs no commands; `reloaded:`, for a key it
+//!   counterpart for because nothing there completes with a value later — its
+//!   commands hand a message straight back; `reloaded:`, for a key it
 //!   does not have; and the terminal-error line, which it prints to stderr on
 //!   its way out instead. Every row-scoped line names the row's key, because
 //!   here there is one and two rows added with `n` share a title.
@@ -209,6 +210,12 @@ enum Message {
     FocusNext,
     SelectPrev,
     SelectNext,
+    /// A key that needs a selected row arrived with none.
+    ///
+    /// A message rather than nothing, so the footer stops describing whatever
+    /// came before it — the reason `select` sets its status before the guard
+    /// that returns early on an empty collection.
+    NoTaskSelected,
     /// Adds a task under a **freshly allocated** key.
     ///
     /// The key is chosen by the reduce and not by the caller on purpose. A
@@ -383,15 +390,20 @@ impl Reducer for Root {
     fn reduce(&self, state: &mut App, message: Message) -> Command<Message> {
         match message {
             Message::Terminal(event) => match event {
-                // Presses only. A terminal that reports releases too —
-                // Windows, or a session with the kitty keyboard protocol on —
-                // would otherwise turn one keystroke into two messages, and
-                // every operation here is one a reader means to perform once:
-                // `n` would add two rows rather than the one asked for, and
-                // Enter would open the pane and then replace it with a second
-                // pane on the same row — a removal the reader never asked for,
-                // in a file about which removals happen.
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                // Not releases. A terminal that reports them — Windows, or a
+                // session with the kitty keyboard protocol on — would
+                // otherwise turn one keystroke into two messages, and every
+                // operation here is one a reader means to perform once: `n`
+                // would add two rows rather than the one asked for, and Enter
+                // would open the pane and then replace it with a second pane on
+                // the same row — a removal the reader never asked for, in a
+                // file about which removals happen.
+                //
+                // A *repeat* is an instruction and is kept. The same protocol
+                // that delivers releases is the one that reports a held key,
+                // so testing for `Press` would drop those too and a held Down
+                // would move the selection once.
+                Event::Key(key) if key.kind != KeyEventKind::Release => {
                     key_message(state, key.code).map_or_else(Command::none, |message| {
                         // A boundary claims a child-addressed message, so the
                         // root never sees it land and the arms for those below
@@ -412,6 +424,10 @@ impl Reducer for Root {
                 Command::quit()
             }
             Message::Quit => Command::quit(),
+            Message::NoTaskSelected => {
+                state.status = "No task selected";
+                Command::none()
+            }
             Message::FocusNext => {
                 state.focus = state.focus.next();
                 state.status = "Changed focus";
@@ -1069,19 +1085,29 @@ fn key_message(state: &App, code: KeyCode) -> Option<Message> {
             Focus::Tasks => Some(Message::SelectNext),
             _ => None,
         },
-        KeyCode::Char(' ') if state.focus == Focus::Tasks => state
-            .selected
-            .map(|id| Message::Task(id, TaskMessage::Toggle)),
+        KeyCode::Char(' ') if state.focus == Focus::Tasks => {
+            Some(state.selected.map_or(Message::NoTaskSelected, |id| {
+                Message::Task(id, TaskMessage::Toggle)
+            }))
+        }
         KeyCode::Char('n') if state.focus == Focus::Tasks => {
             Some(Message::AddTask("New task".to_owned()))
         }
-        KeyCode::Char('d') if state.focus == Focus::Tasks => {
-            state.selected.map(Message::DeleteTask)
-        }
-        KeyCode::Char('r') if state.focus == Focus::Tasks => {
-            state.selected.map(Message::ReloadTask)
-        }
-        KeyCode::Enter if state.focus == Focus::Tasks => state.selected.map(Message::OpenDetails),
+        KeyCode::Char('d') if state.focus == Focus::Tasks => Some(
+            state
+                .selected
+                .map_or(Message::NoTaskSelected, Message::DeleteTask),
+        ),
+        KeyCode::Char('r') if state.focus == Focus::Tasks => Some(
+            state
+                .selected
+                .map_or(Message::NoTaskSelected, Message::ReloadTask),
+        ),
+        KeyCode::Enter if state.focus == Focus::Tasks => Some(
+            state
+                .selected
+                .map_or(Message::NoTaskSelected, Message::OpenDetails),
+        ),
         KeyCode::Char('c') if state.focus == Focus::Activity => {
             Some(Message::Activity(ActivityMessage::Clear))
         }
@@ -1127,7 +1153,7 @@ async fn main() -> Result<()> {
 mod tests {
     use super::*;
 
-    use crossterm::event::{KeyEvent, KeyModifiers};
+    use crossterm::event::{KeyEvent, KeyEventKind, KeyModifiers};
     use ratatui::Terminal;
     use ratatui::backend::{Backend, TestBackend};
     use tears::reducer::Program;
@@ -1238,7 +1264,16 @@ mod tests {
 
     /// The message the terminal subscription produces for a key press.
     fn key_press(code: KeyCode) -> Message {
-        Message::Terminal(Event::Key(KeyEvent::new(code, KeyModifiers::empty())))
+        key_of(code, KeyEventKind::Press)
+    }
+
+    /// The same for the other two kinds a terminal can report.
+    fn key_of(code: KeyCode, kind: KeyEventKind) -> Message {
+        Message::Terminal(Event::Key(KeyEvent::new_with_kind(
+            code,
+            KeyModifiers::empty(),
+            kind,
+        )))
     }
 
     fn recorded(activity: &ActivityLog, line: &str) -> bool {
@@ -1692,5 +1727,68 @@ mod tests {
             state.status, "Toggled the task",
             "and for a row, which is claimed by key"
         );
+    }
+
+    /// A held key is an instruction; the release after it is not.
+    ///
+    /// The protocol that reports releases is the one that reports repeats, so
+    /// a filter written as `== Press` would drop both and a held Down would
+    /// move the selection once.
+    #[test]
+    fn a_repeat_is_an_instruction_and_a_release_is_not() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        for _ in 0..2 {
+            let _added = Root.reduce(&mut state, Message::AddTask("task".to_owned()));
+        }
+        state.focus = Focus::Tasks;
+        state.selected = Some(TaskId(1));
+
+        assert!(
+            !Root
+                .reduce(&mut state, key_of(KeyCode::Down, KeyEventKind::Repeat))
+                .is_none(),
+            "a repeat asks for the move a press would have asked for"
+        );
+        assert!(
+            Root.reduce(&mut state, key_of(KeyCode::Down, KeyEventKind::Release))
+                .is_none(),
+            "and the release after it asks for nothing"
+        );
+    }
+
+    /// A key that needs a selected row says so when there is none.
+    ///
+    /// Silence would leave the footer describing the operation before it — the
+    /// reason `select` sets its status ahead of its own empty-collection
+    /// guard.
+    #[test]
+    fn a_key_needing_a_selection_reports_when_there_is_none() {
+        let (mut state, _bootstrap) = init(Setup {
+            activity: ActivityLog::default(),
+            input: Vec::new(),
+            keyboard: false,
+        });
+        state.focus = Focus::Tasks;
+        assert_eq!(state.selected, None, "nothing has been added");
+
+        for code in [
+            KeyCode::Char(' '),
+            KeyCode::Char('d'),
+            KeyCode::Char('r'),
+            KeyCode::Enter,
+        ] {
+            assert!(
+                matches!(key_message(&state, code), Some(Message::NoTaskSelected)),
+                "{code:?} needs a row and there is none, so it reports rather than \
+                 leaving the last operation's line standing"
+            );
+        }
+
+        let _reported = Root.reduce(&mut state, Message::NoTaskSelected);
+        assert_eq!(state.status, "No task selected");
     }
 }

--- a/examples/dashboard_composed.rs
+++ b/examples/dashboard_composed.rs
@@ -59,10 +59,11 @@
 //!   — which `dashboard.rs` has no counterpart for because it runs no commands.
 //!   Every row-scoped line names the row's key, because here there is one and
 //!   two rows added with `n` share a title.
-//! - **The status line names the request, not the outcome**, for the three
-//!   operations a boundary claims. `dashboard.rs`'s root runs those updates
-//!   itself and reports what they did; here the root sets the line where it
-//!   dispatches the message, before the child has run.
+//! - **The status line is fixed before the child runs**, for every operation
+//!   a boundary claims. `dashboard.rs`'s root runs those updates itself and
+//!   can report what they produced — "Selected section: Today"; here the root
+//!   sets the line where it dispatches the message, so nothing the child
+//!   computes can appear in it.
 //! - **The tasks arrive as messages** rather than as initial state, because
 //!   `init`'s command crosses no boundary and a row's setup has to. That they
 //!   start with the same notes and none marked done is not composition's doing
@@ -376,11 +377,14 @@ impl Reducer for Root {
     fn reduce(&self, state: &mut App, message: Message) -> Command<Message> {
         match message {
             Message::Terminal(event) => match event {
-                // Presses only. A terminal that reports releases too — Windows,
-                // or a session with the kitty keyboard protocol on — would
-                // otherwise turn one keystroke into two messages, and in this
-                // file two `AddTask`s or two `OpenDetails` are two removals
-                // and two teardown lines.
+                // Presses only. A terminal that reports releases too —
+                // Windows, or a session with the kitty keyboard protocol on —
+                // would otherwise turn one keystroke into two messages, and
+                // every operation here is one a reader means to perform once:
+                // `n` would add two rows rather than the one asked for, and
+                // Enter would open the pane and then replace it with a second
+                // pane on the same row — a removal the reader never asked for,
+                // in a file about which removals happen.
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     key_message(state, key.code).map_or_else(Command::none, |message| {
                         // A boundary claims a child-addressed message, so the
@@ -902,15 +906,22 @@ fn reload_task(state: &mut App, id: TaskId) -> Command<Message> {
     // Inserting over an occupied key is a replacement, and a replacement is a
     // removal: the boundary tears the old instance's runs down before this
     // command's spawns start the successor's.
-    let title = task.title.clone();
+    let task_title = task.title.clone();
     state.tasks.insert(
         id,
-        TaskState::new(id, title, "Reloaded from the server.".to_owned()),
+        TaskState::new(
+            id,
+            task_title.clone(),
+            "Reloaded from the server.".to_owned(),
+        ),
     );
     // The pane was opened for the instance that just left, and it holds that
     // instance's title and notes; leaving it open would let a later
     // `SaveNotes` write them back over the reload.
     close_details_opened_on(state, id);
+    state
+        .activity
+        .push(format!("reloaded: #{} {}", id.0, task_title));
     state.status = "Reloaded the task";
     Command::message(Message::Task(id, TaskMessage::Watch)).into()
 }
@@ -1019,8 +1030,9 @@ fn editing_notes(state: &App) -> bool {
 ///
 /// Read at the dispatch rather than at the landing, because a boundary claims
 /// these and the root's `reduce` never sees them. That fixes what the line can
-/// say: `dashboard.rs`'s root runs the child update itself and can report the
-/// outcome — "Selected section: Today" — while this one is naming the request.
+/// say before the child has run: nothing the child computes can appear in it,
+/// so where `dashboard.rs` reports "Selected section: Today" — its root having
+/// run the child update itself — these name the operation and stop there.
 const fn child_status(message: &Message) -> Option<&'static str> {
     match message {
         Message::Navigation(_) => Some("Selected another section"),
@@ -1379,6 +1391,7 @@ mod tests {
                 "added: #2 beta".to_owned(),
                 "closed details: #1 alpha".to_owned(),
                 "closed details: #2 beta".to_owned(),
+                "reloaded: #2 beta".to_owned(),
                 "stopped watching: #2 beta".to_owned(),
                 // The root's own line, written by the reduce that removed the
                 // row, before the teardown it originated ran.


### PR DESCRIPTION
Closes part of #322 — the runnable example, the `TestDriver` test, and the user
guide. The performance guidance stays open there.

## What this is

The composition API has been runnable since 0.11.0 and had no worked
application to read. A new example on a new domain would have shown the API
without answering the question a reader actually has, which is whether their
application wants it — so this is `dashboard.rs` written a second time with the
wiring moved off the root.

The two files run the same application: same panes, same focus cycle, same task
operations. The structure is what the diff is for. What else differs — the
children's runs, three keys, the lines the activity log gains, the status line
naming a request instead of an outcome, and the tasks arriving as messages — is
listed in the example's own module doc rather than left for a diff to turn up.

| `dashboard.rs` | `dashboard_composed.rs` |
| --- | --- |
| root updates `NavigationState` | `scope(Navigation, Segment::Navigation)` |
| root updates `ActivityLogState` | `scope(Activity, Segment::Activity)` |
| `TaskListState { tasks: Vec<Task> }` | `for_each` over `Keyed<TaskId, TaskState>`, one child reducer per row |
| `DetailState`, always present | `presented` over `Slot<DetailsState>` |
| `StatusState`, updated by the root | unchanged — not everything wants a boundary |

Every timer is declared on one interval and every request keyed under one
`CommandId`, deliberately. Written by hand those are collisions: one timer
shared by every row, one sync slot for the whole application. Composed they are
not, and no `.scoped(...)` call appears anywhere in the file.

## Two rules the rewrite makes explicit

- **A child's own work starts as a message routed through the boundary.**
  `init`'s command is the root's and crosses none, so a hook registered there
  would anchor where no teardown reaches it (`TaskMessage::Watch`).
- **Work spanning two children stays the root's.** A child is handed its own
  projected state and can reach neither the collection beside it nor the slot
  around it (`Message::SaveNotes`).

## Tests

`TestDriver` tests drive the same stack the binary runs — the same reducer
value, closed with the same `init` and `view`, started from a `Setup` carrying a
scripted input.

- `identical_child_identities_stay_apart_under_their_boundaries` reads the run
  identities each step started: three timers declared on one interval are three
  subscriptions, three requests keyed on one id are three slots, and none of
  them is the unqualified id the reducers wrote.
- `every_removal_tears_its_instance_down` walks all four removal shapes —
  `Slot::present` over an occupied slot, `Keyed::insert` over an occupied key,
  `Keyed::remove`, `Slot::dismiss` — and asserts one teardown per removal and
  none for the successor row still present. It is observed through the
  `on_teardown` hooks each child registers, since a finalizer produces no
  message by design.

Both were mutation-checked: moving a row's hook registration from the child to
the root makes the second test fail on its `settle` budget, so it is sensitive
to the scope the hook anchors at rather than to the hook existing.

## Example naming

The list in the README gains the two headings the files were already sorted by.
Structure examples are named after the application, because a reader choosing a
structure knows the shape of their problem and not the name of the API; feature
examples are named after the API item, because that is what they arrive looking
for; `http_todo.rs` carries both, as a feature that needs a real application to
be worth showing. No existing file is renamed.

`dashboard.rs` is not renamed or removed either. `Application` is run through an
adapter over the same kernel rather than a legacy path, and the guide needs it
as the shape to keep while a child is a single instance.

## Verification

`cargo test --lib --tests --examples`, `just test-doc`, `just clippy-loom`,
`just test-mirrors`, `cargo clippy --all-targets`, `cargo fmt --check`, `typos`,
and `RUSTDOCFLAGS=-D warnings cargo doc` all pass. The bench targets are not
run here — this touches examples and docs only, and `clippy --all-targets`
covers their compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



