### PR TITLE
docs: say what TestDriver executes that TestStore does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,31 @@ cargo test --example command_cancellation
 cargo test --example dashboard
 ```
 
-`TestStore` takes an `Application`, so a composed `Program` is driven with
-`tears::testing::TestDriver` instead; `examples/dashboard_composed.rs` carries
-worked `TestDriver` tests:
+[`tears::testing::TestDriver`](https://docs.rs/tears/latest/tears/testing/struct.TestDriver.html)
+drives the production kernel a pass at a time: the same construction path, the
+same runtime-owned tasks, with the test scripting what production decides for
+itself. An order the driver establishes is therefore never evidence of a
+production order. It takes a `Program` where `TestStore` takes an
+`Application` — a composed stack becomes one through `into_program`, and an
+`Application` becomes one through
+[`tears::reducer::AppProgram`](https://docs.rs/tears/latest/tears/reducer/struct.AppProgram.html),
+the adapter the `Runtime` facade already applies — and it too is written on a
+plain `#[test]`, for a reason of its own: it owns the executor it turns, and
+turning that one blocks the calling thread, which Tokio refuses on a thread
+already driving tasks.
+
+Driving the real kernel is what puts two things within reach. A declared
+subscription source runs; and in a composed program, the teardown a boundary
+originates when a child leaves runs too, where `TestStore` has no boundary to
+originate one. So reach for `TestStore` when the assertion is about an
+`Application`'s `update` transitions and command effects, and for `TestDriver`
+when it is about a source running at all, or — in a composed program — a
+child's arrival and removal across passes. Not about *when* a time-gated
+source produces, though: that needs a paused runtime the driver cannot be
+given, and so a different test shape, the one *deterministic time without
+`TestStore`* describes in the module docs linked above.
+
+`examples/dashboard_composed.rs` carries worked `TestDriver` tests:
 
 ```bash
 cargo test --example dashboard_composed

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -136,15 +136,19 @@ itself.
 ## Testing a composition
 
 `TestStore` takes an `Application`, so a composed program is driven with
-`tears::testing::TestDriver` instead: it constructs from the same inputs the
-production entry point takes, boots the program, and steps whole passes, with
-the sends a producer makes released one grant at a time. The rows in
-`dashboard_composed.rs` that build a `TestDriver` drive that example's own stack
-that way — the same `Reducer` value `main` runs, closed with the same `init` and
-`view`, and started from a `Setup` carrying a scripted input instead of the
-binary's seed. They are the shape to copy. The rest of that file's rows call the
-root reducer and the key decoder directly, which is a cheaper loop and a
-different claim: it never crosses a boundary, so it would pass with the
+`tears::testing::TestDriver` instead. That is a fact about the store's type
+rather than about the driver's reach: the driver runs the production kernel,
+and an `Application` reaches for it too — through `tears::reducer::AppProgram`,
+the adapter the `Runtime` facade applies — when a test needs what the store
+only declares. The driver constructs from the same inputs the production entry
+point takes, boots the program, and steps whole passes, with the sends a
+producer makes released one grant at a time. The rows in
+`dashboard_composed.rs` that build a `TestDriver` drive that example's own
+stack that way — the same `Reducer` value `main` runs, closed with the same
+`init` and `view`, and started from a `Setup` carrying a scripted input instead
+of the binary's seed. They are the shape to copy. The rest of that file's rows
+call the root reducer and the key decoder directly, which is a cheaper loop and
+a different claim: it never crosses a boundary, so it would pass with the
 composition taken out.
 
 Two observations are worth designing tests around, because they are what


### PR DESCRIPTION
Closes #357.

## The gap

The testing section named `TestDriver` already, in one clause:

> `TestStore` takes an `Application`, so a composed `Program` is driven with
> `tears::testing::TestDriver` instead

That states the boundary on the axis of *what shape you wrote*, and the
question a reader arrives with is *what my assertion is about*. Two paragraphs
earlier the section tells them `TestStore` "does not execute subscription
sources — it observes only the *declared* set via `subscription_ids`", and then
offers nothing that does. A reader whose application is an `Application` — the
shape the whole section is written for — reads the clause above and concludes
the driver is not theirs.

## What this changes

Two documents, one paragraph each. The `TestStore` material is untouched.

**`README.md`.** The driver is introduced by what it drives, and the boundary
is stated on the axis the reader is standing on:

- `TestDriver` drives the production kernel a pass at a time — with the test
  scripting what production decides for itself, so an order the driver
  establishes is never evidence of a production order (RFC 0008 §1.3's own
  line).
- Two things that puts within reach: a declared subscription source *running*,
  and — in a composed program — the teardown a boundary originates when a child
  leaves.
- Which tool each kind of assertion belongs to, and where the driver's answer
  stops: not *when* a time-gated source produces, which needs a paused runtime
  the driver cannot be given.
- Both routes to `Program`, each with its converter: `into_program` for a
  composed stack, `AppProgram` for an `Application`. Without the second, the
  facade reader still has no route.

**`docs/composition.md`.** The same sentence, and the same correction. That
guide is where someone decides whether to compose at all, so its reader is
exactly the `Application` author this issue is about — "so a composed program
is driven with `TestDriver` instead" invites the same inverse there. The
`AppProgram` route is named there too.

## What is deliberately not on the list

**`Command::teardown`'s own cleanups.** An early draft said the driver is where
a registered teardown hook fires. That is wrong: `TestStore` runs them, and
`src/testing.rs`'s `a_teardown_runs_the_cleanup_registered_under_it` is the
test. What `TestStore` cannot reach is a teardown *no command asked for* —
`TestStore<App: Application>` has no boundary to originate one — so the
paragraph says "the teardown a composition boundary originates".

**The driving differential and the lane vocabulary.** Which source begins a
pass, and the grant handshake, are contract that `TestDriver`'s own page opens
with and that the linked example works. The hazard they guard — a test citing
the driver's script as production behaviour — is covered by the citation rule
instead, which needs no vocabulary the README lacks.

## Verification

- `TestDriver::new(AppProgram::<App>::new(), flags, config, terminal)` was
  compiled and run in a throwaway integration test before the claim was
  written; nothing in the tree pairs those two types, so it was not inferred
  from the `P: Program` bound.
- `Runtime` applies `AppProgram` at both constructors (`src/runtime.rs`).
- "a paused runtime the driver cannot be given": both public constructors build
  their own executor with no `start_paused`, and the body that would take one
  is private.
- The two docs.rs links this adds resolve (200), as does the `tears::testing`
  module link the section already had.
- `cargo test --example dashboard_composed` — 20 passed. Its
  `identical_child_identities_stay_apart_under_their_boundaries` reads
  `RunKind::Subscription(id)` off started runs, and
  `every_removal_tears_its_instance_down` observes the boundary-originated
  teardowns.
- `typos` passes. Neither file is pulled in by `include_str!`, so nothing here
  is compiled.

## Split out of this PR

Review of the paragraph turned up a false `# Panics` on `TestDriver::new` —
the page this paragraph links to. That fix, and the six tests holding it, are
in #366, so each change can be reviewed on its own. Until #366 lands, a reader
following this paragraph's `TestDriver` link still meets that claim; #366 is
what closes it.

## Contract

RFC 0008 §1.3 and §9.1: the driver sits beside the store, the store's
non-execution boundary is unmoved, and one driver step executes one whole
production pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
