### PR TITLE
docs(rfcs): stop RFC 0007 §6 enumerating the Benchmarks job

### DIFF
--- a/docs/rfcs/0007-runtime-config.md
+++ b/docs/rfcs/0007-runtime-config.md
@@ -741,10 +741,7 @@ scenarios stay out of CI: they run as
 deliberate acceptance or regression runs (§5), on any machine, with RFC
 0006 §5.1's scoping unchanged — a full run carries acceptance force only
 on the reference machine, and runs on other machines are
-regression-informative, never acceptance. The job's other bench invocations
-are the registry scan and the isolated producer-gauge cost; the subscription
-bench it also ran went with the subscription manager it measured, whose
-reconciliation the kernel's run registry now owns.
+regression-informative, never acceptance.
 
 **The recipe carries the kernel harness's profile.** RFC 0014 §13.5's
 load harness for the reducer-first kernel (`benches/kernel_load.rs`) is


### PR DESCRIPTION
## What

`docs/rfcs/0007-runtime-config.md` §6 stops naming which other benches the
Benchmarks job runs. Pure removal — the paragraph ends at "never acceptance"
and reads whole there.

```diff
-regression-informative, never acceptance. The job's other bench invocations
-are the registry scan and the isolated producer-gauge cost; the subscription
-bench it also ran went with the subscription manager it measured, whose
-reconciliation the kernel's run registry now owns.
+regression-informative, never acceptance.
```

## Why this option

#372 weighs two. #369 took the first — it corrected the count from singular
to plural when it added `gauge` to that job — and recorded that it left the
second open, because correcting a count leaves an Accepted RFC pinning a CI
job's contents, which is what put the sentence out of date to begin with.
This is the second.

The enumeration fails the README's test for a sentence that belongs in an
RFC: a conforming reimplementation reading only this RFC could name any set
of benches in that job and still preserve every §6 guarantee — no latency
criterion, gating on completion, an invocation identical to the local one,
the full scenarios out of CI. So it is not contract, and removing it is a
factual sync rather than an amendment, on the same classification #369
recorded for the singular→plural fix.

RFC 0010's ledger agrees on where the boundary falls: LG-0007-054…063
preserve the scenario set, the gate definitions, the invocation form, the
negative space and the denial of acceptance status. Not one of them is a
property of the job's roster.

The clause about the retired subscription bench goes with it: it is history,
which the README assigns to Git, and it survives as a current fact in RFC
0005's file inventory, where `benches/subscription.rs` is recorded as retired
with the subscription manager.

## Why nothing replaces it

Three review rounds each found a defect in a replacement sentence, and the
third round's own conclusion was that the sentence should not exist. It is
right, and the reason is structural rather than a tally of rounds: an RFC
already has a designated place to say where a section's remit stops — the
header's `Scope` line, which reads "the CI smoke-profile decision". An inline
restatement is a second copy to keep true as the scope moves, which is the
defect this change removes, one level up.

The paragraph does not need it either. The resolution above states which
profile runs in that job; it never claims the job runs nothing else, so
deleting the enumeration leaves no exclusive reading to forestall.

## Pre-review checklist

1. **Quantifiers against the inventory** — pass. The removed sentence was a
   closed enumeration ("the job's other bench invocations *are* X and Y").
   Nothing is added, so no new quantifier and no new definite reference enter
   the paragraph. §6's surviving universals — *each load harness*, *no
   latency criterion*, *never acceptance* — are untouched, and the paragraph
   now carries no sentence that a second load harness or a changed roster
   could leave without a referent.
2. **Adversarial counterexample per invariant** — pass. The construction to
   rule out is a full-scenario load run added to the Benchmarks job on the
   ground that §6 no longer says what else the job contains. It is excluded
   twice, by text the diff does not touch: the same paragraph's "the full
   scenarios stay out of CI", and §6's opening universal "CI runs a smoke
   profile of each load harness, in place of a full-scenario run".
3. **Enforcement class** — N/A. No invariant is added, removed, or
   reclassified; the deleted sentence carried no enforcement class.
4. **Code claims verified against code** — pass. Nothing is added, so no new
   code claim. The claims removed were checked before removal: `justfile`'s
   `bench-test` names `gauge` and `kernel_scan`, and `ci.yml`'s criterion step
   runs `just bench-test` — so the enumeration was correct-but-fragile, not
   wrong. The surviving `just bench-smoke` claims check against `justfile`'s
   `bench-smoke` recipe and the job's second step.
5. **Normative force and readiness** — pass. `Status: Implemented` unchanged;
   `Scope` unchanged and now the only statement of the section's remit. No
   `CHANGELOG` line: nothing observable changes.
6. **Re-derive, don't patch** — changed-claims list:
   - *dropped*: the enumeration of the job's other invocations — pins nothing
     §6 or any dependent relies on (item 8).
   - *dropped*: the subscription-bench clause — history per README §Process;
     preserved as a current fact in RFC 0005's inventory.
   - *added*: nothing.

   Class swept, not the cited site. The class is *an RFC enumerating a CI
   job's contents or naming which bench targets a runner names*.
   `Benchmarks` appears twice more in `docs/`, both naming the job as the
   place the smoke profile runs — the invocation form LG-0007-055 preserves —
   not its roster. The other bench-target names in `docs/` are measurement
   provenance (RFC 0005 §7's quoted rows, RFC 0006 §5's recorded numbers):
   they name the target that produced a number, and are correct as they
   stand. Boundary: the sweep covers `docs/`; `Cargo.toml`'s
   `bench-internals` comment — the adjacent instance #372 names — lost its
   `benches/subscription.rs` line in #369 and now names only benches that
   exist.
7. **Mechanical pass** — pass. No `Amended` / `originally` / `pre-amendment`
   introduced; the edit removes the paragraph's one history clause. Nothing
   added cites an identifier. Subject-vocabulary greps for the removed claim
   ("registry scan", "producer-gauge", "subscription bench") across `docs/`
   find no stale restatement — every surviving producer-gauge hit is RFC 0006
   §4.4's gauges, a different subject. `git diff --check` and `typos` clean.
   English only.
8. **Minimal contract** — the item this change serves, and the one that
   settled it. Deleting the enumeration leaves nothing unpinned: §6's
   contract is the profile, not the roster. Every replacement tried then
   failed the same test from the other side — a claim about the document's
   own scope, duplicating the header's `Scope` line, which the checklist's
   stale-restatement class names as two statements a later change can drift
   apart. *Excluded claims*: the enumeration, paired with nothing, because
   nothing depended on it; the subscription clause, paired with RFC 0005's
   inventory; the remit statement, paired with the header's `Scope` line.
   Kept after suspicion of redundancy: "landed in `ci.yml`" at `:737`, which
   names where the resolution is realized and which `Scope` does not imply.

## Review rounds

**Round 1** — one finding, fixed. "What this section fixes is the profile the
load harness runs **in that job**" scoped §6's remit to the CI job, while §6
fixes a profile whose invocation is explicitly identical locally and in CI —
so read strictly it put a locally divergent `just bench-smoke` outside the
section. Became "the load harness's profile, not which other benches the job
runs".

**Round 2** — one finding, fixed. "not which **other** benches the job runs"
presupposes the job runs other benches: the same coupling to the roster, one
level weaker. The proposed "not the Benchmarks job's contents" was not taken —
§6 *does* fix one element of that job's contents, so denying the whole would
contradict the resolution three sentences above. Removed the contrast clause
instead, on item 8: `What this section fixes is X` is specificational and
already excludes every non-X.

**Round 3** — three findings, all resolved by deletion.

> `:744` — medium. Read as Round 2 argued it should be, the cleft denies that
> §6 fixes anything which is not a property of the profile — but LG-0007-054,
> LG-0007-055 and LG-0007-063 are §6's and are not, and the header's `Scope`
> is wider than "the load harness's profile". A reader asking whether §6
> constrains where the profile is invoked gets "no" from `:744` and "yes" from
> `:737` and `:782`.

> `:745` — low. The definite singular "the load harness's profile" sits in a
> paragraph whose opening quantifies over *each* load harness; the caveat
> licensing the singular is in the next paragraph and covers what follows it.

> `:744` — low. It is a claim about the document, not the system, and the only
> one in §6; deleting the enumeration with no replacement leaves the paragraph
> complete.

Finding 1 is correct and it is Round 2's own argument turned around: if the
cleft excludes every non-X, then naming X too narrowly is a denial, and every
narrowing this paragraph admits was already recorded in RFC 0010's ledger as
§6's. Finding 3's conclusion is the convergent one, and it does not rest on a
count of rounds — the header's `Scope` line is where an RFC states a section's
remit, so an inline restatement was always a duplicate. Finding 2 is moot once
the sentence goes, and its underlying point survives as a reason not to
reintroduce one: the paragraph now contains nothing whose referent a second
load harness would remove.

**Round 4** — zero findings. Stopping condition met.

One observation the round recorded as explicitly not a finding: the ragged
wrap at `:740` ("scenarios stay out of CI: they run as", ~37 cols in a ~72-col
paragraph). Not taken. It sits on an unchanged context line above the hunk, so
this change neither caused it nor is measured by it, and reflowing the
paragraph would put unrelated lines into a contract-document diff that the
review process then has to read. Disposition: left as it stands, deliberately.

## Note on the issue text

#372's premise is partly stale: it quotes the singular sentence and the
`Cargo.toml` comment naming `benches/subscription.rs`, both of which #369
already corrected. What remained open, and what this PR closes, is the
second option — whether the paragraph should enumerate at all.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

