### PR TITLE
chore: make `just bench` run the criterion benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,30 +248,16 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Run criterion benchmarks in test mode
         id: criterion
-        # `--bench <name>` (singular, per-target) rather than `--benches`
-        # (plural): the plural form implicitly also runs the lib's unit
-        # tests, duplicating what the `test` job's matrix already covers.
-        # Criterion's own test mode is the smoke profile for it: one
-        # iteration, no sample, so what it gates is that it still compiles
-        # and runs. Both criterion benches are named, since no gate executes
-        # either anywhere else — `just test` selects targets explicitly now,
-        # and the load harness has the step after this one.
-        #
-        # The exit codes are collected rather than left to `bash -e`, so a red
-        # `gauge` does not stop `kernel_scan` from reporting: they measure
-        # different things and one failing says nothing about the other.
-        # Separate steps would carry the same property, given the condition
-        # the step below has; one step keeps that condition to a single
-        # place.
+        # Invoked through `just`, like the step below, so the bench names are
+        # not a copy of the recipe's and a contributor runs what this runs.
+        # The recipe states the rest: why the invocation names each target
+        # rather than passing `--benches`, and why the set it passes is
+        # `bench-internals` rather than the wider one this step passed before.
         #
         # This job is advisory either way: `Benchmarks` is not among `main`'s
-        # required contexts, so what a name here buys is a red job, not a
+        # required contexts, so a bench failing here is a red job, not a
         # blocked merge.
-        run: |
-          status=0
-          cargo test --bench gauge --features ${{ needs.versions.outputs.features }} || status=1
-          cargo test --bench kernel_scan --features ${{ needs.versions.outputs.features }} || status=1
-          exit $status
+        run: just bench-test
       - name: Run the load harness's smoke profiles
         # Reached whenever the step above ran at all, red or green: the
         # criterion benches say nothing about this one, and this is the

--- a/justfile
+++ b/justfile
@@ -47,6 +47,14 @@
 # reproducible, the mechanism is not established, so treat the numbers above as
 # the reason and re-measure before widening either list. See issue #298.
 
+# The crate's one bench-only feature: what the benches' `required-features`
+# name and what all three bench recipes build under. `build_features` adds it
+# to `user_features` so that the `--all-targets` passes reach the bench
+# targets at all. Singular on purpose — `test-doc-packaged` matches it against
+# one entry of the crate's feature table, so a second bench-only feature is a
+# change to make here rather than a value to append.
+bench_feature := "bench-internals"
+
 # Every feature a dependant can name: the crate's feature table minus the two
 # build-only entries. All three TLS backends are here because they coexist and
 # a doctest gated on one must not go uncompiled because another was picked.
@@ -79,7 +87,7 @@ user_features := "dashmap,http,native-tls,rustls,rustls-tls-webpki-roots,thiserr
 # and `clippy-fix`, which they do not. `clippy-loom` and `build-all` pass
 # `--all-targets` too, under `loom-core` and under no features, so neither
 # reaches a `required-features` bench.
-build_features := user_features + ",bench-internals"
+build_features := user_features + "," + bench_feature
 
 # Default recipe to display help
 default:
@@ -141,21 +149,16 @@ clippy-fix:
 # job that does, is not among `main`'s required contexts. Before this change
 # the only thing in any gate that built and ran a bench was this recipe.
 #
-# No local gate executes one either. `bench-smoke` is the only recipe that
-# runs a bench at all, and it is in neither `check` nor `pre-commit`; it also
-# reaches the harness through `cargo bench`, whose profile inherits `release`,
-# so nothing runs `kernel_load` with `debug_assertions` on any more.
+# No local gate executes one either: `bench`, `bench-test` and `bench-smoke`
+# are in neither `check` nor `pre-commit`. What none of them covers is
+# `kernel_load` with `debug_assertions` on, since `bench-smoke` reaches it
+# through `cargo bench`, whose profile inherits `release`. Typing it by hand
+# gives that back, with a profile argument because the harness given none runs
+# the acceptance matrix — the 22 minutes this recipe just stopped taking:
 #
-# Typing it by hand gives that much back — the harness only. `gauge` and
-# `kernel_scan` lose their last local runner here and get no replacement,
-# which is #370. Given no argument the harness runs the acceptance matrix —
-# not the probe sweep, which is named-rows only — the 22 minutes this recipe
-# just stopped taking, so pass the profiles `bench-smoke` does, under the test
-# profile instead:
-#
-#     features=$(just --evaluate build_features)
-#     cargo test --bench kernel_load --features "$features" -- --self-test
-#     cargo test --bench kernel_load --features "$features" -- --smoke
+#     feature=$(just --evaluate bench_feature)
+#     cargo test --bench kernel_load --features "$feature" -- --self-test
+#     cargo test --bench kernel_load --features "$feature" -- --smoke
 
 # Run the tests
 test:
@@ -259,7 +262,8 @@ test-doc-packaged:
     # inside jq so the two sides cannot disagree on collation.
     jq -e --arg have '{{user_features}}' '
       ([.packages[0].features | keys[]
-        | select(. != "default" and . != "loom-core" and . != "bench-internals")]
+        | select(. != "default" and . != "loom-core"
+                 and . != "{{bench_feature}}")]
        | sort) as $want
       | ($have | split(",") | map(select(length > 0)) | sort) as $got
       | if $want == $got then true
@@ -301,9 +305,42 @@ test-doc-packaged:
 test-loom:
     RUSTFLAGS="--cfg loom" LOOM_MAX_PREEMPTIONS=3 cargo test --features loom-core --lib -- cell_core accounting_core
 
-# Run criterion benchmarks
-bench:
-    cargo bench
+# Naming each target is what keeps `kernel_load` out: a bare `cargo bench`
+# carrying the feature reaches it, and given no argument its `main` runs the
+# full acceptance matrix — a deliberate acceptance run, reached by argument
+# through `bench-smoke` or by hand. `--benches` would reach it too, and the
+# lib besides: running its unit tests under `cargo test`, which the `test`
+# job's matrix already covers, and compiling them only to skip them under
+# `cargo bench`. Every `[[bench]]` quotes the feature in its own
+# `required-features`, and the two forms fail differently without it: a named
+# target errors — `requires the features: bench-internals` — while the bare
+# `cargo bench` this replaced skipped all three and exited 0.
+#
+# `bench_feature` is what those targets require, what both bench files
+# document and what `bench-smoke` passes, so `bench` measures under the
+# configuration its recorded numbers were taken under: criterion keys a stored
+# baseline on the benchmark id alone, so a wider set would be compared against
+# them and the build configuration reported as a regression. `bench-test`
+# takes the same set rather than the `build_features` the Benchmarks job
+# passed before, which trades the wide set's link-and-run coverage — the
+# narrow set had none for these two — for the narrow set's. Type-checking the
+# wide set survives in `Clippy`, the MSRV job's `cargo check --all-targets`,
+# `clippy` and `clippy-fix`, none of which links a binary.
+#
+# Each name is spelled once per recipe rather than held in a variable a loop
+# reads: two lines to edit when a criterion bench is added, and nothing checks
+# either shape against `Cargo.toml`'s `[[bench]]` names anyway, which is #371.
+_criterion subcommand name:
+    cargo {{subcommand}} --bench {{name}} --features "{{bench_feature}}"
+
+# Measure the criterion benchmarks
+bench: (_criterion "bench" "gauge") (_criterion "bench" "kernel_scan")
+
+# Criterion's test mode: one iteration and no sample, so what it proves is that
+# the benches still build and run, not what they cost.
+
+# Run the criterion benchmarks in test mode
+bench-test: (_criterion "test" "gauge") (_criterion "test" "kernel_scan")
 
 # RFC 0007 §6 and RFC 0014 §13.5; the CI Benchmarks profile.
 # Latency-assertion-free: proves the harness builds and the reduced rows
@@ -312,8 +349,8 @@ bench:
 
 # Run the load harness's smoke profiles
 bench-smoke:
-    cargo bench --bench kernel_load --features bench-internals -- --self-test
-    cargo bench --bench kernel_load --features bench-internals -- --smoke
+    cargo bench --bench kernel_load --features "{{bench_feature}}" -- --self-test
+    cargo bench --bench kernel_load --features "{{bench_feature}}" -- --smoke
 
 # Build the library
 build:


### PR DESCRIPTION
Closes #370.

`just bench` was `cargo bench` with no `--features`, so cargo skipped all
three `required-features` benches and the recipe exited 0 having measured
nothing:

```
$ cargo bench
test result: ok. 0 passed; 0 failed; 570 ignored; 0 measured; 0 filtered out

$ cargo bench --no-run
  Executable benches src/lib.rs (target/release/deps/tears-…)
```

Green, with no bench executable built. #369 dropped `--all-targets` from `just
test`, which was the last local path that executed `gauge` and `kernel_scan`,
so this was the only recipe left claiming to run them.

## Why not the one-line fix

`cargo bench --features …` fixes the skipping and reaches `kernel_load` too.
Its `main` given no argument selects every row — the full acceptance matrix,
the 22 minutes #369 measured — which is a deliberate acceptance or regression
run (RFC 0006 §5.1, RFC 0007 §5-6, RFC 0014 §13.5) selected by argument
through `bench-smoke` or by hand, not what typing a recipe named for
measurement asks for.

So each target is named, through one parameterised recipe the two public ones
depend on:

```just
_criterion subcommand name:
    cargo {{subcommand}} --bench {{name}} --features "{{bench_feature}}"

bench: (_criterion "bench" "gauge") (_criterion "bench" "kernel_scan")
bench-test: (_criterion "test" "gauge") (_criterion "test" "kernel_scan")
```

`--benches` is out for the same reason and one more, which was `ci.yml`'s: it
reaches the lib too, running its unit tests under `cargo test` where the
`test` job's matrix already covers them, and compiling them only to skip them
under `cargo bench`.

## Two recipes, because the profiles differ

| recipe | invocation | what it is for |
| --- | --- | --- |
| `bench` | `cargo bench --bench <name>` | measurement, criterion's default sampling |
| `bench-test` | `cargo test --bench <name>` | one iteration, no sample: it still builds and runs |

The Benchmarks job invokes `just bench-test` instead of spelling out the two
`cargo test --bench` lines. Routing a CI job through `just` is what #373
weighs for the `test` job and declines there, because that job produces three
of `main`'s required contexts; `Benchmarks` is not among them, so that
consideration does not arise here.

The names are spelled per recipe rather than held in a variable a shell loop
reads: a criterion bench added is two lines to edit, against a loop to read on
every visit, and nothing checks either shape against `Cargo.toml` anyway
(#371).

Dependencies run in order and stop at the first failure, so this step no
longer reports both benches when both are red — the `run:` block it replaces
collected the two exit codes for that. Declined rather than reproduced:
`bench-smoke` beside it already stops at its first failing profile, so
carrying the collection in one of the two recipes would make neighbours fail
differently, and `Benchmarks` is advisory either way. Recorded here rather
than in a comment, the recipes being the shape `just` gives them.

## The feature set changes, and that is a trade

Both recipes build under `bench_feature` (`bench-internals`), not the
`build_features` the Benchmarks job passed before.

For `bench` it is what the benches themselves document, and what their
recorded numbers were taken under. Criterion keys a stored baseline on the
benchmark id alone — `target/criterion/<id>`, no feature component — so
measuring under a wider set would compare against numbers taken under a
narrower one and report the build configuration as a regression, against the
~36ns / ~17ns figures `benches/gauge.rs` asks the reader to re-run.

For `bench-test` it is a trade, stated in the recipe rather than left to be
discovered:

- **Gained**: under the narrow set only `kernel_load` was ever linked and run,
  by `bench-smoke`. `gauge` and `kernel_scan` now are too.
- **Given up**: nothing links or runs a bench under the wide set any more.
  Type-checking it there survives — `Clippy` (a required context) and the MSRV
  job's `cargo check --all-targets` in CI, the recipes named beside
  `build_features` locally — and none of those produces a binary.

`bench_feature` is a variable because this change would otherwise have added a
second copy of that string one line after adding a variable to stop exactly
that. `build_features` derives from it, `_criterion` and `bench-smoke` pass it,
`test-doc-packaged`'s staleness check matches against it, and so does the
hand-typed `kernel_load` command in the `test` recipe's comment, which was
still naming the wider set.

## Verified

Failure paths run rather than assumed:

- `cargo bench --bench <name> --features bench-internals --no-run` builds both
  executables; before this, only the lib.
- `just bench-test` green (1m28s on a warm tree, dominated by the compile);
  CI's Benchmarks log shows both benches actually executing through it.
- With `gauge` panicking, `just bench-test` exits non-zero and stops before
  `kernel_scan`, confirmed rather than assumed.
- `bench_feature` set to two words: cargo errors rather than landing the
  second as a positional `TESTNAME` and filtering every benchmark out.
- `bench_feature` drifted: `test-doc-packaged` fails with `user_features is
  stale`, exit 5.
- `actionlint` clean, `just fmt-check` clean. No Rust source changed.

## What this does not close

- **#371** — fewer lists exist, but nothing compares them to `Cargo.toml`.
- **#374** — no required context builds or runs a bench either way; both new
  recipes are outside `check` and `pre-commit`, and `Benchmarks` stays
  advisory.
- **#368** — how the load harness should behave under `cargo test`.
- **#375**, filed with this: that the harness is declared a `[[bench]]` at all
  is what made the one-line fix unavailable, and #368, #371 and #374 all touch
  the same target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
