### PR TITLE
docs: keep gated examples where a doctest can read them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,21 @@ An edit is not finished until the changed file's own documentation has been read
 again — the module doc, every doc comment under it, the comments in the body —
 and any disagreement with the code fixed on one side or the other, explicitly.
 
+An example that demonstrates feature-gated API belongs in the module the feature
+gates. A doctest there is compiled by `just test-doc`, whose feature set turns
+the gate on; the same block in a file outside the gate fails `cargo test --doc`
+whenever the feature is off, so it ends up `ignore`, and an `ignore` block is
+one no compiler ever reads. Documentation outside the gate refers to such an
+example rather than restating it — a code span, or the intra-doc link and
+`cfg_attr(not(feature = "…"), doc = "…")` pair `src/subscription.rs` uses for
+its built-in list, which keeps the sentence when the feature is off.
+
+That leaves `ignore` for a block this crate was never going to compile. A
+migration guide's *Before:* snippet names API a release removed, and a
+sketch in a file no `include_str!` pulls into rustdoc — `README.md` is one —
+never reaches a doctest run at all. Neither licenses `ignore` on a block this
+crate can compile.
+
 ## Before you push
 
 [just](https://github.com/casey/just) runs the local gate:

--- a/justfile
+++ b/justfile
@@ -12,18 +12,21 @@
 # What `--all-features` removed is the module from *test-target* builds, and
 # with it the three unit tests below. Measured, on rustc 1.97.0:
 #
-#     cargo test --lib                       540 total,  3 `signal::`
-#     cargo test --lib --all-features        590 total,  0 `signal::`
+#     cargo test --lib                       570 total,  3 `signal::`
+#     cargo test --lib --all-features        620 total,  0 `signal::`
 #     cargo test --lib --features {{build_features}}
-#                                            585 total,  3 `signal::`
+#                                            615 total,  3 `signal::`
 #
-#     cargo test --doc                        61 tests
-#     cargo test --doc --features loom-core   60 tests  (both `Signal` ones gone)
-#     cargo test --doc --all-features         71 tests  (both `Signal` ones gone)
+#     cargo test --doc                        60 tests
+#     cargo test --doc --features loom-core   58 tests  (both `Signal` ones gone)
+#     cargo test --doc --all-features         70 tests  (both `Signal` ones gone)
 #     cargo test --doc --features {{user_features}}
-#                                             73 tests  (superset of all above)
+#                                             72 tests  (superset of all above)
 #
-# The 590 and the 585 differ by the three `signal::` rows gained and eight
+# Doctest rows are `-- --list` counts. What a run prints is split across
+# batches and moves when a doctest fails, so it is not the number above.
+#
+# The 620 and the 615 differ by the three `signal::` rows gained and eight
 # lost: the four `cell_core` and four `accounting_core` rows, which
 # `test-loom` runs under `--cfg loom` — model-checked there rather than merely
 # executed once. So no *test* stops being run, and the three that were being

--- a/src/command/core.rs
+++ b/src/command/core.rs
@@ -665,8 +665,10 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///
     /// This allows you to adapt a command that produces messages of one type
     /// to produce messages of another type. This is particularly useful when
-    /// composing commands from different parts of your application or when
-    /// working with generic operations like HTTP mutations.
+    /// composing commands from different parts of your application.
+    ///
+    /// [`EffectCommand::map`] does this to an effect that has not been
+    /// converted into a `Command` yet.
     ///
     /// # Arguments
     ///
@@ -690,31 +692,6 @@ impl<Msg: Send + 'static> Command<Msg> {
     ///
     /// // Map it to your application's message type
     /// let cmd = cmd.map(Message::DataLoaded);
-    /// ```
-    ///
-    /// # Advanced Example with Mutation
-    ///
-    /// ```rust,ignore
-    /// use tears::prelude::*;
-    /// use tears::subscription::http::{Mutation, QueryError};
-    ///
-    /// enum Message {
-    ///     UserUpdated(User),
-    ///     UpdateFailed(String),
-    /// }
-    ///
-    /// // Carry the mutation's effect into a command
-    /// let cmd: Command<Result<User, QueryError>> = Mutation::mutate(
-    ///     user_data,
-    ///     |input| Box::pin(async move { update_user_api(input).await }),
-    /// )
-    /// .into();
-    ///
-    /// // Map it to your application's message type
-    /// let cmd = cmd.map(|result| match result {
-    ///     Ok(user) => Message::UserUpdated(user),
-    ///     Err(e) => Message::UpdateFailed(e.to_string()),
-    /// });
     /// ```
     pub fn map<T>(self, f: impl Fn(Msg) -> T + Send + 'static) -> Command<T>
     where

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -144,7 +144,13 @@
 //! See the [`mock`] module documentation for complete testing examples.
 
 pub(crate) mod core;
-#[cfg(any(feature = "http", feature = "loom-core"))]
+// This gate carries `test` the way `http.rs` puts it on the submodule
+// `loom-core` reaches in for: compile the module where something inside it is.
+// What that does to a doctest run is measured, not derived — `signal` below
+// reads the same sub-expression the other way (#298); the `loom-core` arm
+// still gives the module none of the `http` its own example needs (#401); and
+// no recipe runs that doctest configuration (#400).
+#[cfg(any(feature = "http", all(feature = "loom-core", test)))]
 pub mod http;
 pub mod mock;
 #[cfg(not(all(feature = "loom-core", test)))]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -26,35 +26,32 @@
 //!
 //! ## Stream-based (WebSocket)
 //!
-//! ```rust,ignore
-//! use tears::subscription::websocket::{WebSocket, WebSocketMessage, WebSocketCommand};
-//! use tokio::sync::mpsc;
+//! The subscription holds one connection open and hands over a sender when it
+//! connects, so a send is a control operation on that connection rather than a
+//! command to start.
 //!
-//! struct App {
-//!     ws_sender: Option<mpsc::UnboundedSender<WebSocketCommand>>,
-//! }
-//!
-//! // Store sender on connection, use it to send messages immediately
-//! ```
+#![cfg_attr(
+    feature = "ws",
+    doc = "See [`websocket::WebSocket`] for the worked example (requires `ws` feature)."
+)]
+#![cfg_attr(
+    not(feature = "ws"),
+    doc = "See `websocket::WebSocket` for the worked example (requires `ws` feature)."
+)]
 //!
 //! ## Transaction-based (HTTP)
 //!
-//! ```rust,ignore
-//! use tears::Subscription;
-//! use tears::subscription::http::Query;
+//! A query is declared like any other subscription, over the client the model
+//! holds; that client is what retains results between passes.
 //!
-//! // In subscriptions(), over the Arc<QueryClient> the model holds: a fresh
-//! // one each pass gives the query a new identity, and it refetches instead
-//! // of serving what it retained.
-//! vec![
-//!     Subscription::new(Query::new(
-//!         "user-123",
-//!         || Box::pin(fetch_user()),
-//!         self.query_client.clone(),
-//!     ))
-//!     .map(Message::UserQuery),
-//! ]
-//! ```
+#![cfg_attr(
+    feature = "http",
+    doc = "See the [`http`] module for the worked example (requires `http` feature)."
+)]
+#![cfg_attr(
+    not(feature = "http"),
+    doc = "See the `http` module for the worked example (requires `http` feature)."
+)]
 //!
 //! # Built-in Subscriptions
 //!

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -387,6 +387,16 @@ type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Se
 /// never takes effect. **To change the request, change the key** (for example
 /// by including the varying parameter in it).
 ///
+/// # Where the client lives
+///
+/// Hold the [`QueryClient`] in the model and clone the `Arc` into each query.
+/// The client's id is part of the subscription's identity, alongside the query
+/// key above, so a client constructed inside
+/// [`Application::subscriptions`](crate::Application::subscriptions) gives the
+/// query a new identity every pass — and a client just constructed retains
+/// nothing, so each pass fetches again instead of serving what the one before
+/// it retained.
+///
 /// # Example
 ///
 /// ```rust

--- a/tests/api_surface.rs
+++ b/tests/api_surface.rs
@@ -14,8 +14,8 @@ use public_api::tokens::Token;
 /// them rather than restated here.
 ///
 /// Not `--all-features`: that turns on `loom-core`, which *removes* code
-/// rather than adding it. The gate that would bite carries a `test`
-/// (`src/subscription.rs`), and rustdoc JSON builds the library without
+/// rather than adding it. The gate that would bite carries a `test` (`signal`,
+/// in `src/subscription.rs`), and rustdoc JSON builds the library without
 /// `cfg(test)`, so nothing is lost from the surface today — but that is a
 /// property of one gate's shape, not of the approach. A plain
 /// `#[cfg(not(feature = "loom-core"))]` compiles its item away whenever


### PR DESCRIPTION
Closes #385.

Three commits: the documentation change, a defect found while verifying it, and
the numbers both of them move.

### `docs: keep gated examples where a doctest can read them`

The three `rust,ignore` blocks #393 left in `src/` all demonstrated
feature-gated API from a file outside the gate, so `ignore` was forced there.
Measured: dropping it from all three fails `cargo test --doc
--no-default-features` on all three, and the first error in each is
`unresolved import`, before the undefined stubs the blocks also carry.

Each already had a compiled twin in the module that gates it, so the copies go
and the documentation outside the gate refers to the original — prose plus the
intra-doc-link and code-span `cfg_attr` pair `src/subscription.rs` already uses
for its built-in list, so the sentence survives with the feature off. The two
pointers name the page that carries the example rather than matching each other:
`websocket::WebSocket` for the connection, the `http` module for the query,
since that is where one is declared inside `subscriptions()` over a model-held
client.

`Command::map`'s block goes without a replacement of its own. Its surviving
prose named HTTP mutations, and the compiled example for that maps before
converting — so it exercises `EffectCommand::map`, not this method. The prose
names that instead, which needs no feature gate.

One sentence was not a copy and moves rather than going: that the model holds
the `QueryClient`, because a fresh one each pass gives the query a new identity.
It is a section on `Query` now, beside the `# Query keys` and `# Changing the
request` sections it belongs with.

`CONTRIBUTING.md` records the convention, and what `ignore` is still for: a
block this crate was never going to compile, which covers the migration guide's
`Before:` snippets and the `README.md` sketch no `include_str!` pulls into
rustdoc.

No guard ships with it, and the two candidates are why: a doctest run with the
feature off catches a block that omitted `ignore` but not one that has it, and a
grep for `ignore` catches the reverse while faulting the two cases above. Which
gate would own either is #395's question.

### `fix(subscription): gate the http module on what compiles inside it`

Found while re-measuring for the third commit: `cargo test --doc --features
loom-core` fails on `main`. `pub mod http;` was gated `any(http, loom-core)`
while everything inside it is narrower — `#[cfg(feature = "http")]`, or
`all(loom-core, test)` for the one submodule `loom-core` reaches in for — so
that configuration reaches the module's documentation with none of the
re-exports its example needs. `http.rs` already states the rule on the
submodule; the module declaration never got it.

Nothing catches it: every doctest this repository runs is run under one feature
set, which has `http` on, and the loom recipes run `--lib`. That gap is #400.

Why the `test` term lands the way it does is not derived, because it does not
follow: `signal`'s gate is built on the same sub-expression and reads the other
way in the same rustdoc run. Probed with three modules and removed again —

| cfg on the module | none | `http` | `loom-core` | `loom-core,http` |
| --- | --- | --- | --- | --- |
| `not(test)` | in | in | in | in |
| `not(all(feature = "loom-core", test))` | in | in | **out** | **out** |
| `any(feature = "http", all(…, test))` | out | in | **out** | in |

— which is #298's unestablished effect, recorded there. This commit relies on
the row it measured.

It does not settle that the `loom-core` arm still gives the module none of the
`http` its own example needs. Nothing compiles that example there, so the gap is
latent rather than a failure, and closing it costs either seventy string
literals over the crate's principal HTTP example or moving the mirror that made
the gate wide — whose own documentation links `super::cell::Cell` and
`super::query`, and which `ci.yml` names twice. That is #401. The gate names it,
and #400 beside it, since no recipe runs the configuration this commit fixes in
either direction.

`--lib` is where `cfg(test)` is unambiguous and nothing there moves:
`test-mirrors`, `test-loom` and `clippy-loom` pass, `cargo clippy --all-targets
--features loom-core` is clean, and `cargo test --lib --all-features` counts 620.

### `chore: re-measure the counts the justfile records, and say how`

The four doctest totals move with both commits above, and could not be
re-measured unambiguously: a passing run prints its merged batch and the
migration guide's two `compile_fail` rows as separate totals, while a run with a
failing doctest prints one total covering everything. That is why `main`'s
`loom-core` row read 60 beside a run printing 62 — the row was not stale, the
run had started failing. The rows are `-- --list` counts now, and the header
says so: 61→60, 60→58, 71→70, 73→72.

The three `--lib` rows are corrected with them, 540 / 590 / 585 to 570 / 620 /
615. This branch does not move those; they had drifted by exactly the net
`#[test]` attributes `src/` gained since the commit that wrote them. Correcting
rather than marking them is the cheaper honesty — a note saying which half of
the block is stale would have to carry the true figures anyway. That nothing
re-measures any of it is #399.

### Review

Six rounds, no correctness defect in the change at any of them. Through five,
every finding was prose of mine claiming more than it had checked or colliding
with vocabulary defined nearby, so rather than take the last three one at a
time the same sweep was run over every sentence this branch adds. It found two
more: `CONTRIBUTING.md` said "every configuration this repository builds
doctests under" where there is one, and `Command::map` called
`EffectCommand::map` "the same transform" where the two carry different state.
The round after the sweep returned nothing of that class. The two since have
been about where a disposition is recorded rather than about the change: #401
and #400 are named at the gate they concern, and the `--lib` rows this branch
had left stale beside numbers it had just refreshed are corrected instead.

### Verified

| command | result |
| --- | --- |
| `just pre-commit` | pass |
| `just test-mirrors`, `just test-loom`, `just clippy-loom` | pass |
| `just test-doc-packaged` | pass |
| `just doc-strict "$(just --evaluate build_features)"`, `just doc-declared` | pass |
| `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`, and with `--features loom-core` | pass |
| `cargo test --doc --no-default-features` | pass, and `src/` contributes no ignored doctest |
| `cargo test --doc --features loom-core` | pass — fails on `main` |
| `cargo test --doc … -- --list` ×4 | 60 / 58 / 70 / 72, the four rows recorded |

Both renders were read rather than only exited: under `http,ws` the pointers
resolve to `websocket/struct.WebSocket.html`, `http/index.html` and
`struct.EffectCommand.html#method.map`; under default features the two gated
ones degrade to code spans.

- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`, or this change needs
      none — CONTRIBUTING.md says which changes do
- [x] This breaks nothing a dependant relies on today, or — where it does,
      whether by a compile error, by changed behaviour, or by raising
      `rust-version` — the commit subject carries `!` before the `:` and the
      changelog entry opens `**Breaking:**`

Pre-1.0, a break here makes the next release a minor.

See [CONTRIBUTING.md](https://github.com/akiomik/tears/blob/main/CONTRIBUTING.md).
