### PR TITLE
docs(reducer): say when a replacement's successor declares again

### DIFF
--- a/docs/composition.md
+++ b/docs/composition.md
@@ -84,7 +84,13 @@ the root reducer, so the root keeps exactly the messages that are its own.
   `Keyed::insert` over an occupied key and `Slot::present` over an occupied slot
   — and the boundary turns each recorded removal into one teardown of that
   instance's scope. The removed instance's subscriptions stop, its in-flight
-  commands are cancelled, and the cleanup hooks it registered run.
+  commands are cancelled, and the cleanup hooks it registered run. Stopping a
+  subscription reaches past the instance that declared it: while any
+  subscription run is stopping the runtime starts none, so a replacement's
+  successor — and any other row's new declarations — wait for that run to
+  quiesce. The combinators state the timing
+  ([`for_each`](https://docs.rs/tears/latest/tears/reducer/trait.ReducerExt.html#method.for_each),
+  [`presented`](https://docs.rs/tears/latest/tears/reducer/trait.ReducerExt.html#method.presented)).
 - **It discards what it cannot route.** A message addressed to a key the
   collection no longer holds, or to a slot with no occupant, reaches no reducer
   and is dropped — with no diagnostic, and with no way for the sender to learn

--- a/justfile
+++ b/justfile
@@ -12,10 +12,10 @@
 # What `--all-features` removed is the module from *test-target* builds, and
 # with it the three unit tests below. Measured, on rustc 1.97.0:
 #
-#     cargo test --lib                       570 total,  3 `signal::`
-#     cargo test --lib --all-features        621 total,  0 `signal::`
+#     cargo test --lib                       573 total,  3 `signal::`
+#     cargo test --lib --all-features        624 total,  0 `signal::`
 #     cargo test --lib --features {{build_features}}
-#                                            616 total,  3 `signal::`
+#                                            619 total,  3 `signal::`
 #
 #     cargo test --doc                        60 tests
 #     cargo test --doc --features loom-core   58 tests  (both `Signal` ones gone)
@@ -26,7 +26,7 @@
 # Doctest rows are `-- --list` counts. What a run prints is split across
 # batches and moves when a doctest fails, so it is not the number above.
 #
-# The 621 and the 616 differ by the three `signal::` rows gained and eight
+# The 624 and the 619 differ by the three `signal::` rows gained and eight
 # lost: the four `cell_core` and four `accounting_core` rows, which
 # `test-loom` runs under `--cfg loom` — model-checked there rather than merely
 # executed once. So no *test* stops being run, and the three that were being

--- a/src/kernel/conformance.rs
+++ b/src/kernel/conformance.rs
@@ -98,10 +98,12 @@
 //! and its key's scope disagree and both still reach it; [`cleanup`] carries
 //! INV-RC8's behavioral clauses and INV-RC12 (a)'s cleanup neighbour;
 //! [`combinator`] carries INV-RC2, INV-RC3, and INV-RC4's rows as the kernel
-//! applies them, over a program that is a closed combinator stack rather
-//! than the scripted reducer; [`admission`] carries RFC 0012's admission
-//! suite — INV-SE1, INV-SE2, INV-SE3's immediate half, and INV-SE4's
-//! mandated supersession sequence — which is INV-RC12's first clause; and
+//! applies them, plus RFC 0014 §5.1's barrier and §5.2's dirt where a
+//! boundary's replacement reaches them, over a program that is a closed
+//! combinator stack rather than the scripted reducer; [`admission`] carries
+//! RFC 0012's admission suite — INV-SE1, INV-SE2, INV-SE3's immediate half,
+//! and INV-SE4's mandated supersession sequence — which is INV-RC12's first
+//! clause; and
 //! [`observability`] carries the batch event's kernel reading, INV-RC15's
 //! behavioural neighbour (RFC 0014 §9 row 9), and the removal condition's
 //! exit-observation half on the gauge surface (its dequeue-site mirror is

--- a/src/kernel/conformance/combinator.rs
+++ b/src/kernel/conformance/combinator.rs
@@ -23,18 +23,39 @@
 //! | [`closing_a_row_tears_down_the_runs_under_it`] | INV-RC3's drain, as the kernel applies it |
 //! | [`dismissing_the_slot_tears_down_its_occupant_s_runs`] | INV-RC3's dismissal shape, likewise |
 //! | [`a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh`] | INV-RC3's no-diff adversary and INV-RC4's batch remove-and-reinsert |
+//! | [`a_replacement_s_successor_declares_again_at_the_predecessor_s_exit`] | §5.1's barrier and §5.2's dirt, over a boundary's replacement |
+//! | [`a_replaced_slot_occupant_s_successor_declares_again_at_the_predecessor_s_exit`] | the same, for the slot's replacing shape |
+//! | [`a_replacement_that_stops_no_subscription_declares_in_the_replacing_pass`] | the same barrier's condition, from its other side |
 //! | [`a_key_addressed_message_after_a_reinsert_reaches_the_new_instance`] | INV-ST8's positive half, §2.5's third routing clause |
 //! | [`a_message_for_a_closed_row_starts_nothing`] | §2.5's routing boundary, INV-ST8's negative half |
 //!
-//! # The one row a mutation was run against
+//! # The rows a mutation was run against
 //!
-//! The no-diff adversary is the only row here whose subject an unrelated
-//! mechanism could satisfy, so it is the one that was checked by mutation
-//! rather than by reading. Replacing the drain with a state-diff-equivalent
-//! one — returning only the keys absent from the collection when the drain
-//! runs — leaves every other row in this file passing and fails that row on
-//! its unkeyed-run assertion. The row's own comment records why the
-//! assertion is on the unkeyed run and not the keyed one.
+//! Four rows here have a subject an unrelated mechanism could satisfy, so
+//! each was checked by mutation rather than by reading. Every mutation
+//! below was run; what is recorded is which rows in **this file** failed,
+//! not which were expected to. Rows elsewhere may fail too — dropping the
+//! barrier reaches one in [`admission`](super::admission), for instance —
+//! and the column does not enumerate them.
+//!
+//! | mutation | rows in this file it fails |
+//! | --- | --- |
+//! | the drain returns only keys absent from the collection at drain time | the no-diff adversary, on its unkeyed run; the keyed replacement, where it asserts the replacing pass admits nothing |
+//! | `any_stopping_sub` dropped from the reconcile barrier | both replacement rows, where they assert the replacing pass admits nothing |
+//! | `Keyed::insert` records the removal without installing the value | the keyed replacement, on the source only its successor declares; the condition row, where it asserts the admission |
+//! | `Slot::present` records the dismissal but keeps the occupant | the slot replacement, likewise |
+//! | `is_stopping_sub` widened to any stopping run | the barrier's condition row, where it asserts the admission |
+//!
+//! The no-diff adversary's own comment records why its assertion is on the
+//! unkeyed run and not the keyed one. The two "records the removal but does
+//! not install" mutations are what the shared-plus-own source pair exists
+//! for on the replacement rows: one identity declared by both instances
+//! cannot tell a successor declaring from a predecessor left in place
+//! re-declaring at its own exit. The condition row needs no such pair — its
+//! successor is the only declarer there — which is why the same mutation
+//! reaches it. What that row does need is a predecessor holding a command
+//! run: holding nothing leaves the barrier nothing to read either, and the
+//! row would pass without its subject being what made it.
 //!
 //! [`ReducerExt::into_program`]: crate::reducer::combinator::ReducerExt::into_program
 
@@ -84,8 +105,8 @@ struct PaneState {
     /// Marked every time *this instance's* state is reduced — how a row
     /// tells the predecessor's state from the successor's.
     seen: Beacon,
-    /// The source this instance declares, when it declares one.
-    declares: Option<ProbeSource>,
+    /// The sources this instance declares, if any.
+    declares: Vec<ProbeSource>,
 }
 
 impl PaneState {
@@ -100,7 +121,7 @@ impl PaneState {
             keyed,
             anon,
             seen: Beacon::default(),
-            declares: None,
+            declares: Vec::new(),
         }
     }
 
@@ -113,8 +134,15 @@ impl PaneState {
     }
 
     fn declaring(reclaimed: Beacon, source: ProbeSource) -> Self {
+        Self::declaring_all(reclaimed, vec![source])
+    }
+
+    /// An instance declaring one or more sources. The two-source case is
+    /// what it exists for: a row that needs one identity shared with
+    /// another instance and one only this instance declares.
+    fn declaring_all(reclaimed: Beacon, sources: Vec<ProbeSource>) -> Self {
         Self {
-            declares: Some(source),
+            declares: sources,
             ..Self::new(reclaimed)
         }
     }
@@ -160,6 +188,13 @@ enum Act {
     /// placed under that same key — so one command carries the journal's
     /// teardown *and* the successor's spawn (RFC 0013 R4).
     Recreate(u8),
+    /// Replace `key`'s occupant through [`Keyed::insert`] alone, returning
+    /// no command — so nothing but the replacement's own teardown drives
+    /// what follows.
+    Replace(u8),
+    /// The slot's shape of [`Act::Replace`]: [`Slot::present`] over an
+    /// occupant, returning no command.
+    Represent,
     /// Empty the slot.
     Dismiss,
 }
@@ -170,8 +205,9 @@ struct RootState {
     panes: Keyed<u8, PaneState>,
     modal: Slot<PaneState>,
     acts: HashMap<u8, Act>,
-    /// The instance each [`Act::Recreate`] installs, in order. The test
-    /// builds them so it can watch each instance's runs separately.
+    /// The instance each act that installs one takes, in order — an act
+    /// that only removes takes none. The test builds them so it can watch
+    /// each instance's runs separately.
     successors: VecDeque<PaneState>,
 }
 
@@ -208,6 +244,22 @@ impl Reducer for Root {
                     .cancellable(CommandId::new("work"))
                     .scoped(key)
                     .into()
+            }
+            Some(Act::Replace(key)) => {
+                let successor = state
+                    .successors
+                    .pop_front()
+                    .expect("the script supplies one successor per replacement");
+                state.panes.insert(key, successor);
+                Command::none()
+            }
+            Some(Act::Represent) => {
+                let successor = state
+                    .successors
+                    .pop_front()
+                    .expect("the script supplies one successor per replacement");
+                state.modal.present(successor);
+                Command::none()
             }
             Some(Act::Dismiss) => {
                 state.modal.dismiss();
@@ -251,7 +303,7 @@ struct Setup {
     modal: Option<PaneState>,
     /// The scripted acts, by step.
     acts: HashMap<u8, Act>,
-    /// One instance per [`Act::Recreate`], in order.
+    /// One instance per act that installs one, in order.
     successors: VecDeque<PaneState>,
     /// The messages the init effect emits, one per grant.
     trigger: Vec<Msg>,
@@ -530,7 +582,8 @@ fn dismissing_the_slot_tears_down_its_occupant_s_runs() {
 // teardown is the only thing that reaches it, and the journal is the only
 // thing that emits one here. Verified by mutation: with the drain filtered
 // to keys absent at drain time (a state-diff-equivalent journal), this row
-// fails on `old_anon` while every other row in this file still passes.
+// fails on `old_anon`. The module doc's table records which other row that
+// mutation reaches.
 #[test]
 fn a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_fresh() {
     let (old_keyed, old_anon, new) = (Beacon::default(), Beacon::default(), Beacon::default());
@@ -571,6 +624,178 @@ fn a_same_update_recreate_tears_the_old_instance_down_and_starts_the_successor_f
     assert!(
         !new.marked(),
         "and the successor is the run that survives the application point"
+    );
+}
+
+// When a replacement's successor starts running what it declares, read
+// through the kernel rather than inferred from the teardown contract.
+//
+// The replacing pass admits nothing: the teardown stop-requests the
+// outgoing row's subscription run, and the uniform barrier defers every
+// admission runtime-wide while a subscription run is still stopping
+// (RFC 0014 §5.1). What ends the gap is the predecessor's own exit — its
+// quiescence marks subscriptions dirty (§5.2) and `ProducerExit` is a wake
+// source — so no unrelated event is needed, and the row drives that pass by
+// that source to say so.
+//
+// The successor declares two sources and the predecessor one of them. The
+// shared identity is the case the gap is hardest to see in — the same
+// `SubscriptionId` leaves and returns, with one pass in between running
+// none of it — and it is on its own indistinguishable from a predecessor
+// left in place re-declaring at its own exit. The source only the successor
+// declares is what tells those apart.
+#[test]
+fn a_replacement_s_successor_declares_again_at_the_predecessor_s_exit() {
+    let shared = ProbeSource::silent("both");
+    let successor_only = ProbeSource::silent("successor");
+    let mut driver = driver(
+        Setup::new(vec![Msg::Act(1)])
+            .opening(vec![(
+                1,
+                PaneState::declaring(Beacon::default(), shared.clone()),
+            )])
+            .acting(1, Act::Replace(1))
+            .succeeding(PaneState::declaring_all(
+                Beacon::default(),
+                vec![shared.clone(), successor_only.clone()],
+            )),
+    );
+    let trigger = driver.boot().started[0].clone();
+    assert_eq!(
+        (shared.admissions(), successor_only.admissions()),
+        (1, 0),
+        "boot admitted the row's one declaration"
+    );
+
+    deliver(&mut driver, &trigger);
+    assert_eq!(
+        (shared.admissions(), successor_only.admissions()),
+        (1, 0),
+        "the replacing pass admits nothing behind its own teardown"
+    );
+
+    // `settle` turns the executor without running a pass, and admission
+    // happens only inside one, so there is nothing to assert between here
+    // and the step below that a mutation could reach.
+    driver.settle(TEST_TURNS, || shared.quiescences() > 0);
+
+    assert!(
+        driver.step_pass(WakeSource::Data).is_err(),
+        "no unrelated arrival is waiting to drive the pass"
+    );
+
+    let stepped = driver
+        .step_pass(WakeSource::ProducerExit)
+        .expect("the predecessor's exit is a wake source of its own");
+    assert_eq!(
+        successor_only.admissions(),
+        1,
+        "the successor is what declares, not a predecessor left in place"
+    );
+    assert_eq!(
+        shared.admissions(),
+        2,
+        "and the identity both instances declare left and returned"
+    );
+    assert_eq!(
+        stepped.started.len(),
+        2,
+        "both are fresh runs, started by that pass"
+    );
+}
+
+// The slot's replacing shape, which is what `ReducerExt::presented` states
+// shares `for_each`'s timing. Only that shape differs from the row above —
+// `Slot::present` over an occupant rather than `Keyed::insert` over a key —
+// so this row reads the two facts the shape has to reach and leaves the
+// wake-source negative probe to the row that established it.
+#[test]
+fn a_replaced_slot_occupant_s_successor_declares_again_at_the_predecessor_s_exit() {
+    let shared = ProbeSource::silent("both");
+    let successor_only = ProbeSource::silent("successor");
+    let mut driver = driver(
+        Setup::new(vec![Msg::Act(1)])
+            .presenting(PaneState::declaring(Beacon::default(), shared.clone()))
+            .acting(1, Act::Represent)
+            .succeeding(PaneState::declaring_all(
+                Beacon::default(),
+                vec![shared.clone(), successor_only.clone()],
+            )),
+    );
+    let trigger = driver.boot().started[0].clone();
+    assert_eq!(
+        (shared.admissions(), successor_only.admissions()),
+        (1, 0),
+        "boot admitted the occupant's one declaration"
+    );
+
+    deliver(&mut driver, &trigger);
+    assert_eq!(
+        (shared.admissions(), successor_only.admissions()),
+        (1, 0),
+        "the replacing pass admits nothing behind its own teardown"
+    );
+
+    driver.settle(TEST_TURNS, || shared.quiescences() > 0);
+    let stepped = driver
+        .step_pass(WakeSource::ProducerExit)
+        .expect("the predecessor's exit is a wake source of its own");
+    assert_eq!(
+        (shared.admissions(), successor_only.admissions()),
+        (2, 1),
+        "the successor is what declares, at the predecessor's exit"
+    );
+    assert_eq!(
+        stepped.started.len(),
+        2,
+        "both are fresh runs, started by that pass"
+    );
+}
+
+// The condition on the row above, from its other side. The defer is
+// `issued || any_stopping_sub`, so a replacement whose predecessor holds a
+// run the barrier does not read leaves it nothing to hold: the successor's
+// declarations are admitted in the pass that replaced it. What
+// `ReducerExt::for_each` states is conditioned on a *subscription* run being
+// stopped, and this is that condition read off the kernel rather than off
+// the sentence.
+//
+// So the predecessor is given a keyed command run to hold — `PaneMsg::Work`
+// before the replacement — and the teardown stops it. A predecessor holding
+// nothing at all would leave the barrier nothing to read either, and the row
+// would pass without the sub-only scope being what made it. That scope is
+// INV-RC12 (a)'s and is pinned in `lifecycle`; what this row adds is a
+// boundary's replacement reaching it.
+#[test]
+fn a_replacement_that_stops_no_subscription_declares_in_the_replacing_pass() {
+    let successor_only = ProbeSource::silent("successor");
+    let mut driver = driver(
+        Setup::new(vec![Msg::Row(1, PaneMsg::Work), Msg::Act(1)])
+            .opening(vec![(1, PaneState::new(Beacon::default()))])
+            .acting(1, Act::Replace(1))
+            .succeeding(PaneState::declaring(
+                Beacon::default(),
+                successor_only.clone(),
+            )),
+    );
+    let trigger = driver.boot().started[0].clone();
+    assert_eq!(
+        successor_only.admissions(),
+        0,
+        "the outgoing row declared nothing to begin with"
+    );
+
+    let started = deliver(&mut driver, &trigger);
+    assert!(
+        matches!(started.as_slice(), [RunKind::Keyed(_)]),
+        "the predecessor holds a command run for the teardown to stop: {started:?}"
+    );
+
+    deliver(&mut driver, &trigger);
+    assert_eq!(
+        successor_only.admissions(),
+        1,
+        "with no subscription run stopping, the replacing pass admits the successor's"
     );
 }
 

--- a/src/reducer/collection.rs
+++ b/src/reducer/collection.rs
@@ -29,8 +29,9 @@
 //!
 //! The two replacement shapes are removals because that is what replacement
 //! *means* here: the old instance is torn down and the new one starts fresh
-//! (RFC 0014 §2.5). Insertion into an absent key and presentation into an
-//! empty slot record nothing — there was no instance to remove.
+//! (RFC 0014 §2.5) — each on the timing its boundary's combinator states.
+//! Insertion into an absent key and presentation into an empty slot record
+//! nothing — there was no instance to remove.
 //!
 //! **Four shapes is the whole surface, and that is deliberate.** There is no
 //! `retain`, no `clear`, no `drain`, no `IndexMut`, and no `&mut` iterator:
@@ -113,9 +114,10 @@ impl<K: ScopeValue, V> Keyed<K, V> {
     /// Inserts `value` under `key`, returning the instance it replaced.
     ///
     /// Replacing an occupied key **records a removal**: the old instance is
-    /// torn down and the new one starts fresh (RFC 0014 §2.5). The position
-    /// in the iteration order is the old instance's, so a replacement does
-    /// not reorder the collection.
+    /// torn down and the new one starts fresh (RFC 0014 §2.5), on the timing
+    /// [`ReducerExt::for_each`](crate::reducer::ReducerExt::for_each)
+    /// states. The position in the iteration order is the old instance's, so
+    /// a replacement does not reorder the collection.
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         if let Some(row) = self.rows.iter_mut().find(|(held, _)| *held == key) {
             self.removals.push(key);
@@ -249,7 +251,9 @@ impl<S> Slot<S> {
     ///
     /// Presenting over an occupied slot **records a removal**, for the reason
     /// [`Keyed::insert`] does: replacement is a teardown of the old instance
-    /// and a fresh start for the new one.
+    /// and a fresh start for the new one, on the timing
+    /// [`ReducerExt::presented`](crate::reducer::ReducerExt::presented)
+    /// states.
     pub const fn present(&mut self, value: S) -> Option<S> {
         let replaced = self.value.replace(value);
         if replaced.is_some() {

--- a/src/reducer/combinator.rs
+++ b/src/reducer/combinator.rs
@@ -149,6 +149,16 @@ pub trait ReducerExt: Reducer + Sized {
     ///
     /// `extract` names the row a message is addressed to; a message for a
     /// key the collection does not hold is discarded.
+    ///
+    /// Replacing a row — [`Keyed::insert`] over an occupied key — tears the
+    /// outgoing instance down before the successor runs anything it
+    /// declares. While any subscription run is still stopping the runtime
+    /// admits no subscription at all, so a row whose replacement stops one
+    /// declares again in a later pass rather than in the pass that replaced
+    /// it. That run's exit is itself a wake source, so what ends the gap is
+    /// its quiescence and not an unrelated arrival. Where both instances
+    /// declare the same subscription, its identity leaves and returns rather
+    /// than staying.
     fn for_each<C, K>(
         self,
         child: C,
@@ -176,6 +186,10 @@ pub trait ReducerExt: Reducer + Sized {
     ///
     /// A message the slot's occupant would have claimed is discarded while
     /// the slot is empty.
+    ///
+    /// Replacing the occupant — [`Slot::present`] over an occupied slot —
+    /// starts the successor's declarations on the timing
+    /// [`for_each`](ReducerExt::for_each) states for a replaced row.
     fn presented<C, Seg>(
         self,
         child: C,


### PR DESCRIPTION
Closes #364.

Replacing a child under the same segment — `Keyed::insert` over an occupied key,
`Slot::present` over an occupied slot — tears the outgoing instance down, and
the successor's declarations do not come back in the same pass. Nothing on the
combinators said so.

## What the kernel does

Read off the kernel rather than inferred from the teardown contract, which is
the issue's second acceptance criterion:

- The teardown stop-requests the outgoing instance's runs
  (`kernel/teardown.rs`).
- `reconcile` returns **before** its admission phase while any subscription run
  is still stopping anywhere in the runtime (`kernel/pass.rs`, RFC 0014 §5.1).
- That run's quiescence marks subscriptions dirty at the next pass's exit
  reflection (§5.2), and a producer exit is one of the three wake sources — so
  the predecessor's own exit drives the pass that declares again.

A conformance row in `kernel/conformance/combinator.rs` reads exactly this: it
replaces a declaring pane through `Keyed::insert` alone, returning no command,
then asserts the replacing pass admits nothing, that `step_pass(Data)` is
refused (nothing else is waiting to drive a pass), and that stepping on
`ProducerExit` admits.

The successor declares two sources and the predecessor one of them. The shared
identity is the case the gap is hardest to see in — the same `SubscriptionId`
leaves and returns, with one pass in between running none of it — but on its own
it cannot tell a successor declaring from a predecessor left in place
re-declaring at its own exit, since both produce one admission of one identity.
The source only the successor declares is what tells those apart.

A second row reads the defer's condition from the other side: its predecessor
holds a keyed command run, which the teardown stops and the barrier does not
read, so the successor's declarations are admitted in the pass that replaced it.
That is the condition `for_each`'s statement rests on, read off the kernel
rather than off the sentence. A predecessor holding *nothing* would leave the
barrier nothing to read either and pass the row without its subject being what
made it, which is why the predecessor is given a run. The subscription-only
scope itself is INV-RC12 (a)'s, pinned in `lifecycle`; what this row adds is a
boundary's replacement reaching it.

A third row is the slot's replacing shape, `Slot::present` over an occupant,
which is what `ReducerExt::presented` states shares `for_each`'s timing — an
unpinned generalization until now.

Five mutations, each run rather than reasoned about, and the module doc records
them as a table of which rows each one fails. Two belong to the file's existing
no-diff adversary, whose paragraph and row comment both claimed every other row
in the file passes under it: the keyed replacement row fails there too, on a
teardown the filtered drain never emits. Both sentences now say so, and the
conformance index's enumeration of what this module carries gains the barrier
and the dirt.

## Where it is stated

`ReducerExt::for_each` states it, and `ReducerExt::presented` states that a
replaced occupant shares that timing. `Keyed::insert` and `Slot::present` each
point at their own boundary's combinator rather than restating it — one hop
from either.

It states the **mechanism** rather than the outcome, which is what keeps it
honest about the case it does not cover: a row whose replacement stops no
subscription run leaves the barrier nothing to defer, and its successor's
declarations are admitted in the replacing pass.

`docs/composition.md` gains a pointer and the rule's width, not the timing
statement. The issue places that with the combinators rather than in a guide
about when to compose, and a pointer honours it; but the same page tells a
reader an optionally-present child's subscriptions "start when it appears"
before it reaches the replacement case, so leaving no path onward is a gap of
its own. The width matters there because the page names the non-replacing
removals two sentences earlier: stopping a subscription reaches past the
instance that declared it, so a plain `Keyed::remove` delays every *other* row's
new declarations the same way a replacement delays its own successor's.

## Issue premises, checked

Three things the issue assumed are not what the kernel does. The statement
avoids all three.

- **"the hole the successor's declaration would fill is not visible yet"** — the
  declared set at the replacing pass's `reconcile` already contains the
  successor's id. The barrier is what defers the admission, not a stale view.
- **"until some unrelated event drives the next pass"** — the predecessor's exit
  is itself a wake source. The row asserts no other arrival is pending and then
  drives the pass by that exit.
- **"a replacement that returns a command … the gap never shows"** — a command
  does not shortcut the barrier. A pass driven by that command re-admits only
  once it has reflected the same exit, so the gap still ends at the
  predecessor's quiescence.

The issue also states the gap unconditionally; it exists only when the outgoing
instance had a subscription run to stop.

Verified separately: both replacement sites in `examples/dashboard_composed.rs`
do return commands, as the issue says.

## Verification

`just pre-commit`, `just doc-strict "$(just --evaluate build_features)"` and
`just doc-declared` all pass (EXIT 0). `--lib` gains the row under every feature
set, so all three counts the justfile records move by three — 570 → 573,
621 → 624, 616 → 619 — re-measured on rustc 1.97.0, the version that block
names.

Two commits, the rows first and the statement they back second.

---

- [x] `CHANGELOG.md` has an entry under `## [Unreleased]`, or this change needs
      none — CONTRIBUTING.md says which changes do
- [x] This breaks nothing a dependant relies on today, or — where it does,
      whether by a compile error, by changed behaviour, or by raising
      `rust-version` — the commit subject carries `!` before the `:` and the
      changelog entry opens `**Breaking:**`
