### PR TITLE
chore: check the docs.rs feature list against the set CI renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,10 +329,17 @@ jobs:
         with:
           toolchain: ${{ needs.versions.outputs.pinned }}
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@just
       - name: Build documentation
-        run: cargo doc --no-deps --features ${{ needs.versions.outputs.features }}
-        env:
-          RUSTDOCFLAGS: -D warnings
+        run: just doc-strict "${{ needs.versions.outputs.features }}"
+      # The set above is a superset of the one `[package.metadata.docs.rs]`
+      # declares, so a rustdoc error that only the narrower set produces
+      # passes the step above: an intra-doc link to an item `bench-internals`
+      # gates resolves there and not here. Invoked via `just` so the local and
+      # CI invocations are identical, and so the narrower list is read from
+      # the manifest rather than restated here.
+      - name: Build documentation under the declared feature list
+        run: just doc-declared
 
   doctest:
     name: Doc Tests

--- a/justfile
+++ b/justfile
@@ -290,6 +290,44 @@ test-doc-packaged:
              | error
         end' <<<"$meta" >/dev/null
 
+    # And the manifest's `[package.metadata.docs.rs]` list, hand-written like
+    # the two above and, until this arm, held against nothing: a rename that
+    # updates the feature table and both lists above leaves this one naming a
+    # feature the crate no longer has, and `docs/releasing.md` prices a failed
+    # documentation build as not fixed by cutting another version.
+    #
+    # Held against `build_features` — which the arm above has just held
+    # against the feature table — rather than against that table itself,
+    # because the subset is what makes `doc-declared` a narrowing of the
+    # `Documentation` job rather than a different build, and `loom-core` is a
+    # feature that removes code. An absent table or an empty list fails here
+    # too; that state is what #351 reported.
+    #
+    # `features` is the only key allowed, `rustdoc-args` included — what the
+    # `doc_auto_cfg` pass #351 leaves open would add that one, and until
+    # `doc-declared` renders under it too the two would disagree in silence.
+    # Same for `all-features`, `no-default-features` and `cargo-args`, which
+    # settle the feature set somewhere neither can read. Adding a key is a
+    # name here and a line there. Which names belong in the list stays a
+    # judgment `Cargo.toml` records and no jq reaches; a `dep/feature` entry
+    # would fail, and there is none.
+    jq -e --arg have '{{build_features}}' '
+      ($have | split(",") | map(select(length > 0))) as $rendered
+      | (.packages[0].metadata.docs.rs // {}) as $table
+      | ($table.features // []) as $docs
+      | ([$table | keys[] | select(. != "features")]) as $unheld
+      | if ($unheld | length) > 0 then
+          ("package.metadata.docs.rs sets \($unheld | join(",")): only features "
+           + "is held here and rendered by doc-declared, so teach both or drop it") | error
+        elif ($docs | length) == 0 then
+          "package.metadata.docs.rs.features is missing or empty" | error
+        else ($docs - $rendered) as $outside
+          | if ($outside | length) == 0 then true
+            else "package.metadata.docs.rs.features is not a subset of build_features: \($outside | join(","))"
+                 | error
+            end
+        end' <<<"$meta" >/dev/null
+
     cargo package --no-verify --allow-dirty
     rm -rf "${out:?}/${pkg}"
     tar xzf "${out}/${pkg}.crate" -C "$out"
@@ -375,6 +413,34 @@ doc:
 # Generate documentation without opening
 doc-build:
     cargo doc --no-deps
+
+# Both of the `Documentation` job's renders go through here, so the flags are
+# written once and the feature set is the only thing that differs between
+# them — which is what makes a failure in either attributable to the set it
+# was given.
+
+# Build the documentation with warnings denied, under the features given
+doc-strict features:
+    RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --features "{{features}}"
+
+# `[package.metadata.docs.rs]`'s list is a subset of `build_features` —
+# `test-doc-packaged` holds it to one — and `build_features` is what that
+# job's other render uses, so what this adds is the render under the subset:
+# an intra-doc link to an item `bench-internals` gates resolves there and
+# fails here.
+#
+# The list is read rather than retyped, which would make a fourth copy of a
+# feature list. The job runs this, so what it catches is caught on the PR
+# that introduces it.
+
+# Build the documentation under the feature list the manifest declares for it
+doc-declared:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    meta=$(cargo metadata --no-deps --format-version 1)
+    features=$(jq -r '.packages[0].metadata.docs.rs.features // [] | join(",")' <<<"$meta")
+    [[ -n $features ]] || { echo "package.metadata.docs.rs.features is missing or empty" >&2; exit 1; }
+    {{just_executable()}} doc-strict "$features"
 
 # Generate code coverage report
 coverage:


### PR DESCRIPTION
Closes #386.

#386 asks whether the docs.rs feature list should be guarded and how much
guarding is worth it. Its suggested shape was a stale-name check and one
hand-written command in `docs/releasing.md` — no recipe, no CI step, no
key-set check. This carries the check and departs from the rest; see
"Departures from #386".

## The check

A third jq arm in `just test-doc-packaged`, beside the two that already hold
`user_features` and `build_features` against `cargo metadata`. It fails when
`[package.metadata.docs.rs].features` names anything outside `build_features`,
when the table is absent or its list empty, and when the table sets any key
but `features`.

The failure it closes is the expensive one: rename `ws`, update the feature
table and both justfile lists, and every existing check passes while the
docs.rs table still says `ws`. `docs/releasing.md` prices a failed
documentation build as not fixed by cutting another version, so the stop
belongs before the tag.

Held against `build_features` rather than the crate's feature table because
the subset is what makes the second render below a *narrowing* of the first
rather than a different build. The feature table alone would admit
`loom-core`, which is a feature and *removes* code, so it would break that and
drop `subscription::signal` from the published documentation at once.

## The second render

The `Documentation` job now renders twice: under `build_features` as before,
then under the list `[package.metadata.docs.rs]` declares, read out of the
manifest rather than retyped. `bench-internals` is the only feature in the
difference between the two sets that gates anything, so a link to an item it
gates is the shape the second render catches — measured below.

Both renders go through one recipe, `doc-strict FEATURES`, so `-D warnings`
and the rest of the invocation are written once and the feature set is the
only thing that differs. Without that they would drift the moment
`rustdoc-args` arrives, and a failure in either would stop being attributable
to its feature set.

Cost: **1s** in CI on this commit's run — the `Documentation` job's two
render steps took 2s and 1s with the cache action warm. Locally, a second
render in a warm target directory is 3.5s against 13.4s for the first from
empty: `cargo doc --no-deps` builds dependencies to rmeta only, and the two
sets differ solely in the TLS backends.

## Departures from #386

- **A recipe.** #386's decline is about fidelity: one named after docs.rs
  cannot be what its name says, so every gap would have to be stated in a
  comment, kept true, and restated wherever it is cited. `doc-declared`
  claims only what it does.

  What it replaces is the hand-written command #386 suggested, which review
  found wrong three rounds running: an inline substitution that swallowed
  `cargo metadata`'s failure, a `jq -e` that exits 0 on empty input, and an
  empty list that renders the default set under a green exit.
- **A CI step.** #386 declines this as a consequence of declining the recipe.
  With the recipe existing, running it where every other check runs costs
  3.5s, and what it catches is caught on the PR that introduces it rather
  than at release time — which is `docs/releasing.md`'s own first principle,
  "whatever can be checked, check in step 1". `docs/releasing.md` is
  therefore unchanged by this PR: with CI holding it, there is no release
  step to add.
- **A key check** — which #386 declines conditionally: rejecting every key
  but `features` "is a defensible design if the recipe exists. If it does
  not, the check is guarding a claim nobody makes". The recipe now exists.
  `rustdoc-args`, what the `doc_auto_cfg` pass #351 leaves open would add, is
  refused with the rest, because `doc-declared` renders from `features` alone
  and a key it does not pass would leave the check and the render disagreeing
  in silence.

## Verification

Each of these was run, not reasoned:

| Claim | How |
| --- | --- |
| Nothing else catches a stale name | probe crate whose docs.rs table names an undeclared feature: `cargo package --list` exits 0 |
| The arm fires, through the recipe | `features = [… "loom-core"]` and `all-features = true` each added to `Cargo.toml` → `just test-doc-packaged` fails before packaging, with the arm's own message |
| Every documented state behaves as the comment says | stale name, `loom-core`, absent table, empty list, `dep/feature`, `rustdoc-args`, `all-features`, `cargo-args`, `no-default-features`, `default-target`, a scalar `features`, clean — run against mutated `cargo metadata` output |
| The second render catches what the first cannot | a temporary `[`LoadObserver`]` link (gated on `bench-internals`) on a public item: `just doc-declared` → `error: unresolved link`; `just doc-strict "$(just --evaluate build_features)"` → clean |
| `doc-declared` fails closed | table removed and `features = []` both → `package.metadata.docs.rs.features is missing or empty`, exit 1, nothing rendered; `meta=$(false)` under `set -euo pipefail` → aborts before the next line |
| `bench-internals` is the only feature in the difference that gates anything | `grep -rho 'feature = "[a-z-]*"' src/ \| sort \| uniq -c` → `bench-internals` 5, `http` 15, `loom-core` 4, `ws` 3 |
| The workflow is valid and the job name unchanged | `actionlint .github/workflows/ci.yml`; `Documentation` still the required context |
| Both recipes pass on this tree | `just doc-strict`, `just doc-declared`, `just test-doc-packaged` |

## Notes

- No changelog entry: nothing the crate ships changes.
- #386 calls the docs.rs table "the third hand-written feature list in the
  manifest". Two of the three are in the `justfile`, not the manifest;
  nothing else in its argument depends on that.
- #386's account of an intra-doc link caught during #384's review is not
  evidence for the feature-set gap — that link (`[`Command`]` in
  `websocket.rs`) fails under `build_features` too, since `ws` is in it. The
  gap is real; the `LoadObserver` instance above is what shows it.
- Bounding the subset by `user_features` instead of `build_features` would be
  tighter — it would also reject `bench-internals` in the docs.rs list.
  Considered and left: `build_features` is what the first render uses, so it
  is the bound that makes the second one a narrowing of it, which is the
  claim the arm's comment reasons from.
- The arm closes the *rename* direction. A new feature that gates a
  documented item is still forced only into `user_features` and
  `build_features`, not into the docs.rs list — that stays the manual
  "Feature-gated API" bullet in `docs/releasing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

