### PR TITLE
docs(readme): stop requiring the `Application` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See the [Optional Features](#optional-features) section for information about en
 
 ### Minimal Example
 
-Every tears application implements the `Application` trait with four required methods:
+A tears application implements the `Application` trait, which has four required methods ([Composing Reducers](#composing-reducers) is the other way to write a program):
 
 ```rust
 use tears::prelude::*;
@@ -213,18 +213,6 @@ Tears follows **The Elm Architecture (TEA)** pattern:
 - **Subscriptions**: External event sources (keyboard, timers, network, etc.)
 - **Commands**: Asynchronous side effects that produce messages
 
-### Built-in Subscriptions
-
-- **Terminal Events** (`terminal::TerminalEvents`): Keyboard, mouse, and resize events
-- **Timer** (`time::Timer`): Periodic tick events
-- **Signal** (`signal::Signal`): OS signal handling (Unix/Windows)
-- **WebSocket** (`websocket::WebSocket`, requires `ws`): Real-time bidirectional communication
-- **Query** (`http::Query`, requires `http`): HTTP data fetching with caching
-- **Mutation** (`http::Mutation`, requires `http`): HTTP data modifications
-- **MockSource** (`mock::MockSource`): Controllable mock for testing
-
-Create custom subscriptions by implementing the `SubscriptionSource` trait.
-
 ### Composing Reducers
 
 A `Reducer` owns one state transition and the subscriptions that state declares.
@@ -237,12 +225,28 @@ keying the same command do not collide. The two whose child can leave —
 `for_each` over a `Keyed` collection and `presented` over a `Slot` —
 additionally tear a departed child's runs down, so no removal leaks a run;
 `scope` composes one child in place, and that child is always there.
+`Command::teardown` is the manual primitive behind the teardowns `for_each`
+and `presented` perform, and `Command::on_teardown` registers a finalizer to
+run when a teardown selects the scope it was built at; one built at a scope
+nothing tears down never runs.
 
 An `Application` is run through an adapter over the same kernel, so this is a
 way to write a program rather than a second runtime. See
 [docs/composition.md](docs/composition.md) for when the rewrite is worth it, and
 [`examples/dashboard_composed.rs`](examples/dashboard_composed.rs) for
 `dashboard.rs` written the other way.
+
+### Built-in Subscriptions
+
+- **Terminal Events** (`terminal::TerminalEvents`): Keyboard, mouse, and resize events
+- **Timer** (`time::Timer`): Periodic tick events
+- **Signal** (`signal::Signal`): OS signal handling (Unix/Windows)
+- **WebSocket** (`websocket::WebSocket`, requires `ws`): Real-time bidirectional communication
+- **Query** (`http::Query`, requires `http`): HTTP data fetching with caching
+- **Mutation** (`http::Mutation`, requires `http`): HTTP data modifications
+- **MockSource** (`mock::MockSource`): Controllable mock for testing
+
+Create custom subscriptions by implementing the `SubscriptionSource` trait.
 
 ## Examples
 


### PR DESCRIPTION
## What

Three changes to `README.md`, 16 lines added and 13 removed, most of which is a
section moving.

```diff
-Every tears application implements the `Application` trait with four required methods:
+A tears application implements the `Application` trait, which has four required methods ([Composing Reducers](#composing-reducers) is the other way to write a program):
```

`### Composing Reducers` moves ahead of `### Built-in Subscriptions`, unchanged,
and gains two sentences naming `Command::teardown` and `Command::on_teardown`.

## What #355 asked for, and what is left of it

The issue's evidence is partly overtaken: it cites
`grep -icE 'reducer|ProgramRuntime|composition|TestDriver|EffectCommand|teardown' README.md`
returning **0**, and it now returns **10**. #360 added the `Composing Reducers`
section one PR after the issue was filed, and #365 the `TestDriver` material.
Checking the four lines it quotes, one at a time:

| Line | Status |
| --- | --- |
| `:41` "**Every** tears application implements the `Application` trait" | **False.** A composed program implements `Program`. Fixed here. |
| `:10` "using **The Elm Architecture (TEA)**" | True of both layers — both run the same six elements over the same kernel (RFC 0014 INV-RC1). |
| `:185` "Tears follows **The Elm Architecture (TEA)** pattern:" | Same. |
| `:187-205` the diagram | Names Model, Message, Update, View, Commands, Subscriptions — `Application` appears in it zero times, so it asserts no single shape. |

So one sentence was false, not a section. Against the issue's scope bullets:
"reference the composition API by name where a reader would look for it" is
#360's, already done; "rewrite the Architecture section so it shows both layers"
is done in substance, and what was left is **where in the section a reader meets
the second layer** — which is the move.

## The three changes

**`:41`.** The quantifier is what was false, so the quantifier is what goes. The
clause stays: it is the sentence's job in a section called Minimal Example, and
`:41` is the first time the file names `Application` at all. All four methods are required, none defaulted
(`src/application.rs:83,111,126,204`). Swept for the class rather than the line:
`grep -niE "every (tears )?application|all applications|must implement"` and a
grep for `Every `/`Each ` find exactly this one sentence, so the class has one
member.

**The move.** `Composing Reducers` sat after `Built-in Subscriptions`, so a
reader going through `## Architecture` top to bottom met the second way to write
a program only after a catalogue of source types. The section now runs from the
loop's six elements to the two ways of writing them, with the reference list
after. Nothing in the section text changes — verified by comparing the file's
word multiset before and after, whose only difference is `:41`'s five removed
words and the teardown sentences' added ones. No heading in this repository is
linked by anchor from anywhere (`grep -rn "#composing-reducers\|#built-in-subscriptions\|#core-concepts\|#architecture"` over `README.md`, `docs/`, `src/` is empty), so the move breaks no link.

**#358's remaining two.** `Command::teardown` and `Command::on_teardown` are not
crate-root re-exports, which is why #378 left them; the README's home for them
is the section that already describes the teardown a boundary performs. Both
lines are read off their own rustdoc:

| Added text | Source |
| --- | --- |
| "the manual primitive behind those teardowns" | `src/command/core.rs:275`: "This is the manual primitive behind RFC 0013's scope teardown" |
| "registers a finalizer to run when a teardown selects the scope it was built at" | `src/command/core.rs:326-327`: "Registers `finalizer` to run when a teardown selects the structural scope at this call boundary" |

## Review rounds

**Round 1** — three findings, all fixed.

> `:41` — the rewrite dropped the *introducing* fact, not just the false
> universal. `Application` is now first named here with a definite article and
> no antecedent, so a first-time reader of Getting Started is no longer told
> that implementing it is *how* you write an application; they must infer it
> from the code block.

Correct, and confirmed: `grep -n "Application" README.md` puts the first mention
at `:41`. The quantifier was the false part, so only the quantifier goes.

> `:229` — the `Command::on_teardown` sentence describes only the success path,
> and the failure it omits is silent. Its rustdoc bolds "**Scope it, or nothing
> can select it.**": an unscoped registration anchors at the root, and
> `Command::teardown` always prefixes at least one segment, so nothing reaches
> it. A reader writing `Command::on_teardown(...)` in a plain
> `Application::update` gets a hook that compiles, arms, and never runs.

Correct, and it outweighs #358's "link instead of restating" criterion here: that
criterion is about not repeating a contract, and this is the condition under
which the item does anything at all. The sentence now carries it in the
rustdoc's own terms — a boundary scopes the registration, or `Command::scoped`
does.

> `:228` — "those teardowns" has a misleading nearest antecedent: the clause
> immediately before it is `scope`'s, the one combinator with no journal to
> drain. A reader can take the sentence as saying `Command::teardown` underlies
> `scope`'s nonexistent teardown.

Correct. The referent is named — "the teardowns `for_each` and `presented`
perform" — rather than pointed at, which is the class that cost #378 four
rounds.

**Round 2** — two findings, both fixed.

> `:230` — "built under a boundary" admits the exact misreading the sentence
> exists to prevent. A boundary scopes only the branch it *claims*
> (`combinator.rs:300-310` maps and `.scoped(...)`s the child branch; the
> `Err(unclaimed)` branch passes the parent's command through unscoped), so a
> reader whose stack has boundaries but who registers from the **root**
> reducer's `reduce` has "built it under a boundary" by that wording and still
> gets a hook nothing can reach. `docs/composition.md:124-126` states the case.
> Secondary: `Command::scoped` is a postfix builder, so nothing is "built under"
> it.

Correct on both counts, verified against `combinator.rs` and `composition.md`.
The sentence now says where a registration anchors rather than what it must sit
beneath — a child's own reduce builds it at that child's scope, one built at the
root anchors where no teardown reaches it — which is `composition.md`'s own
sentence and holds however many boundaries the stack has.

> `:41` — "A tears application implements the `Application` trait" still reads
> generically, which is the same force as the removed "Every" for a reader who
> does not yet have the `Application`-vs-`Program` distinction; that distinction
> appears 175 lines later with no pointer from `:41`.

Correct, and the fix is the pointer rather than a third phrasing of the article:
a generic article is defeasible only if something defeats it, and nothing on the
page did. `:41` now names the other way and links it. That is disclosure, not a
push toward composition — the reader continues straight into the code block —
and it is the form `:35` already uses for `#optional-features`, the only other
anchor link in the tree.

**Round 3** — two findings, both fixed; the first by giving up on stating the
rule.

> `:229` — medium. The dichotomy "a child's own reduce builds it at that child's
> scope, while one built at the root anchors where no teardown reaches it"
> presents *any* child scope as reachable, but `scope` originates no teardown at
> all — `combinator.rs:293-299`: "There is no removal for it to observe and
> therefore no teardown for it to originate", which the README itself says three
> lines earlier. A stack composed only with `scope`, whose child registers a
> hook, arms it at `["child"]` and never fires it. The same never-runs failure
> Rounds 1 and 2 were closing, moved one level down.

Correct, and verified. Three attempts at stating when the finalizer fires have
now been wrong three different ways: omitted (Round 1), "under a boundary"
(Round 2), "below the root" (Round 3). The condition is neither of the last two,
and stating it properly means enumerating which boundaries originate teardowns —
a contract #358's own criterion says to link rather than restate.

So the sentence stops trying. It says when the finalizer runs, and what follows
when nothing makes that true — a registration at a scope nothing tears down
never fires — and claims no scope is reachable. That covers the root case, the
`scope`-only case, and any other, because it is the first clause's contrapositive
rather than a second rule beside it.

> `:41` — the sentence contradicts itself: its first clause defines a tears
> application as the thing that implements `Application`, and its second calls
> composition "the other way to write **an application**". `:234` in the linked
> section says "a way to write a **program**". Secondary: the trailing colon now
> attaches to the composition clause, so the `Application` code block below
> reads as the composition example.

Both correct. The clause is parenthetical now, which returns the colon to the
main clause, and it says *program* — the word the linked section uses, and the
one `src/lib.rs` uses since #378 ("two ways to write such a program"). An
application is then one kind of program rather than the contrast to one.

**Round 4** — zero findings. Stopping condition met.

The round re-derived every claim from source rather than from this body, and
added one check the earlier rounds had not: that no path falsifies "one built at
a scope nothing tears down never runs" — program exit included, since
`src/kernel/cleanup.rs:15-16,77-79` discards armed registrations without running
them. It also confirmed the section move by a sorted word-multiset diff of the
whole file, whose only deletions are `Every`, `with`, and the colon that moved
inside the parenthesis.

## Acceptance criteria (#355)

- [x] A reader who wants to split an application into features can find that the capability exists, and where it lives — `Composing Reducers`, now before the reference catalogue, naming `scope` / `for_each` / `presented` / `into_program` and linking `docs/composition.md` and `examples/dashboard_composed.rs`
- [x] A reader who wants the simple path is not pushed toward composition — `Getting Started` is untouched, and the moved section still opens by saying an `Application` runs through an adapter over the same kernel
- [x] The diagram or its replacement does not assert that `Application` is the framework's only shape — it never named `Application`; verified rather than assumed
- [x] No claim about the runtime that `docs/rfcs/0014-reducer-first-core.md` contradicts

## Acceptance criteria (#358)

- [x] Each item is reachable from at least one user-facing page without already knowing its name — `EffectCommand` and `Exit` from the crate root (#378), `Command::teardown` and `Command::on_teardown` from here
- [x] `just test-doc` stays green — nothing here is compiled; no `include_str!("../README.md")` exists in `src/`, so the README's fenced blocks remain uncompiled, as `docs/api-guidelines.md` and #354 both record
- [x] Nothing here restates a contract the item's own rustdoc already states — both lines are one clause each, linking by name rather than repeating the prefix-selection and at-most-once rules

## Verification

`typos README.md` and `git diff --check` clean. The word-multiset comparison
above is the check that the section move carried its text intact; it is here
because a re-wrap in #378 silently dropped a clause with every gate still green.

Closes #355
Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)




