### PR TITLE
docs(http): compile every example in the http module

### DIFF
--- a/src/subscription/http.rs
+++ b/src/subscription/http.rs
@@ -20,10 +20,20 @@
 //!
 //! # Example
 //!
-// Not compiled: the `impl` is partial and the types are placeholders. #385
-// tracks turning this and its siblings into real doctests, which for this one
-// means a complete `Application`.
-//! ```rust,ignore
+//! ```rust
+//! # use ratatui::Frame;
+//! # use tears::subscription::http::QueryError;
+//! # #[derive(Clone)]
+//! # struct User;
+//! # struct UserData;
+//! # async fn fetch_user() -> Result<User, QueryError> { Ok(User) }
+//! # async fn update_user_api(_input: UserData) -> Result<User, QueryError> { Ok(User) }
+//! # enum Message {
+//! #     UserQuery(QueryResult<User>),
+//! #     UpdateUser(UserData),
+//! #     UserUpdated(User),
+//! #     UpdateFailed(String),
+//! # }
 //! use tears::prelude::*;
 //! use tears::subscription::http::{Mutation, Query, QueryClient, QueryResult};
 //! use std::sync::Arc;
@@ -34,6 +44,16 @@
 //! }
 //!
 //! impl Application for App {
+//! #     type Message = Message;
+//! #     type Flags = ();
+//! #     fn new((): ()) -> (Self, Command<Message>) {
+//! #         let app = App {
+//! #             query_client: Arc::new(QueryClient::new()),
+//! #             user_result: None,
+//! #         };
+//! #         (app, Command::none())
+//! #     }
+//! #     fn view(&self, _frame: &mut Frame<'_>) {}
 //!     fn subscriptions(&self) -> Vec<Subscription<Message>> {
 //!         vec![
 //!             Subscription::new(Query::new(
@@ -63,6 +83,10 @@
 //!             }
 //!             Message::UserUpdated(_) => {
 //!                 self.query_client.invalidate("user-123");
+//!                 Command::none()
+//!             }
+//!             Message::UpdateFailed(_) => {
+//!                 // Handle error
 //!                 Command::none()
 //!             }
 //!         }

--- a/src/subscription/http/mutation.rs
+++ b/src/subscription/http/mutation.rs
@@ -21,7 +21,14 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust
+//! # use std::sync::Arc;
+//! # use ratatui::Frame;
+//! # use tears::subscription::http::QueryClient;
+//! # struct User;
+//! # struct UserData;
+//! # async fn update_user_api(_input: UserData) -> Result<User, QueryError> { Ok(User) }
+//! # struct App { query_client: Arc<QueryClient> }
 //! use tears::prelude::*;
 //! use tears::subscription::http::{Mutation, QueryError};
 //!
@@ -31,6 +38,14 @@
 //!     UpdateFailed(String),
 //! }
 //!
+//! # impl Application for App {
+//! #     type Message = Message;
+//! #     type Flags = ();
+//! #     fn new((): ()) -> (Self, Command<Message>) {
+//! #         (App { query_client: Arc::new(QueryClient::new()) }, Command::none())
+//! #     }
+//! #     fn view(&self, _frame: &mut Frame<'_>) {}
+//! #     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
 //! fn update(&mut self, msg: Message) -> Command<Message> {
 //!     match msg {
 //!         Message::UpdateUser(data) => {
@@ -57,6 +72,7 @@
 //!         }
 //!     }
 //! }
+//! # }
 //! ```
 
 use std::marker::PhantomData;
@@ -126,7 +142,12 @@ impl<T> MutationResult<T> {
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
+/// # use tears::subscription::http::{Mutation, QueryError};
+/// # struct User;
+/// # struct UserData;
+/// # async fn update_user_api(_input: UserData) -> Result<User, QueryError> { Ok(User) }
+/// # let user_data = UserData;
 /// let cmd = Mutation::mutate(
 ///     user_data,
 ///     |input| Box::pin(async move { update_user_api(input).await }),
@@ -153,7 +174,10 @@ where
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
+    /// # struct User;
+    /// # struct UserData;
+    /// # async fn update_user_api(_input: UserData) -> Result<User, QueryError> { Ok(User) }
     /// use tears::prelude::*;
     /// use tears::subscription::http::{Mutation, QueryError};
     ///

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -21,7 +21,13 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust
+//! # use ratatui::Frame;
+//! # use tears::subscription::http::QueryError;
+//! # #[derive(Clone)]
+//! # struct User;
+//! # async fn fetch_user() -> Result<User, QueryError> { Ok(User) }
+//! # enum Message { UserQuery(QueryResult<User>), RefreshUser }
 //! use tears::prelude::*;
 //! use tears::subscription::http::{Query, QueryClient, QueryResult};
 //! use std::sync::Arc;
@@ -32,6 +38,16 @@
 //! }
 //!
 //! impl Application for App {
+//! #     type Message = Message;
+//! #     type Flags = ();
+//! #     fn new((): ()) -> (Self, Command<Message>) {
+//! #         let app = App {
+//! #             query_client: Arc::new(QueryClient::new()),
+//! #             user_result: None,
+//! #         };
+//! #         (app, Command::none())
+//! #     }
+//! #     fn view(&self, _frame: &mut Frame<'_>) {}
 //!     fn subscriptions(&self) -> Vec<Subscription<Message>> {
 //!         vec![
 //!             Subscription::new(Query::new(
@@ -185,7 +201,21 @@ impl QueryClient {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use ratatui::Frame;
+    /// # use tears::prelude::*;
+    /// # use tears::subscription::http::QueryClient;
+    /// # enum Message { UserUpdated }
+    /// # struct App { query_client: Arc<QueryClient> }
+    /// # impl Application for App {
+    /// #     type Message = Message;
+    /// #     type Flags = ();
+    /// #     fn new((): ()) -> (Self, Command<Message>) {
+    /// #         (App { query_client: Arc::new(QueryClient::new()) }, Command::none())
+    /// #     }
+    /// #     fn view(&self, _frame: &mut Frame<'_>) {}
+    /// #     fn subscriptions(&self) -> Vec<Subscription<Message>> { vec![] }
     /// fn update(&mut self, msg: Message) -> Command<Message> {
     ///     match msg {
     ///         Message::UserUpdated => {
@@ -194,6 +224,7 @@ impl QueryClient {
     ///         }
     ///     }
     /// }
+    /// # }
     /// ```
     pub fn invalidate<K>(&self, key: K)
     where
@@ -358,7 +389,12 @@ type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Se
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
+/// # use tears::subscription::http::{QueryError, QueryResult};
+/// # #[derive(Clone)]
+/// # struct User;
+/// # async fn fetch_user() -> Result<User, QueryError> { Ok(User) }
+/// # enum Message { UserQuery(QueryResult<User>) }
 /// use tears::Subscription;
 /// use tears::subscription::http::{Query, QueryClient};
 /// use std::sync::Arc;
@@ -397,7 +433,13 @@ where
     ///
     /// # Example
     ///
-    /// ```rust,ignore
+    /// ```rust
+    /// # use std::sync::Arc;
+    /// # use tears::subscription::http::{Query, QueryClient, QueryError};
+    /// # #[derive(Clone)]
+    /// # struct User;
+    /// # async fn fetch_user_from_api() -> Result<User, QueryError> { Ok(User) }
+    /// # let query_client = Arc::new(QueryClient::new());
     /// let query = Query::new(
     ///     "user-123",
     ///     || Box::pin(async {


### PR DESCRIPTION
Refs #385. All eight `rust,ignore` blocks in the `subscription::http` tree
become doctests. Three `ignore` blocks remain in `src/`, and they are the half
of #385 that needs a decision rather than setup — see below.

## Why they could be compiled

They sit inside `#[cfg(feature = "http")]`, so nothing forced them to be
`ignore`: a doctest there compiles whenever `http` is on, which is every
configuration this repository builds doctests under — `test-doc` and
`test-doc-packaged` both pass `user_features`.

Nothing forced it and nothing checked it, which is how several came to be wrong
at once. #384 and #388 corrected an argument count, a bare async fn where a
boxed closure was required, a mapped effect that did not unify with its
function's return type, and a `reqwest` body whose error type could not satisfy
the bound. Every one was found by reading. They are found by `cargo test --doc`
now.

## What the reader sees

Unchanged, in seven of the eight blocks: all setup is `#`-hidden.

Where a block demonstrates an `Application` method, the hidden wrapper is
`impl Application for App` with the trait's other five items hidden — the form
`application.rs` and `runtime.rs` already use. An inherent `impl App` would also
compile, and would leave the signature the reader is shown unbound to the trait
it is shown as implementing, which is exactly the drift this change exists to
catch.

Every hidden bound is one the compiler asked for rather than one that looked
plausible: `User: Clone` is in the blocks that reach `impl<V> Query<V>`, whose
`where` clause requires it — removing it from either fails the run — and it is
absent from `mutation.rs`'s three, which build without it.

## The one visible change

`http.rs`'s module example builds `Message::UpdateFailed` inside its mutation's
`map` and its `match` has no arm for it — four variants, three arms. It could
not compile without saying what becomes of the failure it constructs, so it
gains the arm its sibling in `mutation.rs` already has. That is a defect in the
example rather than scaffolding, and it is why this block was the last one: the
others needed setup, this one needed an example that handled its own messages.

Swept for the class: no other snippet in `src/`, `docs/`, `README.md`,
`examples/` or `tests/` constructs a message variant its own `match` omits.

## What is left of #385, and why

`subscription.rs`'s two blocks and `command/core.rs`'s sit outside the feature
gate while demonstrating gated API, so dropping `ignore` breaks
`cargo test --doc` under default features. Compiling them means either moving
the example into the gated module or giving the fence one `doc =` per line,
which is the convention decision #385 separates from this work. It is the whole
of what is left of that issue in `src/`.

## Verification

`just test-doc`: 67 passed, 6 ignored — 8 blocks moved from ignored to passed.
`cargo test --doc` with default features and `just test-doc-packaged` both pass,
the latter because `Doc Tests` is a required context now and it is the job that
runs it. Also `cargo fmt --check`, `just pre-commit`, and
`RUSTDOCFLAGS=-D warnings cargo doc --no-deps` under `build_features`, since
rustdoc lints are not in `pre-commit`.

No CHANGELOG entry: nothing about the shipped crate's behaviour or contents
changed.