### PR TITLE
docs: name TCA alongside TEA on the surfaces read first

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "tears"
 version = "0.11.0"
 edition = "2024"
 authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
-description = "A simple and elegant framework for building TUI applications using The Elm Architecture (TEA)"
+description = "A simple and elegant TUI framework with The Elm Architecture (TEA) and TCA-style reducer composition"
 documentation = "https://docs.rs/tears"
 homepage = "https://github.com/akiomik/tears"
 repository = "https://github.com/akiomik/tears"
 license = "Apache-2.0"
 readme = "README.md"
-keywords = ["tui", "tea", "elm-architecture", "ratatui", "framework"]
+keywords = ["tui", "tea", "elm-architecture", "ratatui", "tca"]
 categories = ["command-line-interface", "asynchronous"]
 rust-version = "1.88.0"
 # Anchored with a leading slash: an include pattern without one is a

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@
 [![Rust Version](https://img.shields.io/badge/rust-1.88.0%2B-blue.svg)](https://www.rust-lang.org)
 [![codecov](https://codecov.io/gh/akiomik/tears/graph/badge.svg?token=QF9SO8I0AM)](https://codecov.io/gh/akiomik/tears)
 
-A simple and elegant framework for building TUI applications using **The Elm Architecture (TEA)**.
+A simple and elegant TUI framework with **The Elm Architecture (TEA)** and **TCA**-style reducer composition.
 
 Built on top of [ratatui](https://ratatui.rs/), Tears provides a clean, type-safe, and functional approach to terminal user interface development.
 
 ## Features
 
 - 🎯 **Simple & Predictable**: Based on The Elm Architecture - easy to reason about and test
+- 🧩 **Composable**: Split a program into feature reducers with `scope`, `for_each` and `presented`
 - 🔄 **Async-First**: Built-in support for async operations via Commands
 - 📡 **Subscriptions**: Handle terminal events, timers, and custom event sources
 - 🧪 **Testable**: Pure functions for update logic make testing straightforward
@@ -397,6 +398,7 @@ tears = { version = "0.11", features = ["http"] }
 Tears is inspired by battle-tested architectures:
 
 - **[Elm](https://elm-lang.org/)**: The original Elm Architecture
+- **[The Composable Architecture (TCA)](https://github.com/pointfreeco/swift-composable-architecture)**: Reducer composition, effect cancellation IDs, and the exhaustive testing surface
 - **[iced](https://github.com/iced-rs/iced)**: Rust GUI framework (v0.12 design)
 - **[Bubble Tea](https://github.com/charmbracelet/bubbletea)**: Go TUI framework with TEA
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,12 @@
 //! # Tears - TUI Elm Architecture Runtime System
 //!
-//! Tears is a TUI (Text User Interface) framework based on the Elm Architecture (TEA),
-//! built on top of [ratatui](https://ratatui.rs/). It provides a clean and type-safe
-//! way to build terminal applications using a functional, message-driven architecture.
+//! Tears is a TUI (Text User Interface) framework built on top of
+//! [ratatui](https://ratatui.rs/). It is based on the Elm Architecture (TEA),
+//! with reducer composition in the style of [The Composable
+//! Architecture][tca] (TCA), and provides a clean and type-safe way to build
+//! terminal applications using a functional, message-driven architecture.
+//!
+//! [tca]: https://github.com/pointfreeco/swift-composable-architecture
 //!
 //! ## Architecture
 //!


### PR DESCRIPTION
## What

Four lines on the surfaces a reader meets before opening anything.

```diff
-description = "A simple and elegant framework for building TUI applications using The Elm Architecture (TEA)"
+description = "A simple and elegant TUI framework with The Elm Architecture (TEA) and TCA-style reducer composition"
-keywords = ["tui", "tea", "elm-architecture", "ratatui", "framework"]
+keywords = ["tui", "tea", "elm-architecture", "ratatui", "tca"]
```

`README.md:10` and the crate root's opening sentence take the same clause. The
Features list gains a `Composable` entry beside its `Simple & Predictable` one,
and Inspiration gains The Composable Architecture.

## Why

The crate has had two ways to write a program since 0.11.0, and the second is
TCA-shaped. Someone who wants that architecture, sees TEA, and stops is the
case this closes — the two abbreviations now sit adjacent in one sentence, so
scanning for either finds both.

## `TCA-style`, not `TCA`

Three of that library's core parts are deliberately absent, each recorded as
negative space rather than merely unbuilt:

| TCA core | tears | Recorded at |
| --- | --- | --- |
| `@Dependency` registry | not provided | RFC 0010 `AC-E5` = `adopted(X)`; RFC 0009 §2.2 rejects it |
| macro DSL | not provided | RFC 0010 `AC-E2` = `adopted(X)` |
| per-feature views | not provided — `Reducer` has no `view`; child views are function calls over the root state | RFC 0014 §2.1, stated in `src/reducer.rs` |

`adopted(X)` is that document's verdict for an anti-catalog decision — a thing
the crate declines to provide, not a gap. RFC 0010 `AC-E4`, "Dual runtimes
(TEA/TCA side by side)", is one too, which is why the sentence reads as one
framework with two ways to write in it. #378 and #382 put the same fact in the
crate root and the README: `Runtime` and `ProgramRuntime` build the same kernel
and drive the same pass loop.

## What the name is grounded in

| Claim | Source |
| --- | --- |
| the composition layer follows TCA's | RFC 0005 references: "TCA reducer `Scope`, identified collection composition, and effect cancellation IDs" |
| `Command::cancellable(id)`'s lineage | RFC 0003 references TCA `Effect.cancellable(id:cancelInFlight:)` and `Effect.cancel(id:)` |
| the testing surface's | RFC 0008 §on exhaustive-only: "TCA's experience is that the exhaustive mode is where the testing value concentrates" |
| "TCA-parity" as the standing goal | RFC 0005 §7, RFC 0013 §… — both name TCA-parity collection composition as the client |

Inspiration listed Elm, iced and Bubble Tea and not this, while the RFCs cited
it throughout. That is the gap the entry closes.

## The length trade

The description drops "framework for building TUI applications" for "TUI
framework", which is what pays for the second architecture: **93 characters
before, 100 after**. Shortening `applications` to `apps` was the other option
and buys less — the wordiness was in the phrase, not the noun.

Keeping `(TEA)` costs six characters and is what makes the pairing catch a
skimmer's eye: `The Elm Architecture (TEA) and TCA-style` puts both
abbreviations in one glance.

## The keyword swap

`framework` was the entry with the least discriminating power — `tui` already
places the crate, and nearly any framework crate could carry it. The slot is
worth more to the token someone looking for this architecture actually types.

`tca` over `composable-architecture`: on GitHub topics the two run 234 to 188,
and on crates.io `composable-architecture` returns nothing at all.

`cargo publish --dry-run` accepts the manifest — run rather than assumed, since
it is the check that would reject an over-long or malformed keyword.

## Class sweep

The class is *surfaces a reader meets before opening anything*, which is three
files, not one — Round 1 caught that the first pass had scoped it to
`README.md`.

- **`Cargo.toml`** — `description`, `keywords`. In this diff.
- **`README.md`** — `grep -niE "elm architecture|\bTEA\b"` returns five sites.
  `:10` and `:16` are in this diff, and Inspiration gains its missing entry.
  The other two are correct as they stand: `:185` "Tears follows **The Elm
  Architecture (TEA)** pattern:" is true of *both* layers, which #382 verified
  — they run the same six elements over the same kernel — and `:399` "**Elm**:
  The original Elm Architecture" is accurate, with what was missing beside it
  added here.
- **`src/lib.rs`** — the crate root, which is where crates.io's Documentation
  link sends a reader. Its opening sentence takes the same clause, so the token
  that brings someone in appears on the page it brings them to.

Left as it stands, deliberately: the crate root's H1, "Tears - TUI Elm
Architecture Runtime System". It names the runtime, which does run TEA either
way, and the sentence directly beneath it now carries both architectures — so
the page holds the token without an unwieldy title.

## Review rounds

**Round 1** — one finding, fixed.

> `src/lib.rs:3` — the crate-root doc is the third "surface read before opening
> anything" and was left out of the class sweep, which covered `README.md` only.
> A reader who finds the crate precisely through the new `tca` keyword clicks
> Documentation on crates.io, lands on docs.rs, and gets a TEA-only framing —
> the search term that brought them in does not appear on the page they were
> sent to.

Correct, and it is the sweep discipline failing on the definition rather than
the execution: the class was taken as "README sites naming TEA" when it is
"surfaces read first", and the crate root is the one the new keyword actually
delivers to. Its opening sentence now carries the same clause as the other two,
verified word-for-word against the original so the re-wrap dropped nothing.

**Round 2** — one finding, applied and then **reverted in round 6**. The round
asked for a `CHANGELOG.md` entry, citing `745e019` — a `Cargo.toml`-only change
that earned one. See round 6.

**Round 3** — one finding, fixed.

> `src/lib.rs:4` — the crate root now says "TCA-style" and that is the only
> occurrence of "TCA" in `src/`; the page never expands the acronym or links it,
> while it expands TEA one clause earlier. This is precisely the page the new
> `tca` keyword delivers to, and a docs.rs reader never sees the README, whose
> expansion sits ~390 lines below the same clause anyway.

Correct, and the asymmetry is the sharp part: expanding one abbreviation and not
the other in a single sentence. The crate root now writes the name out and links
it, so a reader arriving on the keyword can resolve the term without leaving the
page they landed on.

The link is reference-style — `[The Composable Architecture][tca]` with the
definition below the paragraph — because the URL inline would put a 94-column
line in a file that wraps at 78 and whose longest doc line is 93. Verified by
reading the generated `target/doc/tears/index.html`: the anchor resolves to the
pointfreeco repository and `TCA` is on the page.

**Round 4** — one finding, fixed.

> `README.md:10` — the same defect Round 3 fixed in `src/lib.rs`, in the sibling
> surface the sweep declared and then missed. `:10` is the file's first and only
> `TCA`, left bare while the same sentence expands TEA, and the Inspiration
> entry 390 lines below writes "The Composable Architecture" without ever
> attaching the abbreviation — so nothing in the file connects the two. crates.io
> renders `README.md` on the crate page, so a reader arriving on the new keyword
> meets an unexplained acronym.

Correct: Round 3 fixed a site, not its class. The abbreviation now rides inside
the Inspiration entry's link text, which connects the two occurrences in one
word and puts the expansion where the credit already is.

That placement rather than expanding `:10` is deliberate, and it closes the
`Cargo.toml` half at the same time. The description has to stay a card-length
summary, so it keeps `TCA-style` — and crates.io renders the description and the
README on one page, so the expansion is on the page the abbreviation appears on.
`src/lib.rs` is the other page, and Round 3 gave it its own expansion and link.

**Round 5** — zero findings. Stopping condition met.

The round also raised, as an incidental observation rather than a finding, that
`cargo publish --dry-run` now packages 108 files where the 0.11.0 entry recorded
105 after the `include` anchoring, and suggested a glance before the next
publish. Taken: `cargo package --list` at `v0.11.0` against this branch differs
by exactly two files, `examples/dashboard_composed.rs` and
`tests/common/gauges.rs`, both landed since that release and both covered by the
existing `examples/**/*` and `tests/**/*` patterns. Nothing entered the package
unintentionally, and nothing left it. Recorded here so the next releaser does
not have to re-derive it.

**Round 6** — no review; a maintainer question, and the answer reverses round 2.

Round 2 asked for a changelog entry and offered `745e019` as precedent. I checked
that the precedent *exists* and not that it is the *same kind of change*, which
is the failure of taking grounds that do not reach the claim.

`745e019`'s entry describes two files that shipped and should not have — the
artifact's contents changed, and a user who vendors or audits the crate sees it.
A description and `keywords` change alters neither what the crate does nor what
ships beyond the manifest text itself. `CHANGELOG.md`'s bar is "All notable
changes", Keep a Changelog's, and `docs/releasing.md` sets no other.

Three things settle it against an entry:

- The README ships in the package too, and #377, #378 and #382 all changed
  user-facing prose in it with no changelog entry — three recent precedents for
  omission, against one for inclusion that is not analogous.
- **This PR changes the same sentence in `README.md:10` and `Cargo.toml`.** An
  entry for one and not the other is incoherent however the bar is read.
- #382 changed `README.md:10` itself and took no entry.

The entry is removed; `CHANGELOG.md` is byte-identical to `main` again.

**Round 7** — zero findings on the final state. Stopping condition met.

The round re-derived each claim from the tree rather than from this body, built
the docs under `-D warnings` and read the rendered `index.html` to confirm the
reference-style link resolves, and checked that `pub mod reducer` is
unconditional under `default = []` — so the description's "TCA-style reducer
composition" holds for a default build rather than a feature-gated one. It
records `CHANGELOG.md` as byte-identical to `main`, matching round 6.

## Not closing #359

The issue says it "is **not** fixed by merging a PR", because metadata reaches
crates.io only at the next publish. Its acceptance criteria 1–3 are met here —
the description is true of the crate without asserting `Application` is its
only shape, `keywords` stays at five with every entry deliberate, and
`--dry-run` accepts it. Criterion 4 is the next release carrying this manifest.
Cutting one is a separate decision: `docs/releasing.md` step 4 is the
irreversible step, and it is the maintainer's to take.

Refs #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)







