### PR TITLE
docs(http): name EffectCommand in Mutation's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,10 +244,11 @@ way to write a program rather than a second runtime. See
 - **Signal** (`signal::Signal`): OS signal handling (Unix/Windows)
 - **WebSocket** (`websocket::WebSocket`, requires `ws`): Real-time bidirectional communication
 - **Query** (`http::Query`, requires `http`): HTTP data fetching with caching
-- **Mutation** (`http::Mutation`, requires `http`): HTTP data modifications
 - **MockSource** (`mock::MockSource`): Controllable mock for testing
 
 Create custom subscriptions by implementing the `SubscriptionSource` trait.
+`http::Mutation` does not implement it: a mutation is a one-off effect,
+dispatched from `update` rather than declared in `subscriptions`.
 
 ## Examples
 

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -695,19 +695,26 @@ impl<Msg: Send + 'static> Command<Msg> {
     /// # Advanced Example with Mutation
     ///
     /// ```rust,ignore
-    /// use tears::subscription::http::Mutation;
+    /// use tears::prelude::*;
+    /// use tears::subscription::http::{Mutation, QueryError};
     ///
     /// enum Message {
     ///     UserUpdated(User),
     ///     UpdateFailed(String),
     /// }
     ///
-    /// // Mutation returns Command<Result<User, Error>>
-    /// let cmd = Mutation::mutate(user_data, update_user_api)
-    ///     .map(|result| match result {
-    ///         Ok(user) => Message::UserUpdated(user),
-    ///         Err(e) => Message::UpdateFailed(e.to_string()),
-    ///     });
+    /// // Carry the mutation's effect into a command
+    /// let cmd: Command<Result<User, QueryError>> = Mutation::mutate(
+    ///     user_data,
+    ///     |input| Box::pin(async move { update_user_api(input).await }),
+    /// )
+    /// .into();
+    ///
+    /// // Map it to your application's message type
+    /// let cmd = cmd.map(|result| match result {
+    ///     Ok(user) => Message::UserUpdated(user),
+    ///     Err(e) => Message::UpdateFailed(e.to_string()),
+    /// });
     /// ```
     pub fn map<T>(self, f: impl Fn(Msg) -> T + Send + 'static) -> Command<T>
     where

--- a/src/subscription/http.rs
+++ b/src/subscription/http.rs
@@ -1,12 +1,12 @@
 //! HTTP query and mutation support with retained data.
 //!
-//! This module provides subscription-based HTTP queries and command-based mutations,
+//! This module provides subscription-based HTTP queries and one-off mutations,
 //! similar to SWR or TanStack Query.
 //!
 //! # Capabilities
 //!
 //! - **Queries**: Subscription-based data fetching with automatic retention and refetching
-//! - **Mutations**: Command-based data modifications (POST, PUT, DELETE, etc.)
+//! - **Mutations**: One-off data modifications (POST, PUT, DELETE, etc.)
 //! - **Retention management**: Automatic retained-data invalidation and updates
 //!
 //! # Feature Flag

--- a/src/subscription/http/mutation.rs
+++ b/src/subscription/http/mutation.rs
@@ -6,16 +6,16 @@
 //! # Design Pattern: Transaction-based Operations
 //!
 //! HTTP mutations use the **transaction-based** pattern. Each mutation operation
-//! returns a `Command` because HTTP requests are discrete side effects with clear
-//! start and end points. This design maintains TEA principles and makes operations
-//! testable and composable.
+//! returns an [`EffectCommand`] because HTTP requests are discrete side effects
+//! with clear start and end points. This design maintains TEA principles and
+//! makes operations testable and composable.
 //!
 //! Unlike queries which are subscriptions, mutations are one-off operations that
-//! return a Command. After a successful mutation, you typically want to invalidate
-//! related queries to trigger refetching.
+//! return an [`EffectCommand`]. After a successful mutation, you typically want
+//! to invalidate related queries to trigger refetching.
 //!
-//! [`Mutation::mutate`] returns a `Command<Result<_, QueryError>>` and does not
-//! emit [`MutationState`] values by itself. [`MutationState`] and
+//! [`Mutation::mutate`] returns an `EffectCommand<Result<_, QueryError>>` and
+//! does not emit [`MutationState`] values by itself. [`MutationState`] and
 //! [`MutationResult`] are helper types for applications that want to store
 //! mutation status in their own model.
 //!
@@ -44,6 +44,7 @@
 //!                 Ok(user) => Message::UserUpdated(user),
 //!                 Err(e) => Message::UpdateFailed(e.to_string()),
 //!             })
+//!             .into()
 //!         }
 //!         Message::UserUpdated(_) => {
 //!             // Invalidate user query to refetch
@@ -68,8 +69,8 @@ use super::query::QueryError;
 
 /// The state of a mutation result.
 ///
-/// This is a helper type for application models. [`Mutation::mutate`] returns a
-/// `Command<Result<_, QueryError>>`; it does not automatically emit
+/// This is a helper type for application models. [`Mutation::mutate`] returns an
+/// `EffectCommand<Result<_, QueryError>>`; it does not automatically emit
 /// `MutationState` values.
 #[derive(Debug, Clone)]
 pub enum MutationState<T> {
@@ -120,18 +121,15 @@ impl<T> MutationResult<T> {
 
 /// A mutation for performing data modifications (POST, PUT, PATCH, DELETE).
 ///
-/// Mutations are one-off operations that return a `Command`. Unlike queries,
-/// they don't maintain state or cache results.
+/// Mutations are one-off operations that return an [`EffectCommand`]. Unlike
+/// queries, they don't maintain state or cache results.
 ///
 /// # Example
 ///
 /// ```rust,ignore
 /// let cmd = Mutation::mutate(
 ///     user_data,
-///     |input| Box::pin(async move {
-///         http_client.put("/api/user").json(&input).send().await
-///     }),
-///     Message::UserUpdated,
+///     |input| Box::pin(async move { update_user_api(input).await }),
 /// );
 /// ```
 pub struct Mutation<I, O> {
@@ -143,10 +141,10 @@ where
     I: Send + 'static,
     O: Send + 'static,
 {
-    /// Executes a mutation and returns a `Command`.
+    /// Executes a mutation and returns an [`EffectCommand`].
     ///
     /// The returned command produces `Result<O, QueryError>` which can be mapped
-    /// to your application's message type using [`Command::map`].
+    /// to your application's message type using [`EffectCommand::map`].
     ///
     /// # Arguments
     ///


### PR DESCRIPTION
Closes #387.

RFC 0014 made every effect constructor return `EffectCommand`, and
`Mutation::mutate`'s signature followed. Its documentation did not.

## What was wrong

Six statements in `src/subscription/http/mutation.rs` said the mutation returns
a `Command` (lines 9, 14, 17, 72, 123 and 146 before this change), and `mutate`'s
own docs sent the reader to `Command::map` for a value that is an
`EffectCommand`. `EffectCommand` has its own `map`, so the link resolved and
rustdoc stayed silent.

Two examples on the same pages were wrong for the same reason:

- `Mutation`'s example passed a third argument to a two-argument function, and
  its mutator body was a `reqwest` call: the wrong error type, and a client
  borrowed into a `'static` future. It named the right function and still could
  not build.
- The module example mapped the returned effect and gave the result as a
  `Command<Message>`, which does not unify. `src/subscription/http.rs`'s module
  example is the same call in the same position and already carries the
  `.into()`, so this brings the two into line.

`Command::map`'s "Advanced Example with Mutation" in `src/command/core.rs`
carried the claim as a comment above a call that predates the boxed-closure
bound.

## What this does

Bare type names become intra-doc links to `EffectCommand`; the two statements
carrying generic arguments stay code spans, because an intra-doc path cannot
hold them.

In `Command::map`'s example, the comment now says what the step does rather than
restating a return type, and the type lives in the annotation on the `.into()`.
That is what the plain example directly above it already does, so both examples
in that block now have one shape — and the example demonstrates the method it
documents, which it previously did not.

Two surfaces a reader meets before any of these carried the same confusion
between the carrier and the pattern. Both are corrected by stating the pattern
rather than by renaming the carrier, so no later rename of the carrier can make
them stale again:

- `src/subscription/http.rs` introduced mutations as "command-based". The
  contrast it draws with queries becomes ongoing versus one-off, which is the
  distinction it is actually making.
- `README.md` listed `Mutation` under "Built-in Subscriptions". Only `Query<V>`
  implements `SubscriptionSource`; `Mutation` is a marker whose one associated
  function returns an effect. A reader following that list writes
  `Subscription::new(Mutation…)` and gets a trait-bound error. The list drops it
  and says why, which the Optional Features section below already got right.

## Verification

Both corrected call shapes were compiled against the crate in a scratch test
before being written back into `ignore` blocks, so the examples are not merely
differently wrong. Also run: `cargo fmt --check`, `just test-doc`,
`just pre-commit`, and `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features
http,ws` — the last under the feature set `[package.metadata.docs.rs]` declares,
since the intra-doc links added here live inside a feature-gated module and the
doc build is not part of `just pre-commit`.

Swept for the class: the only remaining "Command-based" text in the tree is a
historical `CHANGELOG.md` entry, which must not be rewritten. No CHANGELOG entry
is added — nothing about the shipped crate's behaviour or contents changed.

## Declined

`mutation.rs`'s module example and `mutate`'s example both import `QueryError`
without naming it. Left alone: it is unused only because the blocks elide the
`update_user_api` stub, whose signature names `Result<_, QueryError>` — so
converting these to real doctests puts the import back. Removing it now is churn
that #385 would undo.

Whether these blocks stop being `ignore` is #385's question. This PR does not
touch it; these statements are wrong as prose regardless of whether anything
compiles them.