### PR TITLE
docs: name the reducer core on the crate root

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,34 @@
 //! 5. **Subscriptions**: External event sources (keyboard, timers, etc.)
 //! 6. **Commands**: Asynchronous operations and runtime directives
 //!
+//! There are two ways to write such a program, over one execution path.
+//! [`Application`] and its [`Runtime`] entry point are the facade: one type
+//! holds the state and supplies `new`, `update`, `view` and `subscriptions`.
+//! Under them is the [`reducer`] core, where [`Reducer`](reducer::Reducer)
+//! is the state transition and a stack of composition combinators closes
+//! into a [`Program`](reducer::Program). [`ProgramRuntime`] runs any
+//! [`Program`](reducer::Program). [`Runtime`] and [`ProgramRuntime`] build
+//! the same kernel and drive the same pass loop, so the choice changes how a
+//! program is written and not how it is executed. `examples/dashboard.rs` and
+//! `examples/dashboard_composed.rs` are one application written both ways.
+//!
 //! ## Core Components
 //!
 //! - [`Application`]: The main trait that defines your application
 //! - [`Runtime`]: Manages the application lifecycle and event loop
 //! - [`Command`]: Represents asynchronous side effects and runtime directives
-//! - [`Subscription`]: Represents ongoing event sources
+//! - [`EffectCommand`]: The value every effect constructor returns, and the
+//!   only one [`cancellable`](EffectCommand::cancellable) can be called on
+//! - [`Subscription`]: Represents ongoing event sources, built from a
+//!   [`SubscriptionSource`] implementation and identified by a
+//!   [`SubscriptionId`]
 //! - [`install_panic_hook`]: Restores the terminal if the application panics
+//! - [`reducer::Reducer`]: A state transition and the subscriptions that
+//!   state declares
+//! - [`reducer::Program`]: A reducer that can be run — it produces its
+//!   initial state and renders
+//! - [`ProgramRuntime`]: Runs any [`reducer::Program`]
+//! - [`Exit`]: [`ProgramRuntime::run`]'s success type
 //!
 //! ## Example
 //!


### PR DESCRIPTION
## What

`src/lib.rs`'s crate-level docs — the page docs.rs serves as the entry point —
listed five components and described one architecture. RFC 0014 is Implemented
and shipped in 0.11.0, so `pub mod reducer`, `ProgramRuntime`, `Exit` and
`EffectCommand` have been crate-root exports the front page did not name.

The six-element loop list is unchanged: it describes what both layers run.
What follows it is new — which two ways there are to write that loop, and that
the choice does not change how it executes — and the component list gains the
reducer core as a second group.

## Every added claim, and where it comes from

The rule this PR held itself to is that no sentence states a fresh reading of
the kernel; each traces to text already in the tree and already reviewed.

| Claim | Source |
| --- | --- |
| "two ways to write that loop, over one execution path" | `src/runtime.rs`: "Two of them, over one execution path" |
| "`Application` is the facade" | RFC 0014 §2: "`Application` and its `Runtime` entry point are preserved as a facade"; `src/runtime.rs`: "the facade adds a mapping adapter and nothing else" |
| "one type holds the state and supplies `new`, `update`, `view` and `subscriptions`" | `src/application.rs:83,111,126,204` — the four required methods, none defaulted |
| "a stack of composition combinators closes into a `Program`" | `src/runtime.rs`, verbatim |
| "`Runtime` runs an `Application`; `ProgramRuntime` runs any `Program`" | `src/runtime.rs:3`, verbatim |
| "both build the same kernel and drive the same pass loop" | `src/runtime.rs`; RFC 0014 §2.2 / INV-RC1: "Every kernel concern and every phase step executes identical code for `Application` programs and composed programs" |
| "changes how a program is written and not how it is executed" | `docs/composition.md`, verbatim |
| `Reducer`: "A state transition and the subscriptions that state declares" | `src/reducer.rs`, the trait's own doc line |
| `Program`: "A reducer that can be run — it produces its initial state and renders" | `src/reducer.rs`, the trait's own doc line |
| `EffectCommand`: "The value every effect constructor returns, and the only one `cancellable` can be called on" | `src/command/effect_command.rs`: the type's doc line, and "`cancellable` / `cancellable_with` exist here and nowhere else" |
| `Subscription`: "built from a type implementing `SubscriptionSource`" | `Subscription::new`'s own doc line; the form `README.md:226` uses |
| `Exit`: "`ProgramRuntime::run`'s success type" | `src/runtime.rs:153`: `run` returns `Result<Exit, B::Error>` |

## Crate-root re-export inventory

The issue's first acceptance criterion is that every crate-root re-export is
named on the front page or deliberately excluded with a reason recorded in the
source. The full inventory after this change:

| Item | Disposition |
| --- | --- |
| `Application`, `Runtime`, `Command`, `Subscription`, `install_panic_hook` | named (already were) |
| `EffectCommand`, `ProgramRuntime`, `Exit` | named (added here) |
| `SubscriptionSource`, `SubscriptionId` | named, on the `Subscription` line — `docs/api-guidelines.md`'s second Root Promotion test is written over these three together |
| `BoxStream` | not named; existing source comment records it as an external type re-exported because `SubscriptionSource::stream`'s return position requires spelling it |
| `RuntimeConfig` | not named; existing source comment records it as `Runtime::with_config`'s companion, reachable from a component that is named |
| `GAUGE_EVENT_FIELDS`, `LoadObserver`, `BenchKernel`, `CleanupLedgerScan`, `RegistryScan`, `producer_quit` | not named; `#[doc(hidden)]` behind `bench-internals`, which the source records as outside the public API and semver |
| `MigrationGuide0_11` | not named; `cfg(doctest)`, which the source records as keeping it off the public module tree |

The one comment added is about the item — what `SubscriptionId` is and where a
caller can reach it — in the same shape as `BoxStream`'s and `RuntimeConfig`'s,
not a claim about this doc page.

## #358

Two of its four items land here. `EffectCommand` and `Exit` are crate-root
re-exports, so this page is where they belong under #356's own criterion, and
#358 names #355/#356 as the natural place for `Exit` in particular.

`Command::teardown` and `Command::on_teardown` are **not** crate-root
re-exports and are left for the README, whose `Command` material is where a
reader meets them. #358 stays open until that lands.

## Back to one file

Rounds 4-6 grew this PR to three files, chasing a defect it had created for
itself. The comment Round 3 added at the `SubscriptionId` export restated what
the identity comprises, which made every other statement of that identity in
`src/` a sibling this PR then owed a sweep — and each round found another.

Round 6 supplied the exit. `docs/api-guidelines.md`'s **second Root Promotion
test** is written over exactly these three items:

> Every `Subscription` is built (via `From`) from an implementation of
> `SubscriptionSource`, whose associated `Key` and `key()` method let the
> framework construct a `SubscriptionId` — together they are the single general
> mechanism the subscription system is built on, not one feature among several.

So `SubscriptionId` is not an exception to root membership, it is a named
instance of a rule — and `:147-149`'s "document the reason next to its
`pub use`" applies to exceptions, which this is not. The comment was never owed.
What was owed is a front-page mention, and the bullet now carries one in that
document's own words.

With the identity no longer restated here, this PR states nothing about it and
owes no sweep. The two edits in `src/subscription/` are reverted; the omission
they fixed is pre-existing and is now **#380**, with the two sites this PR had
corrected plus the two Round 6 found — including `Query`'s public rustdoc at
`query.rs:354`, which the sweep had missed because the grep behind it keyed on
"identity" and that sentence says "keys the running subscription by".

## Out of scope, recorded rather than done

The issue notes in passing that `testing` also has no front-page statement.
Not taken: it is in neither the issue's Scope nor its acceptance criteria, and
`TestDriver`'s discovery path was placed in the README's testing section by
#365, closing #357. Widening this PR to a second module would add prose with
no criterion measuring it.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features "$(just --evaluate build_features)"` — clean, so every intra-doc link added here resolves. Feature list taken from `just --evaluate` rather than typed, and it is the set CI's `Documentation` job passes.
- `just test-doc` — green. `just fmt-check`, `just clippy` — clean.
- Sibling sweep: `src/lib.rs` holds the only "Core Components" list in the tree. The README's list is "Core Concepts", the six loop elements, which this change does not touch and does not contradict — that document is #355's.

## Review rounds

Every finding so far has been in a clause this PR added. No row of the
grounding table above — the claims taken from existing text — has drawn one.

**Round 1** — two findings, both fixed.

> `:34` — "Represents ongoing event sources, **implemented by**
> `SubscriptionSource`" inverts the type relationship. `Subscription` is a
> struct, so nothing implements it. A reader of the landing page would write
> `impl Subscription for MyTimer`, which does not compile.

Correct, and it was a claim I introduced without a grounding-table row, which
is how it got in. Fixed by taking `Subscription::new`'s own doc line.

> `:33` — "spawn key" is introduced on the front page with no public
> definition; outside this line the term appears only in `src/` doc comments.

Fixed at the time by substituting "cancellation key" — which Round 3 then
found to be worse. See below.

**Round 2** — one finding, fixed.

> `:23` — "[`Runtime`] runs **the first**, [`ProgramRuntime`] **the second**"
> has an ambiguous antecedent, and the wrong reading is self-reinforcing: the
> two entities named most recently are `Reducer` and `Program`, so "the
> second" = `Program` (which `ProgramRuntime` does run, appearing to confirm
> the reading) and "the first" = `Reducer`, yielding the false conclusion that
> `Runtime` runs a reducer. `Runtime::<MyReducer>::new(())` does not compile.

Correct. The ordinals were a compression I introduced; `src/runtime.rs:3` spells
both operands out precisely because of this, and taking that form verbatim
removes the reading entirely.

**Round 3** — three findings, all fixed.

> `:19` — "supplies all **four** methods" is a bare count with no antecedent,
> and the list it follows has **six** numbered elements. Same class as Round
> 2's ordinals.

Fixed the same way: the four are named.

> `:33` — "cancellation key" is off-vocabulary (`src` says "spawn key" in ~18
> places, including the doc this bullet paraphrases) and imprecise:
> `cancellable_with(id, CancelPolicy::KeepInFlight)` uses the key to keep the
> in-flight run and discard the new command, so no cancellation occurs.

Both halves verified — `src/command/cancellation.rs:89` reads "Keep the current
deliverable command and discard the new command stream". This clause has now
drawn a finding in two rounds under two different coined nouns, so the fix is
to stop coining one: the bullet now names the method,
`cancellable`, which is clickable, needs no glossary, and makes no claim about
what the key *does* — so the `KeepInFlight` path cannot falsify it. It is also
what `effect_command.rs` states directly: `cancellable` / `cancellable_with`
"exist here and nowhere else".

> `:36` — "identified by [`SubscriptionId`]" points the reader at a type they
> can neither construct nor read: no public constructor, `Subscription::id()`
> is `pub(crate)`, and its only public appearance is
> `TestStore::subscription_ids`.

Verified and fixed by removing it from the bullet. A "Core Components" line
should name something a reader can act on. Since the criterion still requires
the export to be accounted for, the reason moved to the export site, which had
no comment at all — see the inventory table.

**Self-caught while applying Round 3:** re-wrapping the paragraph dropped "same
kernel and drive the", leaving "Both build the same pass loop" — the
INV-RC1-grounded claim silently gone, with every check still green because the
result was valid prose. Restored before amending; noted here because no gate
would have caught it.

**Round 4** — two findings, both fixed. Both were in the one comment Round 3
added, in its first round of existence.

> `src/lib.rs:164` — medium. "reaches a caller only through
> `TestStore::subscription_ids`" is false: `RunKind::Subscription(SubscriptionId)`
> is a public variant, re-exported from `testing`, and produced by the public
> `RunName::kind()`. A `TestDriver` test obtains a `SubscriptionId` without ever
> constructing a `TestStore`.

Verified — `src/testing/driver.rs:311`, re-exported at `src/testing.rs:107-110`.
The comment is the recorded justification for the export under the acceptance
criterion, so understating where the type surfaces understates why the name is
at the root. Both paths are named now.

> `src/lib.rs:163` — low. "derives it from the source's type and `Key`" omits
> the scope, which is part of the identity: `Subscription::scoped` prefixes
> `id.scope` and `PartialEq` compares it, so two subscriptions over one source
> type and key under different scopes are two ids, not one.

Verified against `PartialEq` and `Hash`, which compare and hash all three. The
round also noted the same omission in `SubscriptionId`'s own rustdoc — not
pre-existing damage this PR may ignore, because the new comment states the same
identity three lines from the link to it. Corrected together; see above.

**Round 5** — two findings, both fixed; the first widened the sweep.

> `src/subscription/core.rs:216` — `SubscriptionSource::key`'s own rustdoc
> still states the two-component identity this PR just corrected 17 lines
> below, and it is the page a *source author* lands on, since `key()` is the
> method they implement.

Correct, and it is Round 4's fix applied to one site instead of to its class —
the checklist's own rule that the sweep is the class, not the site the finding
cited. Swept properly this round: the table above is the result, and it found a
third `src/` site the review had not named (`query.rs`) plus the RFC-side pair
now filed as #379.

> `src/lib.rs:162` — "its `Key`" names the associated *type*, but identity
> compares the erased key **value**; the type is deliberately not compared,
> since the source namespace already fixes it.

Correct — `PartialEq` calls `StructuralKey::value_eq`, and its own comment says
the namespace fixes the erased key type. Now "its structural key", the wording
`SubscriptionId`'s rustdoc three lines away uses.

**Round 6** — four findings. One is fixed here; the other three are reverted
rather than answered, along with the change that invited them.

> `query.rs:354` — medium. `Query`'s public rustdoc still states the identity as
> "(`QueryClient`, key, and value type)", missed by the sweep, in a file this PR
> already edits. A reader building panes with `scope` / `ForEach` concludes two
> `Query`s with the same client, key and `V` are one subscription with one
> in-flight fetch; combinators call `Subscription::scoped` per boundary, so they
> are two.

> `src/lib.rs:162` — low. The export comment records what `SubscriptionId` is
> and where it surfaces, but not why it is at the root, unlike every sibling
> exception comment in the file; and the facts it states are the same grounds
> given for keeping `TestStore` **off** the root.

> `core.rs:216` — low. "the scope of any boundary the subscription is declared
> under" attributes the scope to composition alone; `Subscription::scoped` is
> public and applied directly by application code, as its own example shows.

> `query.rs:163` — low. "this source's `Key`" has no antecedent inside
> `QueryClient::with_config` — `QueryClient` is not a `SubscriptionSource`, and
> the `Key` named is `Query<V>`'s, 265 lines below.

The second finding is the load-bearing one, and following it dissolves the other
three: see "Back to one file" above. All four sites it and Round 5 named are
carried to #380 with the constraints the reviews established — that the scope is
not a boundary-only property, and that `Query`'s `client_id` sits inside the key
rather than beside the source type — so the next attempt starts from them rather
than rediscovering them.

**Round 7** — four findings, three fixed and one declined.

> `:40` — the heading "The [`reducer`] core" groups four items, two of which
> are not reachable through that module: `reducer.rs:36` is
> `pub(crate) use exit::Exit`, and `ProgramRuntime` comes from the crate-private
> `runtime` module. `use tears::reducer::{Program, ProgramRuntime};` is E0432.

Verified both. The heading now reads "For programs written as composed
features:" and claims no container; the paragraph above still names the
[`reducer`] core, where the two items that *are* in it carry their paths.

> `:19` — "`Application` is the facade" adds a third referent for a word the
> tree already places elsewhere: `runtime.rs:167` calls `Runtime` "The facade
> over `ProgramRuntime`", and `reducer/adapter.rs:1` calls `AppProgram` "The
> `Application` facade adapter". Line 30 calls `Application` a trait, so the
> page says the facade is a trait you implement.

Correct. RFC 0014 §2's wording puts it on both — "`Application` and its
`Runtime` entry point are preserved as a facade" — and the sentence now does
too, which also removes the need for the separate "`Runtime` runs an
`Application`" clause later.

> `:18` — nit. "that loop" has no antecedent: the block above is introduced as
> "the Elm Architecture pattern" and never called a loop, and the page's first
> "loop" is *below* it, meaning the runtime's event loop. Same referential class
> as Rounds 2 and 3.

Correct, and the third instance of that class in this PR. "such a program",
which refers back to the whole description rather than coining a noun for it.
Re-checking the paragraph for the class also caught a fourth: "Both build the
same kernel" had become ambiguous between the two layers and the two runtimes,
so it now names `Runtime` and `ProgramRuntime`.

> `:24` — the page advertises a second way to write a program, but its only
> example imports `tears::prelude::*`, which carries `Application`, `Command`,
> `Subscription` and `Runtime` only. A reader reaching for `ProgramRuntime` or
> `ReducerExt` hits E0433/E0599 with nothing on the page saying so.

**Declined**, and the premise is right — `src/prelude.rs:14-17` is those four.
Not taken because the fix does not stop at one line: `EffectCommand` is not in
the prelude either, and it is in the first group, so an import note on the
second group alone would be wrong and one on both is an import guide the page
has never been. The reader has three routes that do not go stale — every bullet
links the item, and docs.rs shows its full path; [`prelude`]'s own module docs
list what it carries; and `docs/api-guidelines.md` "Prelude Membership" states
the rule that keeps these out. Recorded here rather than fixed, so the decision
is on the record rather than silent.

**Round 8** — one finding, fixed in the half that survives packaging.

> `:18` — the page now promises a second way to write a program, but nothing in
> the rustdoc tree routes a docs.rs reader to the material that teaches it:
> `grep -rn "composition.md\|dashboard_composed" src/` returns nothing, so both
> `docs/composition.md` and `examples/dashboard_composed.rs` are reachable only
> from `README.md`. Pre-existing absence, but this PR is the first to make the
> front page promise the route.

Correct, and checking how to close it turned up the constraint that decides the
shape. `Cargo.toml`'s `include` ships `src/**/*`, `examples/**/*`, `tests/**/*`,
`benches/**/*`, `README.md`, `CHANGELOG.md`, `LICENSE`, `Cargo.toml` and one
migration guide — **`docs/composition.md` is not in the package**. Naming it
from the crate root would point the reader whose problem this is, the one
holding the published crate, at a file they do not have.

`examples/dashboard.rs` and `examples/dashboard_composed.rs` are packaged, so
the front page names those: one application written both ways, which is
`docs/composition.md:9-10`'s own description of the pair. The guide itself stays
where every route to it resolves — `README.md`, which is packaged and links it.

**Round 9** — two findings, both fixed; the first structurally.

> `:41` — the heading "For programs written as composed features:" implicitly
> partitions the unlabeled list above it, and four of its six items are not
> partitioned: `Reducer::reduce` returns `Command<Self::Message>` and
> `Reducer::subscriptions` returns `Vec<Subscription<..>>`, so `Command`,
> `EffectCommand` and `Subscription` are used identically both ways, and
> `install_panic_hook` is orthogonal. A reader starting a composed program reads
> the first group as the `Application` route's and concludes the composition API
> has its own effect and subscription vocabulary they have not been shown.

Correct, and no rewording of the second heading closes it: the first list mixes
facade-only items with shared ones, so any heading true of one half is false of
the other. The list is now partitioned by what each way actually names — the
facade pair, the composed four, and the four used either way — which is the
first time this page has said which is which. The facade group stays first.

> `:21` — nit. "Under them is the [`reducer`] core, where `Reducer` … closes
> into a `Program` that `ProgramRuntime` runs" puts three items in a clause
> scoped to that module and only two are in it. Round 7's fix pointed at this
> paragraph, and the mitigation recorded for it — "the two items that *are* in
> it carry their paths" — does not survive rendering: rustdoc puts the module
> path in `href` and `title` only, so the page shows three indistinguishable
> bare names.

Correct on both counts, including that the recorded mitigation was wrong about
what a reader sees; the round confirmed it against the generated
`target/doc/tears/index.html`. `ProgramRuntime` now has its own sentence outside
the `where`-clause.

**Method note.** Re-wrapping the paragraph after these edits was checked
mechanically this time — the doc comment's word sequence compared before and
after, identical — because the same re-wrap silently dropped a clause in Round
3 with every gate still green.

**Round 10** — two findings: one fixed, one filed.

> `:23` — "closes into a `Program`. The entry point that runs **one** is
> `ProgramRuntime`" is another bare pronoun of the class Rounds 2, 3 and 7 each
> flagged. The intended antecedent is `Program`, but `Reducer` and "a stack of
> composition combinators" are also in the sentence, and the wrong reading is
> the same false conclusion Round 2 fixed — that `ProgramRuntime` runs a
> reducer, which `ProgramRuntime<P: Program>` does not compile for.

Correct, and I introduced it in Round 9 while fixing Round 9. Now
"[`ProgramRuntime`] runs any [`Program`]", which is `src/runtime.rs:3` verbatim
and spells the operand out for exactly this reason. Fourth instance of this
class in this PR; the paragraph now contains no pronoun standing for an item.

> `:26` — Round 8's finding was that nothing routes a **docs.rs** reader to the
> composition material. Naming the examples serves the reader holding the
> `.crate` file, but docs.rs's source browser carries only files reachable from
> the crate root, so on the rendered page they are inert code spans. Not a
> regression, but the page now makes the promise, so the gap should be recorded
> rather than read as closed.

Correct — and it is the second half of Round 8's finding, which the fix could
not reach from `src/lib.rs` alone. Filed as **#381** with the four options and
what each costs, rather than only noted here, so it survives this PR being
merged. What Round 8's fix does close stands: a reader holding the crate has the
examples, and `docs/composition.md` is deliberately not named because `include`
does not ship it.

**Round 11** — one finding, fixed.

> `:38` — the composed group mixes two crate-root items (`ProgramRuntime`,
> `Exit`) with two that live only at `tears::reducer::*`, and rustdoc renders
> `[`Reducer`](reducer::Reducer)` as the bare text `Reducer` — the module path
> is in `href`/`title` only. Round 9 accepted that property for the paragraph
> and fixed it there by giving `ProgramRuntime` its own sentence; the list, which
> is the part a reader copies names from, did not get the same treatment.
> `use tears::{Reducer, Program, ProgramRuntime, Exit};` is E0432 on the first two.

Correct. The list now writes the paths in the visible text — `reducer::Reducer`,
`reducer::Program` — so two qualified names and two bare ones say which is which
without clicking. Confirmed against the generated `index.html` that both still
resolve (`reducer/trait.Reducer.html`, `reducer/trait.Program.html`). The
paragraph keeps bare names, where the `where`-clause supplies the scope; the
other two groups hold crate-root items only, so the class is closed.

**Round 12** — three findings, all closed by removing the structure that
produced two of them.

> `:36` — "Writing it as composed features **instead**:" over-scopes
> `reducer::Reducer` and `reducer::Program`. `ReducerExt` is blanket-implemented
> (`impl<R: Reducer + Sized> ReducerExt for R {}`), so a single flat `Reducer`
> with no combinators closes into a `Program` through `into_program` and runs on
> `ProgramRuntime`.

> `:43` — `Exit` is filed under the composed-only heading, but an `Application`
> author reaches it through the testing surface: `TestDriver` drives an
> `Application` through `AppProgram`, and `StepReport::terminated` is
> `pub … Option<Result<Exit, E>>`.

Both verified. Both are defects in the **three-group partition Round 9 added**,
which asserts for each of ten items which way of writing a program names it —
ten classification claims where the flat list made none. Rounds 11 and 12 have
now found three of them wrong.

#356's scope line asks for less than that: "List the reducer core **alongside**
the facade in the component list." The list is flat again, the six original
bullets in their original order with the four new ones after them. That closes
both findings, retires the partition class, and is what the issue asked for.

> `:50` — "whose `key()` lets the framework construct a `SubscriptionId`" names
> only `key()` as the input; `SubscriptionId::from_source` also stores
> `TypeId::of::<Source>()`, and `scoped` prefixes a third component. Two sources
> both returning `Key = String` `"tasks"` are two ids, not one.

Correct, and it is #380's class restated on the front page by text added in
Round 6. The bullet now names `SubscriptionSource` and `SubscriptionId` without
claiming what the identity is composed of — the front page has no reason to
state that, and #380 is where the statements that do are corrected.

**Recorded, not a finding** (the round raised it as such): `RuntimeConfig`'s
pre-existing export comment calls it "`Runtime::with_config`'s companion type",
while `ProgramRuntime::with_config` and the public `TestDriver::new` also take
one. This PR is what puts `ProgramRuntime` on the front page, so the comment is
now one consumer short of what the page implies. Outside the diff and harmless;
noted here so it is not rediscovered from scratch.

**Round 13** — zero findings. Stopping condition met.

The round rebuilt the docs twice (full CI feature set and `--no-default-features`),
forced a rebuild first so a cached "clean" could not stand in for the work, read
the anchors out of the generated `index.html` to confirm every link's target
matches its visible text, re-derived each factual claim from the tree, and
checked that no test, script or workflow reads the edited text. It recorded two
things it considered and deliberately did not raise: the `RuntimeConfig` export
comment (outside the diff, already recorded above), and an ambiguity in the
`EffectCommand` bullet whose two readings point at the same working code.

## Acceptance criteria

- [x] Every crate-root re-export is either named on the front page or deliberately excluded with a reason recorded in the source
- [x] `cargo doc --no-deps` under `RUSTDOCFLAGS=-D warnings` stays clean
- [x] `just test-doc` stays green
- [x] The architecture summary does not contradict `docs/rfcs/0014-reducer-first-core.md`

Closes #356

Spun out during review: #379 (RFC 0005's summary vs its own INV-1), #380
(the subscription identity's statements in `src/` omit the scope), #381 (the
crate root names files a docs.rs reader cannot open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)










