### PR TITLE
fix(package): build the feature-gated modules on docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,14 @@ include = [
     "/CHANGELOG.md",
 ]
 
+# What docs.rs builds with. `grep -rn 'feature = "' src/` returns the four
+# features that gate an item there, and these are the two that gate documented
+# ones — the feature table declares `bench-internals` and `loom-core` not for
+# normal builds. `--all-features` renders the same item pages as these two, so
+# it would build `loom` and every TLS backend for nothing a reader sees.
+[package.metadata.docs.rs]
+features = ["http", "ws"]
+
 [features]
 default = []
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -142,14 +142,11 @@ compiler reports none of it.
   an addition only the changelog names is one a reader has to already know
   to look for.
 
-  Feature-gated API is where presence is genuinely at stake, and this step
-  cannot fix it. docs.rs builds with `default`, which is empty, so nothing
-  under `ws` or `http` reaches it at all
-  ([#351](https://github.com/akiomik/tears/issues/351)). Until that is
-  settled, prose is the only reach such an addition has — and the
-  crate-root `## Optional Features` section is prose docs.rs does render,
-  so it is the half of "the README and the crate-root docs" that reaches a
-  reader who is already there.
+  Feature-gated API is the one case where presence rather than
+  discoverability is at stake: it reaches docs.rs only if the build there
+  enables its feature. Check that a new addition's feature is enabled —
+  `[package.metadata.docs.rs]` is where to look — since one that is not
+  leaves the addition absent there rather than merely hard to find.
 - Everything under `Changed` and `Removed` may have invalidated an example.
   The doctests cover rustdoc and the migration guides; the README's fenced
   blocks are compiled by nothing and have to be read.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -40,10 +40,20 @@
 //! ## Transaction-based (HTTP)
 //!
 //! ```rust,ignore
+//! use tears::Subscription;
 //! use tears::subscription::http::Query;
 //!
-//! // In update():
-//! Query::new(client).fetch(id, fetch_fn, Message::UserLoaded)
+//! // In subscriptions(), over the Arc<QueryClient> the model holds: a fresh
+//! // one each pass gives the query a new identity, and it refetches instead
+//! // of serving what it retained.
+//! vec![
+//!     Subscription::new(Query::new(
+//!         "user-123",
+//!         || Box::pin(fetch_user()),
+//!         self.query_client.clone(),
+//!     ))
+//!     .map(Message::UserQuery),
+//! ]
 //! ```
 //!
 //! # Built-in Subscriptions
@@ -61,6 +71,14 @@
 #![cfg_attr(
     not(feature = "ws"),
     doc = "- `websocket::WebSocket` - WebSocket connections (requires `ws` feature)"
+)]
+#![cfg_attr(
+    feature = "http",
+    doc = "- [`http::Query`] - HTTP data fetching with retention (requires `http` feature)"
+)]
+#![cfg_attr(
+    not(feature = "http"),
+    doc = "- `http::Query` - HTTP data fetching with retention (requires `http` feature)"
 )]
 //!
 //!

--- a/src/subscription/http.rs
+++ b/src/subscription/http.rs
@@ -3,17 +3,29 @@
 //! This module provides subscription-based HTTP queries and command-based mutations,
 //! similar to SWR or TanStack Query.
 //!
-//! # Features
+//! # Capabilities
 //!
 //! - **Queries**: Subscription-based data fetching with automatic retention and refetching
 //! - **Mutations**: Command-based data modifications (POST, PUT, DELETE, etc.)
 //! - **Retention management**: Automatic retained-data invalidation and updates
 //!
+//! # Feature Flag
+//!
+//! The types in this module need the `http` feature:
+//!
+//! ```toml
+//! [dependencies]
+//! tears = { version = "0.11", features = ["http"] }
+//! ```
+//!
 //! # Example
 //!
+// Not compiled: the `impl` is partial and the types are placeholders. #385
+// tracks turning this and its siblings into real doctests, which for this one
+// means a complete `Application`.
 //! ```rust,ignore
 //! use tears::prelude::*;
-//! use tears::subscription::http::{Query, QueryClient, Mutation};
+//! use tears::subscription::http::{Mutation, Query, QueryClient, QueryResult};
 //! use std::sync::Arc;
 //!
 //! struct App {
@@ -40,11 +52,14 @@
 //!                 Command::none()
 //!             }
 //!             Message::UpdateUser(data) => {
-//!                 Mutation::mutate(data, update_user_api)
-//!                     .map(|result| match result {
-//!                         Ok(user) => Message::UserUpdated(user),
-//!                         Err(e) => Message::UpdateFailed(e.to_string()),
-//!                     })
+//!                 Mutation::mutate(data, |input| {
+//!                     Box::pin(async move { update_user_api(input).await })
+//!                 })
+//!                 .map(|result| match result {
+//!                     Ok(user) => Message::UserUpdated(user),
+//!                     Err(e) => Message::UpdateFailed(e.to_string()),
+//!                 })
+//!                 .into()
 //!             }
 //!             Message::UserUpdated(_) => {
 //!                 self.query_client.invalidate("user-123");

--- a/src/subscription/websocket.rs
+++ b/src/subscription/websocket.rs
@@ -9,11 +9,9 @@
 //! WebSocket uses the **stream-based bidirectional** pattern. The subscription
 //! manages a long-lived connection and provides an `mpsc::UnboundedSender` for
 //! immediate send operations. This design reflects the real-time, streaming
-//! nature of WebSocket communication.
-//!
-//! For more details on why this pattern is used instead of `Command`-based
-//! sending, see the "Design Philosophy" section in the [`subscription`](crate::subscription)
-//! module documentation.
+//! nature of WebSocket communication: sending is a control operation on a
+//! connection that already exists, not a new side effect for a
+//! [`Command`](crate::Command) to start.
 //!
 //! # Disconnection and reconnection
 //!


### PR DESCRIPTION
## What

```toml
[package.metadata.docs.rs]
features = ["http", "ws"]
```

plus the comment recording the rule that produced those two, the caveat in
`docs/releasing.md` this removes the need for, and the four rustdoc surfaces
that publishing these modules makes wrong or incomplete.

**Five files, +54/−24.** An earlier revision of this PR also carried two
mechanical checks and a CI step; those are out, and #386 records them with a
recommendation to decline most of what was built.

## The premise, checked

`https://docs.rs/tears/0.11.0/tears/subscription/` — fetched, not recalled —
lists four modules: `mock`, `signal`, `terminal`, `time`. `websocket` and `http`
are not in the module list, while the same page's prose names them and tells a
reader which feature to enable. Everything RFC 0001 designed — `WebSocket`,
`WebSocketCommand`, `Query`, `Mutation`, `QueryClient`, `QueryConfig` — has had
no API reference at all.

## Why `["http", "ws"]`

Not `all-features`: it enables `loom-core` and `bench-internals`, which the
feature table declares not for normal builds.

Not `user_features`, which #351 proposes: six of its eight entries change no
page.

The rule instead of a list:

```console
$ grep -rn 'feature = "' src/
```

returns exactly four features — `http`, `ws`, `bench-internals`, `loom-core`.
Two of them gate documented items. That rule is what the comment records,
because it answers the absences as well as the entries: `dashmap`, `thiserror`,
`tokio-tungstenite` and the three TLS features are all missing from the list
because they gate nothing, and a reader can re-run it rather than trust an
enumeration.

Measured, not reasoned — three doc builds, item pages compared:

| Feature set | Item pages |
| --- | --- |
| `http,ws` | baseline |
| all eight `user_features` | identical |
| `--all-features` | identical |

## Verification

- `cargo metadata` parses the table at **`metadata.docs.rs.features`** — the
  path docs.rs reads, and the check a mistyped section header would fail.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features http,ws` clean, and
  the same with no features, so no `cfg_attr` branch has a dead link. Rendered
  HTML read rather than assumed.
- `cargo publish --dry-run` accepts the manifest; `just test-doc-packaged` and
  `just test-doc` stay green.
- Its effect is observable only after a publish. That property is what #386 is
  about.

## The four rustdoc surfaces

Written while these modules were absent, so publishing them is what turns each
from unread into wrong:

| Site | Defect |
| --- | --- |
| `subscription`'s built-in list | names `websocket::WebSocket`, nothing for `http` |
| `subscription`'s HTTP example | calls `Query::fetch`, which does not exist, at an arity `Query::new` does not have |
| `http`'s module docs | never say which feature its types need; `websocket`'s always have |
| `http`'s example | passes a bare async fn to `Mutation::mutate` where a boxed one is required, and drops the `.into()` its return type needs |
| `websocket` | points at a "Design Philosophy" section deleted in `b1db552` |

The last one is a net removal: the one-sentence rationale comes back to the
module that asks for it, and the cross-file pointer goes.

The list entry and the module note use the `cfg_attr` pair the built-in list
already used for `ws`, so a featureless build keeps the code span.

**Deliberately not taken:** linking the crate root's `## Optional Features`
names. It would work now that the targets exist, but code spans there were never
wrong — that is an improvement, not a fix, and it would introduce `cfg_attr`
doubling into a file that has none.

## `docs/releasing.md`

#351 says closing it "lets that caveat come back out". The caveat asserted
"docs.rs builds with `default`, which is empty", which this makes false. What
replaces it keeps the step's shape — its siblings all name an action — and
states the condition rather than enumerating what decides it, because four
rounds of enumerating produced four different omissions.

## No changelog entry

The crate's behaviour is unchanged and nothing new ships; what changes is how a
third-party site presents it, the category the description and keywords change
was judged not to clear. The counter-argument — a user who enabled `ws` had no
API reference whatsoever — is recorded rather than decided.

## Review after the split

**Round 1** — one finding, fixed: the HTTP example's `.map(Message::UserLoaded)` applies to a
`Subscription<QueryResult<User>>`, so the variant it implies is
`UserLoaded(QueryResult<User>)` while the name reads as "the user finished
loading" — a reader would declare `UserLoaded(User)` and hit a type error. Both
sibling examples use `Message::UserQuery` in exactly this position; the three
agree now.

The guard gap was raised again and needs no action: it is the deliberate
deferral to #386, and the round records it as "a confirmation of the gap rather
than a new objection".


**Round 2** — three findings: one fixed, two declined with the reason recorded.

*Fixed.* The example built its `QueryClient` inline, one line above the
`Subscription` — and a `Subscription` has one destination, `subscriptions()`.
A reader transcribing both lines gets a fresh client every pass, and `Query`'s
key carries `client_id` from a never-reused counter, so the subscription
restarts and refetches instead of serving what it retained. That trap is mine,
introduced in the round that made the snippet stand on its own. Closed with the
framing rather than a restructure.

*Declined — `mutation.rs`'s example passes three arguments to a two-argument
`mutate`.* It is one line, and it is in **#385**'s set. Fixing only the arity
would leave the same file saying `mutate` "returns a `Command`" in two places
where it returns `EffectCommand` — a file half-corrected in a new way is worse
than one tracked whole. The file is otherwise outside this PR.

*Declined — `just doc` and `just doc-build` no longer match docs.rs.* True, and
caused here: before this PR the default build was what docs.rs produced. It is
the same question **#386** exists for — what should reproduce the docs.rs
configuration locally, and at what cost — and it is written up there with the
options this widens it to.


**Round 3** — one finding, fixed. Round 2's comment says "hold it in your
model", and the code moved the sole handle into `Query::new`, so the snippet
held it nowhere: the comment asserted what the code did not demonstrate. Now
`client.clone()`, which is what both sibling examples do.

Third pass over this eight-line example, and each fix was correct for what it
addressed while setting up the next: making it stand on its own dropped the held
client, warning about the held client left the code contradicting the warning.
Worth naming because the pattern is the review loop's characteristic failure,
not this example's.


**Round 4** — two findings: one fixed, one declined on the merits.

*Fixed.* Round 3 changed the argument to `client.clone()` but left the client
built as a local one line above, so a reader transcribing the block into
`subscriptions()` still reproduced the failure the comment warns about. The
construction is gone rather than annotated: the block is a fragment now, over a
client the model holds, which is what both sibling examples show and what the
WebSocket example beside it already is.

Four passes over eight lines, and the diagnosis is that I had been optimising
for a property the block does not need. It is `rust,ignore`; nothing compiles
it; its sibling is a fragment. Making it stand alone is what required a
constructed client, and the constructed client is what taught the bug.

*Declined — the section heading.* The finding is that `## Transaction-based
(HTTP)` sits over an example building a `Subscription`, while
`mutation.rs` says "Unlike queries which are subscriptions, mutations are
one-off operations", so `Mutation` is the transaction-based API and `Query` is
not.

The two texts are on different axes. The Overview's three names — unidirectional,
stream-based, transaction-based — describe the *shape of the operation*: a
`Query` performs discrete HTTP fetches, each a transaction, and that is what
puts it under that heading. `mutation.rs`'s sentence is about *delivery*:
subscription versus command. `Mutation` is transaction-based **and**
command-delivered; `Query` is transaction-based **and** subscription-delivered,
which is why it is the one a subscription module's overview shows. No
contradiction, and nothing to change.


**Round 5** — two findings, and the useful question is why they were raised at
all, since both were already declined here. Three explanations were possible:
the decision is not shared where it needs to be, the two only look alike, or the
round is offering information rather than asking for a change. Checked rather
than assumed:

**Not shared where it needs to be — the main one.** `grep -rn "385" src/`
returned nothing, while issue references in `src/` doc comments are this
repository's own convention: `#318` in `test_support/trace_recorder.rs`, `#305`
and `#342` in `kernel/conformance/support.rs`, `#300` beside them. So a reader
of `src/subscription/http.rs` had no way to learn that the example's state is
tracked — the decision lived in this description and in #385, and neither is
somewhere that file's reader goes. The round says so in as many words:
"flagging so the decision is visible against the diff rather than only in the
PR description."

Closed by putting the note where the block is, as a plain `//` comment inside
the doc block. Verified two ways: a probe crate confirms an interleaved `//`
neither breaks the surrounding `//!` run nor reaches the rendered page, and the
generated `subscription/http/index.html` contains the example and no `385`.
Maintainer-facing, invisible to a user.

**They only look alike — true, and my doing.** `mutation.rs`'s three-argument
`mutate` and `http.rs`'s four missing `Application` items are two defects, and
I answered them as one class. Checking the earlier rounds also corrects the
record in the other direction: `http.rs`'s partial `impl` was not new in round 5
either — round 12, before the split, already named it, and it went to #385 then.

**Information rather than a demand — also true.** Round 2 called the
`mutation.rs` deferral "legitimate"; round 5 asked only for visibility. Neither
round disputed the decision, which is why the answer is a pointer rather than a
change of course.


**Round 6** — two findings: one fixed, one a re-raise the round labels as such.

*Fixed.* The Transaction-based fragment said "In subscriptions()" while its tail
was a `Subscription<Message>` and `subscriptions` returns a `Vec` of them, and
nothing in it revealed that `Query::new`'s third parameter is
`Arc<QueryClient>`. That second half is the sharper one: `QueryClient` derives
`Clone`, so a reader who declares the field as `QueryClient` writes the
*identical* `self.query_client.clone()` and gets a type error the example gives
no hint about. Both are shown now — the `vec![…]` wrapper, and the `Arc` named
in the comment.

*Re-raised, unchanged.* `mutation.rs`'s three-argument `mutate`. This round ran
against `9234ab9`, before the `// #385` note landed in `d9afc3c`, so it is not
evidence the note failed. It does sharpen the reason for declining: the round
counts **five** sentences in that file saying `mutate` "returns a `Command`"
where it returns `EffectCommand`, not the two this PR assumed. Fixing the arity
alone would leave five, which is the half-corrected state the decline exists to
avoid.

No note was added to `mutation.rs`. It is outside this PR's files, and reaching
into a sixth file to mark a defect this PR is not fixing is the accretion that
cutting this PR back was for. #385 carries it, with both specifics.


**Round 7** — zero findings. One of the two observations the round declined to
file was taken anyway, because it showed a justification of mine did not reach
its claim.

Round 4 (before the split) moved `# Feature Flag` to the end of `http.rs`,
recorded as "matching `websocket.rs`'s last-section shape". That is literally
true — `websocket.rs` has no `# Example` section at all, so its feature note is
last. It is also the wrong property to copy: in `http.rs` the note ended up
behind a forty-five-line example, so a reader who tries the example first meets
"module not found" and has to scroll back for the answer. I matched a position
where what transfers is an ordering.

The note sits between `# Capabilities` and `# Example` now. Round 4's actual
complaint was the collision between `# Feature Flag` and a `# Features` meaning
capabilities, and the rename alone settles that — the move never was the fix.
Verified as a pure relocation: the doc comment's word multiset is identical
before and after, and the rendered page has the section ahead of the example.

The other observation is #386's guard gap, deferred as before.


**Round 8** — one finding, declined, and the reason changed under it.

The `mutation.rs` example again, raised a third time — but on a different
argument, and a better one: the earlier declines were on file scope, and *this
PR is what publishes the page*, so it is fair to say the defect becomes public
here.

That argument reaches further than the previous two, and it collides with the
line this PR set for itself — facts corrected, compilability deferred. The
arity and the return type are facts. So the decline had to be re-derived rather
than repeated.

**Counted first.** The reviews said the file names the wrong return type in
"five" places, then "three". It is **six**, and one of those rounds and I would
each have relayed a number we had not checked. `command/core.rs:686` looked like
a seventh and is not — its `.into()` is there, which only reading past the line
the grep matched showed.

**Then the cause.** `command/core.rs:705` carries the same claim, on a page that
has always been on docs.rs. So the cause is the `EffectCommand` rename, not this
PR; this PR widens the audience for part of it. And fixing only the arity — the
cheap option the round offers — publishes a page that is still wrong six ways.

Filed as **#387** with the verified inventory, the adjacent `Command::map` link
that points at the wrong type's method, and the `core.rs` half that no
docs.rs change can be blamed for. Whoever takes it starts from a count that has
been checked rather than estimated.

## Left open

- **#387** — six statements in `Mutation`'s docs name the wrong return type,
  fallout of the `EffectCommand` rename rather than of this change.
- **#386** — whether the list wants a mechanical guard, with a recommendation to
  build only the cheapest arm and decline the rest.
- **#385** — eleven rustdoc examples are `rust,ignore`, which is why
  `Query::fetch` survived; three of the eight unforced ones are confirmed wrong.
- **#351** — whether `--cfg docsrs` should label each gated item with the
  feature it needs. Until it does, a reader arriving at `http::Query` through
  search sees no feature note on the item page.

Refs #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)









