### PR TITLE
docs(rfcs,subscription): defer RFC 0001's identity to RFC 0005

### DIFF
--- a/docs/rfcs/0001-http-module-redesign.md
+++ b/docs/rfcs/0001-http-module-redesign.md
@@ -196,8 +196,8 @@ Per (TypeId, key) there is a **state cell** owned by the `QueryClient`, holding:
 
 ### 5.4 Single-flight (cell contract)
 
-Single-flight does **not** depend on the runtime deduplicating to "one stream
-per identity." It is a **cell contract**, so it holds even when `Query::stream()`
+Single-flight does **not** depend on the runtime deduplicating subscriptions by
+identity. It is a **cell contract**, so it holds even when `Query::stream()`
 is constructed multiple times directly, across multiple `SubscriptionManager`s,
 or via a future alternate runtime.
 
@@ -212,12 +212,16 @@ two concurrent reconciles cannot both acquire the in-flight slot:
   at this generation) neither fetches nor waits; it observes the current
   (stale + Error) snapshot and waits for `invalidate`/generation progress (§5.6).
 
-Any two streams for the same identity share the same cell (via the cell map), so
-single-flight holds across them without runtime deduplication.
+Any two streams reaching the same cell — one `QueryClient`'s cell map resolves
+them by §5.8's cell map key, whatever their subscription ids — share its
+in-flight slot, so single-flight holds across them without runtime
+deduplication.
 
 **Fetcher arbitration** = "the fetcher of the first stream to acquire the
-in-flight slot." For the same identity the request is equivalent by the §5.8
-contract, so any stream's fetcher yields the same result.
+in-flight slot." A stream can therefore observe data its own fetcher never
+produced, so all fetchers reaching one cell must issue an equivalent request.
+That is the caller's obligation, not something the cell can check: two requests
+that differ take two keys.
 
 **On completion the in-flight slot is always released** (success, error, or
 discard) under the mutex (liveness; INV-8). Completion branches into one of:
@@ -327,14 +331,17 @@ needs_fetch := (no_data || generation_stale || (time_stale && reason == InitialO
   `QueryKeyPart::{Str, I64, U64, Bool}` (`#[non_exhaustive]`). `From<&str>`,
   `From<String>`, and small tuple/array conversions are provided. Structured
   keys compare structurally and do not collide.
-- **Subscription identity = (`client_id`, `TypeId::of::<V>()`, `QueryKey`).**
-  Identity must always include `TypeId` so that `Query<i32>("data")` and
-  `Query<String>("data")` are distinct (prevents the 0.8.2 type collision).
-- **Cell map key = (`TypeId`, `QueryKey`).** Client separation is achieved by the
-  `QueryClient` *owning* its cell map (per-client), so `client_id` is not part of
-  the cell map key (that would be redundant double-bookkeeping). Subscription
-  identity still includes `client_id` because the runtime shares one subscription
-  space and must distinguish the same (TypeId, QueryKey) across clients.
+- **Subscription identity is RFC 0005 INV-1's**, which owns what an id compares.
+  What a query contributes to it is its source type, `Query<V>`, and its logical
+  key, `(client_id, QueryKey)`. The value type enters through the source type, so
+  identity always includes a `TypeId` that separates `Query<i32>("data")` from
+  `Query<String>("data")` (prevents the 0.8.2 type collision).
+- **Cell map key = (`TypeId::of::<V>()`, `QueryKey`).** Client separation is
+  achieved by the `QueryClient` *owning* its cell map (per-client), so
+  `client_id` is not part of the cell map key (that would be redundant
+  double-bookkeeping). The query's logical key does carry `client_id`, because
+  the runtime shares one subscription space and must distinguish the same value
+  type and `QueryKey` across clients.
 
 ### 5.9 Type erasure
 
@@ -368,7 +375,7 @@ trait AnyCell: Any + Send + Sync + 'static {
 ### 5.10 GC and cell lifecycle
 
 The cell is the single retention store; there is no separate cache. GC targets
-the cell's *data* (and related metadata), not the cell identity while it is
+the cell's *data* (and related metadata), not its cell map entry while it is
 active.
 
 - **Active cells keep their data regardless of `cache_time`.** `cache_time` is
@@ -388,8 +395,8 @@ active.
 - **Cell creation and the first subscribe are atomic.** `get_or_subscribe_cell`
   performs "insert + first subscribe" under the map shard lock (`entry`), so a
   concurrent GC sweep cannot evict a freshly created cell before its first
-  subscriber registers (which would otherwise split one identity across two cells
-  and break single-flight).
+  subscriber registers (which would otherwise split one cell map key across two
+  cells and break single-flight).
 - **GC runs automatically after each fetch** (`gc_expired` is called on fetch
   completion) and can also be triggered manually via `QueryClient::gc()`. Because
   a fetch always drives a sweep, INV-7 ("inactive data is not retained forever")
@@ -413,10 +420,11 @@ cannot break the contract.
 - **INV-1.** A query subscribed before the `invalidate()` call time `T` (§5.5,
   synchronous bump) does not lose the invalidation issued at `T`.
 - **INV-2.** Single-flight is guaranteed by the cell's `in_flight_generation`
-  contract (§5.4): at most one in-flight fetch per identity. It does not depend on
-  runtime deduplication and holds even with multiple direct `Query::stream()`s.
-  Multiple `invalidate`s during a fetch coalesce into one refetch. Identity is
-  `(client_id, TypeId, QueryKey)`.
+  contract (§5.4): at most one in-flight fetch per cell. The in-flight slot is the
+  cell's, so the unit is §5.8's cell map key within the owning `QueryClient`, not
+  the subscription id. It does not depend on runtime deduplication and holds even
+  with multiple direct `Query::stream()`s. Multiple `invalidate`s during a fetch
+  coalesce into one refetch.
 - **INV-3.** A fetch result is applied only when its target generation equals
   `current_generation` (results from an outdated in-flight fetch are discarded).
 - **INV-4a.** With **data present**, subscribing after `invalidate` (or after
@@ -425,9 +433,13 @@ cannot break the contract.
 - **INV-4b.** With **no data**, subscribing after `invalidate` is observed as
   `is_stale = false` Pending/Fetching and fetches respecting the generation (not
   stale data).
-- **INV-5.** Different `client_id` / `TypeId` / `QueryKey` — differing in any one
-  — hold independent subscriptions and cache slots (includes preventing the 0.8.2
-  type collision).
+- **INV-5.** Queries differing in any one of `client_id`, value type, or
+  `QueryKey` hold independent subscriptions and cache slots. §5.8 has how each
+  axis reaches each unit: cells through a per-client map keyed on
+  `TypeId::of::<V>()` and `QueryKey`, subscriptions through what a query
+  contributes to an id — the source type `Query<V>` and the logical key
+  `(client_id, QueryKey)`. The value type reaching both is what prevents the
+  0.8.2 type collision.
 - **INV-6.** A cell with an active subscriber is not GC'd, and its `data` is not
   dropped by `cache_time` (cell, watch channel, and data are retained; data GC is
   limited to inactive cells).
@@ -494,10 +506,12 @@ Semantic breaks to call out in the migration guide:
   `is_error()` independently (§5.6).
 - **Retention semantics change:** `cache_time` is measured from when the last
   subscriber becomes inactive, not from the fetch timestamp (§5.10).
-- **Replacing a fetcher for the same identity is not supported.** The runtime keys
-  the running subscription by identity (`QueryClient`, key, value type), so a new
-  `Query::new(key, new_fetcher, client)` with an unchanged key keeps the existing
-  subscription and the old fetcher. To change the request, change the key.
+- **Replacing a fetcher for the same identity is not supported.** The runtime
+  keys the running subscription by its identity, which the fetcher is no part of,
+  so a new `Query::new(key, new_fetcher, client)` that changes only the fetcher
+  keeps the existing subscription and the old fetcher. To change the request,
+  change the key — which §5.4 requires of every fetcher reaching one cell, not
+  only of a declaration whose identity is unchanged.
 
 ## 9. Optimistic update
 

--- a/justfile
+++ b/justfile
@@ -13,9 +13,9 @@
 # with it the three unit tests below. Measured, on rustc 1.97.0:
 #
 #     cargo test --lib                       570 total,  3 `signal::`
-#     cargo test --lib --all-features        620 total,  0 `signal::`
+#     cargo test --lib --all-features        621 total,  0 `signal::`
 #     cargo test --lib --features {{build_features}}
-#                                            615 total,  3 `signal::`
+#                                            616 total,  3 `signal::`
 #
 #     cargo test --doc                        60 tests
 #     cargo test --doc --features loom-core   58 tests  (both `Signal` ones gone)
@@ -26,7 +26,7 @@
 # Doctest rows are `-- --list` counts. What a run prints is split across
 # batches and moves when a doctest fails, so it is not the number above.
 #
-# The 620 and the 615 differ by the three `signal::` rows gained and eight
+# The 621 and the 616 differ by the three `signal::` rows gained and eight
 # lost: the four `cell_core` and four `accounting_core` rows, which
 # `test-loom` runs under `--cfg loom` — model-checked there rather than merely
 # executed once. So no *test* stops being run, and the three that were being

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -761,6 +761,7 @@ mod tests {
 
     use tokio::time::{Duration, timeout};
 
+    use crate::Subscription;
     use crate::test_support::{assert_pending_until, gate_fetches};
 
     #[test]
@@ -1428,6 +1429,91 @@ mod tests {
             fetch_count.load(Ordering::SeqCst),
             1,
             "loser stream must not invoke the fetcher after the shared success"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scoped_queries_hold_distinct_ids_and_share_one_cell() {
+        let client = Arc::new(QueryClient::new());
+        let winner_count = Arc::new(AtomicUsize::new(0));
+        let loser_count = Arc::new(AtomicUsize::new(0));
+        let (mut releases, gates) = gate_fetches(1);
+
+        let winner_count_clone = winner_count.clone();
+        let gates_clone = gates.clone();
+        let winner = Query::new(
+            "key",
+            move || {
+                let count = winner_count_clone.clone();
+                let gates = gates_clone.clone();
+                Box::pin(async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    gates.next().await.expect("fetch gate should be released");
+                    Ok::<i32, QueryError>(7)
+                })
+            },
+            client.clone(),
+        );
+
+        let loser_count_clone = loser_count.clone();
+        let loser = Query::new(
+            "key",
+            move || {
+                let count = loser_count_clone.clone();
+                Box::pin(async move {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Ok::<i32, QueryError>(99)
+                })
+            },
+            client,
+        );
+
+        let winner_subscription = Subscription::new(winner).scoped("pane-1");
+        let loser_subscription = Subscription::new(loser).scoped("pane-2");
+        assert_ne!(
+            winner_subscription.id, loser_subscription.id,
+            "two boundaries must hold distinct subscription ids"
+        );
+
+        let mut winner_stream = winner_subscription.into_stream();
+        let mut loser_stream = loser_subscription.into_stream();
+
+        let winner_loading = winner_stream.next().await;
+        assert!(matches!(winner_loading, Some(ref result) if result.is_loading()));
+
+        let winner_success_poll = winner_stream.next();
+        tokio::pin!(winner_success_poll);
+        assert_pending_until(
+            &mut winner_success_poll,
+            || winner_count.load(Ordering::SeqCst) >= 1,
+            "winning fetch completed before its gate was released",
+            "winning fetch should start",
+        )
+        .await;
+
+        let loser_loading = loser_stream.next().await;
+        assert!(matches!(loser_loading, Some(ref result) if result.is_loading()));
+
+        releases.release(0);
+
+        let winner_success = timeout(Duration::from_millis(100), winner_success_poll)
+            .await
+            .expect("winning stream should receive success");
+        assert!(
+            matches!(winner_success, Some(ref result) if result.is_success() && result.data() == Some(&7))
+        );
+
+        let loser_success = timeout(Duration::from_millis(100), loser_stream.next())
+            .await
+            .expect("losing stream should receive the shared success");
+        assert!(
+            matches!(loser_success, Some(ref result) if result.is_success() && result.data() == Some(&7)),
+            "a boundary observes data the winning fetcher produced, not its own"
+        );
+        assert_eq!(
+            loser_count.load(Ordering::SeqCst),
+            0,
+            "the losing query's own fetcher must not run for the shared success"
         );
     }
 

--- a/src/subscription/http/query.rs
+++ b/src/subscription/http/query.rs
@@ -157,9 +157,9 @@ impl QueryClient {
     /// # Panics
     ///
     /// Panics if the process-wide client-id space is exhausted (the allocator
-    /// counter has reached `u64::MAX`): `client_id` is a component of
-    /// subscription identity, so ids are never reused within a process
-    /// (RFC 0001).
+    /// counter has reached `u64::MAX`): `client_id` rides inside the key the
+    /// subscription id compares, so ids are never reused within a process
+    /// (RFC 0001 §5.8).
     #[must_use]
     pub fn new() -> Self {
         Self::with_config(QueryConfig::default())
@@ -170,16 +170,16 @@ impl QueryClient {
     /// # Panics
     ///
     /// Panics if the process-wide client-id space is exhausted (the allocator
-    /// counter has reached `u64::MAX`): `client_id` is a component of
-    /// subscription identity, so ids are never reused within a process
-    /// (RFC 0001).
+    /// counter has reached `u64::MAX`): `client_id` rides inside the key the
+    /// subscription id compares, so ids are never reused within a process
+    /// (RFC 0001 §5.8).
     #[must_use]
     pub fn with_config(config: QueryConfig) -> Self {
         Self {
             // `client_id` is an identity component: it is the first element
             // of `Query<V>::Key`, which the subscription id compares, so
             // reusing an id would collide distinct clients' identities
-            // (RFC 0001 INV-5). The allocator fails before it can reuse a
+            // (RFC 0001 §5.8). The allocator fails before it can reuse a
             // value: on exhaustion the failed `fetch_update` stores nothing,
             // leaving the counter saturated at `u64::MAX`, so this and every
             // later allocation panics instead of wrapping into reuse.
@@ -187,7 +187,7 @@ impl QueryClient {
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_add(1))
                 .expect(
                     "QueryClient id space exhausted; client ids are never \
-                     reused within a process (RFC 0001 subscription identity)",
+                     reused within a process (RFC 0001 §5.8)",
                 ),
             cells: Arc::new(DashMap::new()),
             config,
@@ -371,7 +371,7 @@ type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Se
 ///
 /// # Query keys
 ///
-/// The query key identifies the retained cell and the running subscription.
+/// Within one client and value type, the query key identifies the retained cell.
 /// Include every request parameter used by the fetcher in the key. If the
 /// fetcher captures values such as a user ID, search term, page number, or base
 /// URL but the key does not change, the runtime keeps the existing subscription
@@ -383,17 +383,25 @@ type Fetcher<V> = Arc<dyn Fn() -> BoxFuture<'static, Result<V, QueryError>> + Se
 /// runtime keys the running subscription by its
 /// [`SubscriptionId`](crate::SubscriptionId), which the fetcher is no part of,
 /// so constructing a new `Query::new(key, new_fetcher, client)` with an
-/// unchanged key keeps the existing stream and the old fetcher; the new fetcher
-/// never takes effect. **To change the request, change the key** (for example
-/// by including the varying parameter in it).
+/// unchanged key keeps the existing stream and the old fetcher.
+///
+/// Two subscriptions can share one retained cell, because the cell is keyed by
+/// client, value type and key and takes no account of
+/// [`Subscription::scoped`](crate::Subscription::scoped). Queries differing only
+/// by boundary therefore share one fetch, and whichever starts it serves both —
+/// so fetchers reaching one cell must issue equivalent requests, or a query
+/// renders data its own fetcher never produced.
+///
+/// Either way: **to change the request, change the key** (for example by
+/// including the varying parameter in it).
 ///
 /// # Where the client lives
 ///
 /// Hold the [`QueryClient`] in the model and clone the `Arc` into each query.
-/// The client's id is part of the subscription's identity, alongside the query
-/// key above, so a client constructed inside
+/// The client's id rides in the key the subscription id compares, alongside the
+/// query key above, so a client constructed inside
 /// [`Application::subscriptions`](crate::Application::subscriptions) gives the
-/// query a new identity every pass — and a client just constructed retains
+/// query a new id every pass — and a client just constructed retains
 /// nothing, so each pass fetches again instead of serving what the one before
 /// it retained.
 ///
@@ -1355,7 +1363,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_same_identity_streams_share_single_in_flight_fetch() {
+    async fn test_two_streams_of_one_query_share_the_in_flight_fetch() {
         let client = Arc::new(QueryClient::new());
         let fetch_count = Arc::new(AtomicUsize::new(0));
         let (mut releases, gates) = gate_fetches(1);
@@ -1397,7 +1405,7 @@ mod tests {
         assert_eq!(
             fetch_count.load(Ordering::SeqCst),
             1,
-            "same identity streams must share the cell in-flight fetch"
+            "streams reaching one cell must share its in-flight fetch"
         );
 
         releases.release(0);


### PR DESCRIPTION
Closes #389.

RFC 0001 stated the subscription identity as `(client_id,
TypeId::of::<V>(), QueryKey)` in three places, all predating RFC 0005. RFC 0005
INV-1 is what an id compares, and `subscription/core.rs`'s `PartialEq` agrees
with it.

## The three sites

Following PR #390, which settled the same class in `src/` by stating the
identity once — on the type the fact is about — and having the other sites refer
to it:

- **§5.8** names RFC 0005 INV-1 as the owner and states only what a query
  contributes to an id: its source type `Query<V>` and its logical key
  `(client_id, QueryKey)`. The value type enters through the source type, which
  is what makes `Query<i32>("data")` and `Query<String>("data")` distinct.
- **INV-2 is not a deferral.** Its "per identity" was always the cell — the
  in-flight slot lives on the cell (`http/cell_core.rs`), and cells are keyed by
  §5.8's cell map key inside the owning client (`http/query.rs`). It now says
  so, which is a claim RFC 0001 owns end to end.
- **§8's fetcher bullet** names no era's components at all. §8 is a 0.8.x →
  0.9.0 migration section, and identity came from `SubscriptionSource::id` then;
  naming today's mechanism there would date a true instruction to a window in
  which it reads false. What the bullet needs is only that a change confined to
  the fetcher changes no id, which held in 0.9.0 and holds now. It gains one
  pointer: the remedy it already named — change the key — is what §5.4 asks of
  every fetcher reaching one cell, not only of a declaration whose identity is
  unchanged.

## Beyond the three sites

**Four more sites named the cell "identity"**, and the scope path makes them
*too weak* rather than merely imprecise. Two streams under different boundaries
hold different ids and share one cell, so "any two streams for the same identity
share the same cell" no longer reaches the streams single-flight has to cover.
§5.4 now quantifies over the streams that reach a cell, and §5.10 over the cell
map key a torn create would split and the map entry GC leaves alone while a cell
is active.

**§5.4's fetcher arbitration needed the same widening in the other direction.**
It read "for the same identity the request is equivalent by the §5.8 contract" —
under the old tuple that scoped a caller obligation to exactly one cell, but
nothing states it once "identity" stops meaning the cell. Two `Query`s with
different fetchers under different boundaries hold different ids and resolve to
one cell. The obligation is now stated over the streams reaching one cell — the
unit that actually shares the in-flight slot, and narrower than a cell map key,
which is unique only inside one client's map — grounded on a stream being able
to observe data its own fetcher never produced, not on every stream observing
the winner's result, which the discard branch four paragraphs later refutes. It
carries its own remedy rather than pointing at §8, whose bullet covers only the
equal-id case that single-flight never needed the obligation for.

That case also ends one absolute in `Query`'s rustdoc. "The new fetcher never
takes effect" holds when the ids are equal and the declaration is simply
replaced; under two boundaries both subscriptions run and either fetcher can win
a later in-flight slot. The sentence before it already says what the reader needs
— the existing stream keeps its old fetcher — so the absolute goes.

**INV-5 needed restating too**, though the issue checked it and concluded it
survives. It is still the sufficient condition the issue verified, but it drew
distinctness for "subscriptions and cache slots" *together* from one bare
`TypeId` — unambiguous only while §5.8 gave both units the same one. Tightening
the cell map key to `TypeId::of::<V>()` and moving identity onto the source type
splits them, and a reader pinning INV-5's contract test could no longer tell
which to assert. It now names the value type as the component and says how each
unit carries it.

**The hazard had no executable check.** Both existing single-flight tests
stream one `Query` twice, which gives every stream the same fetcher and one
subscription id — they pin that one fetch serves two streams, not whose fetch it
was, and never reach the boundary case. A second commit wraps two `Query::new`
values, alike in client, key and value type but with fetchers returning
different values, in subscriptions scoped to two panes, and asserts the ids
differ, that one fetch runs, and that the losing boundary renders the winner's
value while its own fetcher never runs for it. Verified by mutation in both
directions: one scope on both boundaries fails the id assertion, and pointing
the losing query at another key fails the rest.

The row is `http`-gated, so of the counts the justfile records only the two that
build the feature move — `--all-features` 620 → 621 and `--features
build_features` 615 → 616, re-measured on rustc 1.97.0, the version that block
names. Their difference is the same five and the plain `--lib` 570 is
unchanged.

**The obligation reached only the RFC.** Deleting "the new fetcher never takes
effect" left the hazard stated nowhere a user reads, and it is reachable through
a supported path: the cell takes no account of `Subscription::scoped`, so two
queries differing only by boundary share one fetch and whichever starts it
serves both. `# Changing the request` now states that. `# Query keys` said the
key identifies the retained cell *and the running subscription*; the cell half
gains its scope (one client and value type) and the subscription half goes,
since the key does not identify a subscription once boundaries are in play.

**`src/` sites.** `QueryClient`'s two `# Panics` notes and its allocator's panic
message still carried the pre-#390 wording, pointing at a §5.8 that no longer
defines identity. Those three and the constructor's own comment now all cite
§5.8, which is where the requirement they need is: the logical key carries
`client_id` because the runtime must distinguish the same cell map key across
clients. `INV-5` does not reach it — it says *differing* components stay
independent, while a reused id is two clients whose components no longer differ,
which is §1's 0.8.3 row, "same key, different client treated as identical". The
test backing INV-2 was also named for identity while building bare
`query.stream()`s, which never reach `Subscription::new` and so have no
subscription id at all, and it is renamed for what its body pins.

## The RFC 0010 ledger rows

Not touched, deliberately.

§8 records the ledger as snapshot evidence dated to §1.1's baseline, "not a
contract that outlives its date", and §8.1 decides against carrying it forward
as a maintained registry — owner RFCs stay the sole normative source, because a
living ledger would be a second normative surface whose divergence is silent.
That decision is an Accepted RFC's, and reversing it is its own amendment.

No row loses its verdict here either. LG-0001-006 and LG-0001-030 stay true as
stated. LG-0001-002, LG-0001-023, LG-0001-031 and LG-0001-038 name the same
*sets* that §5.4, §5.10 and §6 now name — a cell has no scope component, so
`(client_id, TypeId, QueryKey)` is exactly the cell — so what this PR corrects
in them is the word "identity", which RFC 0005 has since given to something
else. §8's legend already says as much: a row's Statement is a "condensed
restatement — the owner RFC text remains the sole normative form".

## Issue premises, checked

- The issue cites `http/query.rs:426` for `Query<V>::Key`. That line is
  `pub struct Query<V>`; the associated type is `:479` and `key()` is `:556`.
  The claim itself holds.
- The issue names LG-0001-030 as the ledger row the change reaches. Six rows
  touch this ground (LG-0001-002, -006, -023, -030, -031, -038); the ones that
  restate the retired vocabulary are LG-0001-002, -023 and -038, and
  LG-0001-030's own statement stays true either way.
- Three sites in the issue; the class runs to twenty-one statements — eleven in
  RFC 0001 and ten in `query.rs` — plus the two justfile counts the new test
  moves.
- `INV-5` is still the sufficient condition the issue verified, but it did need
  the restatement above, and it does not reach the client-id non-reuse claim
  `src/` was citing it for.

## Verification

Two commits: the documentation correction, then the test that binds it. The
intermediate commit was checked out in a scratch worktree and its module's tests
pass there, so neither commit lands broken.

Every required check passes. `codecov/patch`, which is not required, reports
89.06% of the diff hit: the losing query's fetcher closure is the uncovered
part, and the test asserts precisely that it never runs. `just pre-commit` (EXIT 0),
`just doc-strict "$(just --evaluate build_features)"` and `just doc-declared`
all pass on this branch.

---

- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`, or this change needs
      none — CONTRIBUTING.md says which changes do
- [x] This breaks nothing a dependant relies on today, or — where it does,
      whether by a compile error, by changed behaviour, or by raising
      `rust-version` — the commit subject carries `!` before the `:` and the
      changelog entry opens `**Breaking:**`
