### PR TITLE
docs(subscription): state the subscription identity once, with its scope

### DIFF
--- a/docs/rfcs/0005-structural-lifecycle-identity.md
+++ b/docs/rfcs/0005-structural-lifecycle-identity.md
@@ -33,8 +33,8 @@ a correctness failure, not merely an unlikely `HashMap` performance collision.
 This RFC replaces the pre-hashed surrogate with a framework-owned erased
 structural key. Each `SubscriptionSource` returns an associated `Key`, and
 `Subscription::new` combines the concrete source type with that original key.
-A subscription identity compares its source type, logical-key type, and
-logical-key value. Hashing remains an indexing operation; equality is never
+A subscription's local identity compares its source type, logical-key type,
+and logical-key value. Hashing remains an indexing operation; equality is never
 reduced to a hash digest.
 
 Structural local identity is also the foundation for safe feature composition.
@@ -335,7 +335,7 @@ impl<Msg: 'static> Subscription<Msg> {
 }
 
 impl std::fmt::Debug for SubscriptionId { /* diagnostic only */ }
-impl PartialEq for SubscriptionId { /* source type + erased structural key */ }
+impl PartialEq for SubscriptionId { /* local identity, §2.2 */ }
 impl Eq for SubscriptionId {}
 impl std::hash::Hash for SubscriptionId { /* same structural components */ }
 impl std::panic::UnwindSafe for SubscriptionId { /* preserved compatibility */ }

--- a/src/subscription/core.rs
+++ b/src/subscription/core.rs
@@ -213,8 +213,8 @@ pub trait SubscriptionSource: Send {
 
     /// Get the owned structural key for this subscription.
     ///
-    /// The framework combines this value with the concrete source type when it
-    /// constructs the opaque subscription identity.
+    /// The framework carries this value into the opaque [`SubscriptionId`],
+    /// which documents what the identity compares.
     ///
     /// This method must return equal keys for the same logical source identity
     /// across calls, including when fresh source values are constructed by
@@ -230,8 +230,9 @@ pub trait SubscriptionSource: Send {
 ///
 /// Two subscriptions with the same ID are considered identical.
 ///
-/// IDs compare their concrete source type and original structural key. Hashing
-/// is used only for indexing and never makes unequal keys equal.
+/// IDs compare three things: the concrete source type, the original structural
+/// key, and the scope path [`Subscription::scoped`] applies (RFC 0005 INV-1).
+/// Hashing is used only for indexing and never makes unequal keys equal.
 pub struct SubscriptionId {
     pub(super) source_type_id: TypeId,
     source_type_name: &'static str,

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -160,13 +160,13 @@ impl QueryClient {
     #[must_use]
     pub fn with_config(config: QueryConfig) -> Self {
         Self {
-            // `client_id` is an identity component — subscription identity is
-            // `(client_id, TypeId, QueryKey)` (RFC 0001) — so reusing an id
-            // would collide distinct clients' identities. The allocator fails
-            // before it can reuse a value: on exhaustion the failed
-            // `fetch_update` stores nothing, leaving the counter saturated at
-            // `u64::MAX`, so this and every later allocation panics instead of
-            // wrapping into reuse.
+            // `client_id` is an identity component: it is the first element
+            // of `Query<V>::Key`, which the subscription id compares, so
+            // reusing an id would collide distinct clients' identities
+            // (RFC 0001 INV-5). The allocator fails before it can reuse a
+            // value: on exhaustion the failed `fetch_update` stores nothing,
+            // leaving the counter saturated at `u64::MAX`, so this and every
+            // later allocation panics instead of wrapping into reuse.
             client_id: NEXT_QUERY_CLIENT_ID
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_add(1))
                 .expect(
@@ -349,11 +349,12 @@ type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Se
 /// # Changing the request
 ///
 /// Replacing the fetcher while keeping the same key is **not supported**. The
-/// runtime keys the running subscription by its identity (`QueryClient`, key,
-/// and value type), so constructing a new `Query::new(key, new_fetcher, client)`
-/// with an unchanged key keeps the existing stream and the old fetcher; the new
-/// fetcher never takes effect. **To change the request, change the key** (for
-/// example by including the varying parameter in it).
+/// runtime keys the running subscription by its
+/// [`SubscriptionId`](crate::SubscriptionId), which the fetcher is no part of,
+/// so constructing a new `Query::new(key, new_fetcher, client)` with an
+/// unchanged key keeps the existing stream and the old fetcher; the new fetcher
+/// never takes effect. **To change the request, change the key** (for example
+/// by including the varying parameter in it).
 ///
 /// # Example
 ///


### PR DESCRIPTION
Closes #380. Closes #379.

`SubscriptionId` compares three things — the concrete source type, the erased
structural key, and the scope path (`src/subscription/core.rs` `PartialEq` /
`Hash`). RFC 0005 INV-1 says the same. Four statements in `src/` named only the
first two, and RFC 0005's own Summary named only the first two against its INV-1.

## What a reader did with it

The two `query.rs` sites are the sharp ones, because `Query` is the source most
likely to sit under a boundary. "Changing the request" said the runtime keys the
subscription by "`QueryClient`, key, and value type", from which a reader
building panes concludes that two `Query`s with one client, key and value type
are one subscription with one in-flight fetch. Reducer combinators call
`Subscription::scoped` per boundary (`src/reducer/combinator.rs:321,470`), so the
ids differ, each boundary runs its own subscription, and each issues its own
fetch.

## The shape of the fix

Rather than correct four enumerations, this states the identity once — on
`SubscriptionId`, the type the fact is about — and has the others refer to it.
Four independent enumerations of one fact is what let three of them drift.

- `SubscriptionSource::key` says the framework carries the key into the id, and
  points at it.
- `query.rs`'s client-id comment stops naming a tuple shape. It was also wrong at
  the level it claimed: `client_id` rides inside `Query<V>::Key = (u64,
  QueryKey)`, so it is part of the structural key rather than a peer of the
  source type. It now cites RFC 0001 INV-5, which states the non-reuse
  requirement the panic exists for and which — unlike RFC 0001's identity
  equation — is a sufficient condition rather than an exhaustive composition, so
  it survived the addition of the scope path.
- "Changing the request" names the fact it needs — the fetcher is no part of the
  identity — instead of enumerating what is.

In RFC 0005 the same move applies twice, and neither restatement re-enumerates.
The Summary's sentence is §2.2's *local* equality stated without the qualifier
that makes it true, so it gains the qualifier the next paragraph already uses.
§3.1's sketch is the RFC's only sketch of `PartialEq` and §4 never revises it; it
points at §2.2, which is what a Phase A id compares — §8.4 adds the scope path in
Phase B, so naming the full identity there would send a Phase A implementer
looking for a component that section does not yet build.

## Pre-review checklist

Run per `docs/rfcs/README.md` §Process, since this edits an Accepted RFC. Note
that it edits no normative section: INV-1 is untouched, and both edited sites are
a Summary sentence and a non-normative implementation sketch.

1. **Quantifiers against the inventory** — the inventory is every statement of
   the subscription identity in the tracked corpus. Enumerated by grepping the
   subject vocabulary rather than the rewritten sentences: 4 in `src/`, 2 in
   RFC 0005, 3 in RFC 0001. Every member is dispositioned below.
2. **Adversarial counterexample per invariant** — no invariant is added or
   changed. The adversary against the *edit* is a reader who takes "local
   identity" in the Summary as the whole identity: excluded, because §1.3 defines
   the term against "full identity" in the same table and the following paragraph
   introduces the scope path.
3. **Enforcement class** — unchanged; INV-1's enforcement is untouched.
4. **Code claims verified against code** — `PartialEq`/`Hash` read fresh
   (`core.rs:284-303`): three components. `Query<V>::Key` read fresh
   (`query.rs:426`, `key()` at `:503`): `client_id` first. `scoped` read fresh
   (`core.rs:139-145`). §2.2 confirmed titled "Local equality"; §2.1 confirmed to
   state `ScopePath` is empty for every Phase A id; §8.4 confirmed to add the
   scope path in Phase B.
5. **Normative force and readiness** — no normative section edited; no hedges
   introduced.
6. **Re-derive, don't patch** — changed-claims list: (a) `SubscriptionId`
   compares three things; (b) `key`'s value is carried into that id; (c)
   `client_id` is the first element of `Query<V>::Key`; (d) the fetcher is no part
   of the identity; (e) the Summary's sentence is local equality; (f) a Phase A
   `SubscriptionId` compares local identity. The class swept is "a statement of
   the subscription identity that omits the scope path", across the RFCs and the
   `src/` docs they govern. **Boundary recorded:** RFC 0001's three sites are out
   of it and filed as #389 — correcting them is an ownership decision across
   three Accepted RFCs, because `docs/rfcs/0010-runtime-consolidation.md`'s ledger
   row `LG-0001-030` reaffirms `preserved_in=0001 §5.8`.
7. **Mechanical pass** — no `Amended` / `originally` / `pre-amendment` markers
   introduced or present. Cited identifiers resolve inside the tracked corpus
   (§2.1, §2.2, §8.4, INV-1, RFC 0001 INV-5). Header block unchanged, correctly:
   `Status`, `Scope` and `CHANGELOG` describe no behaviour, and none changed.
   Subject-vocabulary sweep for "local identity" / "full identity" / "compare"
   across the whole document found no stale restatement left standing.
8. **Minimal contract** — *excluded claims:* one sentence was drafted for the
   Summary and dropped — "A scope path together with a local identity is the full
   identity a runtime registry compares" — implied by §1.3's glossary row and
   §2.1, and adding it would have made a fifth enumeration of the fact whose
   repetition is what this PR is fixing. *Kept and ruled non-redundant:*
   `SubscriptionId`'s rustdoc enumeration, because it is the crate user's only
   statement of the fact and rustdoc cannot defer to an RFC the reader may not
   open.

## Verification

`cargo fmt --check`, `just pre-commit`, and `RUSTDOCFLAGS=-D warnings cargo doc
--no-deps` under `build_features` — the last because the new intra-doc links are
not covered by `just pre-commit`. No CHANGELOG entry: nothing about the shipped
crate's behaviour or contents changed.