### PR TITLE
docs: record the contribution conventions the repository follows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- What changes, and why. -->
+
+- [ ] `CHANGELOG.md` has an entry under `## [Unreleased]`, or this change needs
+      none — CONTRIBUTING.md says which changes do
+- [ ] This breaks nothing a dependant relies on today, or — where it does,
+      whether by a compile error, by changed behaviour, or by raising
+      `rust-version` — the commit subject carries `!` before the `:` and the
+      changelog entry opens `**Breaking:**`
+
+Pre-1.0, a break here makes the next release a minor.
+
+See [CONTRIBUTING.md](https://github.com/akiomik/tears/blob/main/CONTRIBUTING.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing
+
+Issues and pull requests are welcome.
+
+Most of what a change here has to satisfy is written down already:
+
+- [RFCs](docs/rfcs/README.md) — design contracts, invariants and decision
+  records. A new RFC or an amendment runs the
+  [pre-review checklist](docs/rfcs/pre-review-checklist.md) before review.
+- [API Design Guidelines](docs/api-guidelines.md)
+- [Testing Guidelines](docs/testing.md)
+- [Releasing](docs/releasing.md)
+
+## Language
+
+Everything published is written in English, and that is wider than the tree:
+commit messages, pull request and issue titles and bodies, and the comments on
+them. Where something will be read decides it, not what kind of thing it is — a
+review reply is as public as a page of documentation.
+
+Leave out what a reader outside the repository cannot resolve. Issue and pull
+request numbers, released version numbers and commit SHAs all travel; paths
+`.gitignore` covers, local working-note filenames and work-in-progress labels do
+not, and naming one leaves a reference nobody but its author can follow.
+
+## Commit messages and pull request titles
+
+Commit messages follow [Conventional Commits][cc]: `type(scope): summary`, with
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`,
+`chore` and `bench` as the types. The scope names the area — usually a module
+path (`fix(runtime)`), otherwise the part of the repository the change is in
+(`docs(rfcs)`, `chore(deps)`); it is omitted where the change has no single one,
+and holds a comma-separated pair where it genuinely has two
+(`feat(command,subscription)`). A breaking change takes `!` before the `:`.
+
+Pull request titles take the same shape.
+
+This governs new commits; the log holds a few subjects with types not on this
+list, from before it was written. Nothing verifies it either — there is no
+commit linter here, and no CI job reads a commit message.
+
+## The changelog
+
+`CHANGELOG.md` follows [Keep a Changelog][kac]. Write the entry under
+`## [Unreleased]` in the same pull request as the change. A release moves that
+section under a version heading and edits the file in several other ways;
+[docs/releasing.md](docs/releasing.md) has them.
+
+An entry goes in when the change reaches someone who depends on the published
+crate: its public API, its runtime behaviour, its MSRV, the dependency
+requirements resolved alongside it, or a defect in the set of files it ships.
+This repository's own work is not — documentation, examples, tests, benches, CI
+and the crates.io listing — and neither is a lockfile-only bump, which moves no
+requirement a dependant resolves against. Adding an example stays in that
+second list even though `include` ships it: what earns an entry is the shipped
+set being *wrong*, not its growing as intended.
+
+Mark a breaking entry with a `**Breaking:**` prefix under its category heading
+and put the before/after beside it. Pre-1.0 that also decides the version:
+[docs/releasing.md](docs/releasing.md#choosing-the-version) has the rule, and
+[docs/migrations/README.md](docs/migrations/README.md) says when a release owes
+a migration guide as well.
+
+All of this decides the next entry, not the ones above it. Released sections
+record where the line fell when they were written — including the
+`**BREAKING**:` marker used up to 0.9.0 — and they stay as they are.
+
+## Documentation
+
+An edit is not finished until the changed file's own documentation has been read
+again — the module doc, every doc comment under it, the comments in the body —
+and any disagreement with the code fixed on one side or the other, explicitly.
+
+## Before you push
+
+[just](https://github.com/casey/just) runs the local gate:
+
+```console
+$ just pre-commit
+```
+
+That is `fmt-check`, both clippy passes, the tests, the loom mirrors' rows and
+the doctests. `just check` is the same list with `fmt` in place of `fmt-check`,
+so it formats rather than reporting.
+
+Neither recipe is the whole of CI, and two of the things they leave out are
+worth running by hand:
+
+- `Documentation` builds the docs with warnings denied. Nothing `check` or
+  `pre-commit` reaches builds them at all, so a broken intra-doc link passes the
+  local gate and blocks the merge. It renders twice, under the feature set the
+  other jobs use and under the list `[package.metadata.docs.rs]` declares:
+
+  ```console
+  $ just doc-strict "$(just --evaluate build_features)"
+  $ just doc-declared
+  ```
+
+- `Doc Tests` runs `just test-doc`, which `pre-commit` has, and then
+  `just test-doc-packaged`, which it does not. That one packages the crate,
+  extracts it and runs the doctests against what a consumer gets, which is where
+  a missing `include` entry shows up and nowhere else:
+
+  ```console
+  $ just test-doc-packaged
+  ```
+
+Run them after touching rustdoc, renaming a public item, or moving `include` or
+a feature list — and when in doubt, since neither failure shows up locally any
+other way. Both read the manifest with `jq`, which `just pre-commit` does not
+need.
+
+[cc]: https://www.conventionalcommits.org/en/v1.0.0/
+[kac]: https://keepachangelog.com/en/1.0.0/

--- a/README.md
+++ b/README.md
@@ -421,17 +421,9 @@ Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for detai
 
 Contributions are welcome! Please feel free to submit issues or pull requests.
 
-Design contracts and invariants live in [docs/rfcs](docs/rfcs/README.md).
-If you are writing or amending an RFC, run the
-[pre-review checklist](docs/rfcs/pre-review-checklist.md) before
-requesting review. Testing conventions are documented in
-[docs/testing.md](docs/testing.md), and the release procedure in
-[docs/releasing.md](docs/releasing.md).
-
-An edit is not finished until the changed file's own documentation has been
-read again — the module doc, every doc comment under it, the comments in the
-body — and any disagreement with the code fixed on one side or the other,
-explicitly.
+[CONTRIBUTING.md](CONTRIBUTING.md) has the conventions a change here follows
+and points at the documents that hold the rest — the RFC process, the API
+guidelines, the testing conventions and the release procedure.
 
 ---
 


### PR DESCRIPTION
Closes #391.

Adds `CONTRIBUTING.md` and `.github/pull_request_template.md`, and turns
README's `Contributing` section into a pointer.

## Context for reviewers

Four settled decisions, so they are not re-derived from the diff:

- **The rules are not retroactive, by design.** `CONTRIBUTING.md` says so in
  both places it matters. `CHANGELOG.md`'s released sections were written to
  earlier bars, and the commit log holds a few subjects with types the list
  does not carry; neither is a counterexample to the rule, because the rule
  governs the next entry and the next commit. The alternative — rewriting 24
  released sections — would delete shipped release notes that no longer
  qualify, and is a change to the project's record that belongs in its own
  pull request.
- **No commit linter, deliberately.** 611 of 611 non-merge commits since
  `v0.10.0` are `type(scope): summary` without one. `main`'s required-context
  list is load-bearing enough that adding to it needs a better reason than a
  convention that is already universal, and a lint that rejects a push after
  the work is done is a poor place to first learn a rule.
- **The template is kept even though most pull requests here bypass it.** It
  renders only where GitHub supplies the body, so a `gh pr create --body-file`
  opens past it — 23 of the last 25 merged pull requests carry authored prose
  and no checkboxes. That is a pull-request-authoring problem rather than a
  template problem: whoever opens one is expected to read the template the same
  way they are expected to read `CONTRIBUTING.md`. The template stays because
  it costs eleven lines and makes the question visible wherever it does render.
- **Nothing already written is restated.** `docs/rfcs/README.md`,
  `docs/api-guidelines.md`, `docs/testing.md`, `docs/releasing.md` and
  `docs/migrations/README.md` are linked by their own titles. Earlier drafts
  characterised them in passing and every characterisation came back as a
  finding for being narrower than its source, so the descriptions are gone.

## What it records

Four conventions, each stated in no document and checked by nothing:

- **Language.** English for everything that reaches GitHub, not only for the
  tree, and no references a reader outside the repository cannot resolve.
- **Commit messages and pull request titles.** Conventional Commits, with the
  types and the scope conventions in use.
- **The changelog.** An entry when the change reaches someone who depends on
  the published crate, written in the same pull request as the change.
- **The local gate.** `just pre-commit`, and the two required checks it does
  not reach — `Documentation`, and the `test-doc-packaged` half of `Doc Tests`.

## The issue's premises, re-measured

The issue was filed before `v0.11.1`, so two of its figures have moved:

- Non-merge commits since `v0.10.0` are now **611 of 611** in `type(scope):
  summary` form (the issue counted 608). No commitlint, husky or lefthook
  configuration exists, and no CI job reads a commit message.
- The changelog gap is sharper rather than gone. `v0.11.1` shipped the
  `TestDriver` fix the issue named, and `git log v0.11.0..HEAD -- CHANGELOG.md`
  returns exactly one commit: the release bump. The entry was written by the
  release, not by #344.

The local-gate claim holds as written. `check` and `pre-commit` are both
`fmt(-check) clippy test clippy-loom test-mirrors test-doc`; `Documentation`
and the `test-doc-packaged` half of `Doc Tests` are required contexts that
neither recipe runs.

## The issue's open questions

- **Where it lives** — the root, which is where the four sibling repositories
  put theirs.
- **Whether the commit convention gets a check** — no; see above.
- **What else is unwritten** — the language rule is the one addition beyond the
  issue's three. It reaches review replies and issue comments rather than only
  the tree.

## Separately

Squash and rebase merging are now disabled on the repository, leaving the merge
commit as the only method. All 322 merged pull requests to date used one
already, and the setting was the last place that was not written down; it is a
repository setting rather than a line in this file, so nothing here mentions it.

## Checks

Documentation only; no changelog entry, by the rule this pull request writes
down. `typos` is clean, every link target and `just` recipe named resolves, and
`CONTRIBUTING.md` is outside `Cargo.toml`'s anchored `include`, so it does not
ship.
