### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-11
+
+### Fixed
+
+- `TestDriver::boot` and `TestDriver::step_pass` no longer report a correctly
+  drained kernel as a hang on the step that terminates the program. The
+  quiescent wait that runs at termination polled its condition before each
+  executor turn and never after the last one, so a kernel whose join set
+  drained *on* that final turn was never observed draining: the wait ran out
+  its budget and panicked with "the terminated kernel's join set did not
+  drain", naming a cause that had not happened. The bound now moves before
+  the turn, which is the shape the driver's other bounded waits already use
+
 ## [0.11.0] - 2026-08-29
 
 > Upgrading from 0.10.x? The
@@ -1216,7 +1229,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive API documentation with examples
 - Counter example demonstrating timer and keyboard input
 
-[unreleased]: https://github.com/akiomik/tears/compare/v0.11.0...HEAD
+[unreleased]: https://github.com/akiomik/tears/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/akiomik/tears/releases/tag/v0.11.1
 [0.11.0]: https://github.com/akiomik/tears/releases/tag/v0.11.0
 [0.10.2]: https://github.com/akiomik/tears/releases/tag/v0.10.2
 [0.10.1]: https://github.com/akiomik/tears/releases/tag/v0.10.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,7 +3085,7 @@ dependencies = [
 
 [[package]]
 name = "tears"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "color-eyre",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tears"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 authors = ["Akiomi Kamakura <akiomik@gmail.com>"]
 description = "A simple and elegant TUI framework with The Elm Architecture (TEA) and TCA-style reducer composition"


### PR DESCRIPTION
Step 1 of `docs/releasing.md`. A patch: `main` carries no breaking change since
0.11.0, and the 91 commits between them are documentation, examples and tests
apart from two fixes.

## Why now

Three defects reach a user only through a publish, and merging into `main` does
nothing for any of them.

- **docs.rs has no HTTP or WebSocket API.** 0.11.0's manifest has no
  `[package.metadata.docs.rs]` and `default = []` — read off the tag, not
  recalled — so docs.rs built that version with no features and
  `subscription::http` and `subscription::websocket` are absent from the
  published documentation, taking `Query`, `Mutation`, `QueryClient`,
  `QueryConfig`, `WebSocket` and `WebSocketCommand` with them. `c408c9e` fixed
  the manifest; only a version carries it to docs.rs.
- **The crates.io card names one architecture.** `09a070f` named TCA alongside
  TEA in `description` and `keywords`, and that metadata is read from the
  published version.
- **A shipped module reports a false failure.** A step that terminates the
  program could report a correctly drained kernel as a hang (`a1bdda5`), in
  `tears::testing`.

`docs/releasing.md` rules out the alternative directly: a fix does not wait for
a convenient milestone, because what waiting spends is the time a user carries a
known defect.

## The changelog

One `Fixed` entry, for `a1bdda5`. The other two are excluded on the rule the
existing entries follow: an entry marks a change to the published crate's
behaviour or contents, and crates.io metadata is neither. The 30 `fix(examples)`
commits are excluded on the same rule and on precedent — 0.11.0 shipped an
example rewrite without an entry.

The entry names `TestDriver::boot` and `TestDriver::step_pass` rather than the
wait itself. The wait is a private method, so a reader who hits the panic and
searches the published documentation for its name finds nothing; the two public
calls that reach it are what they can look up, and the panic's text is quoted so
a search by message lands as well.

`CHANGELOG.md` had gone untouched since 0.11.0, so this entry is a backfill
rather than something the pull request that made the change added. Releasing
would otherwise have renamed an empty `## [Unreleased]` into the release's
section. That gap is #391.

## Checks from step 1, run rather than assumed

- **Version pins.** `docs/releasing.md`'s grep returns eight `tears` pins in
  `README.md` and rustdoc; all read `0.11`, so a patch leaves them and none was
  left behind by an earlier minor.
- **MSRV.** `rust-version` is unchanged at 1.88.0, and `README.md`'s badge and
  its "requires Rust 1.88.0 or later" line both agree.
- **Migration guide.** None. `docs/migrations/README.md` warrants a guide for
  breaking changes the compiler cannot name, and there are none.
- **Documentation.** Nothing under `Added`, `Changed` or `Removed`, so no
  public addition needs a route from the README or the crate root, and no
  example was invalidated.
- **`cargo package --list` on the release commit.** 108 files, read in both
  directions: `src` 74, `tests` 13, `examples` 10, `benches` 3, plus
  `README.md`, `LICENSE`, `CHANGELOG.md` and `docs/migrations/0.10-to-0.11.md`
  — the last is the `cfg(doctest)` include and is meant to ship. Only the
  crate's own `README.md` is present, so the unanchored-pattern defect
  `745e019` fixed has not returned.
- **`just publish-check`.** `cargo publish --dry-run` packages 108 files and
  succeeds.
- **`just pre-commit`.** Green.

## The date

`## [0.11.1] - 2026-09-11` is the day of step 3, as `docs/releasing.md`
requires. If publishing slips past the merge, the file records what to do.

## Steps 2 and 3

Not taken here. Before tagging, find the CI run for the merge commit itself and
confirm it is green — `docs/releasing.md` is explicit that neither this pull
request's run nor the merge button stands in for it, since
`strict_required_status_checks_policy` is off and the merge commit can be a tree
no run has seen.
